### PR TITLE
Feature fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "ipympl>=0.9.3",
     "h5py>=3.13.0",
     "dask>=2024.8.0",
+    "waveform-analysis",
 ]
 
 [project.urls]
@@ -62,6 +63,7 @@ dev-dependencies = [
 
 [tool.uv.sources]
 wandas = { workspace = true }
+waveform-analysis = { git = "https://github.com/endolith/waveform-analysis.git", rev = "master" }
 
 [tool.ruff]
 line-length = 88

--- a/tests/core/test_channel_frame.py
+++ b/tests/core/test_channel_frame.py
@@ -595,6 +595,7 @@ def test_rms_plot_overlay_with_ax(monkeypatch: pytest.MonkeyPatch) -> None:
         ax: Optional["Axes"] = None,
         title: Optional[str] = None,
         overlay: bool = True,
+        Aw: bool = False,  # noqa: N803
         plot_kwargs: Optional[dict[str, Any]] = None,
     ) -> Union["Axes", list["Axes"]]:
         call_list.append("called")
@@ -653,6 +654,7 @@ def test_rms_plot_non_overlay(monkeypatch: pytest.MonkeyPatch) -> None:
         ax: Optional["Axes"] = None,
         title: Optional[str] = None,
         overlay: bool = True,
+        Aw: bool = False,  # noqa: N803
         plot_kwargs: Optional[dict[str, Any]] = None,
     ) -> Union["Axes", list["Axes"]]:
         call_list.append("called")

--- a/uv.lock
+++ b/uv.lock
@@ -2630,6 +2630,7 @@ dependencies = [
     { name = "numpy" },
     { name = "scipy", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "scipy", version = "1.15.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "waveform-analysis" },
 ]
 
 [package.dev-dependencies]
@@ -2658,6 +2659,7 @@ requires-dist = [
     { name = "mosqito" },
     { name = "numpy" },
     { name = "scipy" },
+    { name = "waveform-analysis", git = "https://github.com/endolith/waveform-analysis.git?rev=master" },
 ]
 
 [package.metadata.requires-dev]
@@ -2671,6 +2673,11 @@ dev = [
     { name = "ruff", specifier = ">=0.9.9" },
     { name = "wandas", editable = "." },
 ]
+
+[[package]]
+name = "waveform-analysis"
+version = "0.1"
+source = { git = "https://github.com/endolith/waveform-analysis.git?rev=master#baece1e4db3fa2324090086efe1d74cce314e65b" }
 
 [[package]]
 name = "wcwidth"

--- a/wandas/core/channel_frame.py
+++ b/wandas/core/channel_frame.py
@@ -50,7 +50,7 @@ class ChannelFrame(ChannelAccessMixin["Channel"]):
         array: NDArrayReal,
         sampling_rate: int,
         labels: Optional[list[str]] = None,
-        unit: str = "Pa",
+        unit: Optional[str] = None,
     ) -> "ChannelFrame":
         """
         numpy の ndarray から ChannelFrame インスタンスを生成します。
@@ -298,6 +298,7 @@ class ChannelFrame(ChannelAccessMixin["Channel"]):
         ax: Optional["Axes"] = None,
         title: Optional[str] = None,
         overlay: bool = True,
+        Aw: bool = False,  # noqa: N803
         plot_kwargs: Optional[dict[str, Any]] = None,
     ) -> Union["Axes", Iterable["Axes"]]:
         """
@@ -309,7 +310,7 @@ class ChannelFrame(ChannelAccessMixin["Channel"]):
         plotter = ChannelFramePlotter(self)
 
         return plotter.rms_plot(
-            ax=ax, title=title, overlay=overlay, plot_kwargs=plot_kwargs
+            ax=ax, title=title, overlay=overlay, Aw=Aw, plot_kwargs=plot_kwargs
         )
 
     def high_pass_filter(self, cutoff: float, order: int = 5) -> "ChannelFrame":
