### PR TITLE
Feature/add hpss

### DIFF
--- a/tests/core/test_channel_frame.py
+++ b/tests/core/test_channel_frame.py
@@ -929,3 +929,103 @@ def test_channel_frame_cut_nonzero_taper() -> None:
             expected_seg_ch2[i].data,
             err_msg=f"Segment {i + 1} channel 2 data mismatch with taper.",
         )
+
+
+def test_hpss_harmonic(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Test the hpss_harmonic method in ChannelFrame.
+    Verifies that it calls the corresponding method on each channel
+    and returns a new ChannelFrame with the results.
+    """
+    # Create test data with two channels
+    sampling_rate = 1000
+    t = np.linspace(0, 1, sampling_rate)
+    data1 = np.sin(2 * np.pi * 10 * t)  # 10 Hz sine wave
+    data2 = np.sin(2 * np.pi * 100 * t)  # 100 Hz sine wave
+
+    # Create channels and track calls to hpss_harmonic
+    calls = []
+
+    def mock_hpss_harmonic(self: "Channel", **kwargs: Any) -> "Channel":
+        # Record that this was called and with what arguments
+        calls.append((self.label, kwargs))
+        # Return a new channel with the same data (mock implementation)
+        return Channel(
+            data=self.data, sampling_rate=self.sampling_rate, label=self.label
+        )
+
+    # Patch the Channel.hpss_harmonic method
+    monkeypatch.setattr(Channel, "hpss_harmonic", mock_hpss_harmonic)
+
+    # Create channels and channel frame
+    ch1 = Channel(data=data1, sampling_rate=sampling_rate, label="Channel 1")
+    ch2 = Channel(data=data2, sampling_rate=sampling_rate, label="Channel 2")
+    cf = ChannelFrame(channels=[ch1, ch2], label="Test Frame")
+
+    # Set some custom kwargs to verify they're passed through
+    test_kwargs = {"margin": 3.0, "power": 2.0}
+
+    # Call the method being tested
+    harmonic_cf = cf.hpss_harmonic(**test_kwargs)
+
+    # Verify the result is a ChannelFrame
+    assert isinstance(harmonic_cf, ChannelFrame)
+    assert harmonic_cf.label == cf.label
+    assert len(harmonic_cf) == len(cf)
+
+    # Verify all channels had their hpss_harmonic method
+    # called with the right kwargs
+    assert len(calls) == 2
+    assert calls[0][0] == "Channel 1"
+    assert calls[1][0] == "Channel 2"
+    assert all(kwargs == test_kwargs for _, kwargs in calls)
+
+
+def test_hpss_percussive(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Test the hpss_percussive method in ChannelFrame.
+    Verifies that it calls the corresponding method on each channel
+    and returns a new ChannelFrame with the results.
+    """
+    # Create test data with two channels
+    sampling_rate = 1000
+    t = np.linspace(0, 1, sampling_rate)
+    data1 = np.sin(2 * np.pi * 10 * t)  # 10 Hz sine wave
+    data2 = np.sin(2 * np.pi * 100 * t)  # 100 Hz sine wave
+
+    # Create channels and track calls to hpss_percussive
+    calls = []
+
+    def mock_hpss_percussive(self: "Channel", **kwargs: Any) -> "Channel":
+        # Record that this was called and with what arguments
+        calls.append((self.label, kwargs))
+        # Return a new channel with the same data (mock implementation)
+        return Channel(
+            data=self.data, sampling_rate=self.sampling_rate, label=self.label
+        )
+
+    # Patch the Channel.hpss_percussive method
+    monkeypatch.setattr(Channel, "hpss_percussive", mock_hpss_percussive)
+
+    # Create channels and channel frame
+    ch1 = Channel(data=data1, sampling_rate=sampling_rate, label="Channel 1")
+    ch2 = Channel(data=data2, sampling_rate=sampling_rate, label="Channel 2")
+    cf = ChannelFrame(channels=[ch1, ch2], label="Test Frame")
+
+    # Set some custom kwargs to verify they're passed through
+    test_kwargs = {"margin": 2.0, "power": 4.0}
+
+    # Call the method being tested
+    percussive_cf = cf.hpss_percussive(**test_kwargs)
+
+    # Verify the result is a ChannelFrame
+    assert isinstance(percussive_cf, ChannelFrame)
+    assert percussive_cf.label == cf.label
+    assert len(percussive_cf) == len(cf)
+
+    # Verify all channels had their hpss_percussive method
+    # called with the right kwargs
+    assert len(calls) == 2
+    assert calls[0][0] == "Channel 1"
+    assert calls[1][0] == "Channel 2"
+    assert all(kwargs == test_kwargs for _, kwargs in calls)

--- a/tests/core/test_channel_processing.py
+++ b/tests/core/test_channel_processing.py
@@ -1,0 +1,419 @@
+from typing import Any
+from unittest.mock import patch
+
+import librosa
+import numpy as np
+import pytest
+
+from wandas.core import channel_processing, util
+from wandas.core.channel import Channel
+from wandas.utils.types import NDArrayReal
+
+
+def test_apply_add_basic_functionality() -> None:
+    """Test that apply_add correctly combines two channels with the specified SNR."""
+    # Create test channels with known values
+    sampling_rate = 1000
+    data1 = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    data2 = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
+
+    ch1 = Channel(data=data1, sampling_rate=sampling_rate, label="signal")
+    ch2 = Channel(data=data2, sampling_rate=sampling_rate, label="noise")
+
+    # Test with SNR = 10 dB
+    snr = 10.0
+
+    # Calculate expected values manually
+    clean_rms = util.calculate_rms(data1)
+    noise_rms = util.calculate_rms(data2)
+    desired_noise_rms = util.calculate_desired_noise_rms(clean_rms, snr)
+    gain = desired_noise_rms / noise_rms
+    expected_data = data1 + data2 * gain
+
+    # Apply the function
+    result = channel_processing.apply_add(ch1, ch2, snr)
+
+    # Check the result
+    assert isinstance(result, Channel)
+    assert result.sampling_rate == sampling_rate
+    np.testing.assert_array_almost_equal(result.data, expected_data)
+
+
+def test_apply_add_sampling_rate_mismatch() -> None:
+    """Test that apply_add raises ValueError when sampling rates don't match."""
+    # Create channels with different sampling rates
+    data = np.array([1.0, 2.0, 3.0])
+    ch1 = Channel(data=data, sampling_rate=1000, label="ch1")
+    ch2 = Channel(data=data, sampling_rate=2000, label="ch2")
+
+    with pytest.raises(
+        ValueError, match="Sampling rates of the two channels are different."
+    ):
+        channel_processing.apply_add(ch1, ch2, 10.0)
+
+
+def test_apply_add_shape_mismatch() -> None:
+    """Test that apply_add raises ValueError when data shapes don't match."""
+    # Create channels with different data shapes
+    sampling_rate = 1000
+    ch1 = Channel(
+        data=np.array([1.0, 2.0, 3.0]), sampling_rate=sampling_rate, label="ch1"
+    )
+    ch2 = Channel(
+        data=np.array([1.0, 2.0, 3.0, 4.0]), sampling_rate=sampling_rate, label="ch2"
+    )
+
+    with pytest.raises(
+        ValueError, match="Data shapes of the two channels are different."
+    ):
+        channel_processing.apply_add(ch1, ch2, 10.0)
+
+
+def test_apply_add_with_mocks() -> None:
+    """
+    Test apply_add using mocked utility functions for precise control.
+
+    This test mocks the utility functions
+    `calculate_rms` and `calculate_desired_noise_rms`
+    to control their return values and verify that
+    `apply_add` correctly uses these values
+    to compute the expected result.
+    """
+    # Create test channels
+    sampling_rate = 1000
+    data1 = np.array([1.0, 2.0, 3.0])
+    data2 = np.array([0.1, 0.2, 0.3])
+
+    ch1 = Channel(data=data1, sampling_rate=sampling_rate, label="signal")
+    ch2 = Channel(data=data2, sampling_rate=sampling_rate, label="noise")
+
+    # Mock values
+    mock_clean_rms = 3.0
+    mock_noise_rms = 0.5
+    mock_desired_noise_rms = 0.3
+    expected_gain = mock_desired_noise_rms / mock_noise_rms
+
+    # Patch the utility functions
+    with (
+        patch("wandas.core.util.calculate_rms") as mock_calc_rms,
+        patch("wandas.core.util.calculate_desired_noise_rms") as mock_calc_desired_rms,
+    ):
+
+        def mock_rms_side_effect(data: NDArrayReal) -> float:
+            if np.array_equal(data, data1):
+                return mock_clean_rms
+            return mock_noise_rms
+
+        mock_calc_rms.side_effect = mock_rms_side_effect
+        mock_calc_desired_rms.return_value = mock_desired_noise_rms
+
+        # Call the function
+        result = channel_processing.apply_add(ch1, ch2, 10.0)
+
+        # Verify mocks were called correctly
+        assert mock_calc_rms.call_count == 2
+        mock_calc_desired_rms.assert_called_once_with(mock_clean_rms, 10.0)
+
+        # Check the result
+        expected_data = data1 + data2 * expected_gain
+        np.testing.assert_array_almost_equal(result.data, expected_data)
+
+
+def test_apply_add_various_snr_values() -> None:
+    """Test apply_add with a range of SNR values."""
+    # Create test channels
+    sampling_rate = 1000
+    data1 = np.ones(10)  # Signal: all ones
+    data2 = np.ones(10) * 0.1  # Noise: all 0.1
+
+    ch1 = Channel(data=data1, sampling_rate=sampling_rate, label="signal")
+    ch2 = Channel(data=data2, sampling_rate=sampling_rate, label="noise")
+
+    # Test with different SNR values
+    snr_values = [-20.0, -10.0, 0.0, 10.0, 20.0]
+
+    for snr in snr_values:
+        # Calculate expected result
+        clean_rms = util.calculate_rms(data1)
+        noise_rms = util.calculate_rms(data2)
+        desired_noise_rms = util.calculate_desired_noise_rms(clean_rms, snr)
+        gain = desired_noise_rms / noise_rms
+        expected_data = data1 + data2 * gain
+
+        # Call the function
+        result = channel_processing.apply_add(ch1, ch2, snr)
+
+        # Verify result
+        np.testing.assert_array_almost_equal(result.data, expected_data)
+
+
+def test_apply_add_zero_signal_or_noise() -> None:
+    """Test apply_add with zero signal or noise."""
+    sampling_rate = 1000
+
+    # Test with zero signal
+    ch_zero = Channel(data=np.zeros(5), sampling_rate=sampling_rate, label="zero")
+    ch_nonzero = Channel(data=np.ones(5), sampling_rate=sampling_rate, label="nonzero")
+
+    # Zero signal with noise should just return scaled noise
+    result = channel_processing.apply_add(ch_zero, ch_nonzero, 0.0)  # SNR 0 dB
+    result_rms = util.calculate_rms(result.data)
+    expected_rms = util.calculate_rms(ch_zero.data)  # Should be 0
+
+    assert np.isclose(result_rms, expected_rms)
+
+    # Test with zero noise - this might cause division by zero, so handle accordingly
+    with pytest.raises(ValueError, match="RMS of the noise channel is zero."):
+        result = channel_processing.apply_add(ch_nonzero, ch_zero, 0.0)
+
+
+def test_apply_add_preserves_channel_properties() -> None:
+    """Test that apply_add preserves important channel properties."""
+    # Create test channels with metadata
+    sampling_rate = 1000
+    data1 = np.random.random(10)
+    data2 = np.random.random(10)
+
+    ch1 = Channel(data=data1, sampling_rate=sampling_rate, label="signal")
+    ch2 = Channel(data=data2, sampling_rate=sampling_rate, label="noise")
+
+    # Call the function
+    result = channel_processing.apply_add(ch1, ch2, 10.0)
+
+    # Verify important properties are preserved
+    assert result.sampling_rate == sampling_rate
+    # Label would typically come from ch1, but the current implementation
+    # doesn't specify this - we'd need to check the actual behavior
+
+
+def test_apply_hpss_percussive_basic_functionality() -> None:
+    """Test that apply_hpss_percussive correctly extracts percussive components."""
+    # Create a test channel with a simple waveform
+    sampling_rate = 22050
+    # Create a signal with both harmonic and percussive elements
+    t = np.linspace(0, 1, sampling_rate)
+    # Harmonic part (sine wave)
+    harmonic = np.sin(2 * np.pi * 440 * t)
+    # Percussive part (short impulses)
+    percussive = np.zeros_like(t)
+    percussive[::1000] = 1.0  # Impulses every 1000 samples
+    # Combined signal
+    data = harmonic + percussive
+
+    ch = Channel(data=data, sampling_rate=sampling_rate, label="test")
+
+    # Apply the function with default parameters
+    result = channel_processing.apply_hpss_percussive(ch)
+
+    # Check the result
+    assert isinstance(result, dict)
+    assert "data" in result
+    assert isinstance(result["data"], np.ndarray)
+    assert result["data"].shape == data.shape
+    # Percussive component should be different from the original
+    excepted_data = librosa.effects.percussive(data)
+    assert np.array_equal(result["data"], excepted_data)
+
+
+def test_apply_hpss_percussive_with_parameters() -> None:
+    """Test apply_hpss_percussive with different parameter values."""
+    sampling_rate = 22050
+    t = np.linspace(0, 1, sampling_rate)
+    data = np.sin(2 * np.pi * 440 * t) + np.sin(2 * np.pi * 880 * t)
+
+    ch = Channel(data=data, sampling_rate=sampling_rate, label="test")
+
+    # Test with different margin values
+    margin_values = [1.0, 2.0, 3.0]
+
+    previous_result = None
+    for margin in margin_values:
+        result = channel_processing.apply_hpss_percussive(ch, margin=margin)
+
+        # Basic checks
+        assert isinstance(result, dict)
+        assert "data" in result
+        assert isinstance(result["data"], np.ndarray)
+        assert result["data"].shape == data.shape
+
+        # Different margin values should produce different results
+        if previous_result is not None:
+            # Check that results are different (at least slightly)
+
+            assert not np.allclose(result["data"], previous_result["data"])
+
+        previous_result = result
+
+
+@patch("librosa.effects.percussive")
+def test_apply_hpss_percussive_with_mocks(mock_percussive: Any) -> None:
+    """Test apply_hpss_percussive using mocked librosa function for precise control."""
+    # Create test data
+    data = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    sampling_rate = 1000
+    ch = Channel(data=data, sampling_rate=sampling_rate, label="test")
+
+    # Set up the mock to return a known array
+    mock_return = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
+    mock_percussive.return_value = mock_return
+
+    # Call the function with some parameters
+    kwargs = {"margin": 2.0, "kernel_size": 31}
+    result = channel_processing.apply_hpss_percussive(ch, **kwargs)
+
+    # Verify that librosa.effects.percussive was called with correct arguments
+    assert mock_percussive.call_count == 1
+
+    # Check that the result contains our mocked data
+    assert "data" in result
+    np.testing.assert_array_equal(result["data"], mock_return)
+
+
+def test_apply_hpss_percussive_empty_data() -> None:
+    """Test apply_hpss_percussive with empty data."""
+    # Create a channel with empty data
+    data = np.array([])
+    sampling_rate = 1000
+    ch = Channel(data=data, sampling_rate=sampling_rate, label="empty")
+
+    # Apply the function
+    result = channel_processing.apply_hpss_percussive(ch)
+
+    # Check the result
+    assert isinstance(result, dict)
+    assert "data" in result
+    assert isinstance(result["data"], np.ndarray)
+    assert result["data"].size == 0
+
+
+def test_apply_hpss_percussive_return_type() -> None:
+    """Test that apply_hpss_percussive returns the correct type."""
+    # Create a test channel
+    data = np.random.random(100)
+    sampling_rate = 1000
+    ch = Channel(data=data, sampling_rate=sampling_rate, label="test")
+
+    # Apply the function
+    result = channel_processing.apply_hpss_percussive(ch)
+
+    # Check the return type
+    assert isinstance(result, dict)
+    assert "data" in result
+    assert isinstance(result["data"], np.ndarray)
+    assert result["data"].dtype == np.float64 or result["data"].dtype == np.float32
+
+
+def test_apply_hpss_harmonic_basic_functionality() -> None:
+    """Test that apply_hpss_harmonic correctly extracts harmonic components."""
+    # Create a test channel with a simple waveform
+    sampling_rate = 22050
+    # Create a signal with both harmonic and percussive elements
+    t = np.linspace(0, 1, sampling_rate)
+    # Harmonic part (sine wave)
+    harmonic = np.sin(2 * np.pi * 440 * t)
+    # Percussive part (short impulses)
+    percussive = np.zeros_like(t)
+    percussive[::1000] = 1.0  # Impulses every 1000 samples
+    # Combined signal
+    data = harmonic + percussive
+
+    ch = Channel(data=data, sampling_rate=sampling_rate, label="test")
+
+    # Apply the function with default parameters
+    result = channel_processing.apply_hpss_harmonic(ch)
+
+    # Check the result
+    assert isinstance(result, dict)
+    assert "data" in result
+    assert isinstance(result["data"], np.ndarray)
+    assert result["data"].shape == data.shape
+    # Harmonic component should be different from the original
+    excepted_data = librosa.effects.harmonic(data)
+    assert np.array_equal(result["data"], excepted_data)
+
+
+def test_apply_hpss_harmonic_with_parameters() -> None:
+    """Test apply_hpss_harmonic with different parameter values."""
+    sampling_rate = 22050
+    t = np.linspace(0, 1, sampling_rate)
+    data = np.sin(2 * np.pi * 440 * t) + np.sin(2 * np.pi * 880 * t)
+
+    ch = Channel(data=data, sampling_rate=sampling_rate, label="test")
+
+    # Test with different margin values
+    margin_values = [1.0, 2.0, 3.0]
+
+    previous_result = None
+    for margin in margin_values:
+        result = channel_processing.apply_hpss_harmonic(ch, margin=margin)
+
+        # Basic checks
+        assert isinstance(result, dict)
+        assert "data" in result
+        assert isinstance(result["data"], np.ndarray)
+        assert result["data"].shape == data.shape
+
+        # Different margin values should produce different results
+        if previous_result is not None:
+            # Check that results are different (at least slightly)
+            assert not np.allclose(result["data"], previous_result["data"])
+
+        previous_result = result
+
+
+@patch("librosa.effects.harmonic")
+def test_apply_hpss_harmonic_with_mocks(mock_harmonic: Any) -> None:
+    """Test apply_hpss_harmonic using mocked librosa function for precise control."""
+    # Create test data
+    data = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    sampling_rate = 1000
+    ch = Channel(data=data, sampling_rate=sampling_rate, label="test")
+
+    # Set up the mock to return a known array
+    mock_return = np.array([0.1, 0.2, 0.3, 0.4, 0.5])
+    mock_harmonic.return_value = mock_return
+
+    # Call the function with some parameters
+    kwargs = {"margin": 2.0, "kernel_size": 31}
+    result = channel_processing.apply_hpss_harmonic(ch, **kwargs)
+
+    # Verify that librosa.effects.harmonic was called with correct arguments
+    assert mock_harmonic.call_count == 1
+
+    # Check that the result contains our mocked data
+    assert "data" in result
+    np.testing.assert_array_equal(result["data"], mock_return)
+
+
+def test_apply_hpss_harmonic_empty_data() -> None:
+    """Test apply_hpss_harmonic with empty data."""
+    # Create a channel with empty data
+    data = np.array([])
+    sampling_rate = 1000
+    ch = Channel(data=data, sampling_rate=sampling_rate, label="empty")
+
+    # Apply the function
+    result = channel_processing.apply_hpss_harmonic(ch)
+
+    # Check the result
+    assert isinstance(result, dict)
+    assert "data" in result
+    assert isinstance(result["data"], np.ndarray)
+    assert result["data"].size == 0
+
+
+def test_apply_hpss_harmonic_return_type() -> None:
+    """Test that apply_hpss_harmonic returns the correct type."""
+    # Create a test channel
+    data = np.random.random(100)
+    sampling_rate = 1000
+    ch = Channel(data=data, sampling_rate=sampling_rate, label="test")
+
+    # Apply the function
+    result = channel_processing.apply_hpss_harmonic(ch)
+
+    # Check the return type
+    assert isinstance(result, dict)
+    assert "data" in result
+    assert isinstance(result["data"], np.ndarray)
+    assert result["data"].dtype == np.float64 or result["data"].dtype == np.float32

--- a/tests/core/test_time_frequency_channel.py
+++ b/tests/core/test_time_frequency_channel.py
@@ -456,3 +456,54 @@ def test_data_aw_returns_amplitude_converted_values_when_flag_false() -> None:
 
     # Assert that the result matches expected amplitude values
     np.testing.assert_allclose(result, expected_amplitude, rtol=1e-5)
+
+
+def test_frequency_channel_hpss_harmonic(generate_channel: Channel) -> None:
+    """
+    Compare fc.hpss_harmonic() result with librosa.decompose.hpss.
+    """
+
+    ch = generate_channel
+    n_fft = 512
+    win_length = 512
+    window = "hann"
+
+    # Apply HPSS with librosa directly on time-domain data
+    fc = ch.stft(n_fft=n_fft, win_length=win_length, window=window)
+    # Apply HPSS in our FrequencyChannel
+    harmonic_fc = fc.hpss_harmonic()
+    h, _ = librosa.decompose.hpss(fc.data)
+    # Check shape
+    assert harmonic_fc.data.shape == h.shape, (
+        f"Expected shape {h.shape}, got {harmonic_fc.data.shape}"
+    )
+
+    # Compare amplitude
+    result = np.abs(harmonic_fc.data)
+    expected_weighted = np.abs(h)
+    np.testing.assert_allclose(result, expected_weighted)
+
+
+def test_frequency_channel_hpss_percussive(generate_channel: Channel) -> None:
+    """
+    Compare fc.hpss_percussive() result with librosa.decompose.hpss.
+    """
+
+    ch = generate_channel
+    n_fft = 512
+    win_length = 512
+    window = "hann"
+
+    # Apply HPSS with librosa directly on time-domain data
+    fc = ch.stft(n_fft=n_fft, win_length=win_length, window=window)
+    # Apply HPSS in our FrequencyChannel
+    percussive_fc = fc.hpss_percussive()
+    _, p = librosa.decompose.hpss(fc.data)
+    # Check shape
+    assert percussive_fc.data.shape == p.shape, (
+        f"Expected shape {p.shape}, got {percussive_fc.data.shape}"
+    )
+    # Compare amplitude
+    result = np.abs(percussive_fc.data)
+    expected_weighted = np.abs(p)
+    np.testing.assert_allclose(result, expected_weighted)

--- a/wandas/core/channel.py
+++ b/wandas/core/channel.py
@@ -1,6 +1,6 @@
 # wandas/core/channel.py
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union
 
 import ipywidgets as widgets
 import numpy as np
@@ -162,6 +162,76 @@ class Channel(BaseChannel, ArithmeticMixin):
             cutoff=cutoff,
             order=order,
             filter_type="lowpass",
+        )
+        return Channel.from_channel(self, **result)
+
+    def hpss_harmonic(
+        self,
+        kernel_size: Union[int, tuple[int, int], list[int]] = 31,
+        power: float = 2.0,
+        mask: bool = False,
+        margin: Union[float, tuple[float, float], list[float]] = 1.0,
+        n_fft: int = 2048,
+        hop_length: Optional[int] = None,
+        win_length: Optional[int] = None,
+        window: Union[str, NDArrayReal] = "hann",
+        center: bool = True,
+        pad_mode: Literal[
+            "constant", "edge", "linear_ramp", "reflect", "symmetric", "empty"
+        ]
+        | Callable[..., Any] = "constant",
+    ) -> "Channel":
+        """
+        HPSS（Harmonic-Percussive Source Separation）のうち、
+        Harmonic 成分を取得します。
+        """
+        result = channel_processing.apply_hpss_harmonic(
+            ch=self,
+            kernel_size=kernel_size,
+            power=power,
+            mask=mask,
+            margin=margin,
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
+        )
+        return Channel.from_channel(self, **result)
+
+    def hpss_percussive(
+        self,
+        kernel_size: Union[int, tuple[int, int], list[int]] = 31,
+        power: float = 2.0,
+        mask: bool = False,
+        margin: Union[float, tuple[float, float], list[float]] = 1.0,
+        n_fft: int = 2048,
+        hop_length: Optional[int] = None,
+        win_length: Optional[int] = None,
+        window: Union[str, NDArrayReal] = "hann",
+        center: bool = True,
+        pad_mode: Literal[
+            "constant", "edge", "linear_ramp", "reflect", "symmetric", "empty"
+        ]
+        | Callable[..., Any] = "constant",
+    ) -> "Channel":
+        """
+        HPSS（Harmonic-Percussive Source Separation）のうち、
+        Percussive 成分を取得します。
+        """
+        result = channel_processing.apply_hpss_percussive(
+            ch=self,
+            kernel_size=kernel_size,
+            power=power,
+            mask=mask,
+            margin=margin,
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            center=center,
+            pad_mode=pad_mode,
         )
         return Channel.from_channel(self, **result)
 
