### PR TITLE
feat: ChannelTransformMixin.welch defaults

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4389,7 +4389,7 @@ wheels = [
 
 [[package]]
 name = "wandas"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "cattrs" },

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -83,9 +83,9 @@ class ChannelTransformMixin:
 
     def welch(
         self: T_Transform,
-        n_fft: int | None = None,
+        n_fft: int = 2048,
         hop_length: int | None = None,
-        win_length: int = 2048,
+        win_length: int | None = None,
         window: str = "hann",
         average: str = "mean",
     ) -> "SpectralFrame":


### PR DESCRIPTION
This pull request updates the default argument values for the `welch` method in `channel_transform_mixin.py`. The changes clarify and standardize the default behavior for FFT-related parameters.

Parameter default value updates:

* Changed the default value of `n_fft` from `None` to `2048`, ensuring a consistent FFT size when not specified.
* Changed the default value of `win_length` from `2048` to `None`, making it optional and allowing for more flexibility in specifying window length.