@@ -339,6 +340,16 @@ class ChannelFrame(ChannelAccessMixin["Channel"]):
         """
         filtered_channels = [ch.low_pass_filter(cutoff, order) for ch in self]
         return ChannelFrame(filtered_channels, label=self.label)
+
+    def a_weighting(self) -> "ChannelFrame":
+        """
+        A 加重をすべてのチャンネルに適用します。
+
+        Returns:
+            ChannelFrame: A 加重された新しい ChannelFrame オブジェクト。
+        """
+        weighted_channels = [ch.a_weighting() for ch in self]
+        return ChannelFrame(weighted_channels, label=self.label)
 
     def hpss_harmonic(self, **kwargs: Any) -> "ChannelFrame":
         """

--- a/wandas/core/channel_frame_plotter.py
+++ b/wandas/core/channel_frame_plotter.py
@@ -86,6 +86,7 @@ class ChannelFramePlotter:
         ax: Optional["Axes"] = None,
         title: Optional[str] = None,
         overlay: bool = True,
+        Aw: bool = False,  # noqa: N803
         plot_kwargs: Optional[dict[str, Any]] = None,
     ) -> Union["Axes", Iterable["Axes"]]:
         if ax is None:
@@ -96,7 +97,7 @@ class ChannelFramePlotter:
                 fig, ax = plt.subplots(figsize=(10, 4))
 
             for channel in self.cf:
-                channel.rms_plot(ax=ax, title=title, plot_kwargs=plot_kwargs)
+                channel.rms_plot(ax=ax, title=title, Aw=Aw, plot_kwargs=plot_kwargs)
 
             ax.set_title(title or self.cf.label or "Signal RMS")
             ax.grid(True)
@@ -120,7 +121,9 @@ class ChannelFramePlotter:
                 axes_list = list(axs)
 
             for channel, ax_i in zip(self.cf, axes_list):
-                channel.rms_plot(ax=ax_i, title=channel.label, plot_kwargs=plot_kwargs)
+                channel.rms_plot(
+                    ax=ax_i, title=channel.label, Aw=Aw, plot_kwargs=plot_kwargs
+                )
 
             axes_list[-1].set_xlabel("Time [s]")
 

--- a/wandas/core/channel_plotter.py
+++ b/wandas/core/channel_plotter.py
@@ -52,6 +52,7 @@ class ChannelPlotter:
         self,
         ax: Optional["Axes"] = None,
         title: Optional[str] = None,
+        Aw: bool = False,  # noqa: N803
         plot_kwargs: Optional[dict[str, Any]] = None,
     ) -> "Axes":
         _ax = ax
@@ -60,7 +61,7 @@ class ChannelPlotter:
 
         plot_kwargs = plot_kwargs or {}
 
-        rms_channel: Channel = self.channel.rms_trend()
+        rms_channel: Channel = self.channel.rms_trend(Aw=Aw)
         num_samples = len(rms_channel)
         t = np.arange(num_samples) / rms_channel.sampling_rate
 

--- a/wandas/core/channel_processing.py
+++ b/wandas/core/channel_processing.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 import librosa
 import numpy as np
 from scipy.signal import butter, filtfilt
+from waveform_analysis import A_weight
 
 from wandas.core import util
 from wandas.utils.types import NDArrayComplex, NDArrayReal
