### PR TITLE
tests: mock DaArray.visualize to avoid creating graph_*.png.html during tests

### DIFF
--- a/tests/core/test_base_frame.py
+++ b/tests/core/test_base_frame.py
@@ -791,6 +791,8 @@ class TestBaseFrameUtilityMethods:
             result = self.channel_frame.visualize_graph(filename="test_graph.png")
             # Result is the mocked return value
             assert result is mock_return_value
+            # Ensure the filename was forwarded to _data.visualize exactly once
+            mock_visualize.assert_called_once_with(filename="test_graph.png")
 
     def test_visualize_graph_without_filename(self) -> None:
         """Test visualize_graph without filename (auto-generated)."""


### PR DESCRIPTION
Mock DaArray.visualize in tests to prevent generation of graph_*.png.html files during CI and local runs. Updated: tests/core/test_base_frame.py