@@ -348,7 +418,9 @@ class Channel(BaseChannel, ArithmeticMixin):
         """
         return int(self._data.shape[-1])
 
-    def add(self, other: "Channel", snr: Optional[float] = None) -> "Channel":
+    def add(
+        self, other: Union["Channel", NDArrayReal], snr: Optional[float] = None
+    ) -> "Channel":
         """_summary_
 
         Args:
@@ -358,6 +430,9 @@ class Channel(BaseChannel, ArithmeticMixin):
         Returns:
             Channel: _description_
         """
+        if isinstance(other, np.ndarray):
+            other = Channel.from_channel(self, data=other, label="ndarray")
+
         if snr is None:
             return self + other
 

--- a/wandas/core/channel_frame.py
+++ b/wandas/core/channel_frame.py
@@ -340,6 +340,26 @@ class ChannelFrame(ChannelAccessMixin["Channel"]):
         filtered_channels = [ch.low_pass_filter(cutoff, order) for ch in self]
         return ChannelFrame(filtered_channels, label=self.label)
 
+    def hpss_harmonic(self, **kwargs: Any) -> "ChannelFrame":
+        """
+        HPSS（Harmonic-Percussive Source Separation）の Harmonic 成分を抽出します。
+
+        Returns:
+            ChannelFrame: Harmonic 成分を含む新しい ChannelFrame オブジェクト。
+        """
+        harmonic_channels = [ch.hpss_harmonic(**kwargs) for ch in self]
+        return ChannelFrame(harmonic_channels, label=self.label)
+
+    def hpss_percussive(self, **kwargs: Any) -> "ChannelFrame":
+        """
+        HPSS（Harmonic-Percussive Source Separation）の Percussive 成分を抽出します。
+
+        Returns:
+            ChannelFrame: Percussive 成分を含む新しい ChannelFrame オブジェクト。
+        """
+        percussive_channels = [ch.hpss_percussive(**kwargs) for ch in self]
+        return ChannelFrame(percussive_channels, label=self.label)
+
     def fft(
         self,
         n_fft: Optional[int] = None,

--- a/wandas/core/channel_processing.py
+++ b/wandas/core/channel_processing.py
@@ -21,8 +21,11 @@ def apply_add(ch1: "Channel", ch2: "Channel", snr: float) -> "Channel":
     if ch1.data.shape != ch2.data.shape:
         raise ValueError("Data shapes of the two channels are different.")
 
-    clean_rms = util.calculate_rms(ch1.data)
     other_rms = util.calculate_rms(ch2.data)
+    if other_rms == 0:
+        raise ValueError("RMS of the noise channel is zero.")
+
+    clean_rms = util.calculate_rms(ch1.data)
     desired_noise_rms = util.calculate_desired_noise_rms(clean_rms, snr)
     gain = desired_noise_rms / other_rms
 

--- a/wandas/core/channel_processing.py
+++ b/wandas/core/channel_processing.py
@@ -48,6 +48,28 @@ def apply_filter(
         raise ValueError("Filtered data is not a ndarray.")
 
 
+def apply_hpss_harmonic(
+    ch: "Channel",
+    **kwargs: Any,
+) -> dict[str, NDArrayReal]:
+    harmonic = librosa.effects.harmonic(ch.data, **kwargs)
+    result = dict(
+        data=harmonic,
+    )
+    return result
+
+
+def apply_hpss_percussive(
+    ch: "Channel",
+    **kwargs: Any,
+) -> dict[str, NDArrayReal]:
+    percussive = librosa.effects.percussive(ch.data, **kwargs)
+    result = dict(
+        data=percussive,
+    )
+    return result
+
+
 def compute_fft(
     ch: "Channel", n_fft: Optional[int] = None, window: Optional[str] = None
 ) -> dict[str, NDArrayComplex]:

--- a/wandas/core/frequency_channel.py
+++ b/wandas/core/frequency_channel.py
@@ -312,6 +312,26 @@ class FrequencyChannel(BaseChannel):
             librosa.db_to_amplitude(weighted, ref=self.ref), dtype=np.float64
         )
 
+    def hpss_harmonic(self, **kwargs: Any) -> "FrequencyChannel":
+        """
+        ハーモニック成分を抽出します。
+        """
+        harmonic, _ = librosa.decompose.hpss(self.data, **kwargs)
+        result = dict(
+            data=harmonic,
+        )
+        return FrequencyChannel.from_channel(self, **result)
+
+    def hpss_percussive(self, **kwargs: Any) -> "FrequencyChannel":
+        """
+        パーカッシブ成分を抽出します。
+        """
+        _, percussive = librosa.decompose.hpss(self.data, **kwargs)
+        result = dict(
+            data=percussive,
+        )
+        return FrequencyChannel.from_channel(self, **result)
+
     def plot(
         self,
         ax: Optional["Axes"] = None,

--- a/wandas/core/frequency_channel.py
+++ b/wandas/core/frequency_channel.py
@@ -312,26 +312,6 @@ class FrequencyChannel(BaseChannel):
             librosa.db_to_amplitude(weighted, ref=self.ref), dtype=np.float64
         )
 
-    def hpss_harmonic(self, **kwargs: Any) -> "FrequencyChannel":
-        """
-        ハーモニック成分を抽出します。
-        """
-        harmonic, _ = librosa.decompose.hpss(self.data, **kwargs)
-        result = dict(
-            data=harmonic,
-        )
-        return FrequencyChannel.from_channel(self, **result)
-
-    def hpss_percussive(self, **kwargs: Any) -> "FrequencyChannel":
-        """
-        パーカッシブ成分を抽出します。
-        """
-        _, percussive = librosa.decompose.hpss(self.data, **kwargs)
-        result = dict(
-            data=percussive,
-        )
-        return FrequencyChannel.from_channel(self, **result)
-
     def plot(
         self,
         ax: Optional["Axes"] = None,

--- a/wandas/core/time_frequency_channel.py
+++ b/wandas/core/time_frequency_channel.py
@@ -142,6 +142,34 @@ class TimeFrequencyChannel(BaseChannel):
 
         return np.asarray(librosa.db_to_amplitude(weighted), dtype=np.float64)
 
+    def hpss_harmonic(self, **kwargs: Any) -> "TimeFrequencyChannel":
+        """
+        ハーモニック成分を抽出します。
+        """
+        harmonic, _ = librosa.decompose.hpss(self.data, **kwargs)
+        result = dict(
+            data=harmonic,
+            n_fft=self.n_fft,
+            hop_length=self.hop_length,
+            win_length=self.win_length,
+            window=self.window,
+        )
+        return TimeFrequencyChannel.from_channel(self, **result)
+
+    def hpss_percussive(self, **kwargs: Any) -> "TimeFrequencyChannel":
+        """
+        パーカッシブ成分を抽出します。
+        """
+        _, percussive = librosa.decompose.hpss(self.data, **kwargs)
+        result = dict(
+            data=percussive,
+            n_fft=self.n_fft,
+            hop_length=self.hop_length,
+            win_length=self.win_length,
+            window=self.window,
+        )
+        return TimeFrequencyChannel.from_channel(self, **result)
+
     def _plot(
         self,
         ax: "Axes",


### PR DESCRIPTION
This pull request introduces several new methods for Harmonic-Percussive Source Separation (HPSS) and their corresponding tests. The main changes include adding HPSS methods to the `Channel`, `ChannelFrame`, and `TimeFrequencyChannel` classes, as well as implementing tests for these methods.

### New HPSS Methods:
* [`wandas/core/channel.py`](diffhunk://#diff-1a924bf9907e126a3bf4a22bb470e622faf94a282d91cf35bbc4c0b3876a4dccR168-R237): Added `hpss_harmonic` and `hpss_percussive` methods to the `Channel` class for extracting harmonic and percussive components, respectively. [[1]](diffhunk://#diff-1a924bf9907e126a3bf4a22bb470e622faf94a282d91cf35bbc4c0b3876a4dccR168-R237) [[2]](diffhunk://#diff-1a924bf9907e126a3bf4a22bb470e622faf94a282d91cf35bbc4c0b3876a4dccL351-R423)
* [`wandas/core/channel_frame.py`](diffhunk://#diff-87072a5161084b51b87b823738d3bda75bb23017001bf3c20fb05f896c5a9f1bR343-R362): Added `hpss_harmonic` and `hpss_percussive` methods to the `ChannelFrame` class to apply HPSS on all channels within a frame.
* [`wandas/core/time_frequency_channel.py`](diffhunk://#diff-49a543ae723013979fd97be03437df5dcfacf0ecd2fe3ac9268269a992b9e485R145-R172): Added `hpss_harmonic` and `hpss_percussive` methods to the `TimeFrequencyChannel` class for extracting harmonic and percussive components in the frequency domain.

### New Tests:
* [`tests/core/test_channel.py`](diffhunk://#diff-8214a1d16b619724c51d3ee517b2fa049eafb6bb798578e3c1be4e50ea9a935fR497-R623): Added tests for the `hpss_harmonic` and `hpss_percussive` methods of the `Channel` class, including parameter passing verification.
* [`tests/core/test_channel_frame.py`](diffhunk://#diff-326de19d6eb3d623ebc151bb6dc4e0d39412945deb251752eb0999502355186cR932-R1031): Added tests for the `hpss_harmonic` and `hpss_percussive` methods of the `ChannelFrame` class.
* [`tests/core/test_time_frequency_channel.py`](diffhunk://#diff-5932db05ff57b15856841880c4e0954ed4287ddbbd88d6d764106581c6cc5a23R459-R509): Added tests for the `hpss_harmonic` and `hpss_percussive` methods of the `TimeFrequencyChannel` class, comparing results with `librosa.decompose.hpss`.

### Supporting Changes:
* [`wandas/core/channel_processing.py`](diffhunk://#diff-eff3657a193cad7dc7cd437aa504a0a0e362f15fcfd88ee64f505dc11b3b6822R54-R75): Added `apply_hpss_harmonic` and `apply_hpss_percussive` functions to handle the actual HPSS processing using `librosa`.
* [`wandas/core/channel.py`](diffhunk://#diff-1a924bf9907e126a3bf4a22bb470e622faf94a282d91cf35bbc4c0b3876a4dccR433-R435): Modified the `add` method to handle `numpy.ndarray` as input for the `other` parameter.
* [`wandas/core/channel_processing.py`](diffhunk://#diff-eff3657a193cad7dc7cd437aa504a0a0e362f15fcfd88ee64f505dc11b3b6822L24-R28): Improved error handling in the `apply_add` function to raise an error if the RMS of the noise channel is zero.

These changes enhance the functionality of the `Channel`, `ChannelFrame`, and `TimeFrequencyChannel` classes by providing methods to separate harmonic and percussive components, along with comprehensive tests to ensure their correctness.