@@ -143,10 +144,17 @@ def compute_stft(
 
 
 def compute_rms_trend(
-    ch: "Channel", frame_length: int = 2048, hop_length: int = 512
+    ch: "Channel",
+    frame_length: int = 2048,
+    hop_length: int = 512,
+    Aw: bool = False,  # noqa: N803
 ) -> dict[str, Any]:
+    data: NDArrayReal = ch.data
+    if Aw:
+        data = np.array(A_weight(data, ch.sampling_rate))
+
     rms_data = librosa.feature.rms(
-        y=ch.data, frame_length=frame_length, hop_length=hop_length
+        y=data, frame_length=frame_length, hop_length=hop_length
     )
     result = dict(
         data=rms_data.squeeze(),

--- a/wandas/core/util.py
+++ b/wandas/core/util.py
@@ -37,7 +37,7 @@ def amplitude_to_db(amplitude: "NDArrayReal", ref: float) -> "NDArrayReal":
     Convert amplitude to decibel.
     """
     db: NDArrayReal = librosa.amplitude_to_db(
-        np.abs(amplitude), ref=ref, amin=1e-15, top_db=300
+        np.abs(amplitude), ref=ref, amin=1e-15, top_db=None
     )
     return db
 

--- a/wandas/utils/generate_sample.py
+++ b/wandas/utils/generate_sample.py
@@ -39,7 +39,7 @@ def generate_sin(
             data = np.sin(2 * np.pi * freq * t) * 2 * np.sqrt(2)
             channel_label = f"Channel {idx + 1}"
             channel = Channel(
-                data=data, sampling_rate=sampling_rate, label=channel_label, unit="Pa"
+                data=data, sampling_rate=sampling_rate, label=channel_label, unit=None
             )
             channels.append(channel)
     else:
@@ -49,7 +49,7 @@ def generate_sin(
             data=np.squeeze(data),
             sampling_rate=sampling_rate,
             label="Channel 1",
-            unit="Pa",
+            unit=None,
         )
         channels = [channel]
 


### PR DESCRIPTION
This pull request introduces several key changes across multiple files, primarily focusing on adding a new dependency, enhancing functionality related to waveform analysis, and expanding test coverage. The most important changes include adding the `waveform-analysis` dependency, implementing A-weighting functionality, and enhancing the `ChannelFrame` and `Channel` classes.

### Dependency Updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R45): Added `waveform-analysis` to the dependencies and development dependencies. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R45) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R66)

### New Features:
* [`wandas/core/channel.py`](diffhunk://#diff-1a924bf9907e126a3bf4a22bb470e622faf94a282d91cf35bbc4c0b3876a4dccR169-R176): Added `a_weighting` method to apply A-weighting filter to `Channel` objects.
* [`wandas/core/channel_frame.py`](diffhunk://#diff-87072a5161084b51b87b823738d3bda75bb23017001bf3c20fb05f896c5a9f1bR344-R353): Added `a_weighting` method to apply A-weighting filter to all channels in a `ChannelFrame`.
* [`wandas/core/channel_processing.py`](diffhunk://#diff-eff3657a193cad7dc7cd437aa504a0a0e362f15fcfd88ee64f505dc11b3b6822L146-R157): Updated `compute_rms_trend` to support A-weighting.

### Enhancements:
* [`wandas/core/channel.py`](diffhunk://#diff-1a924bf9907e126a3bf4a22bb470e622faf94a282d91cf35bbc4c0b3876a4dccL372-R386): Enhanced `rms_trend` and `rms_plot` methods to support A-weighting. [[1]](diffhunk://#diff-1a924bf9907e126a3bf4a22bb470e622faf94a282d91cf35bbc4c0b3876a4dccL372-R386) [[2]](diffhunk://#diff-1a924bf9907e126a3bf4a22bb470e622faf94a282d91cf35bbc4c0b3876a4dccR421-R429)
* [`wandas/core/channel_frame.py`](diffhunk://#diff-87072a5161084b51b87b823738d3bda75bb23017001bf3c20fb05f896c5a9f1bR301): Enhanced `rms_plot` method to support A-weighting. [[1]](diffhunk://#diff-87072a5161084b51b87b823738d3bda75bb23017001bf3c20fb05f896c5a9f1bR301) [[2]](diffhunk://#diff-87072a5161084b51b87b823738d3bda75bb23017001bf3c20fb05f896c5a9f1bL312-R313)

### Test Coverage:
* [`tests/core/test_channel_frame.py`](diffhunk://#diff-326de19d6eb3d623ebc151bb6dc4e0d39412945deb251752eb0999502355186cL249-R281): Added tests for `ChannelFrame` to WAV file writing and A-weighting functionality. [[1]](diffhunk://#diff-326de19d6eb3d623ebc151bb6dc4e0d39412945deb251752eb0999502355186cL249-R281) [[2]](diffhunk://#diff-326de19d6eb3d623ebc151bb6dc4e0d39412945deb251752eb0999502355186cR598)
* [`tests/core/test_channel_processing.py`](diffhunk://#diff-03a837b34f89cda73c25fce6028b55b0252f4fa493e1ec643203bd786b3601eaR421-R451): Added tests for `compute_rms_trend` with basic usage, custom parameters, and A-weighting.
* [`tests/io/test_wav_io.py`](diffhunk://#diff-3a59d44deff0225d4f01b7f020d63f1c7d49c6dc1e15371c8c487a43f8436745R189-R234): Added tests for writing `ChannelFrame` to WAV files.