### PR TITLE
Add xarray-native frame bridge and operation scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ examples/data/dataset/
 
 # Local/agent-specific settings
 .claude/settings.json
+.worktrees/
 
 # Accidental notebooks (keep repo clean)
 learning-path/06_skill_validation.py

--- a/docs/design/2026-06-09-xarray-native-migration.md
+++ b/docs/design/2026-06-09-xarray-native-migration.md
@@ -1,0 +1,394 @@
+# ADR: xarray-native Migration Plan / xarray-native 移行計画
+
+- **Status**: Proposed / In progress
+- **Date**: 2026-06-09
+- **Related PR**: https://github.com/kasahart/wandas/pull/213
+- **Related ADR**: `docs/design/2025-11-19-channel-wise-chunking.md`
+
+## Summary / 要約
+
+Wandas は長期的に、独自の `BaseFrame + Dask array + metadata + axis-like state` を中核データモデルとして育て続けるのではなく、xarray の `DataArray` / `Dataset` を中核表現として使う方向へ移行する。
+
+ただし、Wandas の価値は xarray 自体ではなく、音声・波形解析のドメイン API、操作履歴、channel metadata、signal-safe chunk policy にある。そのため、既存 API を一気に廃止せず、段階的に xarray-native な内部表現と I/O / operation 実行へ寄せる。
+
+PR #213 はこの移行の **Phase 1: Bridge** を主に実装する。Phase 2-4 は一部の足場だけ入り、完了扱いにはしない。
+
+## Problem Statement / 背景と問題
+
+現行 Wandas は以下を独自に管理している。
+
+- Dask-backed frame data
+- channel labels / units / refs / extra metadata
+- sampling rate and frame metadata
+- operation history
+- time / frequency / band-like axes
+- signal-safe chunking convention
+- WDF-centered persistence
+
+この設計はプロトタイプとして有効だったが、長期的には xarray がすでに解いている labelled multi-dimensional array、dims、coords、attrs、Dask integration、NetCDF/Zarr I/O、selection/alignment と責務が重なる。
+
+Wandas がこの領域を独自に再実装し続けると、保守コストが増え、科学技術 Python stack との接続性も弱くなる。
+
+## Decision / 方針
+
+Wandas は xarray の subclass にはしない。xarray の公式方針に従い、まずは composition と bridge API で進める。
+
+```python
+frame = wd.read_wav("audio.wav")
+da = frame.to_xarray()
+restored = wd.from_xarray(da)
+```
+
+将来的には accessor も検討できる。
+
+```python
+da.wd.stft()
+da.wd.describe()
+```
+
+ただし、最初から accessor 中心にすると既存 Wandas API の互換性とプロダクト感を失いやすいため、Phase 1-2 では frame class を残す。
+
+## Non-goals for PR #213 / PR #213 でやらないこと
+
+PR #213 は full xarray-native migration ではない。以下は未完了であり、follow-up とする。
+
+- `BaseFrame` の独自責務の完全撤去
+- xarray `DataArray` を唯一の authoritative storage にすること
+- operations の `xr.apply_ufunc` / `map_blocks` / `map_overlap` 移行
+- strict / blockwise execution mode の正式設計
+- Zarr support
+- WDF の再定義または非推奨化
+- xarray accessor `.wd` の提供
+
+## Target xarray Schema / 目標 schema
+
+### ChannelFrame
+
+```python
+xr.DataArray(
+    data,
+    dims=("channel", "time"),
+    coords={
+        "channel": labels,
+        "time": time_seconds,
+        "unit": ("channel", units),
+        "ref": ("channel", refs),
+    },
+    attrs={
+        "wandas_frame_type": "ChannelFrame",
+        "sampling_rate": sampling_rate,
+        "label": label,
+        "metadata": metadata,
+        "operation_history": history,
+        "channel_metadata": channel_metadata,
+    },
+)
+```
+
+### SpectralFrame
+
+```python
+xr.DataArray(
+    data,
+    dims=("channel", "frequency"),
+    coords={
+        "channel": labels,
+        "frequency": np.fft.rfftfreq(n_fft, 1 / sampling_rate),
+        "unit": ("channel", units),
+        "ref": ("channel", refs),
+    },
+    attrs={
+        "wandas_frame_type": "SpectralFrame",
+        "sampling_rate": sampling_rate,
+        "n_fft": n_fft,
+        "window": window,
+        "operation_history": history,
+    },
+)
+```
+
+### SpectrogramFrame
+
+```python
+xr.DataArray(
+    data,
+    dims=("channel", "frequency", "time"),
+    coords={
+        "channel": labels,
+        "frequency": np.fft.rfftfreq(n_fft, 1 / sampling_rate),
+        "time": frame_times,
+        "unit": ("channel", units),
+        "ref": ("channel", refs),
+    },
+    attrs={
+        "wandas_frame_type": "SpectrogramFrame",
+        "sampling_rate": sampling_rate,
+        "n_fft": n_fft,
+        "hop_length": hop_length,
+        "win_length": win_length,
+        "window": window,
+        "operation_history": history,
+    },
+)
+```
+
+### NOctFrame
+
+```python
+xr.DataArray(
+    data,
+    dims=("channel", "band"),
+    coords={
+        "channel": labels,
+        "band": center_frequencies,
+        "unit": ("channel", units),
+        "ref": ("channel", refs),
+    },
+    attrs={
+        "wandas_frame_type": "NOctFrame",
+        "sampling_rate": sampling_rate,
+        "fmin": fmin,
+        "fmax": fmax,
+        "n": n,
+        "G": G,
+        "fr": fr,
+        "operation_history": history,
+    },
+)
+```
+
+### RoughnessFrame
+
+Mono roughness is represented without a `channel` dimension because data shape is `(bark, time)`, but channel metadata must still round-trip through attrs.
+
+```python
+xr.DataArray(
+    data,
+    dims=("bark", "time"),
+    coords={
+        "bark": bark_axis,
+        "time": time_seconds,
+    },
+    attrs={
+        "wandas_frame_type": "RoughnessFrame",
+        "sampling_rate": sampling_rate,
+        "overlap": overlap,
+        "channel_metadata": singleton_channel_metadata,
+    },
+)
+```
+
+Multi-channel roughness uses `dims=("channel", "bark", "time")`.
+
+## coords vs attrs / coords と attrs の責務
+
+`coords` に置くもの:
+
+- selection / alignment / validation に効く軸情報
+- `channel`, `time`, `frequency`, `band`, `bark`
+- channel-scoped `unit`, `ref`
+
+`attrs` に置くもの:
+
+- `wandas_frame_type`
+- `sampling_rate`
+- `label`
+- `metadata`
+- `operation_history`
+- frame constructor parameters such as `n_fft`, `hop_length`, `fmin`, `fmax`, `n`, `G`, `fr`, `overlap`
+- `channel_metadata` for metadata that cannot be represented as simple numeric/string coords
+
+Important: xarray does not interpret or reliably maintain `attrs` through arbitrary operations. Wandas must explicitly update and validate attrs when reconstructing frames.
+
+## Coordinate Validation / 座標検証方針
+
+Wandas frame classes currently cannot represent arbitrary xarray-selected axes such as shifted time origins, decimated time axes, reversed frequencies, or reordered octave bands. Therefore `from_xarray()` should reject non-canonical coordinates instead of silently rebuilding a misleading frame.
+
+Validation rules:
+
+- `time`: must start at 0 and match `sampling_rate` or `hop_length` spacing.
+- `frequency`: must match canonical ascending `np.fft.rfftfreq(n_fft, 1 / sampling_rate)`.
+- `band`: must match canonical NOct center frequencies from `fmin`, `fmax`, `n`, `G`, `fr`.
+- length mismatches must fail before frame construction.
+
+This is intentionally strict. A future frame model may preserve selected coordinate offsets, but PR #213 does not introduce that capability.
+
+## Signal-safe Chunk Policy / 信号処理として安全な chunk policy
+
+xarray adoption must not mean `chunks="auto"` for waveform operations. Time and frequency axes have signal-processing semantics.
+
+Default storage/analysis chunks:
+
+```python
+ChannelFrame:     {"channel": 1, "time": -1}
+SpectralFrame:    {"channel": 1, "frequency": -1}
+SpectrogramFrame: {"channel": 1, "frequency": -1, "time": -1}
+NOctFrame:        {"channel": 1, "band": -1}
+RoughnessFrame:   mono {"bark": -1, "time": -1}, multi {"channel": 1, "bark": -1, "time": -1}
+```
+
+Operation policy:
+
+| Operation type | Split time/frequency chunks | Default policy |
+| --- | --- | --- |
+| Elementwise gain / abs / power | Safe | allow |
+| trim / channel selection | Safe | allow |
+| global normalize / RMS scalar | Unsafe unless reduction is explicit | require contiguous core dim |
+| FFT / IFFT | Unsafe across split transform dim | require contiguous core dim |
+| STFT / Welch | Conditionally safe with overlap | strict first, blockwise later |
+| FIR / convolution / moving RMS | Conditionally safe with overlap | future `map_overlap` mode |
+| IIR / `filtfilt` / resampling | Generally unsafe blockwise | strict single core dim first |
+| NOct synthesis | Requires whole frequency spectrum | require contiguous `frequency` |
+
+Strict mode should be default. Any blockwise/overlap implementation must be explicit and recorded in `operation_history`.
+
+## Phase Plan / 移行計画
+
+### Phase 1: Bridge - completed in PR #213
+
+Goal: expose xarray interoperability while keeping existing Wandas API compatible.
+
+Delivered:
+
+- `frame.to_xarray()`
+- `frame.xr`
+- `wd.from_xarray()`
+- `frame.to_netcdf(path)`
+- `wd.open_netcdf(path)`
+- xarray schema for current frame classes
+- strict coordinate validation on import
+- NetCDF-safe attrs encoding/decoding
+- complex real/imag encoding for NetCDF3 compatibility
+- signal-safe chunk validation based on xarray dims
+
+### Phase 2: Internal xarray as authoritative storage - not complete
+
+Goal: make xarray `DataArray` the long-term core data representation.
+
+Required work:
+
+1. Decide `_xr` ownership rules.
+2. Remove or reduce direct `_data` mutation paths.
+3. Convert `.data`, `.compute()`, `.labels`, `.channels`, `.metadata`, `.operation_history` to compatibility properties over `_xr` where possible.
+4. Define when frame constructors accept raw arrays vs `DataArray`.
+5. Add tests that direct xarray storage updates preserve all legacy API behavior.
+6. Update documentation to state that frame semantics are defined by xarray schema.
+
+Exit criteria:
+
+- There is a single authoritative storage object per frame.
+- Legacy `_data` access is either removed, deprecated, or clearly marked as an escape hatch.
+- Existing frame operations no longer rely on independent duplicated metadata state where xarray schema can provide it.
+
+### Phase 3: xarray-aware operations - not complete
+
+Goal: move safe operations to xarray/Dask-native execution while preserving signal correctness.
+
+Required work:
+
+1. Categorize every operation by core dims and blockwise safety.
+2. Keep strict single-core-dim execution for FFT, IIR, `filtfilt`, and resampling until proven safe.
+3. Implement `xr.apply_ufunc` for operations with clear input/output core dims.
+4. Implement `map_overlap` only for operations where overlap semantics are mathematically correct, such as FIR or moving-window metrics.
+5. Record execution mode in `operation_history`.
+6. Add numerical equivalence tests against existing implementations.
+
+Exit criteria:
+
+- At least one representative operation in each safe class is xarray-aware.
+- Unsafe split core chunks fail loudly by default.
+- Any approximate/blockwise mode is explicit and documented.
+
+### Phase 4: I/O repositioning - not complete
+
+Goal: reposition Wandas persistence around xarray-compatible storage without breaking WDF users.
+
+Required work:
+
+1. Decide whether WDF remains HDF5-specific or becomes a Wandas profile over xarray storage.
+2. Add `to_zarr()` / `open_zarr()` if optional dependency policy allows it.
+3. Separate storage chunk policy from analysis chunk policy.
+4. Document rechunking expectations before signal-processing operations.
+5. Preserve existing WDF compatibility or define a deprecation timeline.
+6. Add round-trip tests for large chunked datasets.
+
+Exit criteria:
+
+- Users can store large xarray-backed Wandas data without materializing everything eagerly.
+- Storage chunks may be optimized for I/O, while analysis chunks are validated/rechunked for signal correctness.
+- WDF/NetCDF/Zarr roles are clearly documented.
+
+## Accessor Plan / accessor 方針
+
+Accessor is optional and should follow after Phase 2 stabilizes.
+
+Possible future API:
+
+```python
+da.wd.describe()
+da.wd.stft()
+da.wd.to_frame()
+```
+
+Do not implement this before the frame schema and operation semantics are stable.
+
+## Risks / リスク
+
+- Bridge code can become permanent complexity if Phase 2-4 are not completed.
+- Strict coordinate validation may reject legitimate xarray workflows until Wandas supports arbitrary coordinate offsets.
+- `attrs` can be dropped or changed by xarray operations; Wandas must treat attrs as schema data only at controlled boundaries.
+- NetCDF support does not automatically solve large-data storage; Zarr is still needed for chunked cloud/local stores.
+- Direct `_data` mutation compatibility makes `_xr` ownership harder to reason about.
+
+## Current State After PR #213 / PR #213 後の状態
+
+Completed:
+
+- Phase 1 bridge is implemented and verified.
+- Some Phase 2 scaffolding exists through internal `_xr` sync.
+- Some Phase 3 scaffolding exists through strict chunk policy validation.
+- Some Phase 4 scaffolding exists through NetCDF helpers.
+
+Not completed:
+
+- Full xarray-native internal model.
+- xarray-native operation execution.
+- Zarr support.
+- WDF repositioning.
+- Accessor API.
+
+## Verification Expectations / 検証方針
+
+For every follow-up phase:
+
+1. Write failing regression tests first.
+2. Preserve existing public Wandas API unless a breaking change is explicitly approved.
+3. Run focused tests for changed modules.
+4. Run full suite before merging.
+5. Keep `wandas/xarray_bridge.py` and `wandas/processing/chunk_policy.py` coverage at 100% while they remain small enough for this expectation to be reasonable.
+
+Current PR #213 final verification:
+
+```text
+uv run ruff check wandas tests
+uv run ty check wandas tests
+uv run pytest -q
+uv run coverage report -m wandas/xarray_bridge.py wandas/processing/chunk_policy.py
+```
+
+Latest recorded result:
+
+```text
+1482 passed, 3 skipped, 69 warnings
+wandas/xarray_bridge.py: 100%
+wandas/processing/chunk_policy.py: 100%
+```
+
+## Open Questions / 未決事項
+
+- Should WDF become a Wandas profile over Zarr/NetCDF, or should it remain a legacy HDF5 format?
+- Should `attrs` hold full `channel_metadata`, or should complex metadata eventually move to a sidecar `Dataset` variable?
+- What is the deprecation policy for direct `_data` mutation?
+- Which operations are safe to expose with `mode="blockwise"`?
+- Should xarray-selected non-zero time origins become representable in Wandas frames?
+- Should `.wd` accessor become public API after Phase 2?

--- a/docs/design/2026-06-09-xarray-native-migration.md
+++ b/docs/design/2026-06-09-xarray-native-migration.md
@@ -261,24 +261,29 @@ Delivered:
 - complex real/imag encoding for NetCDF3 compatibility
 - signal-safe chunk validation based on xarray dims
 
-### Phase 2: Internal xarray as authoritative storage - not complete
+### Phase 2: Internal xarray as authoritative storage - completed in PR #213 follow-up
 
 Goal: make xarray `DataArray` the long-term core data representation.
 
-Required work:
+Delivered:
 
-1. Decide `_xr` ownership rules.
-2. Remove or reduce direct `_data` mutation paths.
-3. Convert `.data`, `.compute()`, `.labels`, `.channels`, `.metadata`, `.operation_history` to compatibility properties over `_xr` where possible.
-4. Define when frame constructors accept raw arrays vs `DataArray`.
-5. Add tests that direct xarray storage updates preserve all legacy API behavior.
-6. Update documentation to state that frame semantics are defined by xarray schema.
+1. Made `BaseFrame._xr` the authoritative storage object for frame data and schema metadata.
+2. Kept `BaseFrame._data` as a compatibility escape hatch that reads and writes `BaseFrame._xr.data`. It no longer owns a separate data object.
+3. Backed `sampling_rate`, `label`, `metadata`, `operation_history`, and `_channel_metadata` by `BaseFrame._xr.attrs`, with public xarray coords/attrs refreshed from that internal schema.
+4. Changed `frame.to_xarray(copy=False)` to return the authoritative internal `DataArray`.
+5. Kept `frame.to_xarray()` / `frame.xr` returning a public shallow copy with private internal attrs removed.
+6. Preserved attrs/name when legacy code assigns `frame._data = ...`, so rechunking through the compatibility path does not drop frame schema.
+7. Added regression tests for authoritative storage identity, metadata-backed attrs, and channel metadata-backed coords.
 
-Exit criteria:
+Exit criteria status:
 
-- There is a single authoritative storage object per frame.
-- Legacy `_data` access is either removed, deprecated, or clearly marked as an escape hatch.
-- Existing frame operations no longer rely on independent duplicated metadata state where xarray schema can provide it.
+- Single authoritative storage object per frame: complete.
+- Legacy `_data` access clearly marked as compatibility access to `_xr.data`: complete.
+- Duplicated frame metadata state reduced where xarray schema can provide it: complete for base frame data, frame attrs, operation history, and channel metadata.
+
+Remaining compatibility note:
+
+- Many existing frame methods still call `self._data` for array operations. This is now an escape hatch property over `_xr.data`, not separate storage. Reducing those call sites to `self._xr`/xarray-native operations is incremental cleanup, not a Phase 2 blocker.
 
 ### Phase 3: xarray-aware operations - completed in PR #213 follow-up
 
@@ -356,13 +361,12 @@ Do not implement this before the frame schema and operation semantics are stable
 Completed:
 
 - Phase 1 bridge is implemented and verified.
-- Some Phase 2 scaffolding exists through internal `_xr` sync.
+- Phase 2 internal xarray authoritative storage is implemented and verified.
 - Phase 3 xarray-aware operation dispatch is implemented for representative strict operations and exact reductions.
 - Some Phase 4 scaffolding exists through NetCDF helpers.
 
 Not completed:
 
-- Full xarray-native internal model.
 - Full xarray-native operation coverage for every operation.
 - Public blockwise/overlap execution modes.
 - Zarr support.

--- a/docs/design/2026-06-09-xarray-native-migration.md
+++ b/docs/design/2026-06-09-xarray-native-migration.md
@@ -280,24 +280,35 @@ Exit criteria:
 - Legacy `_data` access is either removed, deprecated, or clearly marked as an escape hatch.
 - Existing frame operations no longer rely on independent duplicated metadata state where xarray schema can provide it.
 
-### Phase 3: xarray-aware operations - not complete
+### Phase 3: xarray-aware operations - completed in PR #213 follow-up
 
-Goal: move safe operations to xarray/Dask-native execution while preserving signal correctness.
+Goal: move safe representative operations to xarray/Dask-native execution while preserving signal correctness. This phase does not mean every existing operation has been rewritten; it means the dispatch path, strict execution semantics, representative operations, and verification pattern are in place.
 
-Required work:
+Delivered:
 
-1. Categorize every operation by core dims and blockwise safety.
-2. Keep strict single-core-dim execution for FFT, IIR, `filtfilt`, and resampling until proven safe.
-3. Implement `xr.apply_ufunc` for operations with clear input/output core dims.
-4. Implement `map_overlap` only for operations where overlap semantics are mathematically correct, such as FIR or moving-window metrics.
-5. Record execution mode in `operation_history`.
-6. Add numerical equivalence tests against existing implementations.
+1. Added `AudioOperation.process_xarray()` and `AudioOperation.process_dataarray()` so real operation instances can opt into xarray-native execution while mocks/stubs and unsupported operations keep the legacy `process()` path.
+2. Added execution metadata to operation history for xarray-aware operations without changing the existing `params` structure.
+3. Implemented `xr.apply_ufunc` strict core-dim execution for:
+   - `normalize(axis=-1)` / time-axis normalization
+   - `fft()` from `ChannelFrame` to `SpectralFrame`
+   - `rms_trend()` moving-window RMS in strict whole-time mode
+4. Implemented exact xarray/Dask reduction execution for:
+   - `remove_dc()` over the `time` dimension
+5. Kept unsafe split-core operations guarded by strict chunk validation.
+6. Added numerical equivalence tests and execution-history tests for the xarray-aware paths.
 
-Exit criteria:
+Blockwise / overlap decision:
 
-- At least one representative operation in each safe class is xarray-aware.
-- Unsafe split core chunks fail loudly by default.
-- Any approximate/blockwise mode is explicit and documented.
+- No approximate blockwise mode is enabled in this phase.
+- `map_overlap` is intentionally not added until a specific operation has a reviewed boundary/trim definition.
+- FIR or moving-window blockwise execution should be a separate follow-up with operation-specific numerical equivalence tests.
+
+Exit criteria status:
+
+- Representative `xr.apply_ufunc` strict operations: complete.
+- Representative exact xarray reduction: complete.
+- Unsafe split core chunks fail loudly by default: complete for operations in `STRICT_CORE_DIMS_BY_OPERATION`.
+- Approximate/blockwise mode is explicit: complete by absence; no public blockwise mode is exposed.
 
 ### Phase 4: I/O repositioning - not complete
 
@@ -346,13 +357,14 @@ Completed:
 
 - Phase 1 bridge is implemented and verified.
 - Some Phase 2 scaffolding exists through internal `_xr` sync.
-- Some Phase 3 scaffolding exists through strict chunk policy validation.
+- Phase 3 xarray-aware operation dispatch is implemented for representative strict operations and exact reductions.
 - Some Phase 4 scaffolding exists through NetCDF helpers.
 
 Not completed:
 
 - Full xarray-native internal model.
-- xarray-native operation execution.
+- Full xarray-native operation coverage for every operation.
+- Public blockwise/overlap execution modes.
 - Zarr support.
 - WDF repositioning.
 - Accessor API.
@@ -389,6 +401,6 @@ wandas/processing/chunk_policy.py: 100%
 - Should WDF become a Wandas profile over Zarr/NetCDF, or should it remain a legacy HDF5 format?
 - Should `attrs` hold full `channel_metadata`, or should complex metadata eventually move to a sidecar `Dataset` variable?
 - What is the deprecation policy for direct `_data` mutation?
-- Which operations are safe to expose with `mode="blockwise"`?
+- Which operations are safe to expose with `mode="blockwise"` after operation-specific boundary tests?
 - Should xarray-selected non-zero time origins become representable in Wandas frames?
 - Should `.wd` accessor become public API after Phase 2?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "types-requests>=2.32.0.20250328",
     "pandas",
     "mosqito",
+    "xarray>=2025.6.1",
 ]
 
 [project.urls]

--- a/tests/core/test_base_frame_additional.py
+++ b/tests/core/test_base_frame_additional.py
@@ -179,7 +179,7 @@ def test_compute_non_ndarray_result_raises_value_error():
         def compute(self):
             return [1, 2, 3]
 
-    f._data = Bad()  # ty: ignore[invalid-assignment]
+    f._data = Bad()
     with pytest.raises(ValueError, match=r"Computed result is not a np.ndarray"):
         f.compute()
 
@@ -193,7 +193,7 @@ def test_visualize_graph_failure_logs_warning_returns_none(caplog):
         def visualize(self, filename=None):
             raise RuntimeError("no graphviz")
 
-    f._data = BadVis()  # ty: ignore[invalid-assignment]
+    f._data = BadVis()
 
     with caplog.at_level("WARNING"):
         res = f.visualize_graph()
@@ -333,7 +333,7 @@ def test_persist_returns_persisted_data():
             return _np.zeros(self.shape)
 
     p = Persister()
-    f._data = p  # ty: ignore[invalid-assignment]
+    f._data = p
     newf = f.persist()
     assert newf._data is p
 

--- a/tests/core/test_xarray_bridge.py
+++ b/tests/core/test_xarray_bridge.py
@@ -992,6 +992,83 @@ def test_from_xarray_scalar_channel_selection_restores_noct_frame_metadata() -> 
     npt.assert_allclose(restored.compute(), data[1:2])
 
 
