### PR TITLE
Dev v0.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wandas"
-version = "0.1.3"
+version = "0.1.4"
 description = "Wandas is an open source library for efficient signal analysis in Python"
 authors = [{name = "kasahart", email="kasahart66@gmail.com"}]
 maintainers = [

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -11,6 +11,7 @@ import soundfile as sf
 from dask.array.core import Array as DaArray
 from matplotlib.axes import Axes
 
+import wandas as wd
 from wandas.core.metadata import ChannelMetadata
 from wandas.frames.channel import ChannelFrame
 from wandas.utils.types import NDArrayReal
@@ -502,7 +503,7 @@ class TestChannelFrame:
         ch_units = ["Pa", "V"]
         metadata = {"gain": 0.5, "device": "microphone"}
         # Create a ChannelFrame from the numpy array
-        cf = ChannelFrame.from_numpy(
+        cf = wd.from_numpy(
             data,
             sampling_rate=sampling_rate,
             label=label,
@@ -510,6 +511,17 @@ class TestChannelFrame:
             ch_units=ch_units,
             metadata=metadata,
         )
+
+        # Check data
+        np.testing.assert_array_equal(cf.data, data)
+        np.testing.assert_array_equal(cf[0].data, data[0:1])
+        np.testing.assert_array_equal(cf[1].data, data[1:2])
+        np.testing.assert_array_equal(cf[:, :1000].data, data[:, :1000])
+        # np.testing.assert_array_equal(cf[0, :1000].data, data[0, :1000])
+        # np.testing.assert_array_equal(cf[1, :1000].data, data[1, :1000])
+        np.testing.assert_array_equal(cf["left"].data, data[0:1])
+        np.testing.assert_array_equal(cf["right"].data, data[1:2])
+
         # Check properties
         assert cf.sampling_rate == sampling_rate
         assert cf.label == label
@@ -521,8 +533,6 @@ class TestChannelFrame:
         assert cf.channels[1].unit == "V"
         assert cf.metadata["gain"] == 0.5
         assert cf.metadata["device"] == "microphone"
-        # Check data
-        np.testing.assert_array_equal(cf.data, data)
 
         # Test ndim=1
         data_1d = np.random.random(16000)

--- a/tests/processing/test_temporal_operations.py
+++ b/tests/processing/test_temporal_operations.py
@@ -238,6 +238,17 @@ class TestRmsTrend:
 
         np.testing.assert_allclose(np.mean(result), expected_rms_db, rtol=0.1)
 
+    def test_db_conversion_with_ref(self) -> None:
+        """Test dB conversion with custom ref value."""
+        # RMS値は1/sqrt(2)
+        rms_value = 1 / np.sqrt(2)
+        # ref=0.5 で dB変換
+        rms_db = RmsTrend(self.sample_rate, dB=True, ref=0.5)
+        result = rms_db.process(self.dask_mono).compute()
+        # 期待されるdB値
+        expected_rms_db = 20 * np.log10(rms_value / 0.5)
+        np.testing.assert_allclose(np.mean(result), expected_rms_db, rtol=0.1)
+
     def test_a_weighting(self) -> None:
         """Test A-weighting effect on RMS."""
         rms_normal = RmsTrend(self.sample_rate)

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -319,6 +319,12 @@ class BaseFrame(ABC, Generic[T]):
         if not isinstance(metadata, dict):
             raise TypeError("Metadata must be a dictionary")
 
+        channel_metadata = kwargs.pop(
+            "channel_metadata", copy.deepcopy(self._channel_metadata)
+        )
+        if not isinstance(channel_metadata, list):
+            raise TypeError("Channel metadata must be a list")
+
         # Get additional initialization arguments from derived classes
         additional_kwargs = self._get_additional_init_kwargs()
         kwargs.update(additional_kwargs)
@@ -328,6 +334,7 @@ class BaseFrame(ABC, Generic[T]):
             sampling_rate=sampling_rate,
             label=label,
             metadata=metadata,
+            channel_metadata=channel_metadata,
             previous=self,
             **kwargs,
         )

--- a/wandas/core/metadata.py
+++ b/wandas/core/metadata.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field  # Direct import from pydantic
 
+from wandas.utils.util import unit_to_ref
+
 
 class ChannelMetadata(BaseModel):
     """
@@ -13,6 +15,12 @@ class ChannelMetadata(BaseModel):
     ref: float = 1.0
     # Additional metadata for extensibility
     extra: dict[str, Any] = Field(default_factory=dict)
+
+    def __init__(self, **data: Any):
+        super().__init__(**data)
+        # unitが指定されていてrefがデフォルト値ならunit_to_refで自動設定
+        if self.unit and ("ref" not in data or data.get("ref", 1.0) == 1.0):
+            self.ref = unit_to_ref(self.unit)
 
     def __getitem__(self, key: str) -> Any:
         """Provide dictionary-like behavior"""
@@ -31,6 +39,7 @@ class ChannelMetadata(BaseModel):
             self.label = value
         elif key == "unit":
             self.unit = value
+            self.ref = unit_to_ref(value)
         elif key == "ref":
             self.ref = value
         else:

--- a/wandas/frames/mixins/protocols.py
+++ b/wandas/frames/mixins/protocols.py
@@ -13,6 +13,9 @@ from wandas.core.metadata import ChannelMetadata
 logger = logging.getLogger(__name__)
 
 
+T_Base = TypeVar("T_Base", bound="BaseFrameProtocol")
+
+
 @runtime_checkable
 class BaseFrameProtocol(Protocol):
     """Protocol that defines basic frame operations.
@@ -52,6 +55,18 @@ class BaseFrameProtocol(Protocol):
         """
         ...
 
+    def _create_new_instance(self: T_Base, data: DaArray, **kwargs: Any) -> T_Base:
+        """Create a new instance of the frame with updated data and metadata.
+        Args:
+            data: The new data for the frame
+            metadata: The new metadata for the frame
+            operation_history: The new operation history for the frame
+            channel_metadata: The new channel metadata for the frame
+        Returns:
+            A new instance of the frame with the updated data and metadata
+        """
+        ...
+
 
 @runtime_checkable
 class ProcessingFrameProtocol(BaseFrameProtocol, Protocol):
@@ -75,7 +90,6 @@ class TransformFrameProtocol(BaseFrameProtocol, Protocol):
 
 
 # Type variable definitions
-T_Base = TypeVar("T_Base", bound=BaseFrameProtocol)
 T_Processing = TypeVar("T_Processing", bound=ProcessingFrameProtocol)
 T_Transform = TypeVar("T_Transform", bound=TransformFrameProtocol)
 
@@ -83,7 +97,5 @@ __all__ = [
     "BaseFrameProtocol",
     "ProcessingFrameProtocol",
     "TransformFrameProtocol",
-    "T_Base",
     "T_Processing",
-    "T_Transform",
 ]


### PR DESCRIPTION
This pull request introduces several changes to the `wandas` library, including a version bump, enhancements to metadata handling, improvements to channel processing methods, and expanded test coverage. The most significant updates involve adding new features for channel metadata management, refactoring channel reduction operations, and introducing comprehensive tests for various processing functionalities.

### Core Library Updates:

* **Channel Metadata Enhancements**:
  - Added automatic reference value (`ref`) assignment based on the `unit` in `ChannelMetadata` using the `unit_to_ref` utility. This ensures that the `ref` value is set correctly when a unit is specified. (`wandas/core/metadata.py`, [[1]](diffhunk://#diff-46e932d703dac6896f05be20922ebc8bce94263e621aa7a342b71a76322da421R19-R24) [[2]](diffhunk://#diff-46e932d703dac6896f05be20922ebc8bce94263e621aa7a342b71a76322da421R42)
  - Updated `_create_new_instance` to support `channel_metadata` as an argument, allowing for more flexible instance creation with updated metadata. (`wandas/core/base_frame.py`, [[1]](diffhunk://#diff-971eda92ca46fdacb83628aaa3eab9dc1fb1c3db8b5d2b39a9be077b6420c9d1R322-R327) [[2]](diffhunk://#diff-971eda92ca46fdacb83628aaa3eab9dc1fb1c3db8b5d2b39a9be077b6420c9d1R337)

* **Refactored Channel Reduction Operations**:
  - Replaced the `apply_operation` approach for `sum` and `mean` with a new `_reduce_channels` helper method. This method handles operations like summing or averaging channels while maintaining consistent metadata and operation history. (`wandas/frames/mixins/channel_processing_mixin.py`, [wandas/frames/mixins/channel_processing_mixin.pyR146-R198](diffhunk://#diff-80674dbe35e22e2f39ca422576031d672d8ded389c4b5a528e236b577429fe56R146-R198))

### Test Suite Enhancements:

* **Expanded Test Coverage**:
  - Introduced tests for new processing methods, including `rms_trend`, `high_pass_filter`, `low_pass_filter`, `band_pass_filter`, `a_weighting`, `abs`, `power`, `trim`, `fix_length`, and `resampling`. These tests validate both the correctness of the operations and the integrity of the resulting `ChannelFrame` attributes. (`tests/frames/test_channel_processing.py`, [tests/frames/test_channel_processing.pyR343-R567](diffhunk://#diff-8eead3ebe2099f932e8c98eb2f06e231f086289487ea8992525e0c4740bda450R343-R567))
  - Added a new test for dB conversion with a custom reference value to ensure proper handling of reference-based computations. (`tests/processing/test_temporal_operations.py`, [tests/processing/test_temporal_operations.pyR241-R251](diffhunk://#diff-d9f17b5ba004317ec6b658be7b2846fc2477719f6d994c818eaea8d990dc3216R241-R251))

* **Improved `test_from_numpy`**:
  - Replaced `ChannelFrame.from_numpy` with `wd.from_numpy` and added assertions to validate the resulting `ChannelFrame` data and slicing behavior. (`tests/frames/test_channel_frame.py`, [[1]](diffhunk://#diff-c513a56441c3bc39fbafe2054ca40aa55afc59cff55d6fc5ecee801900de32c3L505-R524) [[2]](diffhunk://#diff-c513a56441c3bc39fbafe2054ca40aa55afc59cff55d6fc5ecee801900de32c3L524-L525)

### Other Updates:

* **Version Update**:
  - Bumped the library version from `0.1.3` to `0.1.4` in `pyproject.toml`. (`pyproject.toml`, [pyproject.tomlL7-R7](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7))

* **Protocol Enhancements**:
  - Added `_create_new_instance` to the `BaseFrameProtocol` to standardize instance creation across frames. (`wandas/frames/mixins/protocols.py`, [wandas/frames/mixins/protocols.pyR58-R69](diffhunk://#diff-a2b0adb11062fc0411f3b8b0c17573f5bb13694b37991ac7aa11536d4d504309R58-R69))

These changes collectively enhance the functionality, maintainability, and testability of the `wandas` library.