### PR TITLE
Refactor pad_mode type annotation in Channel class for improved clarity

### DIFF
--- a/wandas/core/channel.py
+++ b/wandas/core/channel.py
@@ -185,10 +185,10 @@ class Channel(BaseChannel, ArithmeticMixin):
         win_length: Optional[int] = None,
         window: Union[str, NDArrayReal] = "hann",
         center: bool = True,
-        pad_mode: Literal[
-            "constant", "edge", "linear_ramp", "reflect", "symmetric", "empty"
-        ]
-        | Callable[..., Any] = "constant",
+        pad_mode: Union[
+            Literal["constant", "edge", "linear_ramp", "reflect", "symmetric", "empty"],
+            Callable[..., Any],
+        ] = "constant",
     ) -> "Channel":
         """
         HPSS（Harmonic-Percussive Source Separation）のうち、
@@ -220,10 +220,10 @@ class Channel(BaseChannel, ArithmeticMixin):
         win_length: Optional[int] = None,
         window: Union[str, NDArrayReal] = "hann",
         center: bool = True,
-        pad_mode: Literal[
-            "constant", "edge", "linear_ramp", "reflect", "symmetric", "empty"
-        ]
-        | Callable[..., Any] = "constant",
+        pad_mode: Union[
+            Literal["constant", "edge", "linear_ramp", "reflect", "symmetric", "empty"],
+            Callable[..., Any],
+        ] = "constant",
     ) -> "Channel":
         """
         HPSS（Harmonic-Percussive Source Separation）のうち、


### PR DESCRIPTION
This pull request includes updates to the `wandas/core/channel.py` file, specifically modifying the `pad_mode` parameter in the `hpss_harmonic` and `hpss_percussive` functions to improve readability and maintainability.

Changes to `pad_mode` parameter:

* [`wandas/core/channel.py`](diffhunk://#diff-1a924bf9907e126a3bf4a22bb470e622faf94a282d91cf35bbc4c0b3876a4dccL188-R191): Updated the `pad_mode` parameter in the `hpss_harmonic` function to use `Union` for better readability.
* [`wandas/core/channel.py`](diffhunk://#diff-1a924bf9907e126a3bf4a22bb470e622faf94a282d91cf35bbc4c0b3876a4dccL223-R226): Updated the `pad_mode` parameter in the `hpss_percussive` function to use `Union` for better readability.