### PR TITLE
Feat/notify wandas agent

### DIFF
--- a/.github/workflows/notify-agent.yml
+++ b/.github/workflows/notify-agent.yml
@@ -5,11 +5,25 @@ on:
     tags:
       - "v*.*.*"
 
+permissions: {}
+
 jobs:
   notify:
     runs-on: ubuntu-latest
+    if: github.event.deleted == false
     steps:
+      - name: Validate strict SemVer tag
+        id: validate
+        run: |
+          if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "valid=true" >> $GITHUB_OUTPUT
+          else
+            echo "valid=false" >> $GITHUB_OUTPUT
+            echo "Tag '${{ github.ref_name }}' is not a strict vX.Y.Z release; skipping dispatch."
+          fi
+
       - name: Trigger wandas-agent submodule update
+        if: steps.validate.outputs.valid == 'true'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.WANDAS_AGENT_TOKEN }}

--- a/.github/workflows/notify-agent.yml
+++ b/.github/workflows/notify-agent.yml
@@ -14,11 +14,12 @@ jobs:
     steps:
       - name: Validate strict SemVer tag
         id: validate
+        shell: bash
         run: |
           if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "valid=true" >> $GITHUB_OUTPUT
+            echo "valid=true" >> "$GITHUB_OUTPUT"
           else
-            echo "valid=false" >> $GITHUB_OUTPUT
+            echo "valid=false" >> "$GITHUB_OUTPUT"
             echo "Tag '${{ github.ref_name }}' is not a strict vX.Y.Z release; skipping dispatch."
           fi
 

--- a/.github/workflows/notify-agent.yml
+++ b/.github/workflows/notify-agent.yml
@@ -1,0 +1,17 @@
+name: Notify wandas-agent
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger wandas-agent submodule update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.WANDAS_AGENT_TOKEN }}
+          repository: kasahart/wandas-agent
+          event-type: wandas-updated

--- a/.github/workflows/notify-agent.yml
+++ b/.github/workflows/notify-agent.yml
@@ -2,8 +2,8 @@ name: Notify wandas-agent
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*.*.*"
 
 jobs:
   notify:
@@ -15,3 +15,4 @@ jobs:
           token: ${{ secrets.WANDAS_AGENT_TOKEN }}
           repository: kasahart/wandas-agent
           event-type: wandas-updated
+          client-payload: '{"tag": "${{ github.ref_name }}"}'


### PR DESCRIPTION
  ## Description / 説明

  wandas のリリースタグ（`v*.*.*`）が push された際に、`wandas-agent` リポジトリへ `repository_dispatch`
  で通知し、サブモジュールポインタを自動更新する workflow を追加する。
  タグ名を `client-payload` に含めることで、wandas-agent 側のコミットメッセージに `vX.Y.Z` を反映できる。

  ---

  ## Type of Change / 変更の種類

  - [x] 🔧 Chore / build / CI / その他の保守作業

  ---

  ## Changes / 変更内容

  - `.github/workflows/notify-agent.yml` を新規追加
    - トリガー: `v*.*.*` タグ push
    - `peter-evans/repository-dispatch` で `kasahart/wandas-agent` に `wandas-updated` イベントを送信
    - `client-payload` にタグ名を含める

  ---

  ## Testing / テスト

  - [x] Existing tests pass (`Run pytest` task / `uv run pytest -n auto --cov=wandas
  --cov-report=term-missing`) / 既存のテストが通ること
  - [x] Formatting applied (`Run ruff format` task / `uv run ruff format wandas tests`) /
  フォーマットを適用したこと
  - [x] Lint checks pass (`Run ruff check` task / `uv run ruff check wandas tests --config=pyproject.toml
  -v`) / Lintチェックが通ること

  ※ workflow ファイルのみの変更のため、新規テスト・型チェック・ドキュメントビルドは対象外。

  ---

  ## Notes for Reviewers / レビュアーへのメモ

  - `WANDAS_AGENT_TOKEN` を wandas リポジトリの Secrets に設定する必要があります（`repo` スコープの PAT） 
  - wandas-agent 側には対応する `update-submodule.yml` が別途追加済みです