### PR TITLE
Refactor CD workflow for PyPI publishing and update installation inst…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,28 +43,29 @@
                       name: python-package-distributions
                       path: dist/
 
-        # publish-to-pypi:
-        #     name: >-
-        #         Publish Python distribution to PyPI
-        #     if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
-        #     needs:
-        #     - build
-        #     runs-on: ubuntu-latest
-        #     environment:
-        #         name: pypi
-        #         url: https://pypi.org/project/wandas/  # Replace <package-name> with your PyPI project name
-        #     permissions:
-        #         id-token: write  # IMPORTANT: mandatory for trusted publishing
+        publish-to-pypi:
+            name: >-
+                Publish Python distribution to PyPI
+            if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+            needs:
+            - build
+            runs-on: ubuntu-latest
+            environment:
+                name: pypi
+                url: https://pypi.org/project/wandas/  # Replace <package-name> with your PyPI project name
+            permissions:
+                id-token: write  # IMPORTANT: mandatory for trusted publishing
 
-        #     steps:
-        #     - name: Download all the dists
-        #       uses: actions/download-artifact@v4
-        #       with:
-        #         name: python-package-distributions
-        #         path: dist/
-        #     - name: Publish distribution to PyPI
-        #       uses: pypa/gh-action-pypi-publish@release/v1
-
+            steps:
+            - name: Download all the dists
+              uses: actions/download-artifact@v4
+              with:
+                name: python-package-distributions
+                path: dist/
+            - name: Publish distribution to PyPI
+              uses: pypa/gh-action-pypi-publish@release/v1
+              with:
+                password: ${{secrets.PYPI_API_TOKEN}}
         # github-release:
         #     name: >-
         #         Sign the Python distribution with Sigstore
@@ -108,27 +109,27 @@
         #             "$GITHUB_REF_NAME" dist/**
         #             --repo "$GITHUB_REPOSITORY"
 
-        publish-to-testpypi:
-            name: Publish Python distribution to TestPyPI
-            needs:
-            - build
-            runs-on: ubuntu-latest
+        # publish-to-testpypi:
+        #     name: Publish Python distribution to TestPyPI
+        #     needs:
+        #     - build
+        #     runs-on: ubuntu-latest
 
-            environment:
-              name: testpypi
-              url: https://test.pypi.org/project/wandas/
+        #     environment:
+        #       name: testpypi
+        #       url: https://test.pypi.org/project/wandas/
 
-            permissions:
-              id-token: write  # IMPORTANT: mandatory for trusted publishing
+        #     permissions:
+        #       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
-            steps:
-            - name: Download all the dists
-              uses: actions/download-artifact@v4
-              with:
-                name: python-package-distributions
-                path: dist/
-            - name: Publish distribution to TestPyPI
-              uses: pypa/gh-action-pypi-publish@release/v1
-              with:
-                password: ${{secrets.TEST_PYPI_API_TOKEN}}
-                repository-url: https://test.pypi.org/legacy/
+        #     steps:
+        #     - name: Download all the dists
+        #       uses: actions/download-artifact@v4
+        #       with:
+        #         name: python-package-distributions
+        #         path: dist/
+        #     - name: Publish distribution to TestPyPI
+        #       uses: pypa/gh-action-pypi-publish@release/v1
+        #       with:
+        #         password: ${{secrets.TEST_PYPI_API_TOKEN}}
+        #         repository-url: https://test.pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## インストール
 
 ```bash
-pip install git+https://github.com/kasahart/wandas
+pip install wandas
 ```
 
 ## クイックスタート

--- a/wandas/__init__.py
+++ b/wandas/__init__.py
@@ -1,1 +1,4 @@
 # wandas/__init__.py
+from importlib.metadata import version
+
+__version__ = version(__package__ or "wandas")


### PR DESCRIPTION
This pull request includes several changes to the CI/CD workflow, the `README.md` file, and the `wandas` package initialization. The main changes involve re-enabling the PyPI publishing step in the GitHub Actions workflow, updating the installation instructions in the README, and adding versioning information to the package initialization.

Improvements to CI/CD workflow:

* Re-enabled the `publish-to-pypi` step in `.github/workflows/cd.yml` to publish the Python distribution to PyPI on tag pushes.
* Commented out the `publish-to-testpypi` step in `.github/workflows/cd.yml` to disable publishing to TestPyPI.

Documentation update:

* Updated the installation instructions in `README.md` to use the PyPI package instead of the GitHub repository.

Package initialization:

* Added versioning information to `wandas/__init__.py` using `importlib.metadata`. in README