### PR TITLE
Add append and remove methods to ChannelAccessMixin; implement tests …

### DIFF
--- a/tests/core/test_channel_access_mixin.py
+++ b/tests/core/test_channel_access_mixin.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pytest
+
+from wandas.core.base_channel import BaseChannel
+from wandas.core.channel_access_mixin import ChannelAccessMixin
+
+
+class DummyChannel(BaseChannel):
+    pass
+
+
+class TestChannelAccessMixin:
+    class TestableChannelAccess(ChannelAccessMixin[DummyChannel]):
+        def __init__(self) -> None:
+            self._channels: list[DummyChannel] = []
+            self._channel_dict: dict[str, DummyChannel] = {}
+
+    def test_append_valid_channel(self) -> None:
+        test_signal = np.array([1, 2, 3])
+        fs = 100
+        channel = DummyChannel(test_signal, fs, "ch1")
+
+        access = self.TestableChannelAccess()
+        access.append(channel)
+        assert access.channels == [channel]
+        assert access.channel_dict["ch1"] == channel
+
+    def test_append_duplicate_channel_raises_key_error(self) -> None:
+        test_signal = np.array([1, 2, 3])
+        fs = 100
+        channel = DummyChannel(test_signal, fs, "ch1")
+        access = self.TestableChannelAccess()
+        access.append(channel)
+        with pytest.raises(KeyError):
+            access.append(channel)
+
+    def test_remove_valid_channel(self) -> None:
+        test_signal = np.array([1, 2, 3])
+        fs = 100
+        channel = DummyChannel(test_signal, fs, "ch1")
+
+        access = self.TestableChannelAccess()
+        access.append(channel)
+        access.remove(channel)
+        assert len(access.channels) == 0
+        assert "ch1" not in access.channel_dict
+
+    def test_remove_non_existent_channel_raises_key_error(self) -> None:
+        test_signal = np.array([1, 2, 3])
+        fs = 100
+        channel = DummyChannel(test_signal, fs, "ch1")
+
+        access = self.TestableChannelAccess()
+        with pytest.raises(KeyError):
+            access.remove(channel)

--- a/wandas/core/channel_access_mixin.py
+++ b/wandas/core/channel_access_mixin.py
@@ -104,3 +104,27 @@ class ChannelAccessMixin(Generic[ChannelT]):
         チャンネルのデータ長を返します。
         """
         return len(self._channels)
+
+    def append(self, channel: ChannelT) -> None:
+        """
+        チャンネルを追加します。
+
+        Parameters:
+            channel (Channel): 追加するチャンネル。
+        """
+        if channel.label in self.channel_dict:
+            raise KeyError(f"Channel '{channel.label}' already exists.")
+        self._channels.append(channel)
+        self.channel_dict[channel.label] = channel
+
+    def remove(self, channel: ChannelT) -> None:
+        """
+        チャンネルを削除します。
+
+        Parameters:
+            channel (Channel): 削除するチャンネル。
+        """
+        if channel.label not in self.channel_dict:
+            raise KeyError(f"Channel '{channel.label}' not found.")
+        self._channels.remove(channel)
+        del self.channel_dict[channel.label]


### PR DESCRIPTION
This pull request introduces new methods for managing channels in the `ChannelAccessMixin` class and adds corresponding unit tests to ensure their functionality. The most important changes include the addition of `append` and `remove` methods to the `ChannelAccessMixin` class and the creation of a new test class to validate these methods.

Enhancements to `ChannelAccessMixin`:

* Added `append` method to add a new channel to the mixin, with a check to prevent duplicate channel labels. (`wandas/core/channel_access_mixin.py`)
* Added `remove` method to remove an existing channel from the mixin, with a check to handle non-existent channels. (`wandas/core/channel_access_mixin.py`)

Unit tests:

* Created `TestChannelAccessMixin` class with tests for `append` and `remove` methods to ensure they handle valid, duplicate, and non-existent channels correctly. (`tests/core/test_channel_access_mixin.py`)