+def test_from_xarray_scalar_spectrogram_selection_keeps_frequency_contiguous() -> None:
+    data = np.stack([np.ones((5, 3)), np.full((5, 3), 2.0)]).astype(np.complex128)
+    frame = SpectrogramFrame.from_numpy(
+        data,
+        sampling_rate=16.0,
+        n_fft=8,
+        hop_length=2,
+        channel_metadata=[ChannelMetadata(label="left"), ChannelMetadata(label="right")],
+    )
+    selected = frame.to_xarray().sel(channel="right")
+
+    restored = wd.from_xarray(selected)
+
+    assert isinstance(restored, SpectrogramFrame)
+    assert restored._data.chunks[1] == (5,)
+    assert restored._data.chunks[2] == (3,)
+
+
+def test_from_xarray_infers_noct_frame_when_schema_type_missing() -> None:
+    from wandas.frames.noct import NOctFrame
+
+    frame = NOctFrame(
+        data=da_from_array(np.ones((1, 11)), chunks=(1, -1)),
+        sampling_rate=48_000,
+        fmin=100.0,
+        fmax=1000.0,
+        n=3,
+        G=10,
+        fr=1000,
+    )
+    xr_data = frame.to_xarray()
+    xr_data.attrs.pop("wandas_frame_type")
+
+    restored = wd.from_xarray(xr_data)
+
+    assert isinstance(restored, NOctFrame)
+    npt.assert_allclose(restored.compute(), frame.compute())
+
+
+def test_from_xarray_infers_scalar_noct_frame_when_schema_type_missing() -> None:
+    from wandas.frames.noct import NOctFrame
+
+    frame = NOctFrame(
+        data=da_from_array(np.stack([np.ones(11), np.full(11, 2.0)]), chunks=(1, -1)),
+        sampling_rate=48_000,
+        fmin=100.0,
+        fmax=1000.0,
+        n=3,
+        G=10,
+        fr=1000,
+        channel_metadata=[ChannelMetadata(label="left"), ChannelMetadata(label="right")],
+    )
+    selected = frame.to_xarray().sel(channel="right")
+    selected.attrs.pop("wandas_frame_type")
+
+    restored = wd.from_xarray(selected)
+
+    assert isinstance(restored, NOctFrame)
+    assert restored.labels == ["right"]
+    npt.assert_allclose(restored.compute(), np.full((1, 11), 2.0))
+
+
+def test_from_xarray_rejects_duplicate_label_scalar_channel_selection() -> None:
+    frame = wd.ChannelFrame(
+        data=da_from_array(np.array([[1.0, 2.0], [3.0, 4.0]]), chunks=(1, -1)),
+        sampling_rate=10.0,
+        channel_metadata=[
+            ChannelMetadata(label="dup", unit="Pa", extra={"idx": 0}),
+            ChannelMetadata(label="dup", unit="g", extra={"idx": 1}),
+        ],
+    )
+    selected = frame.to_xarray().isel(channel=1)
+
+    with pytest.raises(ValueError, match="duplicate channel labels"):
+        wd.from_xarray(selected)
+
+
 def test_from_xarray_rejects_missing_time_coordinate_from_internal_schema() -> None:
     frame = wd.ChannelFrame.from_numpy(np.arange(6.0).reshape(1, -1), sampling_rate=2.0)
     sliced_internal = frame.to_xarray(copy=False).isel(time=slice(1, None))

--- a/tests/core/test_xarray_bridge.py
+++ b/tests/core/test_xarray_bridge.py
@@ -212,7 +212,7 @@ def test_noct_frame_round_trips_through_xarray() -> None:
     from wandas.frames.noct import NOctFrame
 
     frame = NOctFrame(
-        data=da_from_array(np.ones((1, 4)), chunks=(1, -1)),
+        data=da_from_array(np.ones((1, 11)), chunks=(1, -1)),
         sampling_rate=48_000,
         fmin=100.0,
         fmax=1000.0,
@@ -494,3 +494,91 @@ def test_dims_for_frame_falls_back_to_positional_dim_names() -> None:
     frame = SimpleNamespace(_data=np.ones((2, 3, 4)))
 
     assert _dims_for_frame(cast(Any, frame)) == ("dim_0", "dim_1", "dim_2")
+
+
+def test_transform_methods_reject_split_time_chunks() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.arange(64.0).reshape(1, -1), sampling_rate=128.0)
+    frame._data = frame._data.rechunk((1, 16))
+
+    with pytest.raises(ValueError, match="Operation 'fft' requires contiguous chunks along time"):
+        frame.fft(n_fft=64)
+
+    with pytest.raises(ValueError, match="Operation 'stft' requires contiguous chunks along time"):
+        frame.stft(n_fft=16, hop_length=4)
+
+    with pytest.raises(ValueError, match="Operation 'welch' requires contiguous chunks along time"):
+        frame.welch(n_fft=16)
+
+
+def test_cross_channel_transform_rejects_split_time_chunks() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.vstack([np.arange(64.0), np.arange(64.0)]), sampling_rate=128.0)
+    frame._data = frame._data.rechunk((1, 16))
+
+    with pytest.raises(ValueError, match="Operation 'coherence' requires contiguous chunks along time"):
+        frame.coherence(n_fft=16)
+
+
+def test_normalize_axis_one_rejects_split_time_chunks() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, 2.0, 3.0, 4.0]]), sampling_rate=4.0)
+    frame._data = frame._data.rechunk((1, 2))
+
+    with pytest.raises(ValueError, match="Operation 'normalize' requires contiguous chunks along time"):
+        frame.normalize(axis=1)
+
+
+def test_roughness_frame_round_trips_through_netcdf(tmp_path) -> None:
+    from wandas.frames.roughness import RoughnessFrame
+
+    bark_axis = np.linspace(0.5, 23.5, 47)
+    original = RoughnessFrame(
+        data=da_from_array(np.ones((47, 3)), chunks=(47, -1)),
+        sampling_rate=10.0,
+        bark_axis=bark_axis,
+        overlap=0.5,
+        label="roughness",
+    )
+    path = tmp_path / "roughness.nc"
+
+    original.to_netcdf(path)
+    restored = wd.open_netcdf(path)
+
+    assert isinstance(restored, RoughnessFrame)
+    assert restored.overlap == original.overlap
+    npt.assert_allclose(restored.bark_axis, bark_axis)
+    npt.assert_allclose(restored.compute(), original.compute())
+
+
+def test_from_xarray_rejects_sliced_noct_band_axis() -> None:
+    from wandas.frames.noct import NOctFrame
+
+    frame = NOctFrame(
+        data=da_from_array(np.ones((1, 11)), chunks=(1, -1)),
+        sampling_rate=48_000,
+        fmin=100.0,
+        fmax=1000.0,
+        n=3,
+        G=10,
+        fr=1000,
+    )
+    sliced = frame.to_xarray().isel(band=slice(0, 2))
+
+    with pytest.raises(ValueError, match="band dimension length"):
+        wd.from_xarray(sliced)
+
+
+def test_complex_spectral_frame_round_trips_through_netcdf(tmp_path) -> None:
+    original = SpectralFrame(
+        data=da_from_array(np.array([[1.0 + 2.0j, 3.0 + 4.0j, 5.0 + 6.0j]]), chunks=(1, -1)),
+        sampling_rate=8.0,
+        n_fft=4,
+        window="hann",
+        label="complex-spectrum",
+    )
+    path = tmp_path / "spectrum.nc"
+
+    original.to_netcdf(path)
+    restored = wd.open_netcdf(path)
+
+    assert isinstance(restored, SpectralFrame)
+    assert restored.n_fft == original.n_fft
+    npt.assert_allclose(restored.compute(), original.compute())

--- a/tests/core/test_xarray_bridge.py
+++ b/tests/core/test_xarray_bridge.py
@@ -1,4 +1,5 @@
 from typing import Any, cast
+from unittest import mock
 
 import numpy as np
 import numpy.testing as npt
@@ -409,6 +410,19 @@ def test_from_xarray_ignores_malformed_channel_extra_metadata() -> None:
     assert [ch.extra for ch in restored.channels] == [{}, {}]
 
 
+def test_noct_frame_to_xarray_omits_band_coordinate_when_freqs_are_not_defined() -> None:
+    from wandas.frames.noct import NOctFrame
+
+    frame = NOctFrame(
+        data=da_from_array(np.ones((1, 4)), chunks=(1, -1)),
+        sampling_rate=48_000,
+    )
+
+    xr_data = frame.to_xarray()
+
+    assert "band" not in xr_data.coords
+
+
 def test_noct_frame_to_xarray_includes_optional_band_coordinate() -> None:
     from wandas.frames.noct import NOctFrame
 
@@ -782,3 +796,76 @@ def test_mono_roughness_frame_preserves_channel_metadata_through_netcdf(tmp_path
     assert restored.channels[0].unit == "asper"
     assert restored.channels[0].ref == 2.0
     assert restored.channels[0].extra == {"source": "mono"}
+
+
+def test_normalize_time_axis_uses_xarray_apply_ufunc_and_records_execution() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, -2.0, 4.0], [2.0, -4.0, 8.0]]), sampling_rate=3.0)
+
+    with mock.patch("xarray.apply_ufunc", wraps=xr.apply_ufunc) as apply_ufunc:
+        result = frame.normalize()
+        npt.assert_allclose(result.compute(), np.array([[0.25, -0.5, 1.0], [0.25, -0.5, 1.0]]))
+
+    assert apply_ufunc.called
+    assert result.operation_history[-1]["operation"] == "normalize"
+    assert result.operation_history[-1]["execution"] == {
+        "engine": "xarray.apply_ufunc",
+        "mode": "strict",
+        "core_dims": ["time"],
+    }
+
+
+def test_remove_dc_uses_xarray_reduction_with_split_time_chunks() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, 2.0, 3.0, 4.0]]), sampling_rate=4.0)
+    frame._data = frame._data.rechunk((1, 2))
+
+    result = frame.remove_dc()
+
+    npt.assert_allclose(result.compute(), np.array([[-1.5, -0.5, 0.5, 1.5]]))
+    assert result.operation_history[-1]["execution"] == {
+        "engine": "xarray",
+        "mode": "exact-reduction",
+        "core_dims": ["time"],
+    }
+
+
+def test_rms_trend_uses_xarray_apply_ufunc_strict_execution() -> None:
+    from wandas.processing.temporal import RmsTrend
+
+    data = np.array([[1.0, 0.0, -1.0, 0.0, 1.0, 0.0, -1.0, 0.0]])
+    frame = wd.ChannelFrame.from_numpy(data, sampling_rate=8.0)
+
+    with mock.patch("xarray.apply_ufunc", wraps=xr.apply_ufunc) as apply_ufunc:
+        result = frame.rms_trend(frame_length=4, hop_length=2)
+        expected = RmsTrend(8.0, frame_length=4, hop_length=2)._process_array(data)
+        npt.assert_allclose(result.compute(), expected)
+
+    assert apply_ufunc.called
+    assert result.sampling_rate == 4.0
+    assert result.operation_history[-1]["operation"] == "rms_trend"
+    assert result.operation_history[-1]["execution"] == {
+        "engine": "xarray.apply_ufunc",
+        "mode": "strict",
+        "core_dims": ["time"],
+        "output_core_dims": ["time"],
+    }
+
+
+def test_fft_uses_xarray_apply_ufunc_and_records_execution() -> None:
+    data = np.array([[0.0, 1.0, 0.0, -1.0]])
+    frame = wd.ChannelFrame.from_numpy(data, sampling_rate=4.0)
+
+    with mock.patch("xarray.apply_ufunc", wraps=xr.apply_ufunc) as apply_ufunc:
+        result = frame.fft(n_fft=4, window="boxcar")
+        expected = np.fft.rfft(data, n=4, axis=-1)
+        expected[..., 1:-1] *= 2.0
+        expected = expected / 4.0
+        npt.assert_allclose(result.compute(), expected)
+
+    assert apply_ufunc.called
+    assert result.operation_history[-1]["operation"] == "fft"
+    assert result.operation_history[-1]["execution"] == {
+        "engine": "xarray.apply_ufunc",
+        "mode": "strict",
+        "core_dims": ["time"],
+        "output_core_dims": ["frequency"],
+    }

--- a/tests/core/test_xarray_bridge.py
+++ b/tests/core/test_xarray_bridge.py
@@ -582,3 +582,70 @@ def test_complex_spectral_frame_round_trips_through_netcdf(tmp_path) -> None:
     assert isinstance(restored, SpectralFrame)
     assert restored.n_fft == original.n_fft
     npt.assert_allclose(restored.compute(), original.compute())
+
+
+def test_from_xarray_realigns_channel_extra_after_channel_selection() -> None:
+    frame = wd.ChannelFrame(
+        data=da_from_array(np.array([[1.0, 2.0], [3.0, 4.0]]), chunks=(1, -1)),
+        sampling_rate=10.0,
+        channel_metadata=[
+            ChannelMetadata(label="left", extra={"side": "left"}),
+            ChannelMetadata(label="right", extra={"side": "right"}),
+        ],
+    )
+    selected = frame.to_xarray().sel(channel=["right"])
+
+    restored = wd.from_xarray(selected)
+
+    assert restored.labels == ["right"]
+    assert [ch.extra for ch in restored.channels] == [{"side": "right"}]
+
+
+def test_from_xarray_rejects_reversed_spectral_frequency_coordinate() -> None:
+    frame = SpectralFrame(
+        data=da_from_array(np.ones((1, 5), dtype=np.complex128), chunks=(1, -1)),
+        sampling_rate=16.0,
+        n_fft=8,
+    )
+    reversed_frequency = frame.to_xarray().isel(frequency=slice(None, None, -1))
+
+    with pytest.raises(ValueError, match="frequency coordinate"):
+        wd.from_xarray(reversed_frequency)
+
+
+def test_from_xarray_decodes_netcdf_attrs_loaded_by_xarray(tmp_path) -> None:
+    original = wd.ChannelFrame.from_numpy(
+        np.array([[1.0, 2.0]]),
+        sampling_rate=2.0,
+        metadata={"source": "direct-xarray"},
+        ch_labels=["mic"],
+    )
+    original.operation_history.append({"operation": "gain", "factor": 2.0})
+    path = tmp_path / "direct_xarray.nc"
+    original.to_netcdf(path)
+
+    xr_data = xr.open_dataarray(path).load()
+    try:
+        restored = wd.from_xarray(xr_data)
+    finally:
+        xr_data.close()
+
+    assert restored.metadata == original.metadata
+    assert restored.operation_history == original.operation_history
+    assert restored.labels == ["mic"]
+
+
+def test_from_xarray_rejects_noncanonical_channel_time_coordinate() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.arange(6.0).reshape(1, -1), sampling_rate=2.0)
+    decimated = frame.to_xarray().isel(time=slice(None, None, 2))
+
+    with pytest.raises(ValueError, match="time coordinate"):
+        wd.from_xarray(decimated)
+
+
+def test_from_xarray_rejects_nonzero_start_channel_time_coordinate() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.arange(6.0).reshape(1, -1), sampling_rate=2.0)
+    shifted = frame.to_xarray().isel(time=slice(1, None))
+
+    with pytest.raises(ValueError, match="time coordinate"):
+        wd.from_xarray(shifted)

--- a/tests/core/test_xarray_bridge.py
+++ b/tests/core/test_xarray_bridge.py
@@ -467,7 +467,7 @@ def test_from_xarray_ignores_malformed_channel_extra_metadata() -> None:
     assert [ch.extra for ch in restored.channels] == [{}, {}]
 
 
-def test_noct_frame_to_xarray_omits_band_coordinate_when_freqs_are_not_defined() -> None:
+def test_noct_frame_to_xarray_rejects_unreadable_schema_without_band_coordinate() -> None:
     from wandas.frames.noct import NOctFrame
 
     frame = NOctFrame(
@@ -475,9 +475,8 @@ def test_noct_frame_to_xarray_omits_band_coordinate_when_freqs_are_not_defined()
         sampling_rate=48_000,
     )
 
-    xr_data = frame.to_xarray()
-
-    assert "band" not in xr_data.coords
+    with pytest.raises(ValueError, match="NOctFrame xarray export requires a valid band coordinate"):
+        frame.to_xarray()
 
 
 def test_noct_frame_to_xarray_includes_optional_band_coordinate() -> None:
@@ -853,6 +852,143 @@ def test_mono_roughness_frame_preserves_channel_metadata_through_netcdf(tmp_path
     assert restored.channels[0].unit == "asper"
     assert restored.channels[0].ref == 2.0
     assert restored.channels[0].extra == {"source": "mono"}
+
+
+def test_from_xarray_preserves_duplicate_label_channel_extras_positionally() -> None:
+    frame = wd.ChannelFrame(
+        data=da_from_array(np.array([[1.0, 2.0], [3.0, 4.0]]), chunks=(1, -1)),
+        sampling_rate=10.0,
+        channel_metadata=[
+            ChannelMetadata(label="dup", extra={"idx": 0}),
+            ChannelMetadata(label="dup", extra={"idx": 1}),
+        ],
+    )
+
+    restored = wd.from_xarray(frame.to_xarray())
+
+    assert [ch.label for ch in restored.channels] == ["dup", "dup"]
+    assert [ch.extra for ch in restored.channels] == [{"idx": 0}, {"idx": 1}]
+
+
+def test_from_xarray_scalar_roughness_channel_selection_keeps_selected_metadata() -> None:
+    from wandas.frames.roughness import RoughnessFrame
+
+    bark_axis = np.linspace(0.5, 23.5, 47)
+    frame = RoughnessFrame(
+        data=da_from_array(np.ones((2, 47, 3)), chunks=(1, 47, -1)),
+        sampling_rate=10.0,
+        bark_axis=bark_axis,
+        overlap=0.5,
+        channel_metadata=[
+            ChannelMetadata(label="left", extra={"side": "left"}),
+            ChannelMetadata(label="right", extra={"side": "right"}),
+        ],
+    )
+    selected = frame.to_xarray().sel(channel="right")
+
+    restored = wd.from_xarray(selected)
+
+    assert restored.n_channels == 1
+    assert restored.channels[0].label == "right"
+    assert restored.channels[0].extra == {"side": "right"}
+
+
+def test_to_xarray_copy_false_does_not_materialize_dense_time_coordinate() -> None:
+    frame = wd.ChannelFrame(
+        data=da_from_array(np.zeros((1, 100_000)), chunks=(1, -1)),
+        sampling_rate=10.0,
+    )
+
+    internal = frame.to_xarray(copy=False)
+    exported = frame.to_xarray()
+
+    assert "time" not in internal.coords
+    assert "time" in exported.coords
+    npt.assert_allclose(exported.coords["time"].values[:3], np.array([0.0, 0.1, 0.2]))
+
+
+def test_scalar_channel_coord_without_matching_metadata_uses_label_extra_fallback() -> None:
+    from wandas.xarray_bridge import _channel_metadata_from_coords
+
+    xr_data = xr.DataArray(
+        np.ones((47, 3)),
+        dims=("bark", "time"),
+        coords={"channel": "selected"},
+        attrs={"channel_extra_by_label": {"selected": {"role": "picked"}}},
+    )
+
+    metadata = _channel_metadata_from_coords(xr_data)
+
+    assert len(metadata) == 1
+    assert metadata[0].label == "selected"
+    assert metadata[0].extra == {"role": "picked"}
+
+
+def test_json_safe_falls_back_for_non_json_objects() -> None:
+    from wandas.xarray_bridge import _json_safe
+
+    class NonJson:
+        pass
+
+    result = _json_safe(NonJson())
+
+    assert result["type"] == "NonJson"
+    assert "NonJson" in result["repr"]
+
+
+def test_add_with_snr_result_can_be_written_to_netcdf(tmp_path) -> None:
+    signal = wd.ChannelFrame.from_numpy(np.array([[1.0, 2.0, 3.0, 4.0]]), sampling_rate=4.0)
+    noise = wd.ChannelFrame.from_numpy(np.array([[0.25, -0.25, 0.5, -0.5]]), sampling_rate=4.0)
+    result = signal.add(noise, snr=10.0)
+    path = tmp_path / "snr.nc"
+
+    result.to_netcdf(path)
+    restored = wd.open_netcdf(path)
+
+    assert restored.operation_history[-1]["params"]["other"]["type"] == "dask.array"
+    npt.assert_allclose(restored.compute(), result.compute())
+
+
+def test_normalize_axis_none_preserves_global_legacy_semantics() -> None:
+    data = np.array([[1.0, 2.0], [10.0, 20.0]])
+    frame = wd.ChannelFrame.from_numpy(data, sampling_rate=2.0)
+
+    result = frame.normalize(axis=None)
+
+    npt.assert_allclose(result.compute(), data / 20.0)
+    assert "execution" not in result.operation_history[-1]
+
+
+def test_remove_dc_preserves_nan_propagation() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, np.nan, 3.0]]), sampling_rate=3.0)
+
+    result = frame.remove_dc()
+
+    assert np.isnan(result.compute()).all()
+
+
+def test_rms_trend_db_multichannel_preserves_channel_count() -> None:
+    frame = wd.ChannelFrame(
+        data=da_from_array(
+            np.array([[1.0, 0.0, -1.0, 0.0], [2.0, 0.0, -2.0, 0.0]]),
+            chunks=(1, -1),
+        ),
+        sampling_rate=4.0,
+        channel_metadata=[ChannelMetadata(label="a", unit="Pa"), ChannelMetadata(label="b", unit="Pa")],
+    )
+
+    result = frame.rms_trend(frame_length=2, hop_length=2, dB=True)
+
+    assert result.shape[0] == 2
+    assert result.compute().shape[0] == 2
+
+
+def test_roughness_dw_spec_rejects_split_time_chunks() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.arange(9600.0).reshape(1, -1), sampling_rate=48_000)
+    frame._data = frame._data.rechunk((1, 2400))
+
+    with pytest.raises(ValueError, match="Operation 'roughness_dw_spec' requires contiguous chunks along time"):
+        frame.roughness_dw_spec()
 
 
 def test_normalize_time_axis_uses_xarray_apply_ufunc_and_records_execution() -> None:

--- a/tests/core/test_xarray_bridge.py
+++ b/tests/core/test_xarray_bridge.py
@@ -1,15 +1,18 @@
 from typing import Any, cast
 from unittest import mock
 
+import dask.array as da
 import numpy as np
 import numpy.testing as npt
 import pytest
 import xarray as xr
 
 import wandas as wd
+from wandas.core.base_frame import BaseFrame
 from wandas.core.metadata import ChannelMetadata
 from wandas.frames.spectral import SpectralFrame
 from wandas.frames.spectrogram import SpectrogramFrame
+from wandas.processing.base import AudioOperation
 from wandas.utils.dask_helpers import da_from_array
 
 
@@ -1062,3 +1065,205 @@ def test_fft_uses_xarray_apply_ufunc_and_records_execution() -> None:
         "core_dims": ["time"],
         "output_core_dims": ["frequency"],
     }
