### PR TITLE
Prevent memory leak by adding fig.clf() in ChannelFrame.describe

### DIFF
--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -656,6 +656,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
 
             display(fig)
             if is_close and fig is not None:
+                fig.clf()  # Clear the figure to free memory
                 plt.close(fig)
 
             # Play audio for each channel


### PR DESCRIPTION
This pull request introduces a minor improvement to the memory management in the plotting workflow. After displaying a figure, the code now explicitly clears the figure before closing it, which helps free up memory resources more efficiently.