### PR TITLE
fix: Add missing checkout step in CI workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,6 +53,9 @@ jobs:
         needs: build
         runs-on: ubuntu-latest
         steps:
+          - name: リポジトリをチェックアウト
+              uses: actions/checkout@v4
+
             - name: uv をインストール
               uses: astral-sh/setup-uv@v5
               with:


### PR DESCRIPTION
This pull request makes a small update to the `.github/workflows/cd.yml` file by adding a step to check out the repository before proceeding with subsequent actions.

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R56-R58): Added a step named "リポジトリをチェックアウト" that uses the `actions/checkout@v4` action to ensure the repository is checked out before running other steps.