### PR TITLE
Feat improved add

### DIFF
--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -279,7 +279,7 @@ class ChannelFrame(
         if other.duration != self.duration:
             other = other.fix_length(length=self.n_samples)
 
-        if snr is not None:
+        if snr is None:
             return self + other
 
         return self.apply_operation("add_with_snr", other=other._data, snr=snr)

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -156,6 +156,24 @@ class ChannelProcessingMixin:
         result = self.apply_operation("trim", start=start, end=end)
         return cast(T_Processing, result)
 
+    def fix_length(
+        self: T_Processing,
+        length: Optional[int] = None,
+        duration: Optional[float] = None,
+    ) -> T_Processing:
+        """信号を指定された時間にする。
+
+        Args:
+            duration: 信号の長さ（秒）
+            length: 信号の長さ（サンプル数）
+
+        Returns:
+            指定された長さに調整された信号を含む新しいChannelFrame
+        """
+
+        result = self.apply_operation("fix_length", length=length, duration=duration)
+        return cast(T_Processing, result)
+
     def rms_trend(
         self: T_Processing,
         frame_length: int = 2048,

--- a/wandas/processing/effects.py
+++ b/wandas/processing/effects.py
@@ -84,7 +84,7 @@ class AddWithSNR(AudioOperation[NDArrayReal, NDArrayReal]):
 
     name = "add_with_snr"
 
-    def __init__(self, sampling_rate: float, other: DaArray, snr: float):
+    def __init__(self, sampling_rate: float, other: DaArray, snr: float = 1.0):
         """
         Initialize addition operation considering SNR
 

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -283,5 +283,5 @@ class RmsTrend(AudioOperation[NDArrayReal, NDArrayReal]):
 
 
 # Register all operations
-for op_class in [ReSampling, Trim, RmsTrend]:
+for op_class in [ReSampling, Trim, RmsTrend, FixLength]:
     register_operation(op_class)


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the signal processing framework, focusing on handling signals of varying lengths and improving flexibility in operations. Key changes include the addition of a new `FixLength` operation, updates to the `add` method in `ChannelFrame` to handle mismatched durations, and corresponding unit tests to validate these features.

### New Features and Enhancements:
* **New `FixLength` Operation**:
  - Added a new `FixLength` class in `wandas/processing/temporal.py` to adjust signal lengths by either padding or trimming. The operation can be initialized with a target length (in samples) or duration (in seconds). (`[[1]](diffhunk://#diff-908a4e9083dc58100697801c523c994f5c6ea527be61ac3280800a95b470d9b6R123-R183)`, `[[2]](diffhunk://#diff-908a4e9083dc58100697801c523c994f5c6ea527be61ac3280800a95b470d9b6L225-R286)`)
  - Registered `FixLength` in the operation registry and added a corresponding `fix_length` method in `ChannelProcessingMixin`. (`[[1]](diffhunk://#diff-80674dbe35e22e2f39ca422576031d672d8ded389c4b5a528e236b577429fe56R159-R176)`, `[[2]](diffhunk://#diff-908a4e9083dc58100697801c523c994f5c6ea527be61ac3280800a95b470d9b6L225-R286)`)

* **Enhancements to `add` Method**:
  - Updated the `add` method in `ChannelFrame` to handle signals of different lengths by using the `fix_length` operation. This ensures compatibility between signals before addition. (`[wandas/frames/channel.pyL259-R286](diffhunk://#diff-1cce27f05fda7932bdfedb203e4731a206772487e13f04d92f5d666082fe66d5L259-R286)`)
  - Changed the default value of the `snr` parameter in the `add` method to `1` for better defaults. (`[wandas/frames/channel.pyL240-R241](diffhunk://#diff-1cce27f05fda7932bdfedb203e4731a206772487e13f04d92f5d666082fe66d5L240-R241)`)

### Unit Tests:
* **Tests for `FixLength`**:
  - Added a `TestFixLength` class in `tests/processing/test_temporal_operations.py` to validate initialization, output shape, and processing behavior of the `FixLength` operation. Tests include scenarios for padding short signals and trimming long signals. (`[tests/processing/test_temporal_operations.pyR269-R375](diffhunk://#diff-d9f17b5ba004317ec6b658be7b2846fc2477719f6d994c818eaea8d990dc3216R269-R375)`)
* **Tests for `add` Method**:
  - Added a new test `test_add_with_different_lengths` in `tests/frames/test_channel_frame.py` to verify the behavior of the `add` method when combining signals of different lengths. (`[tests/frames/test_channel_frame.pyR1217-R1256](diffhunk://#diff-c513a56441c3bc39fbafe2054ca40aa55afc59cff55d6fc5ecee801900de32c3R1217-R1256)`)

### Minor Improvements:
* Registered `FixLength` in the operation registry to ensure it is available for use. (`[wandas/processing/temporal.pyL225-R286](diffhunk://#diff-908a4e9083dc58100697801c523c994f5c6ea527be61ac3280800a95b470d9b6L225-R286)`)
* Adjusted the default value of the `snr` parameter in `AddWithSNR` for consistency. (`[wandas/processing/effects.pyL87-R87](diffhunk://#diff-3db82b2d032b9cb9425c0f2632be6ccb44c36e0a92d45ab53097dddb81871b19L87-R87)`)