### PR TITLE
fix: テストとスクリプトのパス解決を絶対パスに修正

### DIFF
--- a/scripts/test_installation.py
+++ b/scripts/test_installation.py
@@ -2,6 +2,7 @@ import sys
 
 import wandas as wd
 
+
 def main() -> int:
     try:
         print(f"Successfully imported wandas version: {wd.__version__}")

--- a/scripts/test_installation.py
+++ b/scripts/test_installation.py
@@ -2,16 +2,20 @@ import sys
 
 import wandas as wd
 
-try:
-    print(f"Successfully imported wandas version: {wd.__version__}")
-    # ここに、必要に応じてさらに基本的な機能テストを追加できます
-    signal = wd.generate_sin(freqs=[5000, 1000], duration=1)
-    signal.fft()
+def main() -> int:
+    try:
+        print(f"Successfully imported wandas version: {wd.__version__}")
+        # Keep this as a lightweight smoke test for local installation checks.
+        signal = wd.generate_sin(freqs=[5000, 1000], duration=1)
+        signal.fft()
+        return 0
+    except ImportError:
+        print("Error: Failed to import wandas.")
+        return 1
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        return 1
 
-    sys.exit(0)
-except ImportError:
-    print("Error: Failed to import wandas.")
-    sys.exit(1)
-except Exception as e:
-    print(f"An unexpected error occurred: {e}")
-    sys.exit(1)
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_installation.py
+++ b/scripts/test_installation.py
@@ -1,10 +1,10 @@
 import sys
 
-import wandas as wd
-
 
 def main() -> int:
     try:
+        import wandas as wd
+
         print(f"Successfully imported wandas version: {wd.__version__}")
         # Keep this as a lightweight smoke test for local installation checks.
         signal = wd.generate_sin(freqs=[5000, 1000], duration=1)

--- a/tests/docs/test_docs_links.py
+++ b/tests/docs/test_docs_links.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
 
 def _collect_nav_paths(nav):
     """Recursively collect path strings from mkdocs `nav` structure."""
@@ -25,7 +27,7 @@ def _collect_nav_paths(nav):
 
 def test_mkdocs_nav_targets_exist():
     """Test that all markdown files referenced in mkdocs.yml nav exist."""
-    mk_path = Path("docs/mkdocs.yml")
+    mk_path = REPO_ROOT / "docs/mkdocs.yml"
     assert mk_path.exists(), "docs/mkdocs.yml must exist"
     raw = mk_path.read_text(encoding="utf-8", errors="replace")
     # Remove python-specific YAML tags like !!python/name:... before parsing
@@ -43,7 +45,7 @@ def test_mkdocs_nav_targets_exist():
         nav_block = m.group(1)
         paths = re.findall(r"([A-Za-z0-9_\-/]+\.md)", nav_block)
 
-    base = Path("docs/src")
+    base = REPO_ROOT / "docs/src"
     assert base.exists(), f"Docs source directory {base} must exist"
 
     missing = []
@@ -66,13 +68,13 @@ def test_mkdocs_nav_targets_exist():
 
 def test_index_images_exist():
     """Test that all image files referenced in index.md exist."""
-    index = Path("docs/src/index.md")
+    index = REPO_ROOT / "docs/src/index.md"
     assert index.exists(), "docs/src/index.md must exist"
     text = index.read_text(encoding="utf-8", errors="replace")
 
     # find markdown image references ![alt](path)
     imgs = re.findall(r"!\[.*?\]\(([^)]+)\)", text)
-    base = Path("docs/src")
+    base = REPO_ROOT / "docs/src"
     missing = []
     for img in imgs:
         img = img.strip()
@@ -95,7 +97,7 @@ def test_index_images_exist():
 def test_learning_path_notebooks_exist():
     """Test that all learning-path notebooks referenced in tutorial exist."""
     # tutorial/index.md links to learning-path notebooks by absolute repo path
-    lp = Path("learning-path")
+    lp = REPO_ROOT / "learning-path"
     assert lp.exists(), "learning-path directory must exist in repository root"
 
     expected = [


### PR DESCRIPTION
## Description / 説明

サブモジュール配下や異なる作業ディレクトリから実行した際に、相対パス前提の実装によって失敗する問題を修正します。

Source branch: fix/test-path-resolution

---

## Type of Change / 変更の種類

- [x] 🐛 Bug fix (non-breaking change that fixes an issue) / バグ修正（既存機能を壊さない変更）
- [ ] ✨ New feature (non-breaking change that adds functionality) / 新機能（既存機能を壊さない機能追加）
- [ ] ⚠️ Breaking change (fix or feature that causes existing functionality to change) / 破壊的変更
- [ ] 🧹 Refactor / code cleanup / リファクタリング・コード整理
- [ ] 📝 Documentation update / ドキュメント更新
- [x] 🧪 Test improvement / テスト改善
- [ ] 🔧 Chore / build / CI / その他の保守作業

---

## Changes / 変更内容

- tests/docs/test_docs_links.py で REPO_ROOT を基準に絶対パスを解決するように変更し、実行ディレクトリに依存しないよう修正
- scripts/test_installation.py を main() 関数化し、成功時と失敗時のリターンコードを明示して呼び出し側から扱いやすく修正

---

## Testing / テスト

- [ ] Existing tests pass (Run pytest task / uv run pytest -n auto --cov=wandas --cov-report=term-missing) / 既存のテストが通ること
- [ ] Formatting applied (Run ruff format task / uv run ruff format wandas tests) / フォーマットを適用したこと
- [ ] New tests added for the changes / 変更に対応するテストを追加した
- [ ] Type checks pass (Run ty (red-knot) check task / uv run ty check wandas tests) / 型チェックが通ること
- [x] Lint checks pass (Run ruff check task / uv run ruff check wandas tests --config=pyproject.toml -v) / Lintチェックが通ること
- [ ] Documentation build checked when docs/, src/, README.md, or other MkDocs-backed user-facing markdown changed (Build MkDocs Documentation task / uv run mkdocs build -f docs/mkdocs.yml) / docs/、src/、README.md、または MkDocs 対象のユーザー向け Markdown を変更した場合にドキュメントビルドを確認した

Targeted verification:
- リポジトリ外の作業ディレクトリから tests/docs/test_docs_links.py を実行し、3件のテストが通ることを確認
- /workspaces を作業ディレクトリにして scripts/test_installation.py を実行し、wandas の import とスモークテストが成功することを確認

Skipped:
- フルの pytest、ty、ruff、format、docs build は未実行

---

## Notes for Reviewers / レビュアーへのメモ

相対パス依存を除去した変更なので、リポジトリルート以外からの実行でも安定して動くかを中心に確認いただけると助かります。特に docs リンク検証テストと installation スクリプトの終了コードの扱いを見てもらえると十分です。