+
+
+class _BaseFrameProbe(BaseFrame[np.ndarray]):
+    @property
+    def _n_channels(self) -> int:
+        return int(self._data.shape[0]) if self._data.ndim else 1
+
+    def plot(self, plot_type: str = "default", ax: Any = None, **kwargs: Any) -> Any:
+        raise NotImplementedError
+
+    def _get_dataframe_index(self) -> Any:
+        import pandas as pd
+
+        return pd.RangeIndex(stop=int(self._data.shape[-1]) if self._data.ndim else 1)
+
+
+class _NumpyBackedXarrayOperation(AudioOperation[np.ndarray, np.ndarray]):
+    name = "_test_numpy_xarray_result"
+    _display = "txr"
+
+    def _setup_processor(self) -> None:
+        return None
+
+    def process_xarray(self, data_array: xr.DataArray) -> xr.DataArray | None:
+        computed = data_array.compute()
+        return xr.DataArray(np.asarray(computed.data) + 1.0, dims=data_array.dims, attrs=data_array.attrs)
+
+    def _process_array(self, x: np.ndarray) -> np.ndarray:
+        return x + 1.0
+
+
+class _MissingRequiredArgFrame(wd.ChannelFrame):
+    def __init__(self, *args: Any, required_arg: str, **kwargs: Any):
+        self.required_arg = required_arg
+        super().__init__(*args, **kwargs)
+
+
+def test_phase2_default_attrs_are_reconstructed_from_internal_xarray() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, 2.0]]), sampling_rate=2.0)
+    frame._xr.attrs.pop("label", None)
+    frame._xr.name = None
+    frame._xr.attrs.pop("metadata", None)
+    frame._xr.attrs["source_file"] = "input.wav"
+    frame._xr.attrs["operation_history"] = "not-a-list"
+
+    assert frame.label == "unnamed_frame"
+    assert frame.metadata.source_file == "input.wav"
+    assert frame.operation_history == []
+    assert frame._xr.attrs["operation_history"] == []
+
+    frame.metadata = None
+
+    assert frame.metadata.source_file is None
+    assert "source_file" not in frame._xr.attrs
+
+
+def test_phase2_channel_metadata_restores_from_public_attr_and_coords() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, 2.0], [3.0, 4.0]]), sampling_rate=2.0)
+    frame._xr.attrs.pop("_wandas_internal_channel_metadata", None)
+    frame._xr.attrs["channel_metadata"] = [
+        ChannelMetadata(label="front", unit="Pa", ref=2.0, extra={"role": "reference"}),
+        {"label": "rear", "unit": "g", "ref": 3.0, "extra": {"role": "response"}},
+    ]
+
+    restored = frame._channel_metadata
+
+    assert [ch.label for ch in restored] == ["front", "rear"]
+    assert [ch.unit for ch in restored] == ["Pa", "g"]
+    assert [ch.ref for ch in restored] == [2.0, 3.0]
+    assert [ch.extra for ch in restored] == [{"role": "reference"}, {"role": "response"}]
+
+    frame._xr.attrs.pop("_wandas_internal_channel_metadata", None)
+    frame._xr.attrs.pop("channel_metadata", None)
+    frame._xr = frame._xr.assign_coords(
+        channel=("channel", ["left", "right"]),
+        unit=("channel", ["Pa", "m/s2"]),
+        ref=("channel", [20e-6, 1.0]),
+    )
+
+    fallback = frame._channel_metadata
+
+    assert [ch.label for ch in fallback] == ["left", "right"]
+    assert [ch.unit for ch in fallback] == ["Pa", "m/s2"]
+    assert [ch.ref for ch in fallback] == [20e-6, 1.0]
+
+
+def test_phase2_channel_metadata_setter_rejects_invalid_items() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, 2.0]]), sampling_rate=2.0)
+
+    with pytest.raises(ValueError, match="Invalid channel_metadata at index 0"):
+        frame._channel_metadata = [{"label": 123}]
+
+    with pytest.raises(TypeError, match="Invalid type in channel_metadata at index 0"):
+        setattr(frame, "_channel_metadata", [object()])
+
+
+def test_binary_frame_operations_reject_channel_count_and_shape_mismatch() -> None:
+    left = wd.ChannelFrame.from_numpy(np.ones((2, 3)), sampling_rate=10.0)
+    one_channel = wd.ChannelFrame.from_numpy(np.ones((1, 3)), sampling_rate=10.0)
+    different_shape = wd.ChannelFrame.from_numpy(np.ones((2, 4)), sampling_rate=10.0)
+
+    with pytest.raises(ValueError, match="Channel count mismatch"):
+        _ = left + one_channel
+
+    with pytest.raises(ValueError, match="Frame shape mismatch"):
+        _ = left + different_shape
+
+
+def test_apply_operation_impl_uses_xarray_path_and_wraps_numpy_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    from wandas.processing.base import _OPERATION_REGISTRY, register_operation
+
+    previous = _OPERATION_REGISTRY.get(_NumpyBackedXarrayOperation.name)
+    register_operation(_NumpyBackedXarrayOperation)
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, 2.0]]), sampling_rate=2.0)
+
+    try:
+        result = frame._apply_operation_impl(_NumpyBackedXarrayOperation.name)
+    finally:
+        if previous is None:
+            monkeypatch.delitem(_OPERATION_REGISTRY, _NumpyBackedXarrayOperation.name, raising=False)
+        else:
+            monkeypatch.setitem(_OPERATION_REGISTRY, _NumpyBackedXarrayOperation.name, previous)
+
+    assert isinstance(result._data, da.Array)
+    npt.assert_allclose(result.compute(), np.array([[2.0, 3.0]]))
+    assert "execution" not in result.operation_history[-1]
+
+
+def test_apply_operation_instance_reports_bad_output_frame_constructor() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, 2.0]]), sampling_rate=2.0)
+    operation = _NumpyBackedXarrayOperation(sampling_rate=2.0)
+
+    with pytest.raises(TypeError, match="Invalid output_frame_class constructor"):
+        frame._apply_operation_instance(operation, output_frame_class=_MissingRequiredArgFrame)
+
+
+def test_operation_xarray_fallbacks_for_non_time_schemas() -> None:
+    from wandas.processing.effects import RemoveDC
+    from wandas.processing.spectral import FFT
+
+    data_array = xr.DataArray(np.array([1.0, 2.0]), dims=("sample",))
+
+    assert RemoveDC(sampling_rate=2.0).process_xarray(data_array) is None
+    assert FFT(sampling_rate=2.0).process_xarray(data_array) is None
+
+
+def test_fade_accepts_1d_input_by_restoring_channel_axis() -> None:
+    from wandas.processing.effects import Fade
+
+    result = Fade(sampling_rate=10.0, fade_ms=100.0)._process_array(np.ones(10))
+
+    assert result.shape == (1, 10)
+
+
+def test_istft_output_shape_honors_length_override() -> None:
+    from wandas.processing.spectral import ISTFT
+
+    operation = ISTFT(sampling_rate=16.0, n_fft=8, hop_length=2, length=5)
+
+    assert operation.calculate_output_shape((1, 5, 4)) == (1, 5)
+
+
+def test_base_frame_rechunks_scalar_dask_input_as_single_chunk() -> None:
+    frame = _BaseFrameProbe(da.from_array(np.array(1.0), chunks=()), sampling_rate=1.0)
+
+    assert frame._data.chunks == ()
+
+
+def test_getitem_slice_wraps_scalar_channel_metadata_slice_result() -> None:
+    class ScalarSliceMetadata(list[ChannelMetadata]):
+        def __getitem__(self, key: Any) -> Any:
+            if isinstance(key, slice):
+                return super().__getitem__(0)
+            return super().__getitem__(key)
+
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, 2.0]]), sampling_rate=2.0)
+    frame._xr.attrs["_wandas_internal_channel_metadata"] = ScalarSliceMetadata(
+        [ChannelMetadata(label="mic", unit="Pa")]
+    )
+
+    selected = frame[:1]
+
+    assert selected.labels == ["mic"]
+
+
+def test_base_frame_apply_operation_impl_uses_xarray_audio_operation(monkeypatch: pytest.MonkeyPatch) -> None:
+    from wandas.processing.base import _OPERATION_REGISTRY, register_operation
+
+    previous = _OPERATION_REGISTRY.get(_NumpyBackedXarrayOperation.name)
+    register_operation(_NumpyBackedXarrayOperation)
+    frame = _BaseFrameProbe(da_from_array(np.array([[1.0, 2.0]]), chunks=(1, -1)), sampling_rate=2.0)
+
+    try:
+        result = frame._apply_operation_impl(_NumpyBackedXarrayOperation.name)
+    finally:
+        if previous is None:
+            monkeypatch.delitem(_OPERATION_REGISTRY, _NumpyBackedXarrayOperation.name, raising=False)
+        else:
+            monkeypatch.setitem(_OPERATION_REGISTRY, _NumpyBackedXarrayOperation.name, previous)
+
+    assert isinstance(result._data, da.Array)
+    npt.assert_allclose(result.compute(), np.array([[2.0, 3.0]]))

--- a/tests/core/test_xarray_bridge.py
+++ b/tests/core/test_xarray_bridge.py
@@ -1,0 +1,114 @@
+import numpy as np
+import numpy.testing as npt
+
+import wandas as wd
+from wandas.core.metadata import ChannelMetadata
+from wandas.frames.spectral import SpectralFrame
+from wandas.frames.spectrogram import SpectrogramFrame
+from wandas.utils.dask_helpers import da_from_array
+
+
+def test_channel_frame_to_xarray_uses_wandas_schema() -> None:
+    frame = wd.ChannelFrame.from_numpy(
+        np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        sampling_rate=10.0,
+        label="signal",
+        metadata={"source": "fixture"},
+        ch_labels=["left", "right"],
+        ch_units=["Pa", "Pa"],
+    )
+    frame.operation_history.append({"operation": "gain", "factor": 2.0})
+
+    xr_data = frame.to_xarray()
+
+    assert xr_data.dims == ("channel", "time")
+    assert xr_data.name == "signal"
+    assert xr_data.attrs["wandas_frame_type"] == "ChannelFrame"
+    assert xr_data.attrs["sampling_rate"] == 10.0
+    assert xr_data.attrs["label"] == "signal"
+    assert xr_data.attrs["metadata"] == {"source": "fixture"}
+    assert xr_data.attrs["operation_history"] == [{"operation": "gain", "factor": 2.0}]
+    assert xr_data.chunks == ((1, 1), (3,))
+    npt.assert_array_equal(xr_data.coords["channel"].values, np.array(["left", "right"], dtype=object))
+    npt.assert_allclose(xr_data.coords["time"].values, np.array([0.0, 0.1, 0.2]))
+    npt.assert_array_equal(xr_data.coords["unit"].values, np.array(["Pa", "Pa"], dtype=object))
+    npt.assert_allclose(xr_data.coords["ref"].values, np.array([20e-6, 20e-6]))
+
+
+def test_xr_property_returns_dataarray_copy_by_default() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, 2.0]]), sampling_rate=2.0)
+
+    xr_data = frame.xr
+    xr_data.attrs["label"] = "changed"
+
+    assert frame.label == "numpy_data"
+    assert frame.xr.attrs["label"] == "numpy_data"
+
+
+def test_spectral_frame_to_xarray_uses_frequency_dimension() -> None:
+    data = np.ones((2, 5), dtype=np.complex128)
+    frame = SpectralFrame(
+        data=da_from_array(data, chunks=(1, -1)),
+        sampling_rate=16.0,
+        n_fft=8,
+        window="hann",
+        label="spectrum",
+        channel_metadata=[ChannelMetadata(label="a", unit="Pa"), ChannelMetadata(label="b", unit="Pa")],
+    )
+
+    xr_data = frame.to_xarray()
+
+    assert xr_data.dims == ("channel", "frequency")
+    assert xr_data.attrs["wandas_frame_type"] == "SpectralFrame"
+    assert xr_data.attrs["n_fft"] == 8
+    assert xr_data.attrs["window"] == "hann"
+    assert xr_data.chunks == ((1, 1), (5,))
+    npt.assert_allclose(xr_data.coords["frequency"].values, frame.freqs)
+
+
+def test_spectrogram_frame_to_xarray_uses_frequency_and_time_dimensions() -> None:
+    data = np.ones((2, 5, 3), dtype=np.complex128)
+    frame = SpectrogramFrame.from_numpy(
+        data,
+        sampling_rate=16.0,
+        n_fft=8,
+        hop_length=2,
+        label="stft",
+        channel_metadata=[ChannelMetadata(label="a"), ChannelMetadata(label="b")],
+    )
+
+    xr_data = frame.to_xarray()
+
+    assert xr_data.dims == ("channel", "frequency", "time")
+    assert xr_data.attrs["wandas_frame_type"] == "SpectrogramFrame"
+    assert xr_data.attrs["n_fft"] == 8
+    assert xr_data.attrs["hop_length"] == 2
+    assert xr_data.attrs["win_length"] == 8
+    assert xr_data.attrs["window"] == "hann"
+    assert xr_data.chunks == ((1, 1), (5,), (3,))
+    npt.assert_allclose(xr_data.coords["frequency"].values, frame.freqs)
+    npt.assert_allclose(xr_data.coords["time"].values, frame.times)
+
+
+def test_from_xarray_round_trips_channel_frame_metadata_and_data() -> None:
+    original = wd.ChannelFrame.from_numpy(
+        np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        sampling_rate=10.0,
+        label="signal",
+        metadata={"source": "fixture"},
+        ch_labels=["left", "right"],
+        ch_units=["Pa", "g"],
+    )
+    original.operation_history.append({"operation": "normalize"})
+
+    restored = wd.from_xarray(original.to_xarray())
+
+    assert isinstance(restored, wd.ChannelFrame)
+    assert restored.sampling_rate == original.sampling_rate
+    assert restored.label == original.label
+    assert restored.metadata == original.metadata
+    assert restored.operation_history == original.operation_history
+    assert restored.labels == original.labels
+    assert [ch.unit for ch in restored.channels] == ["Pa", "g"]
+    npt.assert_allclose(restored.compute(), original.compute())
+    assert restored._data.chunks == ((1, 1), (3,))

--- a/tests/core/test_xarray_bridge.py
+++ b/tests/core/test_xarray_bridge.py
@@ -896,6 +896,110 @@ def test_from_xarray_scalar_roughness_channel_selection_keeps_selected_metadata(
     assert restored.channels[0].extra == {"side": "right"}
 
 
+def test_from_xarray_scalar_channel_selection_restores_channel_frame_metadata() -> None:
+    frame = wd.ChannelFrame(
+        data=da_from_array(np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]), chunks=(1, -1)),
+        sampling_rate=10.0,
+        channel_metadata=[
+            ChannelMetadata(label="left", unit="Pa", extra={"side": "left"}),
+            ChannelMetadata(label="right", unit="g", extra={"side": "right"}),
+        ],
+    )
+    selected = frame.to_xarray().sel(channel="right")
+
+    restored = wd.from_xarray(selected)
+
+    assert isinstance(restored, wd.ChannelFrame)
+    assert restored.n_channels == 1
+    assert restored.channels[0].label == "right"
+    assert restored.channels[0].unit == "g"
+    assert restored.channels[0].extra == {"side": "right"}
+    npt.assert_allclose(restored.compute(), np.array([[4.0, 5.0, 6.0]]))
+
+
+def test_from_xarray_scalar_channel_selection_restores_spectral_frame_metadata() -> None:
+    frame = SpectralFrame(
+        data=da_from_array(np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], dtype=np.complex128), chunks=(1, -1)),
+        sampling_rate=16.0,
+        n_fft=8,
+        channel_metadata=[
+            ChannelMetadata(label="left", unit="Pa", extra={"side": "left"}),
+            ChannelMetadata(label="right", unit="g", extra={"side": "right"}),
+        ],
+    )
+    selected = frame.to_xarray().sel(channel="right")
+
+    restored = wd.from_xarray(selected)
+
+    assert isinstance(restored, SpectralFrame)
+    assert restored.n_channels == 1
+    assert restored.channels[0].label == "right"
+    assert restored.channels[0].unit == "g"
+    assert restored.channels[0].extra == {"side": "right"}
+    npt.assert_allclose(restored.compute(), np.array([[6, 7, 8, 9, 10]], dtype=np.complex128))
+
+
+def test_from_xarray_scalar_channel_selection_restores_spectrogram_frame_metadata() -> None:
+    data = np.stack([np.ones((5, 3)), np.full((5, 3), 2.0)]).astype(np.complex128)
+    frame = SpectrogramFrame.from_numpy(
+        data,
+        sampling_rate=16.0,
+        n_fft=8,
+        hop_length=2,
+        channel_metadata=[
+            ChannelMetadata(label="left", unit="Pa", extra={"side": "left"}),
+            ChannelMetadata(label="right", unit="g", extra={"side": "right"}),
+        ],
+    )
+    selected = frame.to_xarray().sel(channel="right")
+
+    restored = wd.from_xarray(selected)
+
+    assert isinstance(restored, SpectrogramFrame)
+    assert restored.n_channels == 1
+    assert restored.channels[0].label == "right"
+    assert restored.channels[0].unit == "g"
+    assert restored.channels[0].extra == {"side": "right"}
+    npt.assert_allclose(restored.compute(), data[1:2])
+
+
+def test_from_xarray_scalar_channel_selection_restores_noct_frame_metadata() -> None:
+    from wandas.frames.noct import NOctFrame
+
+    data = np.stack([np.ones(11), np.full(11, 2.0)])
+    frame = NOctFrame(
+        data=da_from_array(data, chunks=(1, -1)),
+        sampling_rate=48_000,
+        fmin=100.0,
+        fmax=1000.0,
+        n=3,
+        G=10,
+        fr=1000,
+        channel_metadata=[
+            ChannelMetadata(label="left", unit="Pa", extra={"side": "left"}),
+            ChannelMetadata(label="right", unit="g", extra={"side": "right"}),
+        ],
+    )
+    selected = frame.to_xarray().sel(channel="right")
+
+    restored = wd.from_xarray(selected)
+
+    assert isinstance(restored, NOctFrame)
+    assert restored.n_channels == 1
+    assert restored.channels[0].label == "right"
+    assert restored.channels[0].unit == "g"
+    assert restored.channels[0].extra == {"side": "right"}
+    npt.assert_allclose(restored.compute(), data[1:2])
+
+
+def test_from_xarray_rejects_missing_time_coordinate_from_internal_schema() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.arange(6.0).reshape(1, -1), sampling_rate=2.0)
+    sliced_internal = frame.to_xarray(copy=False).isel(time=slice(1, None))
+
+    with pytest.raises(ValueError, match="explicit canonical time coordinate"):
+        wd.from_xarray(sliced_internal)
+
+
 def test_to_xarray_copy_false_does_not_materialize_dense_time_coordinate() -> None:
     frame = wd.ChannelFrame(
         data=da_from_array(np.zeros((1, 100_000)), chunks=(1, -1)),

--- a/tests/core/test_xarray_bridge.py
+++ b/tests/core/test_xarray_bridge.py
@@ -112,3 +112,23 @@ def test_from_xarray_round_trips_channel_frame_metadata_and_data() -> None:
     assert [ch.unit for ch in restored.channels] == ["Pa", "g"]
     npt.assert_allclose(restored.compute(), original.compute())
     assert restored._data.chunks == ((1, 1), (3,))
+
+
+def test_frame_keeps_internal_xarray_storage_in_sync_with_data_property() -> None:
+    frame = wd.ChannelFrame.from_numpy(
+        np.array([[1.0, 2.0], [3.0, 4.0]]),
+        sampling_rate=4.0,
+        ch_labels=["a", "b"],
+    )
+
+    assert hasattr(frame, "_xr")
+    assert frame._xr.dims == ("channel", "time")
+    assert frame._data is frame._xr.data
+
+    replacement = da_from_array(np.array([[5.0, 6.0]]), chunks=(1, -1))
+    frame._data = replacement
+
+    assert frame._xr.dims == ("channel", "time")
+    assert frame._data is frame._xr.data
+    assert frame._xr.chunks == ((1,), (2,))
+    npt.assert_allclose(frame.compute(), np.array([[5.0, 6.0]]))

--- a/tests/core/test_xarray_bridge.py
+++ b/tests/core/test_xarray_bridge.py
@@ -139,6 +139,63 @@ def test_frame_keeps_internal_xarray_storage_in_sync_with_data_property() -> Non
     npt.assert_allclose(frame.compute(), np.array([[5.0, 6.0]]))
 
 
+def test_phase2_to_xarray_copy_false_returns_authoritative_internal_storage() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, 2.0]]), sampling_rate=2.0, ch_labels=["mic"])
+
+    xr_data = frame.to_xarray(copy=False)
+
+    assert xr_data is frame._xr
+    assert frame._data is frame._xr.data
+
+
+def test_frame_to_xarray_helper_copy_branch_returns_distinct_dataarray() -> None:
+    from wandas.xarray_bridge import frame_to_xarray
+
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, 2.0]]), sampling_rate=2.0, ch_labels=["mic"])
+
+    copied = frame_to_xarray(frame, copy_dataarray=True)
+
+    assert copied is not frame._xr
+    assert copied.data is frame._data
+
+
+def test_phase2_frame_metadata_properties_are_backed_by_internal_xarray_attrs() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, 2.0]]), sampling_rate=2.0)
+
+    frame.sampling_rate = 4.0
+    frame.label = "renamed"
+    frame.metadata = {"source": "phase2"}
+    frame.metadata.source_file = "input.wav"
+    frame.operation_history.append({"operation": "phase2"})
+
+    xr_data = frame.to_xarray(copy=False)
+
+    assert xr_data.attrs["sampling_rate"] == 4.0
+    assert xr_data.attrs["label"] == "renamed"
+    assert xr_data.name == "renamed"
+    assert xr_data.attrs["metadata"] == {"source": "phase2"}
+    assert xr_data.attrs["source_file"] == "input.wav"
+    assert xr_data.attrs["operation_history"] == [{"operation": "phase2"}]
+
+
+def test_phase2_channel_metadata_is_backed_by_internal_xarray_schema() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, 2.0], [3.0, 4.0]]), sampling_rate=2.0)
+    frame._channel_metadata = [
+        ChannelMetadata(label="front", unit="Pa", extra={"role": "reference"}),
+        ChannelMetadata(label="rear", unit="g", extra={"role": "response"}),
+    ]
+
+    xr_data = frame.to_xarray(copy=False)
+
+    npt.assert_array_equal(xr_data.coords["channel"].values, np.array(["front", "rear"], dtype=object))
+    npt.assert_array_equal(xr_data.coords["unit"].values, np.array(["Pa", "g"], dtype=object))
+    npt.assert_allclose(xr_data.coords["ref"].values, np.array([20e-6, 1.0]))
+    assert xr_data.attrs["channel_extra_by_label"] == {
+        "front": {"role": "reference"},
+        "rear": {"role": "response"},
+    }
+
+
 def test_strict_time_core_operation_rejects_split_time_chunks() -> None:
     frame = wd.ChannelFrame.from_numpy(np.arange(64.0).reshape(1, -1), sampling_rate=128.0)
     frame._data = frame._data.rechunk((1, 16))

--- a/tests/core/test_xarray_bridge.py
+++ b/tests/core/test_xarray_bridge.py
@@ -696,9 +696,89 @@ def test_channel_extra_list_fallback_still_rejects_malformed_lengths() -> None:
     assert [ch.extra for ch in restored.channels] == [{}, {}]
 
 
+def test_channel_metadata_attrs_ignores_malformed_entries() -> None:
+    from wandas.xarray_bridge import _channel_metadata_from_attrs
+
+    restored = _channel_metadata_from_attrs(["bad", {"label": "mic", "extra": ["bad"]}])
+
+    assert len(restored) == 1
+    assert restored[0].label == "mic"
+    assert restored[0].extra == {}
+
+
 def test_axis_targets_dim_handles_none_string_and_nonmatching_axis() -> None:
     from wandas.processing.chunk_policy import _axis_targets_dim
 
     assert _axis_targets_dim(None, ("channel", "time"), "time")
     assert _axis_targets_dim("time", ("channel", "time"), "time")
     assert not _axis_targets_dim("frequency", ("channel", "time"), "time")
+
+
+def test_noct_frame_to_xarray_uses_frequency_band_coordinate_by_default() -> None:
+    from wandas.frames.noct import NOctFrame
+
+    frame = NOctFrame(
+        data=da_from_array(np.ones((1, 11)), chunks=(1, -1)),
+        sampling_rate=48_000,
+        fmin=100.0,
+        fmax=1000.0,
+        n=3,
+        G=10,
+        fr=1000,
+    )
+
+    xr_data = frame.to_xarray()
+
+    npt.assert_allclose(xr_data.coords["band"].values, frame.freqs)
+
+
+def test_from_xarray_rejects_reordered_noct_band_coordinate() -> None:
+    from wandas.frames.noct import NOctFrame
+
+    frame = NOctFrame(
+        data=da_from_array(np.ones((1, 11)), chunks=(1, -1)),
+        sampling_rate=48_000,
+        fmin=100.0,
+        fmax=1000.0,
+        n=3,
+        G=10,
+        fr=1000,
+    )
+    reordered = frame.to_xarray().isel(band=slice(None, None, -1))
+
+    with pytest.raises(ValueError, match="band coordinate"):
+        wd.from_xarray(reordered)
+
+
+def test_noct_synthesis_rejects_split_frequency_chunks() -> None:
+    frame = SpectralFrame(
+        data=da_from_array(np.ones((1, 5), dtype=np.complex128), chunks=(1, -1)),
+        sampling_rate=48_000,
+        n_fft=8,
+    )
+    frame._data = frame._data.rechunk((1, 2))
+
+    with pytest.raises(ValueError, match="Operation 'noct_synthesis' requires contiguous chunks along frequency"):
+        frame.noct_synthesis(fmin=100.0, fmax=1000.0)
+
+
+def test_mono_roughness_frame_preserves_channel_metadata_through_netcdf(tmp_path) -> None:
+    from wandas.frames.roughness import RoughnessFrame
+
+    bark_axis = np.linspace(0.5, 23.5, 47)
+    original = RoughnessFrame(
+        data=da_from_array(np.ones((47, 3)), chunks=(47, -1)),
+        sampling_rate=10.0,
+        bark_axis=bark_axis,
+        overlap=0.5,
+        channel_metadata=[ChannelMetadata(label="rough", unit="asper", ref=2.0, extra={"source": "mono"})],
+    )
+    path = tmp_path / "mono_roughness_metadata.nc"
+
+    original.to_netcdf(path)
+    restored = wd.open_netcdf(path)
+
+    assert restored.channels[0].label == "rough"
+    assert restored.channels[0].unit == "asper"
+    assert restored.channels[0].ref == 2.0
+    assert restored.channels[0].extra == {"source": "mono"}

