### PR TITLE
refactor: simplify psychoacoustic class retrieval and enhance logger reset functionality

### DIFF
--- a/tests/processing/test_mosqito_unavailable.py
+++ b/tests/processing/test_mosqito_unavailable.py
@@ -16,15 +16,6 @@ import pytest
 import wandas.frames.noct as noct_module
 import wandas.processing.psychoacoustic as psychoacoustic_module
 import wandas.processing.spectral as spectral_module
-from wandas.processing.psychoacoustic import (
-    LoudnessZwst,
-    LoudnessZwtv,
-    RoughnessDw,
-    RoughnessDwSpec,
-    SharpnessDin,
-    SharpnessDinSt,
-)
-from wandas.processing.spectral import NOctSpectrum, NOctSynthesis
 
 _da_from_array = da.from_array  # type: ignore [unused-ignore]
 
@@ -34,6 +25,14 @@ _MODULES_UNDER_TEST = (
     psychoacoustic_module,
     noct_module,
 )
+
+
+def _psychoacoustic_class(name: str) -> type:
+    return getattr(psychoacoustic_module, name)
+
+
+def _spectral_class(name: str) -> type:
+    return getattr(spectral_module, name)
 
 
 def _reload_with_import_error(
@@ -73,7 +72,7 @@ class TestPsychoacousticUnavailable:
     def test_loudness_zwtv_raises(self, mosqito_unavailable: None) -> None:
         t = np.linspace(0, 0.1, int(48000 * 0.1))
         signal = np.array([np.sin(2 * np.pi * 1000 * t)])
-        op = LoudnessZwtv(48000)
+        op = _psychoacoustic_class("LoudnessZwtv")(48000)
         dask_signal = _da_from_array(signal)
         with pytest.raises(ImportError, match=_INSTALL_HINT):
             op.process(dask_signal).compute()
@@ -81,7 +80,7 @@ class TestPsychoacousticUnavailable:
     def test_loudness_zwst_raises(self, mosqito_unavailable: None) -> None:
         t = np.linspace(0, 0.1, int(48000 * 0.1))
         signal = np.array([np.sin(2 * np.pi * 1000 * t)])
-        op = LoudnessZwst(48000)
+        op = _psychoacoustic_class("LoudnessZwst")(48000)
         dask_signal = _da_from_array(signal)
         with pytest.raises(ImportError, match=_INSTALL_HINT):
             op.process(dask_signal).compute()
@@ -89,19 +88,19 @@ class TestPsychoacousticUnavailable:
     def test_roughness_dw_raises(self, mosqito_unavailable: None) -> None:
         t = np.linspace(0, 1.0, int(44100 * 1.0))
         signal = np.array([np.sin(2 * np.pi * 1000 * t)])
-        op = RoughnessDw(44100)
+        op = _psychoacoustic_class("RoughnessDw")(44100)
         dask_signal = _da_from_array(signal)
         with pytest.raises(ImportError, match=_INSTALL_HINT):
             op.process(dask_signal).compute()
 
     def test_roughness_dw_spec_raises(self, mosqito_unavailable: None) -> None:
         with pytest.raises(ImportError, match=_INSTALL_HINT):
-            RoughnessDwSpec(44100)
+            _psychoacoustic_class("RoughnessDwSpec")(44100)
 
     def test_sharpness_din_raises(self, mosqito_unavailable: None) -> None:
         t = np.linspace(0, 0.1, int(48000 * 0.1))
         signal = np.array([np.sin(2 * np.pi * 1000 * t)])
-        op = SharpnessDin(48000)
+        op = _psychoacoustic_class("SharpnessDin")(48000)
         dask_signal = _da_from_array(signal)
         with pytest.raises(ImportError, match=_INSTALL_HINT):
             op.process(dask_signal).compute()
@@ -109,7 +108,7 @@ class TestPsychoacousticUnavailable:
     def test_sharpness_din_st_raises(self, mosqito_unavailable: None) -> None:
         t = np.linspace(0, 0.1, int(48000 * 0.1))
         signal = np.array([np.sin(2 * np.pi * 1000 * t)])
-        op = SharpnessDinSt(48000)
+        op = _psychoacoustic_class("SharpnessDinSt")(48000)
         dask_signal = _da_from_array(signal)
         with pytest.raises(ImportError, match=_INSTALL_HINT):
             op.process(dask_signal).compute()
@@ -120,11 +119,11 @@ class TestSpectralUnavailable:
 
     def test_noct_spectrum_raises(self, mosqito_unavailable: None) -> None:
         with pytest.raises(ImportError, match=_INSTALL_HINT):
-            NOctSpectrum(48000, fmin=20.0, fmax=20000.0)
+            _spectral_class("NOctSpectrum")(48000, fmin=20.0, fmax=20000.0)
 
     def test_noct_synthesis_raises(self, mosqito_unavailable: None) -> None:
         with pytest.raises(ImportError, match=_INSTALL_HINT):
-            NOctSynthesis(48000, fmin=20.0, fmax=20000.0)
+            _spectral_class("NOctSynthesis")(48000, fmin=20.0, fmax=20000.0)
 
 
 class TestNOctFrameUnavailable:

--- a/tests/processing/test_psychoacoustic_operations.py
+++ b/tests/processing/test_psychoacoustic_operations.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 from dask.array.core import Array as DaArray
 
+import wandas.processing.psychoacoustic as psychoacoustic_module
 from wandas.processing.base import create_operation, get_operation
 from wandas.processing.psychoacoustic import (
     LoudnessZwst,
@@ -28,6 +29,10 @@ except ModuleNotFoundError:
 pytestmark = pytest.mark.skipif(not _MOSQITO_AVAILABLE, reason="mosqito not installed")
 
 _da_from_array = da.from_array  # type: ignore [unused-ignore]
+
+
+def _psychoacoustic_class(name: str) -> type:
+    return getattr(psychoacoustic_module, name)
 
 
 class TestLoudnessZwtv:
@@ -85,13 +90,13 @@ class TestLoudnessZwtv:
     def test_operation_registration(self) -> None:
         """Test that operation is properly registered."""
         op_class = get_operation("loudness_zwtv")
-        assert op_class == LoudnessZwtv
+        assert op_class is _psychoacoustic_class("LoudnessZwtv")
 
     def test_create_operation(self) -> None:
         """Test creating operation via create_operation function."""
         op = create_operation("loudness_zwtv", self.sample_rate, field_type="diffuse")
-        assert isinstance(op, LoudnessZwtv)
-        assert op.field_type == "diffuse"
+        assert type(op) is _psychoacoustic_class("LoudnessZwtv")
+        assert getattr(op, "field_type") == "diffuse"
 
     def test_mono_signal_shape(self) -> None:
         """Test loudness calculation output shape for mono signal."""
@@ -358,7 +363,7 @@ class TestLoudnessZwtvIntegration:
         from wandas.processing.base import _OPERATION_REGISTRY
 
         assert "loudness_zwtv" in _OPERATION_REGISTRY
-        assert _OPERATION_REGISTRY["loudness_zwtv"] == LoudnessZwtv
+        assert _OPERATION_REGISTRY["loudness_zwtv"] is _psychoacoustic_class("LoudnessZwtv")
 
     def test_channel_frame_loudness_method_exists(self) -> None:
         """Test that ChannelFrame has loudness_zwtv method."""
@@ -439,13 +444,13 @@ class TestLoudnessZwst:
     def test_operation_registration(self) -> None:
         """Test that operation is properly registered."""
         op_class = get_operation("loudness_zwst")
-        assert op_class == LoudnessZwst
+        assert op_class is _psychoacoustic_class("LoudnessZwst")
 
     def test_create_operation(self) -> None:
         """Test creating operation via create_operation function."""
         op = create_operation("loudness_zwst", self.sample_rate, field_type="diffuse")
-        assert isinstance(op, LoudnessZwst)
-        assert op.field_type == "diffuse"
+        assert type(op) is _psychoacoustic_class("LoudnessZwst")
+        assert getattr(op, "field_type") == "diffuse"
 
     def test_mono_signal_shape(self) -> None:
         """Test steady-state loudness calculation output shape for mono signal."""
@@ -670,7 +675,7 @@ class TestLoudnessZwstIntegration:
         from wandas.processing.base import _OPERATION_REGISTRY
 
         assert "loudness_zwst" in _OPERATION_REGISTRY
-        assert _OPERATION_REGISTRY["loudness_zwst"] == LoudnessZwst
+        assert _OPERATION_REGISTRY["loudness_zwst"] is _psychoacoustic_class("LoudnessZwst")
 
     def test_channel_frame_loudness_method_exists(self) -> None:
         """Test that ChannelFrame has loudness_zwst method."""
@@ -810,13 +815,13 @@ class TestRoughnessDw:
     def test_operation_registration(self) -> None:
         """Test that operation is properly registered."""
         op_class = get_operation("roughness_dw")
-        assert op_class == RoughnessDw
+        assert op_class is _psychoacoustic_class("RoughnessDw")
 
     def test_create_operation(self) -> None:
         """Test creating operation via create_operation function."""
         op = create_operation("roughness_dw", self.sample_rate, overlap=0.75)
-        assert isinstance(op, RoughnessDw)
-        assert op.overlap == 0.75
+        assert type(op) is _psychoacoustic_class("RoughnessDw")
+        assert getattr(op, "overlap") == 0.75
 
     def test_mono_signal_shape(self) -> None:
         """Test roughness calculation output shape for mono signal."""
@@ -1029,7 +1034,7 @@ class TestRoughnessDwIntegration:
         from wandas.processing.base import _OPERATION_REGISTRY
 
         assert "roughness_dw" in _OPERATION_REGISTRY
-        assert _OPERATION_REGISTRY["roughness_dw"] == RoughnessDw
+        assert _OPERATION_REGISTRY["roughness_dw"] is _psychoacoustic_class("RoughnessDw")
 
     def test_channel_frame_roughness_method_exists(self) -> None:
         """Test that ChannelFrame has roughness_dw method."""
@@ -1160,17 +1165,13 @@ class TestRoughnessDwSpec:
     def test_operation_registration(self) -> None:
         """Test that operation is properly registered."""
         op_class = get_operation("roughness_dw_spec")
-        from wandas.processing.psychoacoustic import RoughnessDwSpec
-
-        assert op_class == RoughnessDwSpec
+        assert op_class is _psychoacoustic_class("RoughnessDwSpec")
 
     def test_create_operation(self) -> None:
         """Test creating operation via create_operation function."""
         op = create_operation("roughness_dw_spec", self.sample_rate, overlap=0.75)
-        from wandas.processing.psychoacoustic import RoughnessDwSpec
-
-        assert isinstance(op, RoughnessDwSpec)
-        assert op.overlap == 0.75
+        assert type(op) is _psychoacoustic_class("RoughnessDwSpec")
+        assert getattr(op, "overlap") == 0.75
 
     def test_mono_signal_shape(self) -> None:
         """Test roughness_spec calculation output shape for mono signal."""
@@ -1391,10 +1392,9 @@ class TestRoughnessDwSpecIntegration:
     def test_roughness_spec_in_operation_registry(self) -> None:
         """Test that roughness_dw_spec operation is in registry."""
         from wandas.processing.base import _OPERATION_REGISTRY
-        from wandas.processing.psychoacoustic import RoughnessDwSpec
 
         assert "roughness_dw_spec" in _OPERATION_REGISTRY
-        assert _OPERATION_REGISTRY["roughness_dw_spec"] == RoughnessDwSpec
+        assert _OPERATION_REGISTRY["roughness_dw_spec"] is _psychoacoustic_class("RoughnessDwSpec")
 
     def test_channel_frame_roughness_spec_method_exists(self) -> None:
         """Test that ChannelFrame has roughness_dw_spec method."""
@@ -1521,12 +1521,12 @@ class TestSharpnessDin:
     def test_operation_registration(self) -> None:
         """Test that operation is properly registered."""
         op_class = get_operation("sharpness_din")
-        assert op_class == SharpnessDin
+        assert op_class is _psychoacoustic_class("SharpnessDin")
 
     def test_create_operation(self) -> None:
         """Test creating operation via create_operation function."""
         op = create_operation("sharpness_din", self.sample_rate)
-        assert isinstance(op, SharpnessDin)
+        assert type(op) is _psychoacoustic_class("SharpnessDin")
 
     def test_mono_signal_shape(self) -> None:
         """Test sharpness calculation output shape for mono signal."""
@@ -1740,7 +1740,7 @@ class TestSharpnessDinIntegration:
         from wandas.processing.base import _OPERATION_REGISTRY
 
         assert "sharpness_din" in _OPERATION_REGISTRY
-        assert _OPERATION_REGISTRY["sharpness_din"] == SharpnessDin
+        assert _OPERATION_REGISTRY["sharpness_din"] is _psychoacoustic_class("SharpnessDin")
 
     def test_channel_frame_sharpness_method_exists(self) -> None:
         """Test that ChannelFrame has sharpness_din method."""
@@ -1857,12 +1857,12 @@ class TestSharpnessDinSt:
     def test_operation_registration(self) -> None:
         """Test that operation is properly registered."""
         op_class = get_operation("sharpness_din_st")
-        assert op_class == SharpnessDinSt
+        assert op_class is _psychoacoustic_class("SharpnessDinSt")
 
     def test_create_operation(self) -> None:
         """Test creating operation via create_operation function."""
         op = create_operation("sharpness_din_st", self.sample_rate)
-        assert isinstance(op, SharpnessDinSt)
+        assert type(op) is _psychoacoustic_class("SharpnessDinSt")
 
     def test_mono_signal_shape(self) -> None:
         """Test steady-state sharpness calculation output shape for mono signal."""
@@ -2026,7 +2026,7 @@ class TestSharpnessDinStIntegration:
         from wandas.processing.base import _OPERATION_REGISTRY
 
         assert "sharpness_din_st" in _OPERATION_REGISTRY
-        assert _OPERATION_REGISTRY["sharpness_din_st"] == SharpnessDinSt
+        assert _OPERATION_REGISTRY["sharpness_din_st"] is _psychoacoustic_class("SharpnessDinSt")
 
     def test_channel_frame_sharpness_st_method_exists(self) -> None:
         """Test that ChannelFrame has sharpness_din_st method."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,12 +12,20 @@ import wandas
 def reset_logger():
     """各テストの前にロガーのハンドラーをリセット"""
     logger = logging.getLogger("wandas")
+    original_level = logger.level
+    original_disabled = logger.disabled
+    original_propagate = logger.propagate
+    original_handlers = logger.handlers[:]
     for handler in logger.handlers[:]:
         logger.removeHandler(handler)
     yield
-    # テスト後も同様にリセット
     for handler in logger.handlers[:]:
         logger.removeHandler(handler)
+    logger.setLevel(original_level)
+    logger.disabled = original_disabled
+    logger.propagate = original_propagate
+    for handler in original_handlers:
+        logger.addHandler(handler)
 
 
 def test_default_settings():

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Union
+from typing import Any
 
 import dask.array as da
 import librosa
@@ -409,7 +409,7 @@ class SoundLevel(AudioOperation[NDArrayReal, NDArrayReal]):
     @staticmethod
     def _output_dtype(
         input_dtype: np.dtype[Any],
-    ) -> Union[np.dtype[np.float32], np.dtype[np.float64]]:
+    ) -> np.dtype[np.float32] | np.dtype[np.float64]:
         """Return the floating output dtype for the given input dtype."""
         if np.dtype(input_dtype) == np.dtype(np.float32):
             return np.dtype(np.float32)
@@ -445,14 +445,13 @@ class SoundLevel(AudioOperation[NDArrayReal, NDArrayReal]):
             self.time_weighting,
         )
         output_dtype = self._output_dtype(x.dtype)
-        working_dtype = np.float32 if output_dtype == np.dtype(np.float32) else np.float64
-        weighted_input = x if x.dtype == working_dtype else np.asarray(x, dtype=working_dtype)
+        weighted_input = x if x.dtype == np.float64 else np.asarray(x, dtype=np.float64)
         if self.freq_weighting == "Z":
             weighted = weighted_input
         else:
             weighted = frequency_weight(weighted_input, self.sampling_rate, curve=self.freq_weighting)
         squared = np.square(weighted)
-        alpha = np.asarray(np.exp(-1.0 / (self.sampling_rate * self.time_constant)), dtype=working_dtype).item()
+        alpha = np.asarray(np.exp(-1.0 / (self.sampling_rate * self.time_constant)), dtype=np.float64).item()
         smoothed = lfilter([1.0 - alpha], [1.0, -alpha], squared, axis=-1)
         if self.dB:
             ref_squared_broadcast = self._reference_squared(smoothed.shape[0])[:, np.newaxis]


### PR DESCRIPTION
## Summary
- make logger reset in tests restore level, disabled, propagate, and handlers to prevent cross-test logging pollution
- make psychoacoustic tests reload-safe by resolving classes from current module bindings after importlib.reload
- improve SoundLevel float32 precision by computing internally in float64 and casting the final output back to the expected dtype

## Validation
- pytest full suite: 1250 passed, 3 skipped
- mypy passed
- ruff check passed

## Reviewer Notes
- base branch should be v0.1.17
- HEAD is one commit ahead of origin/v0.1.17
- working tree was clean at publish time