### PR TITLE
test: add comprehensive edge case tests for frame_dataset coverage improvement (target 98%)

### DIFF
--- a/tests/utils/test_frame_dataset.py
+++ b/tests/utils/test_frame_dataset.py
@@ -2125,7 +2125,10 @@ class TestSpectrogramFrameDatasetExceptionEdgeCases:
         with patch.object(type(result), "plot", None):
             with caplog.at_level(logging.WARNING):
                 stft_ds.plot(0)  # Should not raise, but log a warning
-        assert any("does not have a plot method" in record.message and record.levelname == "WARNING" for record in caplog.records)
+        assert any(
+            "does not have a plot method" in record.message and record.levelname == "WARNING"
+            for record in caplog.records
+        )
 
 
 # --- Test LazyFrame Exception Edge Cases ---


### PR DESCRIPTION
- Added TestChannelFrameDatasetNormalizeEdgeCases: test normalize with various kwargs, L2 norm, axis parameter, and exception handling
- Added TestChannelFrameDatasetResampleEdgeCases: test resample with valid/invalid target_sr values including 0 and negative rates
- Added TestChannelFrameDatasetExceptionEdgeCases: test invalid kwargs for normalize/resample, STFT with mocked exceptions
- Added TestSpectrogramFrameDatasetExceptionEdgeCases: test plot method edge cases
- Added TestLazyFrameExceptionEdgeCases: test ensure_loaded with invalid file data
- Added TestFrameDatasetConstructorExceptionEdgeCases: test nonexistent folder and empty folder handling
- Added TestApplyExceptionEdgeCases: test transform that raises/returns None
- Added TestSampledFrameDatasetExceptionEdgeCases: test out-of-range indices

Uses pytest patch.object with side_effect to mock exceptions without actual computation.