--- a/tests/core/test_xarray_bridge.py
+++ b/tests/core/test_xarray_bridge.py
@@ -1,5 +1,6 @@
 import numpy as np
 import numpy.testing as npt
+import pytest
 
 import wandas as wd
 from wandas.core.metadata import ChannelMetadata
@@ -132,3 +133,45 @@ def test_frame_keeps_internal_xarray_storage_in_sync_with_data_property() -> Non
     assert frame._data is frame._xr.data
     assert frame._xr.chunks == ((1,), (2,))
     npt.assert_allclose(frame.compute(), np.array([[5.0, 6.0]]))
+
+
+def test_strict_time_core_operation_rejects_split_time_chunks() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.arange(64.0).reshape(1, -1), sampling_rate=128.0)
+    frame._data = frame._data.rechunk((1, 16))
+
+    with pytest.raises(ValueError, match="requires contiguous chunks along time"):
+        frame.low_pass_filter(10.0)
+
+
+def test_elementwise_operation_allows_split_time_chunks() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.array([[-1.0, 2.0, -3.0, 4.0]]), sampling_rate=4.0)
+    frame._data = frame._data.rechunk((1, 2))
+
+    result = frame.abs()
+
+    npt.assert_allclose(result.compute(), np.array([[1.0, 2.0, 3.0, 4.0]]))
+
+
+def test_netcdf_round_trip_preserves_channel_frame_schema(tmp_path) -> None:
+    original = wd.ChannelFrame.from_numpy(
+        np.array([[1.0, 2.0, 3.0]]),
+        sampling_rate=12.0,
+        label="io-signal",
+        metadata={"source": "netcdf-test"},
+        ch_labels=["mic"],
+        ch_units=["Pa"],
+    )
+    original.operation_history.append({"operation": "gain", "factor": 0.5})
+    path = tmp_path / "frame.nc"
+
+    original.to_netcdf(path)
+    restored = wd.open_netcdf(path)
+
+    assert isinstance(restored, wd.ChannelFrame)
+    assert restored.sampling_rate == original.sampling_rate
+    assert restored.label == original.label
+    assert restored.metadata == original.metadata
+    assert restored.operation_history == original.operation_history
+    assert restored.labels == original.labels
+    assert [ch.unit for ch in restored.channels] == ["Pa"]
+    npt.assert_allclose(restored.compute(), original.compute())

--- a/tests/core/test_xarray_bridge.py
+++ b/tests/core/test_xarray_bridge.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -263,3 +265,232 @@ def test_as_dask_channelwise_handles_scalar_and_1d_dataarrays() -> None:
     assert scalar.chunks == ()
     assert one_dim.shape == (2,)
     assert one_dim.chunks == ((2,),)
+
+
+def test_from_xarray_infers_channel_frame_when_schema_type_missing() -> None:
+    original = wd.ChannelFrame.from_numpy(
+        np.array([[1.0, 2.0, 3.0]]),
+        sampling_rate=10.0,
+        label="signal",
+        ch_labels=["mic"],
+    )
+    xr_data = original.to_xarray()
+    xr_data.attrs.pop("wandas_frame_type")
+
+    restored = wd.from_xarray(xr_data)
+
+    assert isinstance(restored, wd.ChannelFrame)
+    assert restored.labels == ["mic"]
+    npt.assert_allclose(restored.compute(), original.compute())
+
+
+def test_from_xarray_round_trips_spectral_frame() -> None:
+    original = SpectralFrame(
+        data=da_from_array(np.ones((1, 5), dtype=np.complex128), chunks=(1, -1)),
+        sampling_rate=16.0,
+        n_fft=8,
+        window="boxcar",
+        label="spectrum",
+    )
+
+    restored = wd.from_xarray(original.to_xarray())
+
+    assert isinstance(restored, SpectralFrame)
+    assert restored.n_fft == 8
+    assert restored.window == "boxcar"
+    npt.assert_allclose(restored.compute(), original.compute())
+
+
+def test_from_xarray_infers_spectral_frame_when_schema_type_missing() -> None:
+    original = SpectralFrame(
+        data=da_from_array(np.ones((1, 5), dtype=np.complex128), chunks=(1, -1)),
+        sampling_rate=16.0,
+        n_fft=8,
+    )
+    xr_data = original.to_xarray()
+    xr_data.attrs.pop("wandas_frame_type")
+
+    restored = wd.from_xarray(xr_data)
+
+    assert isinstance(restored, SpectralFrame)
+    npt.assert_allclose(restored.compute(), original.compute())
+
+
+def test_from_xarray_round_trips_spectrogram_frame() -> None:
+    original = SpectrogramFrame.from_numpy(
+        np.ones((1, 5, 3), dtype=np.complex128),
+        sampling_rate=16.0,
+        n_fft=8,
+        hop_length=2,
+        win_length=4,
+        window="boxcar",
+        label="stft",
+    )
+
+    restored = wd.from_xarray(original.to_xarray())
+
+    assert isinstance(restored, SpectrogramFrame)
+    assert restored.n_fft == 8
+    assert restored.hop_length == 2
+    assert restored.win_length == 4
+    assert restored.window == "boxcar"
+    npt.assert_allclose(restored.compute(), original.compute())
+
+
+def test_from_xarray_infers_spectrogram_frame_when_schema_type_missing() -> None:
+    original = SpectrogramFrame.from_numpy(
+        np.ones((1, 5, 3), dtype=np.complex128),
+        sampling_rate=16.0,
+        n_fft=8,
+        hop_length=2,
+    )
+    xr_data = original.to_xarray()
+    xr_data.attrs.pop("wandas_frame_type")
+
+    restored = wd.from_xarray(xr_data)
+
+    assert isinstance(restored, SpectrogramFrame)
+    npt.assert_allclose(restored.compute(), original.compute())
+
+
+def test_from_xarray_rejects_unknown_untyped_dims() -> None:
+    xr_data = xr.DataArray(
+        np.ones((2, 3)),
+        dims=("sensor", "sample"),
+        attrs={"sampling_rate": 10.0},
+    )
+
+    with pytest.raises(ValueError, match="Cannot infer Wandas frame type"):
+        wd.from_xarray(xr_data)
+
+
+def test_from_xarray_rejects_invalid_typed_dims() -> None:
+    xr_data = xr.DataArray(
+        np.ones((2, 3)),
+        dims=("time", "channel"),
+        attrs={"wandas_frame_type": "ChannelFrame", "sampling_rate": 10.0},
+    )
+
+    with pytest.raises(ValueError, match="Invalid dims for ChannelFrame"):
+        wd.from_xarray(xr_data)
+
+
+def test_from_xarray_rejects_unsupported_typed_frame() -> None:
+    xr_data = xr.DataArray(
+        np.ones((2, 3)),
+        dims=("row", "column"),
+        attrs={"wandas_frame_type": "UnknownFrame", "sampling_rate": 10.0},
+    )
+
+    with pytest.raises(ValueError, match="Unsupported Wandas xarray frame type"):
+        wd.from_xarray(xr_data)
+
+
+def test_to_xarray_uses_source_file_attr_from_metadata() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, 2.0]]), sampling_rate=2.0)
+    frame.metadata.source_file = "input.wav"
+
+    restored = wd.from_xarray(frame.to_xarray())
+
+    assert restored.metadata.source_file == "input.wav"
+
+
+def test_from_xarray_ignores_malformed_channel_extra_metadata() -> None:
+    frame = wd.ChannelFrame.from_numpy(
+        np.array([[1.0, 2.0], [3.0, 4.0]]),
+        sampling_rate=10.0,
+        ch_labels=["front", "rear"],
+    )
+    xr_data = frame.to_xarray()
+    xr_data.attrs["channel_extra"] = [{"role": "reference"}]
+
+    restored = wd.from_xarray(xr_data)
+
+    assert [ch.extra for ch in restored.channels] == [{}, {}]
+
+
+def test_noct_frame_to_xarray_includes_optional_band_coordinate() -> None:
+    from wandas.frames.noct import NOctFrame
+
+    frame = NOctFrame(
+        data=da_from_array(np.ones((1, 4)), chunks=(1, -1)),
+        sampling_rate=48_000,
+        fmin=100.0,
+        fmax=1000.0,
+        n=3,
+        G=10,
+        fr=1000,
+    )
+    bands = np.array([100.0, 125.0, 160.0, 200.0])
+    setattr(frame, "bands", bands)
+
+    xr_data = frame.to_xarray()
+
+    npt.assert_allclose(xr_data.coords["band"].values, bands)
+
+
+def test_coord_values_falls_back_for_missing_and_scalar_coords() -> None:
+    from wandas.xarray_bridge import _coord_values
+
+    xr_data = xr.DataArray(np.array([1.0, 2.0]), dims=("time",), coords={"unit": "Pa"})
+
+    assert _coord_values(xr_data, "missing", ["fallback"]) == ["fallback"]
+    assert _coord_values(xr_data, "unit", ["", ""]) == ["Pa", "Pa"]
+
+
+def test_strict_chunk_policy_allows_unchunked_xarray_data() -> None:
+    from wandas.processing.chunk_policy import validate_strict_chunks
+
+    class DummyFrame:
+        def to_xarray(self, *, copy: bool = False) -> xr.DataArray:
+            return xr.DataArray(np.ones((1, 4)), dims=("channel", "time"))
+
+    validate_strict_chunks(DummyFrame(), "lowpass_filter")
+
+
+def test_roughness_frame_to_xarray_uses_bark_time_schema() -> None:
+    from wandas.frames.roughness import RoughnessFrame
+
+    bark_axis = np.linspace(0.5, 23.5, 47)
+    frame = RoughnessFrame(
+        data=da_from_array(np.ones((47, 3)), chunks=(47, -1)),
+        sampling_rate=10.0,
+        bark_axis=bark_axis,
+        overlap=0.5,
+    )
+
+    xr_data = frame.to_xarray()
+
+    assert xr_data.dims == ("bark", "time")
+    npt.assert_allclose(xr_data.coords["bark"].values, bark_axis)
+    npt.assert_allclose(xr_data.coords["time"].values, frame.time)
+
+
+def test_multichannel_roughness_frame_to_xarray_uses_channel_bark_time_schema() -> None:
+    from wandas.frames.roughness import RoughnessFrame
+
+    bark_axis = np.linspace(0.5, 23.5, 47)
+    frame = RoughnessFrame(
+        data=da_from_array(np.ones((2, 47, 3)), chunks=(1, 47, -1)),
+        sampling_rate=10.0,
+        bark_axis=bark_axis,
+        overlap=0.5,
+        channel_metadata=[ChannelMetadata(label="left"), ChannelMetadata(label="right")],
+    )
+
+    xr_data = frame.to_xarray()
+
+    assert xr_data.dims == ("channel", "bark", "time")
+    npt.assert_array_equal(xr_data.coords["channel"].values, np.array(["left", "right"], dtype=object))
+    npt.assert_allclose(xr_data.coords["bark"].values, bark_axis)
+    npt.assert_allclose(xr_data.coords["time"].values, frame.time)
+
+
+def test_dims_for_frame_falls_back_to_positional_dim_names() -> None:
+    from types import SimpleNamespace
+
+    from wandas.xarray_bridge import _dims_for_frame
+
+    frame = SimpleNamespace(_data=np.ones((2, 3, 4)))
+
+    assert _dims_for_frame(cast(Any, frame)) == ("dim_0", "dim_1", "dim_2")

--- a/tests/core/test_xarray_bridge.py
+++ b/tests/core/test_xarray_bridge.py
@@ -649,3 +649,56 @@ def test_from_xarray_rejects_nonzero_start_channel_time_coordinate() -> None:
 
     with pytest.raises(ValueError, match="time coordinate"):
         wd.from_xarray(shifted)
+
+
+def test_from_xarray_infers_roughness_frame_without_schema_type() -> None:
+    from wandas.frames.roughness import RoughnessFrame
+
+    bark_axis = np.linspace(0.5, 23.5, 47)
+    original = RoughnessFrame(
+        data=da_from_array(np.ones((47, 3)), chunks=(47, -1)),
+        sampling_rate=10.0,
+        bark_axis=bark_axis,
+        overlap=0.5,
+    )
+    xr_data = original.to_xarray()
+    xr_data.attrs.pop("wandas_frame_type")
+
+    restored = wd.from_xarray(xr_data)
+
+    assert isinstance(restored, RoughnessFrame)
+    npt.assert_allclose(restored.compute(), original.compute())
+
+
+def test_from_xarray_rejects_invalid_roughness_dims() -> None:
+    xr_data = xr.DataArray(
+        np.ones((47, 3)),
+        dims=("bark", "sample"),
+        attrs={"wandas_frame_type": "RoughnessFrame", "sampling_rate": 10.0, "metadata": {"overlap": 0.5}},
+    )
+
+    with pytest.raises(ValueError, match="Invalid dims for RoughnessFrame"):
+        wd.from_xarray(xr_data)
+
+
+def test_channel_extra_list_fallback_still_rejects_malformed_lengths() -> None:
+    frame = wd.ChannelFrame.from_numpy(
+        np.array([[1.0, 2.0], [3.0, 4.0]]),
+        sampling_rate=10.0,
+        ch_labels=["front", "rear"],
+    )
+    xr_data = frame.to_xarray()
+    xr_data.attrs.pop("channel_extra_by_label")
+    xr_data.attrs["channel_extra"] = [{"role": "reference"}]
+
+    restored = wd.from_xarray(xr_data)
+
+    assert [ch.extra for ch in restored.channels] == [{}, {}]
+
+
+def test_axis_targets_dim_handles_none_string_and_nonmatching_axis() -> None:
+    from wandas.processing.chunk_policy import _axis_targets_dim
+
+    assert _axis_targets_dim(None, ("channel", "time"), "time")
+    assert _axis_targets_dim("time", ("channel", "time"), "time")
+    assert not _axis_targets_dim("frequency", ("channel", "time"), "time")

--- a/tests/core/test_xarray_bridge.py
+++ b/tests/core/test_xarray_bridge.py
@@ -1,6 +1,7 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
+import xarray as xr
 
 import wandas as wd
 from wandas.core.metadata import ChannelMetadata
@@ -175,3 +176,90 @@ def test_netcdf_round_trip_preserves_channel_frame_schema(tmp_path) -> None:
     assert restored.labels == original.labels
     assert [ch.unit for ch in restored.channels] == ["Pa"]
     npt.assert_allclose(restored.compute(), original.compute())
+
+
+def test_from_xarray_preserves_channel_extra_metadata() -> None:
+    frame = wd.ChannelFrame(
+        data=da_from_array(np.array([[1.0, 2.0], [3.0, 4.0]]), chunks=(1, -1)),
+        sampling_rate=10.0,
+        channel_metadata=[
+            ChannelMetadata(label="front", unit="Pa", extra={"role": "reference", "axis": "x"}),
+            ChannelMetadata(label="rear", unit="g", extra={"role": "response", "axis": "z"}),
+        ],
+    )
+
+    restored = wd.from_xarray(frame.to_xarray())
+
+    assert [ch.extra for ch in restored.channels] == [ch.extra for ch in frame.channels]
+    assert restored.get_channel(query={"role": "response"}).labels == ["rear"]
+
+
+def test_from_xarray_rejects_sliced_spectral_frequency_axis() -> None:
+    frame = SpectralFrame(
+        data=da_from_array(np.ones((1, 5), dtype=np.complex128), chunks=(1, -1)),
+        sampling_rate=16.0,
+        n_fft=8,
+    )
+    sliced = frame.to_xarray().isel(frequency=slice(0, 2))
+
+    with pytest.raises(ValueError, match="frequency dimension length"):
+        wd.from_xarray(sliced)
+
+
+def test_noct_frame_round_trips_through_xarray() -> None:
+    from wandas.frames.noct import NOctFrame
+
+    frame = NOctFrame(
+        data=da_from_array(np.ones((1, 4)), chunks=(1, -1)),
+        sampling_rate=48_000,
+        fmin=100.0,
+        fmax=1000.0,
+        n=3,
+        G=10,
+        fr=1000,
+        channel_metadata=[ChannelMetadata(label="mic", unit="Pa")],
+    )
+
+    restored = wd.from_xarray(frame.to_xarray())
+
+    assert isinstance(restored, NOctFrame)
+    assert restored.fmin == frame.fmin
+    assert restored.fmax == frame.fmax
+    assert restored.n == frame.n
+    assert restored.G == frame.G
+    assert restored.fr == frame.fr
+    npt.assert_allclose(restored.compute(), frame.compute())
+
+
+def test_normalize_axis_zero_allows_split_time_chunks() -> None:
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, 2.0, 3.0, 4.0], [2.0, 4.0, 6.0, 8.0]]), sampling_rate=4.0)
+    frame._data = frame._data.rechunk((1, 2))
+
+    result = frame.normalize(axis=0)
+
+    npt.assert_allclose(result.compute(), np.array([[0.5, 0.5, 0.5, 0.5], [1.0, 1.0, 1.0, 1.0]]))
+
+
+def test_netcdf_round_trip_encodes_nested_numpy_attrs(tmp_path) -> None:
+    frame = wd.ChannelFrame.from_numpy(np.array([[1.0, 2.0]]), sampling_rate=2.0)
+    frame.operation_history.append(
+        {"operation": "custom", "params": {"ref": np.array([1.0, 2.0]), "scale": np.float64(0.5)}}
+    )
+    path = tmp_path / "numpy_attrs.nc"
+
+    frame.to_netcdf(path)
+    restored = wd.open_netcdf(path)
+
+    assert restored.operation_history == [{"operation": "custom", "params": {"ref": [1.0, 2.0], "scale": 0.5}}]
+
+
+def test_as_dask_channelwise_handles_scalar_and_1d_dataarrays() -> None:
+    from wandas.xarray_bridge import _as_dask_channelwise
+
+    scalar = _as_dask_channelwise(xr.DataArray(np.array(1.0)))
+    one_dim = _as_dask_channelwise(xr.DataArray(np.array([1.0, 2.0]), dims=("time",)))
+
+    assert scalar.shape == ()
+    assert scalar.chunks == ()
+    assert one_dim.shape == (2,)
+    assert one_dim.chunks == ((2,),)

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -1118,7 +1118,7 @@ def test_reduce_channels_unsupported_op_raises() -> None:
     """_reduce_channels raises ValueError for unsupported operation (line 313)."""
     cf = ChannelFrame.from_numpy(np.random.default_rng(42).random((2, 100)), sampling_rate=1000)
     with pytest.raises(ValueError, match="Unsupported reduction operation"):
-        cf._reduce_channels("median")  # ty: ignore[call-non-callable]
+        cf._reduce_channels("median")
 
 
 def test_roughness_dw_spec_missing_bark_axis() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -4666,6 +4666,8 @@ dependencies = [
     { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tqdm" },
     { name = "types-requests" },
+    { name = "xarray", version = "2025.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "xarray", version = "2026.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -4717,6 +4719,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.13.0" },
     { name = "tqdm" },
     { name = "types-requests", specifier = ">=2.32.0.20250328" },
+    { name = "xarray", specifier = ">=2025.6.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -4987,6 +4990,42 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/01/3a/07cd60a9d26fe73efead61c7830af975dfdba8537632d410462672e4432b/wrapt-2.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:61c4956171c7434634401db448371277d07032a81cc21c599c22953374781395", size = 64038, upload-time = "2025-11-07T00:45:00.948Z" },
     { url = "https://files.pythonhosted.org/packages/41/99/8a06b8e17dddbf321325ae4eb12465804120f699cd1b8a355718300c62da/wrapt-2.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:35cdbd478607036fee40273be8ed54a451f5f23121bd9d4be515158f9498f7ad", size = 60634, upload-time = "2025-11-07T00:45:02.087Z" },
     { url = "https://files.pythonhosted.org/packages/15/d1/b51471c11592ff9c012bd3e2f7334a6ff2f42a7aed2caffcf0bdddc9cb89/wrapt-2.0.1-py3-none-any.whl", hash = "sha256:4d2ce1bf1a48c5277d7969259232b57645aae5686dba1eaeade39442277afbca", size = 44046, upload-time = "2025-11-07T00:45:32.116Z" },
+]
+
+[[package]]
+name = "xarray"
+version = "2025.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pandas", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/ec/e50d833518f10b0c24feb184b209bb6856f25b919ba8c1f89678b930b1cd/xarray-2025.6.1.tar.gz", hash = "sha256:a84f3f07544634a130d7dc615ae44175419f4c77957a7255161ed99c69c7c8b0", size = 3003185, upload-time = "2025-06-12T03:04:09.099Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/8a/6b50c1dd2260d407c1a499d47cf829f59f07007e0dcebafdabb24d1d26a5/xarray-2025.6.1-py3-none-any.whl", hash = "sha256:8b988b47f67a383bdc3b04c5db475cd165e580134c1f1943d52aee4a9c97651b", size = 1314739, upload-time = "2025-06-12T03:04:06.708Z" },
+]
+
+[[package]]
+name = "xarray"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pandas", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/a6/6fe936a798a3a38a79c7422d1a31afd2e9a14690fcb0ccff96bc01f04bf2/xarray-2026.4.0.tar.gz", hash = "sha256:c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b", size = 3132311, upload-time = "2026-04-13T19:45:36.688Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/83/6d810a8a9ebc9c307989b418840c20e46907c74d707beb67ab566773e6fc/xarray-2026.4.0-py3-none-any.whl", hash = "sha256:d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08", size = 1414326, upload-time = "2026-04-13T19:45:34.659Z" },
 ]
 
 [[package]]

--- a/wandas/__init__.py
+++ b/wandas/__init__.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 # Import from frames instead of core
 from .frames.channel import ChannelFrame
 from .utils import generate_sample
-from .xarray_bridge import from_xarray
+from .xarray_bridge import from_xarray, open_netcdf
 
 if TYPE_CHECKING:
     from .utils.frame_dataset import ChannelFrameDataset
@@ -24,6 +24,7 @@ __all__ = [
     "from_folder",
     "from_ndarray",
     "from_xarray",
+    "open_netcdf",
     "generate_sin",
     "read_csv",
     "read_wav",

--- a/wandas/__init__.py
+++ b/wandas/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 # Import from frames instead of core
 from .frames.channel import ChannelFrame
 from .utils import generate_sample
+from .xarray_bridge import from_xarray
 
 if TYPE_CHECKING:
     from .utils.frame_dataset import ChannelFrameDataset
@@ -18,7 +19,15 @@ from_numpy = ChannelFrame.from_numpy
 from_ndarray = ChannelFrame.from_ndarray
 
 generate_sin = generate_sample.generate_sin_lazy
-__all__ = ["ChannelFrameDataset", "from_folder", "from_ndarray", "generate_sin", "read_csv", "read_wav"]
+__all__ = [
+    "ChannelFrameDataset",
+    "from_folder",
+    "from_ndarray",
+    "from_xarray",
+    "generate_sin",
+    "read_csv",
+    "read_wav",
+]
 
 
 def from_folder(

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -220,7 +220,7 @@ class BaseFrame(ABC, Generic[T]):
         if not isinstance(self._data, DaArray):
             return
         channel_metadata = self._xr.attrs.get(_INTERNAL_CHANNEL_METADATA_ATTR)
-        refreshed = frame_to_xarray(self, copy_dataarray=False)
+        refreshed = frame_to_xarray(self, copy_dataarray=False, include_dense_coords=False)
         if channel_metadata is not None:
             refreshed.attrs[_INTERNAL_CHANNEL_METADATA_ATTR] = channel_metadata
         self._xr = refreshed
@@ -1274,13 +1274,10 @@ class BaseFrame(ABC, Generic[T]):
         self._sync_xarray_schema()
         if not copy:
             return self._xr
-        import copy as copy_module
 
-        data_array = self._xr.copy(deep=False)
-        data_array.attrs = copy_module.deepcopy(
-            {key: value for key, value in self._xr.attrs.items() if not key.startswith(_PRIVATE_XARRAY_ATTR_PREFIX)}
-        )
-        return data_array
+        from wandas.xarray_bridge import frame_to_xarray
+
+        return frame_to_xarray(self, copy_dataarray=True, include_dense_coords=True)
 
     @property
     def xr(self) -> Any:

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -853,6 +853,7 @@ class BaseFrame(ABC, Generic[T]):
         self,
         operation_name: str,
         params: dict[str, Any],
+        execution: dict[str, Any] | None = None,
     ) -> tuple[FrameMetadata, list[dict[str, Any]]]:
         """Build new metadata dict and operation history after an operation.
 
@@ -863,7 +864,10 @@ class BaseFrame(ABC, Generic[T]):
         """
         new_metadata = self.metadata.copy()
         new_metadata[operation_name] = params
-        new_history = [*self.operation_history, {"operation": operation_name, "params": params}]
+        history_entry: dict[str, Any] = {"operation": operation_name, "params": params}
+        if execution is not None:
+            history_entry["execution"] = execution
+        new_history = [*self.operation_history, history_entry]
         return new_metadata, new_history
 
     def _apply_operation_impl(self: S, operation_name: str, **params: Any) -> S:
@@ -878,12 +882,22 @@ class BaseFrame(ABC, Generic[T]):
         from wandas.processing import create_operation
 
         operation = create_operation(operation_name, self.sampling_rate, **params)
+        from wandas.processing.base import AudioOperation
         from wandas.processing.chunk_policy import validate_strict_chunks
 
         validate_strict_chunks(self, operation_name, params)
-        processed_data = operation.process(self._data)
+        if AudioOperation in type(operation).mro():
+            processed_data = operation.process_dataarray(self.to_xarray(copy=False))
+            execution = operation.get_execution_info()
+        else:
+            processed_data = operation.process(self._data)
+            execution = None
 
-        new_metadata, new_history = self._updated_metadata_and_history(operation_name, params)
+        new_metadata, new_history = self._updated_metadata_and_history(
+            operation_name,
+            params,
+            execution,
+        )
 
         return self._create_new_instance(
             data=processed_data,
@@ -940,13 +954,23 @@ class BaseFrame(ABC, Generic[T]):
         if operation_name is None:
             operation_name = getattr(operation, "name", "unknown_operation")
 
+        from wandas.processing.base import AudioOperation
         from wandas.processing.chunk_policy import validate_strict_chunks
 
         params = getattr(operation, "params", {})
         validate_strict_chunks(self, operation_name, params)
-        processed_data = operation.process(self._data)
+        if AudioOperation in type(operation).mro():
+            processed_data = operation.process_dataarray(self.to_xarray(copy=False))
+            execution = operation.get_execution_info()
+        else:
+            processed_data = operation.process(self._data)
+            execution = None
 
-        new_metadata, new_history = self._updated_metadata_and_history(operation_name, params)
+        new_metadata, new_history = self._updated_metadata_and_history(
+            operation_name,
+            params,
+            execution,
+        )
 
         metadata_updates = operation.get_metadata_updates()
 

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -5,6 +5,7 @@ import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator
 from re import Pattern
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
 
 import numpy as np
@@ -77,7 +78,7 @@ class BaseFrame(ABC, Generic[T]):
         History of operations performed on this frame.
     """
 
-    _data: DaArray
+    _xr: Any
     sampling_rate: float
     label: str
     metadata: FrameMetadata
@@ -160,12 +161,57 @@ class BaseFrame(ABC, Generic[T]):
                 ChannelMetadata(label=f"ch{i}", unit="", extra={}) for i in range(self._n_channels)
             ]
 
+        self._refresh_xarray_storage()
+
         try:
             # Display information for newer dask versions
             logger.debug(f"Dask graph layers: {list(self._data.dask.layers.keys())}")
             logger.debug(f"Dask graph dependencies: {len(self._data.dask.dependencies)}")
         except Exception as e:
             logger.debug(f"Dask graph visualization details unavailable: {e}")
+
+    @property
+    def _data(self) -> Any:
+        """Compatibility access to the xarray-backed array data."""
+        return self._xr.data
+
+    @_data.setter
+    def _data(self, data: Any) -> None:
+        """Update internal xarray storage while preserving the legacy `_data` API."""
+        self._set_xarray_data(data)
+
+    def _xarray_dims_for_data(self, data: Any) -> tuple[str, ...]:
+        """Return Wandas schema dims for *data* based on the frame type."""
+        frame_type = type(self).__name__
+        if frame_type == "ChannelFrame" and data.ndim == 2:
+            return ("channel", "time")
+        if frame_type == "SpectralFrame" and data.ndim == 2:
+            return ("channel", "frequency")
+        if frame_type == "SpectrogramFrame" and data.ndim == 3:
+            return ("channel", "frequency", "time")
+        if frame_type == "NOctFrame" and data.ndim == 2:
+            return ("channel", "band")
+        if frame_type == "RoughnessFrame" and data.ndim == 2:
+            return ("channel", "time")
+        return tuple(f"dim_{idx}" for idx in range(data.ndim))
+
+    def _set_xarray_data(self, data: Any) -> None:
+        """Set raw data into `_xr`; full coords are refreshed after metadata exists."""
+        import xarray as xr
+
+        if not isinstance(data, DaArray):
+            self._xr = SimpleNamespace(data=data)
+            return
+
+        self._xr = xr.DataArray(data, dims=self._xarray_dims_for_data(data))
+
+    def _refresh_xarray_storage(self) -> None:
+        """Refresh `_xr` so coords and attrs mirror the current frame metadata."""
+        from wandas.xarray_bridge import frame_to_xarray
+
+        if not isinstance(self._data, DaArray):
+            return
+        self._xr = frame_to_xarray(self, copy_dataarray=False)
 
     @property
     def _n_channels(self) -> int:

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -191,8 +191,11 @@ class BaseFrame(ABC, Generic[T]):
             return ("channel", "frequency", "time")
         if frame_type == "NOctFrame" and data.ndim == 2:
             return ("channel", "band")
-        if frame_type == "RoughnessFrame" and data.ndim == 2:
-            return ("channel", "time")
+        if frame_type == "RoughnessFrame":
+            if data.ndim == 2:
+                return ("bark", "time")
+            if data.ndim == 3:
+                return ("channel", "bark", "time")
         return tuple(f"dim_{idx}" for idx in range(data.ndim))
 
     def _set_xarray_data(self, data: Any) -> None:
@@ -875,6 +878,9 @@ class BaseFrame(ABC, Generic[T]):
         from wandas.processing import create_operation
 
         operation = create_operation(operation_name, self.sampling_rate, **params)
+        from wandas.processing.chunk_policy import validate_strict_chunks
+
+        validate_strict_chunks(self, operation_name)
         processed_data = operation.process(self._data)
 
         new_metadata, new_history = self._updated_metadata_and_history(operation_name, params)
@@ -931,10 +937,14 @@ class BaseFrame(ABC, Generic[T]):
             Extra constructor keyword arguments required by *output_frame_class*
             (e.g. ``{"n_fft": 1024, "window": "hann"}``).
         """
-        processed_data = operation.process(self._data)
-
         if operation_name is None:
             operation_name = getattr(operation, "name", "unknown_operation")
+
+        from wandas.processing.chunk_policy import validate_strict_chunks
+
+        validate_strict_chunks(self, operation_name)
+        processed_data = operation.process(self._data)
+
         params = getattr(operation, "params", {})
 
         new_metadata, new_history = self._updated_metadata_and_history(operation_name, params)
@@ -1101,6 +1111,12 @@ class BaseFrame(ABC, Generic[T]):
     def xr(self) -> Any:
         """Return an xarray DataArray view of this frame using the Wandas schema."""
         return self.to_xarray(copy=True)
+
+    def to_netcdf(self, path: str | Any) -> None:
+        """Write the frame to NetCDF using the Wandas xarray schema."""
+        from wandas.xarray_bridge import encode_attrs_for_netcdf
+
+        encode_attrs_for_netcdf(self.to_xarray(copy=True)).to_netcdf(path)
 
     def to_tensor(self, framework: str = "torch", device: str | None = None) -> Any:
         """

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -37,6 +37,8 @@ T = TypeVar("T", NDArrayComplex, NDArrayReal)
 S = TypeVar("S", bound="BaseFrame[Any]")
 S_Out = TypeVar("S_Out", bound="BaseFrame[Any]")
 QueryType = str | Pattern[str] | Callable[["ChannelMetadata"], bool] | dict[str, Any]
+_INTERNAL_CHANNEL_METADATA_ATTR = "_wandas_internal_channel_metadata"
+_PRIVATE_XARRAY_ATTR_PREFIX = "_wandas_internal_"
 
 
 class BaseFrame(ABC, Generic[T]):
@@ -79,11 +81,6 @@ class BaseFrame(ABC, Generic[T]):
     """
 
     _xr: Any
-    sampling_rate: float
-    label: str
-    metadata: FrameMetadata
-    operation_history: list[dict[str, Any]]
-    _channel_metadata: list[ChannelMetadata]
     _previous: "BaseFrame[Any] | None"
 
     def __init__(
@@ -199,22 +196,170 @@ class BaseFrame(ABC, Generic[T]):
         return tuple(f"dim_{idx}" for idx in range(data.ndim))
 
     def _set_xarray_data(self, data: Any) -> None:
-        """Set raw data into `_xr`; full coords are refreshed after metadata exists."""
+        """Set raw data into `_xr` while preserving existing schema attrs."""
         import xarray as xr
 
+        previous = getattr(self, "_xr", None)
+        attrs = copy.deepcopy(getattr(previous, "attrs", {}))
+        name = getattr(previous, "name", None)
+
         if not isinstance(data, DaArray):
-            self._xr = SimpleNamespace(data=data)
+            self._xr = SimpleNamespace(data=data, attrs=attrs, name=name)
             return
 
-        self._xr = xr.DataArray(data, dims=self._xarray_dims_for_data(data))
+        self._xr = xr.DataArray(data, dims=self._xarray_dims_for_data(data), attrs=attrs, name=name)
 
     def _refresh_xarray_storage(self) -> None:
         """Refresh `_xr` so coords and attrs mirror the current frame metadata."""
+        self._sync_xarray_schema()
+
+    def _sync_xarray_schema(self) -> None:
+        """Make the internal xarray object reflect the current Wandas schema."""
         from wandas.xarray_bridge import frame_to_xarray
 
         if not isinstance(self._data, DaArray):
             return
-        self._xr = frame_to_xarray(self, copy_dataarray=False)
+        channel_metadata = self._xr.attrs.get(_INTERNAL_CHANNEL_METADATA_ATTR)
+        refreshed = frame_to_xarray(self, copy_dataarray=False)
+        if channel_metadata is not None:
+            refreshed.attrs[_INTERNAL_CHANNEL_METADATA_ATTR] = channel_metadata
+        self._xr = refreshed
+
+    @property
+    def sampling_rate(self) -> float:
+        """Sampling rate stored in the authoritative xarray attrs."""
+        return self._xr.attrs.get("sampling_rate", 0.0)
+
+    @sampling_rate.setter
+    def sampling_rate(self, value: float) -> None:
+        self._xr.attrs["sampling_rate"] = value
+
+    @property
+    def label(self) -> str:
+        """Frame label stored in the authoritative xarray attrs/name."""
+        value = self._xr.attrs.get("label", self._xr.name)
+        if value is None:
+            return "unnamed_frame"
+        return str(value)
+
+    @label.setter
+    def label(self, value: str | None) -> None:
+        label = value or "unnamed_frame"
+        self._xr.attrs["label"] = label
+        self._xr.name = label
+
+    @property
+    def metadata(self) -> FrameMetadata:
+        """Frame metadata stored in the authoritative xarray attrs."""
+        value = self._xr.attrs.get("metadata")
+        if isinstance(value, FrameMetadata):
+            return value
+        if isinstance(value, dict):
+            metadata = FrameMetadata(value)
+        else:
+            metadata = FrameMetadata()
+        source_file = self._xr.attrs.get("source_file")
+        if source_file is not None:
+            metadata.source_file = str(source_file)
+        self._xr.attrs["metadata"] = metadata
+        return metadata
+
+    @metadata.setter
+    def metadata(self, value: FrameMetadata | dict[str, Any] | None) -> None:
+        if isinstance(value, FrameMetadata):
+            metadata = value
+        elif value is not None:
+            metadata = FrameMetadata(value)
+        else:
+            metadata = FrameMetadata()
+        self._xr.attrs["metadata"] = metadata
+        if metadata.source_file is not None:
+            self._xr.attrs["source_file"] = metadata.source_file
+        else:
+            self._xr.attrs.pop("source_file", None)
+
+    @property
+    def operation_history(self) -> list[dict[str, Any]]:
+        """Operation history stored in the authoritative xarray attrs."""
+        value = self._xr.attrs.get("operation_history")
+        if isinstance(value, list):
+            return value
+        history: list[dict[str, Any]] = []
+        self._xr.attrs["operation_history"] = history
+        return history
+
+    @operation_history.setter
+    def operation_history(self, value: list[dict[str, Any]] | None) -> None:
+        self._xr.attrs["operation_history"] = value or []
+
+    @property
+    def _channel_metadata(self) -> list[ChannelMetadata]:
+        """Channel metadata stored in the authoritative xarray attrs/coords."""
+        value = self._xr.attrs.get(_INTERNAL_CHANNEL_METADATA_ATTR)
+        if isinstance(value, list) and all(isinstance(ch, ChannelMetadata) for ch in value):
+            return value
+
+        public_value = self._xr.attrs.get("channel_metadata")
+        if isinstance(public_value, list):
+            metadata = []
+            for idx, item in enumerate(public_value):
+                if isinstance(item, ChannelMetadata):
+                    metadata.append(item.model_copy(deep=True))
+                elif isinstance(item, dict):
+                    raw_item = cast(dict[str, Any], item)
+                    extra = raw_item.get("extra", {})
+                    metadata.append(
+                        ChannelMetadata(
+                            label=str(raw_item.get("label", f"ch{idx}")),
+                            unit=str(raw_item.get("unit", "")),
+                            ref=float(raw_item.get("ref", 1.0)),
+                            extra=copy.deepcopy(extra) if isinstance(extra, dict) else {},
+                        )
+                    )
+            if metadata:
+                self._xr.attrs[_INTERNAL_CHANNEL_METADATA_ATTR] = metadata
+                return metadata
+
+        n_channels = int(self._xr.sizes.get("channel", self._xr.shape[0] if self._xr.ndim else 1))
+        labels = [f"ch{i}" for i in range(n_channels)]
+        if "channel" in self._xr.coords:
+            labels = [str(item) for item in self._xr.coords["channel"].values.tolist()]
+        units = [""] * n_channels
+        if "unit" in self._xr.coords:
+            units = [str(item) for item in self._xr.coords["unit"].values.tolist()]
+        refs = [1.0] * n_channels
+        if "ref" in self._xr.coords:
+            refs = [float(item) for item in self._xr.coords["ref"].values.tolist()]
+        metadata = [ChannelMetadata(label=labels[idx], unit=units[idx], ref=refs[idx]) for idx in range(n_channels)]
+        self._xr.attrs[_INTERNAL_CHANNEL_METADATA_ATTR] = metadata
+        return metadata
+
+    @_channel_metadata.setter
+    def _channel_metadata(self, value: list[ChannelMetadata] | list[dict[str, Any]]) -> None:
+        metadata: list[ChannelMetadata] = []
+        for idx, item in enumerate(value):
+            if isinstance(item, ChannelMetadata):
+                metadata.append(item.model_copy(deep=True))
+            elif isinstance(item, dict):
+                try:
+                    metadata.append(ChannelMetadata(**item))
+                except ValidationError as e:
+                    raise ValueError(
+                        f"Invalid channel_metadata at index {idx}\n"
+                        f"  Got: {item}\n"
+                        f"  Validation error: {e}\n"
+                        f"Ensure all dict keys match ChannelMetadata fields "
+                        f"(label, unit, ref, extra) and have correct types."
+                    ) from e
+            else:
+                raise TypeError(
+                    f"Invalid type in channel_metadata at index {idx}\n"
+                    f"  Got: {type(item).__name__} ({item!r})\n"
+                    f"  Expected: ChannelMetadata or dict\n"
+                    f"Use ChannelMetadata objects or dicts with valid fields."
+                )
+        self._xr.attrs[_INTERNAL_CHANNEL_METADATA_ATTR] = metadata
+        self._sync_xarray_schema()
 
     @property
     def _n_channels(self) -> int:
@@ -1126,9 +1271,16 @@ class BaseFrame(ABC, Generic[T]):
 
     def to_xarray(self, copy: bool = True) -> Any:
         """Convert the frame to an xarray DataArray using the Wandas schema."""
-        from wandas.xarray_bridge import frame_to_xarray
+        self._sync_xarray_schema()
+        if not copy:
+            return self._xr
+        import copy as copy_module
 
-        return frame_to_xarray(self, copy_dataarray=copy)
+        data_array = self._xr.copy(deep=False)
+        data_array.attrs = copy_module.deepcopy(
+            {key: value for key, value in self._xr.attrs.items() if not key.startswith(_PRIVATE_XARRAY_ATTR_PREFIX)}
+        )
+        return data_array
 
     @property
     def xr(self) -> Any:

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -1045,6 +1045,17 @@ class BaseFrame(ABC, Generic[T]):
         """
         return self.data
 
+    def to_xarray(self, copy: bool = True) -> Any:
+        """Convert the frame to an xarray DataArray using the Wandas schema."""
+        from wandas.xarray_bridge import frame_to_xarray
+
+        return frame_to_xarray(self, copy_dataarray=copy)
+
+    @property
+    def xr(self) -> Any:
+        """Return an xarray DataArray view of this frame using the Wandas schema."""
+        return self.to_xarray(copy=True)
+
     def to_tensor(self, framework: str = "torch", device: str | None = None) -> Any:
         """
         Convert the Dask array to a tensor in the specified framework.

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -880,7 +880,7 @@ class BaseFrame(ABC, Generic[T]):
         operation = create_operation(operation_name, self.sampling_rate, **params)
         from wandas.processing.chunk_policy import validate_strict_chunks
 
-        validate_strict_chunks(self, operation_name)
+        validate_strict_chunks(self, operation_name, params)
         processed_data = operation.process(self._data)
 
         new_metadata, new_history = self._updated_metadata_and_history(operation_name, params)
@@ -942,10 +942,9 @@ class BaseFrame(ABC, Generic[T]):
 
         from wandas.processing.chunk_policy import validate_strict_chunks
 
-        validate_strict_chunks(self, operation_name)
-        processed_data = operation.process(self._data)
-
         params = getattr(operation, "params", {})
+        validate_strict_chunks(self, operation_name, params)
+        processed_data = operation.process(self._data)
 
         new_metadata, new_history = self._updated_metadata_and_history(operation_name, params)
 
@@ -1109,7 +1108,7 @@ class BaseFrame(ABC, Generic[T]):
 
     @property
     def xr(self) -> Any:
-        """Return an xarray DataArray view of this frame using the Wandas schema."""
+        """Return an xarray DataArray copy of this frame using the Wandas schema."""
         return self.to_xarray(copy=True)
 
     def to_netcdf(self, path: str | Any) -> None:

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -877,6 +877,10 @@ class ChannelProcessingMixin:
         operation_name = "roughness_dw_spec"
         logger.debug(f"Applying operation={operation_name} with params={params} (lazy)")
 
+        from wandas.processing.chunk_policy import validate_strict_chunks
+
+        validate_strict_chunks(self, operation_name, params)
+
         # Create operation instance via factory
         operation = create_operation(operation_name, self.sampling_rate, **params)
 

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -147,7 +147,14 @@ class ChannelTransformMixin:
         operation = create_operation(operation_name, self.sampling_rate, **params)
         operation = cast("FFT", operation)
         # Apply processing to data
-        spectrum_data = operation.process(self._data)
+        from wandas.processing.base import AudioOperation
+
+        if AudioOperation in type(operation).mro():
+            spectrum_data = operation.process_dataarray(cast(BaseFrame[Any], self).to_xarray(copy=False))
+            execution = operation.get_execution_info()
+        else:
+            spectrum_data = operation.process(self._data)
+            execution = None
 
         logger.debug(f"Created new SpectralFrame with operation {operation_name} added to graph")
 
@@ -166,7 +173,11 @@ class ChannelTransformMixin:
             metadata=self.metadata.merged(window=window, n_fft=_n_fft),
             operation_history=[
                 *self.operation_history,
-                {"operation": "fft", "params": {"n_fft": _n_fft, "window": window}},
+                {
+                    "operation": "fft",
+                    "params": {"n_fft": _n_fft, "window": window},
+                    **({"execution": execution} if execution else {}),
+                },
             ],
             channel_metadata=self._channel_metadata,
             previous=self._as_base_frame,

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -46,6 +46,16 @@ def _build_cross_channel_metadata(
     return result
 
 
+def _validate_transform_chunks(
+    frame: TransformFrameProtocol,
+    operation_name: str,
+    params: dict[str, Any],
+) -> None:
+    from wandas.processing.chunk_policy import validate_strict_chunks
+
+    validate_strict_chunks(frame, operation_name, params)
+
+
 class ChannelTransformMixin:
     """Mixin providing methods related to frequency transformations.
 
@@ -74,6 +84,7 @@ class ChannelTransformMixin:
         from ..spectral import SpectralFrame
 
         logger.debug(f"Applying operation={operation_name} with params={params} (lazy)")
+        _validate_transform_chunks(self, operation_name, params)
 
         operation = create_operation(operation_name, self.sampling_rate, **params)
         result_data = operation.process(self._data)
@@ -130,6 +141,7 @@ class ChannelTransformMixin:
         params = {"n_fft": n_fft, "window": window}
         operation_name = "fft"
         logger.debug(f"Applying operation={operation_name} with params={params} (lazy)")
+        _validate_transform_chunks(self, operation_name, params)
 
         # Create operation instance
         operation = create_operation(operation_name, self.sampling_rate, **params)
@@ -193,6 +205,7 @@ class ChannelTransformMixin:
         }
         operation_name = "welch"
         logger.debug(f"Applying operation={operation_name} with params={params} (lazy)")
+        _validate_transform_chunks(self, operation_name, params)
 
         # Create operation instance
         operation = create_operation(operation_name, self.sampling_rate, **params)
@@ -244,6 +257,7 @@ class ChannelTransformMixin:
         params = {"fmin": fmin, "fmax": fmax, "n": n, "G": G, "fr": fr}
         operation_name = "noct_spectrum"
         logger.debug(f"Applying operation={operation_name} with params={params} (lazy)")
+        _validate_transform_chunks(self, operation_name, params)
 
         # Create operation instance
         operation = create_operation(operation_name, self.sampling_rate, **params)
@@ -309,6 +323,7 @@ class ChannelTransformMixin:
         }
         operation_name = "stft"
         logger.debug(f"Applying operation={operation_name} with params={params} (lazy)")
+        _validate_transform_chunks(self, operation_name, params)
 
         # Create operation instance
         operation = create_operation(operation_name, self.sampling_rate, **params)

--- a/wandas/frames/spectral.py
+++ b/wandas/frames/spectral.py
@@ -274,6 +274,9 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         params = {"n_fft": self.n_fft, "window": self.window}
         operation_name = "ifft"
         logger.debug(f"Applying operation={operation_name} with params={params} (lazy)")
+        from wandas.processing.chunk_policy import validate_strict_chunks
+
+        validate_strict_chunks(self, operation_name, params)
 
         # Create operation instance
         operation = create_operation(operation_name, self.sampling_rate, **params)
@@ -357,7 +360,11 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         params = {"fmin": fmin, "fmax": fmax, "n": n, "G": G, "fr": fr}
         operation_name = "noct_synthesis"
         logger.debug(f"Applying operation={operation_name} with params={params} (lazy)")
+        from wandas.processing.chunk_policy import validate_strict_chunks
+
         from ..processing import create_operation
+
+        validate_strict_chunks(self, operation_name, params)
 
         # Create operation instance
         operation = create_operation(operation_name, self.sampling_rate, **params)

--- a/wandas/frames/spectrogram.py
+++ b/wandas/frames/spectrogram.py
@@ -443,6 +443,9 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         }
         operation_name = "istft"
         logger.debug(f"Applying operation={operation_name} with params={params} (lazy)")
+        from wandas.processing.chunk_policy import validate_strict_chunks
+
+        validate_strict_chunks(self, operation_name, params)
 
         # Create operation instance
         operation = create_operation(operation_name, self.sampling_rate, **params)

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any, ClassVar, Generic, TypeVar
 
 import dask.array as da
+import xarray as xr
 from dask.array.core import Array as DaArray
 from dask.delayed import delayed
 
@@ -45,6 +46,7 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
         self.sampling_rate = sampling_rate
         self.pure = pure
         self.params = params
+        self._last_execution: dict[str, Any] | None = None
 
         # Validate parameters during initialization
         self.validate_params()
@@ -175,11 +177,35 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
         """
         return input_shape
 
+    def process_xarray(self, data_array: xr.DataArray) -> xr.DataArray | None:
+        """Return an xarray-native result, or ``None`` to use the legacy path."""
+        return None
+
+    def _set_execution_info(self, *, engine: str, mode: str, core_dims: list[str], **extra: Any) -> None:
+        """Record how the most recent operation was added to the graph."""
+        self._last_execution = {"engine": engine, "mode": mode, "core_dims": core_dims, **extra}
+
+    def get_execution_info(self) -> dict[str, Any] | None:
+        """Return execution metadata for the most recent processing call."""
+        return self._last_execution
+
+    def process_dataarray(self, data_array: xr.DataArray) -> DaArray:
+        """Execute the operation using xarray when the subclass supports it."""
+        self._last_execution = None
+        xarray_result = self.process_xarray(data_array)
+        if xarray_result is not None:
+            data = xarray_result.data
+            if not isinstance(data, DaArray):
+                data = da.from_array(data, chunks=xarray_result.shape)
+            return data
+        return self.process(data_array.data)
+
     def process(self, data: DaArray) -> DaArray:
         """
         Execute operation and return result
         data shape is (channels, samples)
         """
+        self._last_execution = None
         logger.debug("Adding delayed operation to computation graph")
         delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)

--- a/wandas/processing/chunk_policy.py
+++ b/wandas/processing/chunk_policy.py
@@ -22,6 +22,7 @@ STRICT_CORE_DIMS_BY_OPERATION: dict[str, tuple[str, ...]] = {
     "loudness_zwtv": ("time",),
     "loudness_zwst": ("time",),
     "roughness_dw": ("time",),
+    "roughness_dw_spec": ("time",),
     "sharpness_din": ("time",),
     "sharpness_din_st": ("time",),
     "ifft": ("frequency",),

--- a/wandas/processing/chunk_policy.py
+++ b/wandas/processing/chunk_policy.py
@@ -31,9 +31,13 @@ STRICT_CORE_DIMS_BY_OPERATION: dict[str, tuple[str, ...]] = {
 }
 
 
-def validate_strict_chunks(frame: Any, operation_name: str) -> None:
+def validate_strict_chunks(frame: Any, operation_name: str, params: dict[str, Any] | None = None) -> None:
     """Reject unsafe split chunks for operations with signal core dimensions."""
     core_dims = STRICT_CORE_DIMS_BY_OPERATION.get(operation_name)
+    if operation_name == "normalize":
+        axis = None if params is None else params.get("axis", -1)
+        if axis not in (-1, None, "time"):
+            return
     if not core_dims:
         return
 

--- a/wandas/processing/chunk_policy.py
+++ b/wandas/processing/chunk_policy.py
@@ -40,8 +40,8 @@ def validate_strict_chunks(frame: Any, operation_name: str, params: dict[str, An
 
     data_array = frame.to_xarray(copy=False)
     if operation_name == "normalize":
-        axis = None if params is None else params.get("axis", -1)
-        if not _axis_targets_dim(axis, data_array.dims, "time"):
+        axis = params.get("axis", -1) if params is not None else -1
+        if axis is None or not _axis_targets_dim(axis, data_array.dims, "time"):
             return
 
     if data_array.chunks is None:

--- a/wandas/processing/chunk_policy.py
+++ b/wandas/processing/chunk_policy.py
@@ -27,7 +27,7 @@ STRICT_CORE_DIMS_BY_OPERATION: dict[str, tuple[str, ...]] = {
     "ifft": ("frequency",),
     "istft": ("frequency", "time"),
     "noct_spectrum": ("time",),
-    "noct_synthesis": ("band",),
+    "noct_synthesis": ("frequency",),
 }
 
 

--- a/wandas/processing/chunk_policy.py
+++ b/wandas/processing/chunk_policy.py
@@ -34,14 +34,15 @@ STRICT_CORE_DIMS_BY_OPERATION: dict[str, tuple[str, ...]] = {
 def validate_strict_chunks(frame: Any, operation_name: str, params: dict[str, Any] | None = None) -> None:
     """Reject unsafe split chunks for operations with signal core dimensions."""
     core_dims = STRICT_CORE_DIMS_BY_OPERATION.get(operation_name)
-    if operation_name == "normalize":
-        axis = None if params is None else params.get("axis", -1)
-        if axis not in (-1, None, "time"):
-            return
     if not core_dims:
         return
 
     data_array = frame.to_xarray(copy=False)
+    if operation_name == "normalize":
+        axis = None if params is None else params.get("axis", -1)
+        if not _axis_targets_dim(axis, data_array.dims, "time"):
+            return
+
     if data_array.chunks is None:
         return
 
@@ -54,3 +55,14 @@ def validate_strict_chunks(frame: Any, operation_name: str, params: dict[str, An
                 f"  Got chunks for {dim}: {chunks}\n"
                 f"  Rechunk the frame so {dim} is a single chunk before running this operation."
             )
+
+
+def _axis_targets_dim(axis: Any, dims: tuple[str, ...], dim: str) -> bool:
+    if axis is None:
+        return True
+    if axis == dim:
+        return True
+    if isinstance(axis, int):
+        normalized = axis if axis >= 0 else len(dims) + axis
+        return 0 <= normalized < len(dims) and dims[normalized] == dim
+    return False

--- a/wandas/processing/chunk_policy.py
+++ b/wandas/processing/chunk_policy.py
@@ -1,0 +1,52 @@
+"""Signal-safe chunk policy validation for processing operations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+STRICT_CORE_DIMS_BY_OPERATION: dict[str, tuple[str, ...]] = {
+    "highpass_filter": ("time",),
+    "lowpass_filter": ("time",),
+    "bandpass_filter": ("time",),
+    "a_weighting": ("time",),
+    "normalize": ("time",),
+    "resampling": ("time",),
+    "rms_trend": ("time",),
+    "sound_level": ("time",),
+    "fft": ("time",),
+    "stft": ("time",),
+    "welch": ("time",),
+    "coherence": ("time",),
+    "csd": ("time",),
+    "transfer_function": ("time",),
+    "loudness_zwtv": ("time",),
+    "loudness_zwst": ("time",),
+    "roughness_dw": ("time",),
+    "sharpness_din": ("time",),
+    "sharpness_din_st": ("time",),
+    "ifft": ("frequency",),
+    "istft": ("frequency", "time"),
+    "noct_spectrum": ("time",),
+    "noct_synthesis": ("band",),
+}
+
+
+def validate_strict_chunks(frame: Any, operation_name: str) -> None:
+    """Reject unsafe split chunks for operations with signal core dimensions."""
+    core_dims = STRICT_CORE_DIMS_BY_OPERATION.get(operation_name)
+    if not core_dims:
+        return
+
+    data_array = frame.to_xarray(copy=False)
+    if data_array.chunks is None:
+        return
+
+    chunks_by_dim = dict(zip(data_array.dims, data_array.chunks, strict=True))
+    for dim in core_dims:
+        chunks = chunks_by_dim.get(dim)
+        if chunks is not None and len(chunks) > 1:
+            raise ValueError(
+                f"Operation '{operation_name}' requires contiguous chunks along {dim}\n"
+                f"  Got chunks for {dim}: {chunks}\n"
+                f"  Rechunk the frame so {dim} is a single chunk before running this operation."
+            )

--- a/wandas/processing/effects.py
+++ b/wandas/processing/effects.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 import numpy as np
+import xarray as xr
 from dask.array.core import Array as DaArray
 from librosa import effects
 from librosa import util as librosa_util
@@ -134,6 +135,32 @@ class Normalize(AudioOperation[NDArrayReal, NDArrayReal]):
             f"Initialized Normalize operation with norm={norm}, axis={axis}, threshold={threshold}, fill={fill}"
         )
 
+    def process_xarray(self, data_array: xr.DataArray) -> xr.DataArray | None:
+        """Normalize along the time core dimension via xarray.apply_ufunc."""
+        from wandas.processing.chunk_policy import _axis_targets_dim
+
+        dims = tuple(str(dim) for dim in data_array.dims)
+        if "time" not in dims or not _axis_targets_dim(self.axis, dims, "time"):
+            return None
+
+        def normalize_time(x: NDArrayReal) -> NDArrayReal:
+            result: NDArrayReal = librosa_util.normalize(
+                x, norm=self.norm, axis=-1, threshold=self.threshold, fill=self.fill
+            )
+            return result
+
+        normalized = xr.apply_ufunc(
+            normalize_time,
+            data_array,
+            input_core_dims=[["time"]],
+            output_core_dims=[["time"]],
+            dask="parallelized",
+            output_dtypes=[data_array.dtype],
+            keep_attrs=True,
+        ).transpose(*data_array.dims)
+        self._set_execution_info(engine="xarray.apply_ufunc", mode="strict", core_dims=["time"])
+        return normalized
+
     def _process_array(self, x: NDArrayReal) -> NDArrayReal:
         """Perform normalization processing"""
         logger.debug(f"Applying normalization to array with shape: {x.shape}, norm={self.norm}, axis={self.axis}")
@@ -167,6 +194,15 @@ class RemoveDC(AudioOperation[NDArrayReal, NDArrayReal]):
         """
         super().__init__(sampling_rate)
         logger.debug("Initialized RemoveDC operation")
+
+    def process_xarray(self, data_array: xr.DataArray) -> xr.DataArray | None:
+        """Remove the time-axis mean using exact xarray/Dask reductions."""
+        if "time" not in data_array.dims:
+            return None
+        result = data_array - data_array.mean(dim="time")
+        result.attrs = data_array.attrs.copy()
+        self._set_execution_info(engine="xarray", mode="exact-reduction", core_dims=["time"])
+        return result
 
     def _process_array(self, x: NDArrayReal) -> NDArrayReal:
         """Perform DC removal processing.

--- a/wandas/processing/effects.py
+++ b/wandas/processing/effects.py
@@ -139,6 +139,9 @@ class Normalize(AudioOperation[NDArrayReal, NDArrayReal]):
         """Normalize along the time core dimension via xarray.apply_ufunc."""
         from wandas.processing.chunk_policy import _axis_targets_dim
 
+        if self.axis is None:
+            return None
+
         dims = tuple(str(dim) for dim in data_array.dims)
         if "time" not in dims or not _axis_targets_dim(self.axis, dims, "time"):
             return None
@@ -199,7 +202,7 @@ class RemoveDC(AudioOperation[NDArrayReal, NDArrayReal]):
         """Remove the time-axis mean using exact xarray/Dask reductions."""
         if "time" not in data_array.dims:
             return None
-        result = data_array - data_array.mean(dim="time")
+        result = data_array - data_array.mean(dim="time", skipna=False)
         result.attrs = data_array.attrs.copy()
         self._set_execution_info(engine="xarray", mode="exact-reduction", core_dims=["time"])
         return result

--- a/wandas/processing/spectral.py
+++ b/wandas/processing/spectral.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 import numpy as np
+import xarray as xr
 from mosqito.sound_level_meter import noct_spectrum, noct_synthesis
 from mosqito.sound_level_meter.noct_spectrum._center_freq import _center_freq
 from scipy.signal import ShortTimeFFT
@@ -171,6 +172,32 @@ class FFT(AudioOperation[NDArrayReal, NDArrayComplex]):
         """
         n_freqs = self.n_fft // 2 + 1 if self.n_fft else input_shape[-1] // 2 + 1
         return (*input_shape[:-1], n_freqs)
+
+    def process_xarray(self, data_array: xr.DataArray) -> xr.DataArray | None:
+        """Apply FFT along the time core dimension via xarray.apply_ufunc."""
+        if "time" not in data_array.dims:
+            return None
+
+        n_freqs = self.calculate_output_shape(tuple(data_array.shape))[-1]
+        transformed = xr.apply_ufunc(
+            self._process_array,
+            data_array,
+            input_core_dims=[["time"]],
+            output_core_dims=[["frequency"]],
+            dask="parallelized",
+            output_dtypes=[np.dtype(np.complex128)],
+            dask_gufunc_kwargs={"output_sizes": {"frequency": n_freqs}},
+            keep_attrs=True,
+        )
+        leading_dims = tuple(dim for dim in data_array.dims if dim != "time")
+        transformed = transformed.transpose(*leading_dims, "frequency")
+        self._set_execution_info(
+            engine="xarray.apply_ufunc",
+            mode="strict",
+            core_dims=["time"],
+            output_core_dims=["frequency"],
+        )
+        return transformed
 
     def _process_array(self, x: NDArrayReal) -> NDArrayComplex:
         """Apply FFT to the input array."""

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -4,6 +4,7 @@ from typing import Any
 import dask.array as da
 import librosa
 import numpy as np
+import xarray as xr
 from dask.array.core import Array as DaArray
 from dask.delayed import delayed
 from scipy.signal import lfilter
@@ -296,6 +297,33 @@ class RmsTrend(AudioOperation[NDArrayReal, NDArrayReal]):
             hop_length=self.hop_length,
         ).shape[-1]
         return (*input_shape[:-1], n_frames)
+
+    def process_xarray(self, data_array: xr.DataArray) -> xr.DataArray | None:
+        """Calculate RMS trend along the time core dimension via xarray.apply_ufunc."""
+        if "time" not in data_array.dims:
+            return None
+
+        n_frames = self.calculate_output_shape(tuple(data_array.shape))[-1]
+        result = xr.apply_ufunc(
+            self._process_array,
+            data_array,
+            input_core_dims=[["time"]],
+            output_core_dims=[["time"]],
+            exclude_dims={"time"},
+            dask="parallelized",
+            output_dtypes=[data_array.dtype],
+            dask_gufunc_kwargs={"output_sizes": {"time": n_frames}},
+            keep_attrs=True,
+        )
+        leading_dims = tuple(dim for dim in data_array.dims if dim != "time")
+        result = result.transpose(*leading_dims, "time")
+        self._set_execution_info(
+            engine="xarray.apply_ufunc",
+            mode="strict",
+            core_dims=["time"],
+            output_core_dims=["time"],
+        )
+        return result
 
     def _process_array(self, x: NDArrayReal) -> NDArrayReal:
         """Create processor function for RMS calculation"""

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -300,7 +300,7 @@ class RmsTrend(AudioOperation[NDArrayReal, NDArrayReal]):
 
     def process_xarray(self, data_array: xr.DataArray) -> xr.DataArray | None:
         """Calculate RMS trend along the time core dimension via xarray.apply_ufunc."""
-        if "time" not in data_array.dims:
+        if "time" not in data_array.dims or self.dB or self.Aw:
             return None
 
         n_frames = self.calculate_output_shape(tuple(data_array.shape))[-1]

--- a/wandas/xarray_bridge.py
+++ b/wandas/xarray_bridge.py
@@ -40,6 +40,9 @@ def frame_to_xarray(frame: BaseFrame[Any], *, copy_dataarray: bool = True) -> xr
 
 def from_xarray(data_array: xr.DataArray) -> BaseFrame[Any]:
     """Create a Wandas frame from a Wandas-schema xarray DataArray."""
+    if data_array.attrs.get("wandas_attrs_encoding") == "json-v1" or data_array.attrs.get("wandas_complex_encoding"):
+        data_array = decode_attrs_from_netcdf(data_array)
+
     frame_type = str(data_array.attrs.get("wandas_frame_type", ""))
     if not frame_type:
         frame_type = _infer_frame_type(data_array)
@@ -194,6 +197,7 @@ def _attrs_for_frame(frame: BaseFrame[Any], frame_type: str) -> dict[str, Any]:
 
     if len(frame.channels) == frame.n_channels:
         attrs["channel_extra"] = copy.deepcopy([ch.extra for ch in frame.channels])
+        attrs["channel_extra_by_label"] = copy.deepcopy({ch.label: ch.extra for ch in frame.channels})
 
     for name in ("n_fft", "hop_length", "win_length", "window", "fmin", "fmax", "n", "G", "fr", "overlap"):
         if hasattr(frame, name):
@@ -236,6 +240,7 @@ def _validate_dims(data_array: xr.DataArray, frame_type: str) -> None:
 
 
 def _validate_frame_shape(data_array: xr.DataArray, frame_type: str) -> None:
+    _validate_time_coordinate(data_array, frame_type)
     if frame_type in {"SpectralFrame", "SpectrogramFrame"}:
         n_fft = int(data_array.attrs["n_fft"])
         expected_frequency = n_fft // 2 + 1
@@ -244,6 +249,13 @@ def _validate_frame_shape(data_array: xr.DataArray, frame_type: str) -> None:
             raise ValueError(
                 f"Invalid frequency dimension length for {frame_type}: "
                 f"expected {expected_frequency} from n_fft={n_fft}, got {actual_frequency}"
+            )
+        expected_coord = np.fft.rfftfreq(n_fft, d=1 / float(data_array.attrs["sampling_rate"]))
+        actual_coord = np.asarray(data_array.coords["frequency"].values, dtype=float)
+        if not np.allclose(actual_coord, expected_coord):
+            raise ValueError(
+                f"Invalid frequency coordinate for {frame_type}: "
+                "expected canonical ascending rfftfreq values from sampling_rate and n_fft"
             )
     if frame_type == "NOctFrame":
         expected_bands = _expected_noct_band_count(data_array.attrs)
@@ -268,6 +280,25 @@ def _expected_noct_band_count(attrs: dict[Any, Any]) -> int:
     return len(freqs)
 
 
+def _validate_time_coordinate(data_array: xr.DataArray, frame_type: str) -> None:
+    if "time" not in data_array.dims or "time" not in data_array.coords:
+        return
+
+    sampling_rate = float(data_array.attrs["sampling_rate"])
+    time_size = int(data_array.sizes["time"])
+    if frame_type == "SpectrogramFrame":
+        step = int(data_array.attrs["hop_length"]) / sampling_rate
+    else:
+        step = 1 / sampling_rate
+    expected = np.arange(time_size, dtype=float) * step
+    actual = np.asarray(data_array.coords["time"].values, dtype=float)
+    if not np.allclose(actual, expected):
+        raise ValueError(
+            f"Invalid time coordinate for {frame_type}: "
+            "expected canonical values starting at 0 from sampling_rate/hop_length"
+        )
+
+
 def _metadata_from_attrs(attrs: dict[Any, Any]) -> FrameMetadata:
     metadata = FrameMetadata(copy.deepcopy(attrs.get("metadata", {})))
     source_file = attrs.get("source_file")
@@ -281,14 +312,23 @@ def _channel_metadata_from_coords(data_array: xr.DataArray) -> list[ChannelMetad
     labels = _coord_values(data_array, "channel", [f"ch{i}" for i in range(n_channels)])
     units = _coord_values(data_array, "unit", [""] * n_channels)
     refs = _coord_values(data_array, "ref", [1.0] * n_channels)
-    extras = copy.deepcopy(data_array.attrs.get("channel_extra", [{} for _ in range(n_channels)]))
-    if not isinstance(extras, list) or len(extras) != n_channels:
-        extras = [{} for _ in range(n_channels)]
+    extras = _channel_extras_from_attrs(data_array.attrs, labels, n_channels)
 
     return [
         ChannelMetadata(label=str(labels[idx]), unit=str(units[idx]), ref=float(refs[idx]), extra=extras[idx])
         for idx in range(n_channels)
     ]
+
+
+def _channel_extras_from_attrs(attrs: dict[Any, Any], labels: list[Any], n_channels: int) -> list[dict[str, Any]]:
+    extras_by_label = attrs.get("channel_extra_by_label")
+    if isinstance(extras_by_label, dict):
+        return [copy.deepcopy(extras_by_label.get(str(label), {})) for label in labels]
+
+    extras = copy.deepcopy(attrs.get("channel_extra", [{} for _ in range(n_channels)]))
+    if not isinstance(extras, list) or len(extras) != n_channels:
+        return [{} for _ in range(n_channels)]
+    return extras
 
 
 def _coord_values(data_array: xr.DataArray, name: str, default: list[Any]) -> list[Any]:
@@ -332,7 +372,7 @@ def encode_attrs_for_netcdf(data_array: xr.DataArray) -> xr.DataArray:
     """Return a DataArray with NetCDF-safe Wandas attrs."""
     encoded = _encode_complex_for_netcdf(data_array)
     attrs = copy.deepcopy(dict(encoded.attrs))
-    for key in ("metadata", "operation_history", "channel_extra"):
+    for key in ("metadata", "operation_history", "channel_extra", "channel_extra_by_label"):
         if key in attrs:
             attrs[key] = json.dumps(_json_safe(attrs[key]))
     attrs["wandas_attrs_encoding"] = "json-v1"
@@ -345,7 +385,7 @@ def decode_attrs_from_netcdf(data_array: xr.DataArray) -> xr.DataArray:
     decoded = data_array.copy(deep=False)
     attrs = copy.deepcopy(dict(decoded.attrs))
     if attrs.get("wandas_attrs_encoding") == "json-v1":
-        for key in ("metadata", "operation_history", "channel_extra"):
+        for key in ("metadata", "operation_history", "channel_extra", "channel_extra_by_label"):
             if key in attrs and isinstance(attrs[key], str):
                 attrs[key] = json.loads(attrs[key])
         attrs.pop("wandas_attrs_encoding", None)

--- a/wandas/xarray_bridge.py
+++ b/wandas/xarray_bridge.py
@@ -248,6 +248,19 @@ def _infer_frame_type(data_array: xr.DataArray) -> str:
     raise ValueError(f"Cannot infer Wandas frame type from dims: {dims!r}")
 
 
+def _has_scalar_channel_coord(data_array: xr.DataArray) -> bool:
+    if "channel" in data_array.dims or "channel" not in data_array.coords:
+        return False
+    return np.ndim(data_array.coords["channel"].values) == 0
+
+
+def _valid_dims_for_frame(data_array: xr.DataArray, frame_type: str, expected: tuple[str, ...]) -> set[tuple[str, ...]]:
+    valid = {expected}
+    if _has_scalar_channel_coord(data_array) and expected and expected[0] == "channel":
+        valid.add(expected[1:])
+    return valid
+
+
 def _validate_dims(data_array: xr.DataArray, frame_type: str) -> None:
     expected = {
         "ChannelFrame": ("channel", "time"),
@@ -264,8 +277,10 @@ def _validate_dims(data_array: xr.DataArray, frame_type: str) -> None:
         return
     if expected is None:
         return
-    if tuple(data_array.dims) != expected:
-        raise ValueError(f"Invalid dims for {frame_type}: expected {expected}, got {tuple(data_array.dims)}")
+    valid_dims = _valid_dims_for_frame(data_array, frame_type, expected)
+    if tuple(data_array.dims) not in valid_dims:
+        expected_text = " or ".join(str(item) for item in sorted(valid_dims))
+        raise ValueError(f"Invalid dims for {frame_type}: expected {expected_text}, got {tuple(data_array.dims)}")
 
 
 def _validate_frame_shape(data_array: xr.DataArray, frame_type: str) -> None:
@@ -316,8 +331,12 @@ def _expected_noct_band_values(attrs: dict[Any, Any]) -> np.ndarray:
 
 
 def _validate_time_coordinate(data_array: xr.DataArray, frame_type: str) -> None:
-    if "time" not in data_array.dims or "time" not in data_array.coords:
+    if "time" not in data_array.dims:
         return
+    if "time" not in data_array.coords:
+        raise ValueError(
+            f"Invalid time coordinate for {frame_type}: Wandas imports require an explicit canonical time coordinate"
+        )
 
     sampling_rate = float(data_array.attrs["sampling_rate"])
     time_size = int(data_array.sizes["time"])

--- a/wandas/xarray_bridge.py
+++ b/wandas/xarray_bridge.py
@@ -16,6 +16,9 @@ if TYPE_CHECKING:
     from wandas.core.base_frame import BaseFrame
 
 
+_COMPLEX_COMPONENT_DIM = "complex_component"
+
+
 def frame_to_xarray(frame: BaseFrame[Any], *, copy_dataarray: bool = True) -> xr.DataArray:
     """Convert a Wandas frame to an xarray DataArray using the Wandas schema."""
     frame_type = type(frame).__name__
@@ -111,6 +114,22 @@ def from_xarray(data_array: xr.DataArray) -> BaseFrame[Any]:
             channel_metadata=channel_metadata,
         )
 
+    if frame_type == "RoughnessFrame":
+        from wandas.frames.roughness import RoughnessFrame
+
+        bark_axis = np.asarray(data_array.coords["bark"].values, dtype=float)
+        overlap = float(data_array.attrs.get("overlap", metadata.get("overlap", 0.0)))
+        return RoughnessFrame(
+            data=dask_data,
+            sampling_rate=sampling_rate,
+            bark_axis=bark_axis,
+            overlap=overlap,
+            label=label,
+            metadata=metadata,
+            operation_history=operation_history,
+            channel_metadata=channel_metadata if "channel" in data_array.dims else None,
+        )
+
     raise ValueError(f"Unsupported Wandas xarray frame type: {frame_type!r}")
 
 
@@ -176,7 +195,7 @@ def _attrs_for_frame(frame: BaseFrame[Any], frame_type: str) -> dict[str, Any]:
     if len(frame.channels) == frame.n_channels:
         attrs["channel_extra"] = copy.deepcopy([ch.extra for ch in frame.channels])
 
-    for name in ("n_fft", "hop_length", "win_length", "window", "fmin", "fmax", "n", "G", "fr"):
+    for name in ("n_fft", "hop_length", "win_length", "window", "fmin", "fmax", "n", "G", "fr", "overlap"):
         if hasattr(frame, name):
             attrs[name] = getattr(frame, name)
 
@@ -191,6 +210,8 @@ def _infer_frame_type(data_array: xr.DataArray) -> str:
         return "SpectralFrame"
     if dims == ("channel", "frequency", "time"):
         return "SpectrogramFrame"
+    if dims in {("bark", "time"), ("channel", "bark", "time")}:
+        return "RoughnessFrame"
     raise ValueError(f"Cannot infer Wandas frame type from dims: {dims!r}")
 
 
@@ -201,6 +222,13 @@ def _validate_dims(data_array: xr.DataArray, frame_type: str) -> None:
         "SpectrogramFrame": ("channel", "frequency", "time"),
         "NOctFrame": ("channel", "band"),
     }.get(frame_type)
+    if frame_type == "RoughnessFrame":
+        if tuple(data_array.dims) not in {("bark", "time"), ("channel", "bark", "time")}:
+            raise ValueError(
+                "Invalid dims for RoughnessFrame: expected "
+                f"('bark', 'time') or ('channel', 'bark', 'time'), got {tuple(data_array.dims)}"
+            )
+        return
     if expected is None:
         return
     if tuple(data_array.dims) != expected:
@@ -217,6 +245,27 @@ def _validate_frame_shape(data_array: xr.DataArray, frame_type: str) -> None:
                 f"Invalid frequency dimension length for {frame_type}: "
                 f"expected {expected_frequency} from n_fft={n_fft}, got {actual_frequency}"
             )
+    if frame_type == "NOctFrame":
+        expected_bands = _expected_noct_band_count(data_array.attrs)
+        actual_bands = int(data_array.sizes["band"])
+        if actual_bands != expected_bands:
+            raise ValueError(
+                f"Invalid band dimension length for NOctFrame: "
+                f"expected {expected_bands} from NOct attrs, got {actual_bands}"
+            )
+
+
+def _expected_noct_band_count(attrs: dict[Any, Any]) -> int:
+    from wandas.frames.noct import _center_freq
+
+    _, freqs = _center_freq(
+        fmin=float(attrs["fmin"]),
+        fmax=float(attrs["fmax"]),
+        n=int(attrs["n"]),
+        G=int(attrs["G"]),
+        fr=int(attrs["fr"]),
+    )
+    return len(freqs)
 
 
 def _metadata_from_attrs(attrs: dict[Any, Any]) -> FrameMetadata:
@@ -281,7 +330,7 @@ def _json_safe(value: Any) -> Any:
 
 def encode_attrs_for_netcdf(data_array: xr.DataArray) -> xr.DataArray:
     """Return a DataArray with NetCDF-safe Wandas attrs."""
-    encoded = data_array.copy(deep=False)
+    encoded = _encode_complex_for_netcdf(data_array)
     attrs = copy.deepcopy(dict(encoded.attrs))
     for key in ("metadata", "operation_history", "channel_extra"):
         if key in attrs:
@@ -300,6 +349,31 @@ def decode_attrs_from_netcdf(data_array: xr.DataArray) -> xr.DataArray:
             if key in attrs and isinstance(attrs[key], str):
                 attrs[key] = json.loads(attrs[key])
         attrs.pop("wandas_attrs_encoding", None)
+    decoded.attrs = attrs
+    return _decode_complex_from_netcdf(decoded)
+
+
+def _encode_complex_for_netcdf(data_array: xr.DataArray) -> xr.DataArray:
+    if not np.issubdtype(data_array.dtype, np.complexfloating):
+        return data_array.copy(deep=False)
+
+    encoded = xr.concat(
+        [data_array.real, data_array.imag],
+        dim=xr.IndexVariable(_COMPLEX_COMPONENT_DIM, ["real", "imag"]),
+    ).transpose(*data_array.dims, _COMPLEX_COMPONENT_DIM)
+    encoded.attrs = copy.deepcopy(dict(data_array.attrs))
+    encoded.attrs["wandas_complex_encoding"] = "real-imag-v1"
+    return encoded
+
+
+def _decode_complex_from_netcdf(data_array: xr.DataArray) -> xr.DataArray:
+    if data_array.attrs.get("wandas_complex_encoding") != "real-imag-v1":
+        return data_array
+
+    attrs = copy.deepcopy(dict(data_array.attrs))
+    attrs.pop("wandas_complex_encoding", None)
+    decoded = data_array.sel({_COMPLEX_COMPONENT_DIM: "real"}) + 1j * data_array.sel({_COMPLEX_COMPONENT_DIM: "imag"})
+    decoded = decoded.drop_vars(_COMPLEX_COMPONENT_DIM, errors="ignore")
     decoded.attrs = attrs
     return decoded
 

--- a/wandas/xarray_bridge.py
+++ b/wandas/xarray_bridge.py
@@ -1,0 +1,215 @@
+"""xarray conversion helpers for Wandas frames."""
+
+from __future__ import annotations
+
+import copy
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import xarray as xr
+
+from wandas.core.metadata import ChannelMetadata, FrameMetadata
+from wandas.utils.dask_helpers import da_from_array
+
+if TYPE_CHECKING:
+    from wandas.core.base_frame import BaseFrame
+
+
+def frame_to_xarray(frame: BaseFrame[Any], *, copy_dataarray: bool = True) -> xr.DataArray:
+    """Convert a Wandas frame to an xarray DataArray using the Wandas schema."""
+    frame_type = type(frame).__name__
+    dims = _dims_for_frame(frame)
+    coords = _coords_for_frame(frame, dims)
+    attrs = _attrs_for_frame(frame, frame_type)
+
+    data_array = xr.DataArray(
+        frame._data,
+        dims=dims,
+        coords=coords,
+        attrs=attrs,
+        name=frame.label,
+    )
+    if copy_dataarray:
+        return data_array.copy(deep=False)
+    return data_array
+
+
+def from_xarray(data_array: xr.DataArray) -> BaseFrame[Any]:
+    """Create a Wandas frame from a Wandas-schema xarray DataArray."""
+    frame_type = str(data_array.attrs.get("wandas_frame_type", ""))
+    if not frame_type:
+        frame_type = _infer_frame_type(data_array)
+
+    _validate_dims(data_array, frame_type)
+
+    sampling_rate = float(data_array.attrs["sampling_rate"])
+    label_attr = data_array.attrs.get("label")
+    label = str(label_attr) if label_attr is not None else None
+    metadata = _metadata_from_attrs(data_array.attrs)
+    operation_history = copy.deepcopy(data_array.attrs.get("operation_history", []))
+    channel_metadata = _channel_metadata_from_coords(data_array)
+    dask_data = _as_dask_channelwise(data_array)
+
+    if frame_type == "ChannelFrame":
+        from wandas.frames.channel import ChannelFrame
+
+        return ChannelFrame(
+            data=dask_data,
+            sampling_rate=sampling_rate,
+            label=label,
+            metadata=metadata,
+            operation_history=operation_history,
+            channel_metadata=channel_metadata,
+        )
+
+    if frame_type == "SpectralFrame":
+        from wandas.frames.spectral import SpectralFrame
+
+        return SpectralFrame(
+            data=dask_data,
+            sampling_rate=sampling_rate,
+            n_fft=int(data_array.attrs["n_fft"]),
+            window=str(data_array.attrs.get("window", "hann")),
+            label=label,
+            metadata=metadata,
+            operation_history=operation_history,
+            channel_metadata=channel_metadata,
+        )
+
+    if frame_type == "SpectrogramFrame":
+        from wandas.frames.spectrogram import SpectrogramFrame
+
+        return SpectrogramFrame(
+            data=dask_data,
+            sampling_rate=sampling_rate,
+            n_fft=int(data_array.attrs["n_fft"]),
+            hop_length=int(data_array.attrs["hop_length"]),
+            win_length=int(data_array.attrs.get("win_length", data_array.attrs["n_fft"])),
+            window=str(data_array.attrs.get("window", "hann")),
+            label=label,
+            metadata=metadata,
+            operation_history=operation_history,
+            channel_metadata=channel_metadata,
+        )
+
+    raise ValueError(f"Unsupported Wandas xarray frame type: {frame_type!r}")
+
+
+def _dims_for_frame(frame: BaseFrame[Any]) -> tuple[str, ...]:
+    frame_type = type(frame).__name__
+    if frame_type == "ChannelFrame":
+        return ("channel", "time")
+    if frame_type == "SpectralFrame":
+        return ("channel", "frequency")
+    if frame_type == "SpectrogramFrame":
+        return ("channel", "frequency", "time")
+    if frame_type == "NOctFrame":
+        return ("channel", "band")
+    if frame_type == "RoughnessFrame":
+        return ("channel", "time")
+    return tuple(f"dim_{idx}" for idx in range(frame._data.ndim))
+
+
+def _coords_for_frame(frame: BaseFrame[Any], dims: tuple[str, ...]) -> dict[str, Any]:
+    coords: dict[str, Any] = {}
+    if "channel" in dims:
+        coords["channel"] = np.asarray(frame.labels, dtype=object)
+        coords["unit"] = ("channel", np.asarray([ch.unit for ch in frame.channels], dtype=object))
+        coords["ref"] = ("channel", np.asarray([ch.ref for ch in frame.channels], dtype=float))
+
+    if "time" in dims:
+        if hasattr(frame, "times"):
+            coords["time"] = np.asarray(getattr(frame, "times"), dtype=float)
+        else:
+            coords["time"] = np.asarray(getattr(frame, "time"), dtype=float)
+
+    if "frequency" in dims:
+        coords["frequency"] = np.asarray(getattr(frame, "freqs"), dtype=float)
+
+    if "band" in dims and hasattr(frame, "bands"):
+        coords["band"] = np.asarray(getattr(frame, "bands"), dtype=float)
+
+    return coords
+
+
+def _attrs_for_frame(frame: BaseFrame[Any], frame_type: str) -> dict[str, Any]:
+    attrs: dict[str, Any] = {
+        "wandas_frame_type": frame_type,
+        "sampling_rate": frame.sampling_rate,
+        "label": frame.label,
+        "metadata": copy.deepcopy(dict(frame.metadata)),
+        "operation_history": copy.deepcopy(frame.operation_history),
+    }
+    source_file = getattr(frame.metadata, "source_file", None)
+    if source_file is not None:
+        attrs["source_file"] = source_file
+
+    for name in ("n_fft", "hop_length", "win_length", "window"):
+        if hasattr(frame, name):
+            attrs[name] = getattr(frame, name)
+
+    return attrs
+
+
+def _infer_frame_type(data_array: xr.DataArray) -> str:
+    dims = tuple(data_array.dims)
+    if dims == ("channel", "time"):
+        return "ChannelFrame"
+    if dims == ("channel", "frequency"):
+        return "SpectralFrame"
+    if dims == ("channel", "frequency", "time"):
+        return "SpectrogramFrame"
+    raise ValueError(f"Cannot infer Wandas frame type from dims: {dims!r}")
+
+
+def _validate_dims(data_array: xr.DataArray, frame_type: str) -> None:
+    expected = {
+        "ChannelFrame": ("channel", "time"),
+        "SpectralFrame": ("channel", "frequency"),
+        "SpectrogramFrame": ("channel", "frequency", "time"),
+    }.get(frame_type)
+    if expected is None:
+        return
+    if tuple(data_array.dims) != expected:
+        raise ValueError(f"Invalid dims for {frame_type}: expected {expected}, got {tuple(data_array.dims)}")
+
+
+def _metadata_from_attrs(attrs: dict[Any, Any]) -> FrameMetadata:
+    metadata = FrameMetadata(copy.deepcopy(attrs.get("metadata", {})))
+    source_file = attrs.get("source_file")
+    if source_file is not None:
+        metadata.source_file = str(source_file)
+    return metadata
+
+
+def _channel_metadata_from_coords(data_array: xr.DataArray) -> list[ChannelMetadata]:
+    n_channels = int(data_array.sizes.get("channel", 1))
+    labels = _coord_values(data_array, "channel", [f"ch{i}" for i in range(n_channels)])
+    units = _coord_values(data_array, "unit", [""] * n_channels)
+    refs = _coord_values(data_array, "ref", [1.0] * n_channels)
+
+    return [
+        ChannelMetadata(label=str(labels[idx]), unit=str(units[idx]), ref=float(refs[idx])) for idx in range(n_channels)
+    ]
+
+
+def _coord_values(data_array: xr.DataArray, name: str, default: list[Any]) -> list[Any]:
+    if name not in data_array.coords:
+        return default
+    values = data_array.coords[name].values
+    if np.ndim(values) == 0:
+        return [values.item()] * len(default)
+    return list(values)
+
+
+def _as_dask_channelwise(data_array: xr.DataArray) -> Any:
+    data = data_array.data
+    if hasattr(data, "rechunk"):
+        dask_data = data
+    else:
+        dask_data = da_from_array(np.asarray(data), chunks=tuple([1] + [-1] * (data_array.ndim - 1)))
+
+    if data_array.ndim >= 2:
+        chunks = tuple([1] + [-1] * (data_array.ndim - 1))
+        return dask_data.rechunk(chunks)
+    return dask_data.rechunk((-1,))

--- a/wandas/xarray_bridge.py
+++ b/wandas/xarray_bridge.py
@@ -130,7 +130,7 @@ def from_xarray(data_array: xr.DataArray) -> BaseFrame[Any]:
             label=label,
             metadata=metadata,
             operation_history=operation_history,
-            channel_metadata=channel_metadata if "channel" in data_array.dims else None,
+            channel_metadata=channel_metadata,
         )
 
     raise ValueError(f"Unsupported Wandas xarray frame type: {frame_type!r}")
@@ -174,8 +174,18 @@ def _coords_for_frame(frame: BaseFrame[Any], dims: tuple[str, ...]) -> dict[str,
     if "frequency" in dims:
         coords["frequency"] = np.asarray(getattr(frame, "freqs"), dtype=float)
 
-    if "band" in dims and hasattr(frame, "bands"):
-        coords["band"] = np.asarray(getattr(frame, "bands"), dtype=float)
+    if "band" in dims:
+        band_size = int(frame._data.shape[dims.index("band")])
+        band_values: np.ndarray[Any, Any] | None = None
+        try:
+            band_values = np.asarray(getattr(frame, "bands"), dtype=float)
+        except AttributeError:
+            try:
+                band_values = np.asarray(getattr(frame, "freqs"), dtype=float)
+            except (AttributeError, ValueError):
+                band_values = None
+        if band_values is not None and len(band_values) == band_size:
+            coords["band"] = band_values
 
     if "bark" in dims and hasattr(frame, "bark_axis"):
         coords["bark"] = np.asarray(getattr(frame, "bark_axis"), dtype=float)
@@ -198,6 +208,9 @@ def _attrs_for_frame(frame: BaseFrame[Any], frame_type: str) -> dict[str, Any]:
     if len(frame.channels) == frame.n_channels:
         attrs["channel_extra"] = copy.deepcopy([ch.extra for ch in frame.channels])
         attrs["channel_extra_by_label"] = copy.deepcopy({ch.label: ch.extra for ch in frame.channels})
+        attrs["channel_metadata"] = copy.deepcopy(
+            [{"label": ch.label, "unit": ch.unit, "ref": ch.ref, "extra": ch.extra} for ch in frame.channels]
+        )
 
     for name in ("n_fft", "hop_length", "win_length", "window", "fmin", "fmax", "n", "G", "fr", "overlap"):
         if hasattr(frame, name):
@@ -258,16 +271,22 @@ def _validate_frame_shape(data_array: xr.DataArray, frame_type: str) -> None:
                 "expected canonical ascending rfftfreq values from sampling_rate and n_fft"
             )
     if frame_type == "NOctFrame":
-        expected_bands = _expected_noct_band_count(data_array.attrs)
+        expected_coord = _expected_noct_band_values(data_array.attrs)
+        expected_bands = len(expected_coord)
         actual_bands = int(data_array.sizes["band"])
         if actual_bands != expected_bands:
             raise ValueError(
                 f"Invalid band dimension length for NOctFrame: "
                 f"expected {expected_bands} from NOct attrs, got {actual_bands}"
             )
+        actual_coord = np.asarray(data_array.coords["band"].values, dtype=float)
+        if not np.allclose(actual_coord, expected_coord):
+            raise ValueError(
+                "Invalid band coordinate for NOctFrame: expected canonical center frequencies from fmin/fmax/n/G/fr"
+            )
 
 
-def _expected_noct_band_count(attrs: dict[Any, Any]) -> int:
+def _expected_noct_band_values(attrs: dict[Any, Any]) -> np.ndarray:
     from wandas.frames.noct import _center_freq
 
     _, freqs = _center_freq(
@@ -277,7 +296,7 @@ def _expected_noct_band_count(attrs: dict[Any, Any]) -> int:
         G=int(attrs["G"]),
         fr=int(attrs["fr"]),
     )
-    return len(freqs)
+    return np.asarray(freqs, dtype=float)
 
 
 def _validate_time_coordinate(data_array: xr.DataArray, frame_type: str) -> None:
@@ -308,6 +327,11 @@ def _metadata_from_attrs(attrs: dict[Any, Any]) -> FrameMetadata:
 
 
 def _channel_metadata_from_coords(data_array: xr.DataArray) -> list[ChannelMetadata]:
+    if "channel" not in data_array.dims:
+        encoded = data_array.attrs.get("channel_metadata")
+        if isinstance(encoded, list):
+            return _channel_metadata_from_attrs(encoded)
+
     n_channels = int(data_array.sizes.get("channel", 1))
     labels = _coord_values(data_array, "channel", [f"ch{i}" for i in range(n_channels)])
     units = _coord_values(data_array, "unit", [""] * n_channels)
@@ -318,6 +342,23 @@ def _channel_metadata_from_coords(data_array: xr.DataArray) -> list[ChannelMetad
         ChannelMetadata(label=str(labels[idx]), unit=str(units[idx]), ref=float(refs[idx]), extra=extras[idx])
         for idx in range(n_channels)
     ]
+
+
+def _channel_metadata_from_attrs(encoded: list[Any]) -> list[ChannelMetadata]:
+    metadata: list[ChannelMetadata] = []
+    for idx, item in enumerate(encoded):
+        if not isinstance(item, dict):
+            continue
+        extra = copy.deepcopy(item.get("extra", {}))
+        metadata.append(
+            ChannelMetadata(
+                label=str(item.get("label", f"ch{idx}")),
+                unit=str(item.get("unit", "")),
+                ref=float(item.get("ref", 1.0)),
+                extra=extra if isinstance(extra, dict) else {},
+            )
+        )
+    return metadata
 
 
 def _channel_extras_from_attrs(attrs: dict[Any, Any], labels: list[Any], n_channels: int) -> list[dict[str, Any]]:
@@ -372,7 +413,7 @@ def encode_attrs_for_netcdf(data_array: xr.DataArray) -> xr.DataArray:
     """Return a DataArray with NetCDF-safe Wandas attrs."""
     encoded = _encode_complex_for_netcdf(data_array)
     attrs = copy.deepcopy(dict(encoded.attrs))
-    for key in ("metadata", "operation_history", "channel_extra", "channel_extra_by_label"):
+    for key in ("metadata", "operation_history", "channel_extra", "channel_extra_by_label", "channel_metadata"):
         if key in attrs:
             attrs[key] = json.dumps(_json_safe(attrs[key]))
     attrs["wandas_attrs_encoding"] = "json-v1"
@@ -385,7 +426,7 @@ def decode_attrs_from_netcdf(data_array: xr.DataArray) -> xr.DataArray:
     decoded = data_array.copy(deep=False)
     attrs = copy.deepcopy(dict(decoded.attrs))
     if attrs.get("wandas_attrs_encoding") == "json-v1":
-        for key in ("metadata", "operation_history", "channel_extra", "channel_extra_by_label"):
+        for key in ("metadata", "operation_history", "channel_extra", "channel_extra_by_label", "channel_metadata"):
             if key in attrs and isinstance(attrs[key], str):
                 attrs[key] = json.loads(attrs[key])
         attrs.pop("wandas_attrs_encoding", None)

--- a/wandas/xarray_bridge.py
+++ b/wandas/xarray_bridge.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import xarray as xr
+from dask.array.core import Array as DaArray
 
 from wandas.core.metadata import ChannelMetadata, FrameMetadata
 from wandas.utils.dask_helpers import da_from_array
@@ -19,11 +20,16 @@ if TYPE_CHECKING:
 _COMPLEX_COMPONENT_DIM = "complex_component"
 
 
-def frame_to_xarray(frame: BaseFrame[Any], *, copy_dataarray: bool = True) -> xr.DataArray:
+def frame_to_xarray(
+    frame: BaseFrame[Any],
+    *,
+    copy_dataarray: bool = True,
+    include_dense_coords: bool = True,
+) -> xr.DataArray:
     """Convert a Wandas frame to an xarray DataArray using the Wandas schema."""
     frame_type = type(frame).__name__
     dims = _dims_for_frame(frame)
-    coords = _coords_for_frame(frame, dims)
+    coords = _coords_for_frame(frame, dims, include_dense_coords=include_dense_coords)
     attrs = _attrs_for_frame(frame, frame_type)
 
     data_array = xr.DataArray(
@@ -154,7 +160,12 @@ def _dims_for_frame(frame: BaseFrame[Any]) -> tuple[str, ...]:
     return tuple(f"dim_{idx}" for idx in range(frame._data.ndim))
 
 
-def _coords_for_frame(frame: BaseFrame[Any], dims: tuple[str, ...]) -> dict[str, Any]:
+def _coords_for_frame(
+    frame: BaseFrame[Any],
+    dims: tuple[str, ...],
+    *,
+    include_dense_coords: bool = True,
+) -> dict[str, Any]:
     coords: dict[str, Any] = {}
     if "channel" in dims:
         channel_size = int(frame._data.shape[dims.index("channel")])
@@ -165,7 +176,7 @@ def _coords_for_frame(frame: BaseFrame[Any], dims: tuple[str, ...]) -> dict[str,
         coords["unit"] = ("channel", np.asarray(units, dtype=object))
         coords["ref"] = ("channel", np.asarray(refs, dtype=float))
 
-    if "time" in dims:
+    if "time" in dims and include_dense_coords:
         if hasattr(frame, "times"):
             coords["time"] = np.asarray(getattr(frame, "times"), dtype=float)
         else:
@@ -186,6 +197,11 @@ def _coords_for_frame(frame: BaseFrame[Any], dims: tuple[str, ...]) -> dict[str,
                 band_values = None
         if band_values is not None and len(band_values) == band_size:
             coords["band"] = band_values
+        elif include_dense_coords and type(frame).__name__ == "NOctFrame":
+            raise ValueError(
+                "NOctFrame xarray export requires a valid band coordinate; "
+                "set fmin/fmax/n/G/fr so canonical bands match the data shape."
+            )
 
     if "bark" in dims and hasattr(frame, "bark_axis"):
         coords["bark"] = np.asarray(getattr(frame, "bark_axis"), dtype=float)
@@ -329,6 +345,15 @@ def _metadata_from_attrs(attrs: dict[Any, Any]) -> FrameMetadata:
 def _channel_metadata_from_coords(data_array: xr.DataArray) -> list[ChannelMetadata]:
     if "channel" not in data_array.dims:
         encoded = data_array.attrs.get("channel_metadata")
+        if "channel" in data_array.coords:
+            selected_label = str(data_array.coords["channel"].item())
+            if isinstance(encoded, list):
+                for item in _channel_metadata_from_attrs(encoded):
+                    if item.label == selected_label:
+                        return [item]
+            extras_by_label = data_array.attrs.get("channel_extra_by_label")
+            extra = copy.deepcopy(extras_by_label.get(selected_label, {})) if isinstance(extras_by_label, dict) else {}
+            return [ChannelMetadata(label=selected_label, extra=extra if isinstance(extra, dict) else {})]
         if isinstance(encoded, list):
             return _channel_metadata_from_attrs(encoded)
 
@@ -363,7 +388,7 @@ def _channel_metadata_from_attrs(encoded: list[Any]) -> list[ChannelMetadata]:
 
 def _channel_extras_from_attrs(attrs: dict[Any, Any], labels: list[Any], n_channels: int) -> list[dict[str, Any]]:
     extras_by_label = attrs.get("channel_extra_by_label")
-    if isinstance(extras_by_label, dict):
+    if isinstance(extras_by_label, dict) and len({str(label) for label in labels}) == n_channels:
         return [copy.deepcopy(extras_by_label.get(str(label), {})) for label in labels]
 
     extras = copy.deepcopy(attrs.get("channel_extra", [{} for _ in range(n_channels)]))
@@ -402,10 +427,21 @@ def _json_safe(value: Any) -> Any:
         return [_json_safe(item) for item in value.tolist()]
     if isinstance(value, np.generic):
         return value.item()
+    if isinstance(value, DaArray):
+        return {
+            "type": "dask.array",
+            "shape": list(value.shape),
+            "chunks": _json_safe(value.chunks),
+            "dtype": str(value.dtype),
+        }
     if isinstance(value, dict):
         return {str(key): _json_safe(item) for key, item in value.items()}
     if isinstance(value, list | tuple):
         return [_json_safe(item) for item in value]
+    try:
+        json.dumps(value)
+    except TypeError:
+        return {"type": type(value).__name__, "repr": repr(value)}
     return value
 
 

--- a/wandas/xarray_bridge.py
+++ b/wandas/xarray_bridge.py
@@ -243,9 +243,15 @@ def _infer_frame_type(data_array: xr.DataArray) -> str:
         return "SpectralFrame"
     if dims == ("channel", "frequency", "time"):
         return "SpectrogramFrame"
+    if dims in {("channel", "band"), ("band",)} and _has_noct_attrs(data_array.attrs):
+        return "NOctFrame"
     if dims in {("bark", "time"), ("channel", "bark", "time")}:
         return "RoughnessFrame"
     raise ValueError(f"Cannot infer Wandas frame type from dims: {dims!r}")
+
+
+def _has_noct_attrs(attrs: dict[Any, Any]) -> bool:
+    return all(name in attrs for name in ("fmin", "fmax", "n", "G", "fr"))
 
 
 def _has_scalar_channel_coord(data_array: xr.DataArray) -> bool:
@@ -367,9 +373,14 @@ def _channel_metadata_from_coords(data_array: xr.DataArray) -> list[ChannelMetad
         if "channel" in data_array.coords:
             selected_label = str(data_array.coords["channel"].item())
             if isinstance(encoded, list):
-                for item in _channel_metadata_from_attrs(encoded):
-                    if item.label == selected_label:
-                        return [item]
+                matches = [item for item in _channel_metadata_from_attrs(encoded) if item.label == selected_label]
+                if len(matches) == 1:
+                    return [matches[0]]
+                if len(matches) > 1:
+                    raise ValueError(
+                        "Cannot restore scalar channel selection with duplicate channel labels; "
+                        "select channels by a unique label or keep the channel dimension."
+                    )
             extras_by_label = data_array.attrs.get("channel_extra_by_label")
             extra = copy.deepcopy(extras_by_label.get(selected_label, {})) if isinstance(extras_by_label, dict) else {}
             return [ChannelMetadata(label=selected_label, extra=extra if isinstance(extra, dict) else {})]
@@ -425,16 +436,14 @@ def _coord_values(data_array: xr.DataArray, name: str, default: list[Any]) -> li
     return list(values)
 
 
-def _chunks_for_ndim(ndim: int) -> tuple[int, ...]:
-    if ndim == 0:
+def _chunks_for_dims(dims: tuple[str, ...]) -> tuple[int, ...]:
+    if not dims:
         return ()
-    if ndim == 1:
-        return (-1,)
-    return tuple([1] + [-1] * (ndim - 1))
+    return tuple(1 if dim == "channel" else -1 for dim in dims)
 
 
 def _as_dask_channelwise(data_array: xr.DataArray) -> Any:
-    chunks = _chunks_for_ndim(data_array.ndim)
+    chunks = _chunks_for_dims(tuple(str(dim) for dim in data_array.dims))
     data = data_array.data
     if hasattr(data, "rechunk"):
         return data.rechunk(chunks)

--- a/wandas/xarray_bridge.py
+++ b/wandas/xarray_bridge.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import json
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -106,16 +107,23 @@ def _dims_for_frame(frame: BaseFrame[Any]) -> tuple[str, ...]:
     if frame_type == "NOctFrame":
         return ("channel", "band")
     if frame_type == "RoughnessFrame":
-        return ("channel", "time")
+        if frame._data.ndim == 2:
+            return ("bark", "time")
+        if frame._data.ndim == 3:
+            return ("channel", "bark", "time")
     return tuple(f"dim_{idx}" for idx in range(frame._data.ndim))
 
 
 def _coords_for_frame(frame: BaseFrame[Any], dims: tuple[str, ...]) -> dict[str, Any]:
     coords: dict[str, Any] = {}
     if "channel" in dims:
-        coords["channel"] = np.asarray(frame.labels, dtype=object)
-        coords["unit"] = ("channel", np.asarray([ch.unit for ch in frame.channels], dtype=object))
-        coords["ref"] = ("channel", np.asarray([ch.ref for ch in frame.channels], dtype=float))
+        channel_size = int(frame._data.shape[dims.index("channel")])
+        labels = frame.labels if len(frame.labels) == channel_size else [f"ch{i}" for i in range(channel_size)]
+        units = [ch.unit for ch in frame.channels] if len(frame.channels) == channel_size else [""] * channel_size
+        refs = [ch.ref for ch in frame.channels] if len(frame.channels) == channel_size else [1.0] * channel_size
+        coords["channel"] = np.asarray(labels, dtype=object)
+        coords["unit"] = ("channel", np.asarray(units, dtype=object))
+        coords["ref"] = ("channel", np.asarray(refs, dtype=float))
 
     if "time" in dims:
         if hasattr(frame, "times"):
@@ -128,6 +136,9 @@ def _coords_for_frame(frame: BaseFrame[Any], dims: tuple[str, ...]) -> dict[str,
 
     if "band" in dims and hasattr(frame, "bands"):
         coords["band"] = np.asarray(getattr(frame, "bands"), dtype=float)
+
+    if "bark" in dims and hasattr(frame, "bark_axis"):
+        coords["bark"] = np.asarray(getattr(frame, "bark_axis"), dtype=float)
 
     return coords
 
@@ -213,3 +224,37 @@ def _as_dask_channelwise(data_array: xr.DataArray) -> Any:
         chunks = tuple([1] + [-1] * (data_array.ndim - 1))
         return dask_data.rechunk(chunks)
     return dask_data.rechunk((-1,))
+
+
+def encode_attrs_for_netcdf(data_array: xr.DataArray) -> xr.DataArray:
+    """Return a DataArray with NetCDF-safe Wandas attrs."""
+    encoded = data_array.copy(deep=False)
+    attrs = copy.deepcopy(dict(encoded.attrs))
+    for key in ("metadata", "operation_history"):
+        if key in attrs:
+            attrs[key] = json.dumps(attrs[key])
+    attrs["wandas_attrs_encoding"] = "json-v1"
+    encoded.attrs = attrs
+    return encoded
+
+
+def decode_attrs_from_netcdf(data_array: xr.DataArray) -> xr.DataArray:
+    """Decode Wandas attrs loaded from NetCDF."""
+    decoded = data_array.copy(deep=False)
+    attrs = copy.deepcopy(dict(decoded.attrs))
+    if attrs.get("wandas_attrs_encoding") == "json-v1":
+        for key in ("metadata", "operation_history"):
+            if key in attrs and isinstance(attrs[key], str):
+                attrs[key] = json.loads(attrs[key])
+        attrs.pop("wandas_attrs_encoding", None)
+    decoded.attrs = attrs
+    return decoded
+
+
+def open_netcdf(path: str | Any) -> BaseFrame[Any]:
+    """Open a Wandas NetCDF file as a frame."""
+    data_array = xr.open_dataarray(path).load()
+    try:
+        return from_xarray(decode_attrs_from_netcdf(data_array))
+    finally:
+        data_array.close()

--- a/wandas/xarray_bridge.py
+++ b/wandas/xarray_bridge.py
@@ -49,6 +49,7 @@ def from_xarray(data_array: xr.DataArray) -> BaseFrame[Any]:
     metadata = _metadata_from_attrs(data_array.attrs)
     operation_history = copy.deepcopy(data_array.attrs.get("operation_history", []))
     channel_metadata = _channel_metadata_from_coords(data_array)
+    _validate_frame_shape(data_array, frame_type)
     dask_data = _as_dask_channelwise(data_array)
 
     if frame_type == "ChannelFrame":
@@ -87,6 +88,23 @@ def from_xarray(data_array: xr.DataArray) -> BaseFrame[Any]:
             hop_length=int(data_array.attrs["hop_length"]),
             win_length=int(data_array.attrs.get("win_length", data_array.attrs["n_fft"])),
             window=str(data_array.attrs.get("window", "hann")),
+            label=label,
+            metadata=metadata,
+            operation_history=operation_history,
+            channel_metadata=channel_metadata,
+        )
+
+    if frame_type == "NOctFrame":
+        from wandas.frames.noct import NOctFrame
+
+        return NOctFrame(
+            data=dask_data,
+            sampling_rate=sampling_rate,
+            fmin=float(data_array.attrs["fmin"]),
+            fmax=float(data_array.attrs["fmax"]),
+            n=int(data_array.attrs["n"]),
+            G=int(data_array.attrs["G"]),
+            fr=int(data_array.attrs["fr"]),
             label=label,
             metadata=metadata,
             operation_history=operation_history,
@@ -155,7 +173,10 @@ def _attrs_for_frame(frame: BaseFrame[Any], frame_type: str) -> dict[str, Any]:
     if source_file is not None:
         attrs["source_file"] = source_file
 
-    for name in ("n_fft", "hop_length", "win_length", "window"):
+    if len(frame.channels) == frame.n_channels:
+        attrs["channel_extra"] = copy.deepcopy([ch.extra for ch in frame.channels])
+
+    for name in ("n_fft", "hop_length", "win_length", "window", "fmin", "fmax", "n", "G", "fr"):
         if hasattr(frame, name):
             attrs[name] = getattr(frame, name)
 
@@ -178,11 +199,24 @@ def _validate_dims(data_array: xr.DataArray, frame_type: str) -> None:
         "ChannelFrame": ("channel", "time"),
         "SpectralFrame": ("channel", "frequency"),
         "SpectrogramFrame": ("channel", "frequency", "time"),
+        "NOctFrame": ("channel", "band"),
     }.get(frame_type)
     if expected is None:
         return
     if tuple(data_array.dims) != expected:
         raise ValueError(f"Invalid dims for {frame_type}: expected {expected}, got {tuple(data_array.dims)}")
+
+
+def _validate_frame_shape(data_array: xr.DataArray, frame_type: str) -> None:
+    if frame_type in {"SpectralFrame", "SpectrogramFrame"}:
+        n_fft = int(data_array.attrs["n_fft"])
+        expected_frequency = n_fft // 2 + 1
+        actual_frequency = int(data_array.sizes["frequency"])
+        if actual_frequency != expected_frequency:
+            raise ValueError(
+                f"Invalid frequency dimension length for {frame_type}: "
+                f"expected {expected_frequency} from n_fft={n_fft}, got {actual_frequency}"
+            )
 
 
 def _metadata_from_attrs(attrs: dict[Any, Any]) -> FrameMetadata:
@@ -198,9 +232,13 @@ def _channel_metadata_from_coords(data_array: xr.DataArray) -> list[ChannelMetad
     labels = _coord_values(data_array, "channel", [f"ch{i}" for i in range(n_channels)])
     units = _coord_values(data_array, "unit", [""] * n_channels)
     refs = _coord_values(data_array, "ref", [1.0] * n_channels)
+    extras = copy.deepcopy(data_array.attrs.get("channel_extra", [{} for _ in range(n_channels)]))
+    if not isinstance(extras, list) or len(extras) != n_channels:
+        extras = [{} for _ in range(n_channels)]
 
     return [
-        ChannelMetadata(label=str(labels[idx]), unit=str(units[idx]), ref=float(refs[idx])) for idx in range(n_channels)
+        ChannelMetadata(label=str(labels[idx]), unit=str(units[idx]), ref=float(refs[idx]), extra=extras[idx])
+        for idx in range(n_channels)
     ]
 
 
@@ -213,26 +251,41 @@ def _coord_values(data_array: xr.DataArray, name: str, default: list[Any]) -> li
     return list(values)
 
 
+def _chunks_for_ndim(ndim: int) -> tuple[int, ...]:
+    if ndim == 0:
+        return ()
+    if ndim == 1:
+        return (-1,)
+    return tuple([1] + [-1] * (ndim - 1))
+
+
 def _as_dask_channelwise(data_array: xr.DataArray) -> Any:
+    chunks = _chunks_for_ndim(data_array.ndim)
     data = data_array.data
     if hasattr(data, "rechunk"):
-        dask_data = data
-    else:
-        dask_data = da_from_array(np.asarray(data), chunks=tuple([1] + [-1] * (data_array.ndim - 1)))
+        return data.rechunk(chunks)
+    return da_from_array(np.asarray(data), chunks=chunks)
 
-    if data_array.ndim >= 2:
-        chunks = tuple([1] + [-1] * (data_array.ndim - 1))
-        return dask_data.rechunk(chunks)
-    return dask_data.rechunk((-1,))
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return [_json_safe(item) for item in value.tolist()]
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_json_safe(item) for item in value]
+    return value
 
 
 def encode_attrs_for_netcdf(data_array: xr.DataArray) -> xr.DataArray:
     """Return a DataArray with NetCDF-safe Wandas attrs."""
     encoded = data_array.copy(deep=False)
     attrs = copy.deepcopy(dict(encoded.attrs))
-    for key in ("metadata", "operation_history"):
+    for key in ("metadata", "operation_history", "channel_extra"):
         if key in attrs:
-            attrs[key] = json.dumps(attrs[key])
+            attrs[key] = json.dumps(_json_safe(attrs[key]))
     attrs["wandas_attrs_encoding"] = "json-v1"
     encoded.attrs = attrs
     return encoded
@@ -243,7 +296,7 @@ def decode_attrs_from_netcdf(data_array: xr.DataArray) -> xr.DataArray:
     decoded = data_array.copy(deep=False)
     attrs = copy.deepcopy(dict(decoded.attrs))
     if attrs.get("wandas_attrs_encoding") == "json-v1":
-        for key in ("metadata", "operation_history"):
+        for key in ("metadata", "operation_history", "channel_extra"):
             if key in attrs and isinstance(attrs[key], str):
                 attrs[key] = json.loads(attrs[key])
         attrs.pop("wandas_attrs_encoding", None)


### PR DESCRIPTION
## Summary

This PR implements the first xarray migration steps for Wandas: a compatibility-preserving xarray bridge, xarray-backed internal frame storage, schema validation, signal-safe chunk checks, representative xarray-aware operation execution, and an initial NetCDF storage path.

Important scope clarification: this PR completes Phase 1, Phase 2, and Phase 3 as scoped below. Phase 4 remains partial scaffolding. The existing Wandas frame API remains the public API.

Implemented:
- Add `xarray>=2025.6.1` dependency.
- Add `frame.to_xarray()`, `frame.xr`, and top-level `wd.from_xarray()`.
- Make `BaseFrame._xr` the authoritative internal storage object for frame data and schema metadata.
- Keep `BaseFrame._data` as a compatibility escape hatch over `BaseFrame._xr.data`; it no longer owns separate storage.
- Back `sampling_rate`, `label`, `metadata`, `operation_history`, and `_channel_metadata` by `BaseFrame._xr.attrs`.
- Preserve attrs/name when legacy code assigns `frame._data = ...`, including rechunking through the compatibility path.
- Add xarray schema conversion for:
  - `ChannelFrame`: `dims=("channel", "time")`
  - `SpectralFrame`: `dims=("channel", "frequency")`
  - `SpectrogramFrame`: `dims=("channel", "frequency", "time")`
  - `RoughnessFrame`: `dims=("bark", "time")` or `dims=("channel", "bark", "time")`
  - `NOctFrame`: `dims=("channel", "band")`
- Preserve Wandas signal-safe chunking policy: channel chunks are `1`, signal core dimensions stay contiguous by default.
- Add strict operation chunk policy validation for unsafe time/frequency core chunks, including direct transform/inverse paths.
- Add xarray-aware operation dispatch via `AudioOperation.process_xarray()` / `process_dataarray()`.
- Add representative xarray-native operation execution:
  - `normalize(axis=-1)` via strict `xr.apply_ufunc`
  - `fft()` via strict `xr.apply_ufunc`
  - `rms_trend()` via strict `xr.apply_ufunc`
  - `remove_dc()` via exact xarray/Dask reduction
- Record execution metadata for xarray-aware operation history entries.
- Add NetCDF round-trip helpers: `frame.to_netcdf(path)` and `wd.open_netcdf(path)`.
- Add focused tests for schema, coords, attrs, chunking, copy behavior, authoritative internal storage, strict chunk policy, xarray-aware execution, and NetCDF I/O.
- Add migration design document: `docs/design/2026-06-09-xarray-native-migration.md`.

Review follow-up fixes:
- Preserve `ChannelMetadata.extra` and full channel metadata across xarray/NetCDF round-trips.
- Keep channel extras aligned after xarray channel selection, including scalar channel selections for `RoughnessFrame`.
- Preserve positional extras when channel labels are duplicated.
- Validate spectral frequency axis length and canonical coordinate values during xarray import.
- Restore `NOctFrame` and `RoughnessFrame` from their advertised xarray schemas.
- Reject sliced/reordered `NOctFrame` band axes and non-canonical time coordinates on import.
- Reject public `NOctFrame.to_xarray()` export when a valid round-trippable band coordinate cannot be emitted.
- Keep `normalize(axis=0)` usable with split time chunks while enforcing time-axis validation for `axis=1`.
- Preserve global legacy semantics for `normalize(axis=None)` by using the legacy path.
- Preserve NaN propagation in `remove_dc()` with `skipna=False`.
- Avoid `rms_trend(dB=True/Aw=True)` xarray blockwise reference broadcasting by using the legacy path.
- Make `noct_synthesis` require contiguous `frequency` chunks on `SpectralFrame`.
- Make `roughness_dw_spec` require contiguous `time` chunks on direct method execution.
- Encode nested NumPy arrays/scalars and Dask arrays in structured NetCDF attrs and decode NetCDF attrs inside `from_xarray()`.
- Encode complex spectra as real/imag components for NetCDF3-compatible writes.
- Clarify `.xr` copy semantics and harden scalar/1D xarray import chunking.
- Avoid eager dense time coordinates on internal `_xr`; public `to_xarray()` still exports full time coordinates.

## Phase Status

- [x] Phase 1: Bridge
  - [x] `to_xarray()` / `.xr`
  - [x] `wd.from_xarray()`
  - [x] Wandas xarray schema for current frame classes
  - [x] Schema round-trip tests and coordinate validation
  - [x] Existing core/frame/I/O compatibility checks

- [x] Phase 2: Internal xarray storage as the long-term core representation
  - [x] `BaseFrame._xr` is the authoritative internal storage object.
  - [x] `_data` is a compatibility property over `_xr.data`, not a separate data owner.
  - [x] `sampling_rate`, `label`, `metadata`, `operation_history`, and `_channel_metadata` are backed by `_xr.attrs`.
  - [x] `frame.to_xarray(copy=False)` returns the authoritative internal `DataArray`.
  - [x] `frame.to_xarray()` / `.xr` return public shallow copies with private internal attrs removed.
  - [x] Legacy `_data` assignment preserves xarray attrs/name.
  - [x] Phase 2 regression tests cover storage identity, metadata attrs, and channel metadata coords.

- [x] Phase 3: xarray-aware operations
  - [x] Add xarray-aware operation dispatch while preserving legacy `process()` fallback.
  - [x] Add operation-level strict chunk policy validation using xarray dims.
  - [x] Direct transform/inverse methods use the same strict validation.
  - [x] Add representative strict `xr.apply_ufunc` operations: `normalize`, `fft`, `rms_trend`.
  - [x] Add representative exact xarray/Dask reduction: `remove_dc`.
  - [x] Record xarray execution mode in operation history.
  - [x] Keep public blockwise/overlap mode disabled until operation-specific boundary semantics are reviewed.

- [ ] Phase 4: I/O repositioning
  - [x] Partial: existing HDF5 WDF compatibility remains unchanged.
  - [x] Partial: add xarray-backed NetCDF entry points.
  - [x] Partial: encode/decode Wandas structured attrs and complex arrays for NetCDF-safe round-trips.
  - [ ] Not complete: decide whether WDF becomes a Wandas profile over Zarr/NetCDF.
  - [ ] Not complete: add Zarr support and storage/analysis chunk separation policy.
  - [ ] Not complete: deprecate or reposition legacy WDF behavior.

## Verification

Fresh final verification after review follow-up:

- `uv run pytest -q`
  - `1501 passed, 3 skipped, 81 warnings`
- `uv run coverage report -m wandas/xarray_bridge.py wandas/processing/chunk_policy.py`
  - `wandas/xarray_bridge.py`: 100%
  - `wandas/processing/chunk_policy.py`: 100%
- `uv run ruff check wandas tests`
  - passed
- `uv run ty check wandas tests`
  - passed

Intermediate checks:

- Phase 1 RED: bridge tests failed on missing `to_xarray`, `.xr`, `wd.from_xarray`.
- Phase 1 GREEN: bridge tests passed.
- Phase 2 RED: authoritative storage tests failed while `to_xarray(copy=False)` rebuilt a separate DataArray, `metadata` assignment stayed as a plain dict, and channel metadata schema sync was incomplete.
- Phase 2 GREEN: authoritative storage tests pass with `_xr` as the storage owner and `_data` as a compatibility property over `_xr.data`.
- Chunk policy RED/GREEN: strict time-core operation did not reject split time chunks before validation and passed after policy changes.
- NetCDF RED/GREEN: NetCDF round-trip failed on missing `to_netcdf` before bridge storage helper and passed after implementation.
- Review RED/GREEN: focused review regression tests failed before the fixes and pass now.
- Phase 3 RED/GREEN: xarray-aware execution tests for `normalize`, `remove_dc`, `fft`, and `rms_trend` failed before implementation and pass now.

## Notes

This PR intentionally keeps WDF untouched and introduces NetCDF as the first xarray-backed storage path. The full follow-up plan is documented in `docs/design/2026-06-09-xarray-native-migration.md`, including remaining Phase 4 I/O repositioning, Zarr, public blockwise/overlap modes, and accessor API decisions.