### PR TITLE
Phase 1: use xarray as storage-only data container

### DIFF
--- a/docs/superpowers/plans/2026-06-09-xarray-storage-only.md
+++ b/docs/superpowers/plans/2026-06-09-xarray-storage-only.md
@@ -105,7 +105,7 @@ def test_base_frame_owns_xarray_dataarray() -> None:
     assert frame._data is frame._xr.data
     assert frame._data.chunks == ((1, 1), (8,))
     assert list(frame._xr.coords["channel"].values) == ["left", "right"]
-    assert frame._xr.coords["time"].values.tolist() == [0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
+    assert "time" not in frame._xr.coords
 
 
 def test_data_alias_is_read_only() -> None:
@@ -242,26 +242,27 @@ Add these methods inside `BaseFrame` after `__init__` and before `_n_channels`:
         )
 
     def _xarray_dims(self, data: DaArray) -> tuple[str, ...]:
-        """Return conservative dimension names for the internal xarray container."""
-        if data.ndim == 2:
-            return ("channel", "time")
-        if data.ndim == 3:
-            return ("channel", "frequency", "time")
-        if data.ndim >= 1:
-            return tuple(["channel"] + [f"dim_{i}" for i in range(1, data.ndim)])
-        return ()
+        """Return neutral dimension names for the internal xarray container."""
+        return tuple(f"dim_{i}" for i in range(data.ndim))
 
     def _xarray_coords(self, data: DaArray) -> dict[str, Any]:
-        """Return minimal coordinates that are already owned by the frame."""
-        dims = self._xarray_dims(data)
-        coords: dict[str, Any] = {}
-        if "channel" in dims and data.ndim >= 1:
-            coords["channel"] = [ch.label for ch in self._channel_metadata]
-        if "time" in dims:
-            time_axis = dims.index("time")
-            n_samples = int(data.shape[time_axis])
-            coords["time"] = np.arange(n_samples, dtype=float) / self.sampling_rate
-        return coords
+        """Return conservative base coordinates for the internal xarray container."""
+        return {}
+```
+
+`ChannelFrame` may then provide the only Phase 1 semantic override:
+
+```python
+    def _xarray_dims(self, data: DaArray) -> tuple[str, ...]:
+        """Return ChannelFrame dimension names for the internal xarray container."""
+        return ("channel", "time")
+
+    def _xarray_coords(self, data: DaArray) -> dict[str, Any]:
+        """Return cheap ChannelFrame coordinates owned by the frame."""
+        labels = [ch.label for ch in self._channel_metadata]
+        if len(labels) != self._channel_count_from_data(data):
+            return {}
+        return {"channel": labels}
 ```
 
 - [ ] **Step 3: Refactor `__init__` to create `_xr`**

--- a/docs/superpowers/plans/2026-06-09-xarray-storage-only.md
+++ b/docs/superpowers/plans/2026-06-09-xarray-storage-only.md
@@ -1,0 +1,795 @@
+# xarray Storage-Only Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `BaseFrame`'s direct Dask-array storage with `xr.DataArray` storage while keeping Wandas operations, metadata ownership, and lazy execution unchanged.
+
+**Architecture:** `BaseFrame` owns `_xr: xr.DataArray` as the only data container. `_data` becomes a read-only compatibility property returning `_xr.data`, and explicit `_replace_data()` handles the few internal in-place update paths. xarray is used only for data, dims, and coords; Wandas continues to own sampling rate, labels, metadata, operation history, channel metadata, and operation execution.
+
+**Tech Stack:** Python, Dask array, xarray, pytest, ruff, ty.
+
+---
+
+## File Structure
+
+- Modify `pyproject.toml`
+  - Add `xarray` runtime dependency.
+- Modify `uv.lock`
+  - Updated by `uv lock` or dependency sync after adding xarray.
+- Modify `wandas/core/base_frame.py`
+  - Import xarray.
+  - Replace direct `_data` ownership with `_xr`.
+  - Add read-only `_data` property.
+  - Add `_replace_data()`, `_build_xarray()`, `_xarray_dims()`, `_xarray_coords()`, `to_xarray()`, and `xr`.
+  - Keep metadata, operation history, channel metadata, and operation execution unchanged.
+- Modify `wandas/frames/channel.py`
+  - Replace the production `_data = new_data` in `_finalize_channel_update()` with `_replace_data(new_data)`.
+- Create `tests/core/test_xarray_storage_only.py`
+  - Focused tests for `_xr`, read-only `_data`, attrs non-ownership, coords, chunking, and lazy execution.
+- Modify existing tests that directly assign fake objects to `_data`
+  - Replace fake `_data` assignment tests with public behavior or `_replace_data()` tests where the same behavior remains meaningful.
+
+---
+
+### Task 1: Add xarray dependency
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `uv.lock`
+
+- [ ] **Step 1: Add dependency**
+
+In `pyproject.toml`, add xarray to the runtime dependencies:
+
+```toml
+"xarray>=2025.6.1",
+```
+
+Place it near the existing scientific stack dependencies.
+
+- [ ] **Step 2: Update lockfile**
+
+Run:
+
+```bash
+uv lock
+```
+
+Expected: `uv.lock` updates successfully and includes xarray if it was not already locked.
+
+- [ ] **Step 3: Commit dependency change**
+
+Run:
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "build: add xarray dependency"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 2: Write RED tests for xarray-backed storage
+
+**Files:**
+- Create: `tests/core/test_xarray_storage_only.py`
+
+- [ ] **Step 1: Create failing storage tests**
+
+Create `tests/core/test_xarray_storage_only.py` with:
+
+```python
+import pytest
+import xarray as xr
+from dask import array as da, delayed
+
+from wandas import ChannelFrame
+from wandas.core.metadata import ChannelMetadata, FrameMetadata
+
+
+def test_base_frame_owns_xarray_dataarray() -> None:
+    data = da.ones((2, 8), chunks=(2, 4))
+    frame = ChannelFrame(
+        data=data,
+        sampling_rate=4.0,
+        label="signal",
+        channel_metadata=[
+            ChannelMetadata(label="left", unit="Pa"),
+            ChannelMetadata(label="right", unit="Pa"),
+        ],
+    )
+
+    assert isinstance(frame._xr, xr.DataArray)
+    assert frame._xr.dims == ("channel", "time")
+    assert frame._data is frame._xr.data
+    assert frame._data.chunks == ((1, 1), (8,))
+    assert list(frame._xr.coords["channel"].values) == ["left", "right"]
+    assert frame._xr.coords["time"].values.tolist() == [0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75]
+
+
+def test_data_alias_is_read_only() -> None:
+    frame = ChannelFrame.from_numpy([1.0, 2.0, 3.0], sampling_rate=3.0)
+
+    with pytest.raises(AttributeError):
+        frame._data = da.zeros((1, 3), chunks=(1, -1))  # type: ignore[misc]
+
+
+def test_replace_data_updates_xarray_container_only() -> None:
+    metadata = FrameMetadata({"source": "test"}, source_file="input.wav")
+    frame = ChannelFrame.from_numpy(
+        [[1.0, 2.0, 3.0]],
+        sampling_rate=3.0,
+        label="original",
+        metadata=metadata,
+    )
+    original_metadata = frame.metadata
+    original_history = frame.operation_history
+    replacement = da.full((1, 4), 2.0, chunks=(1, -1))
+
+    frame._replace_data(replacement)
+
+    assert frame._data is frame._xr.data
+    assert frame._data.shape == (1, 4)
+    assert frame._data.chunks == ((1,), (4,))
+    assert frame.metadata is original_metadata
+    assert frame.operation_history is original_history
+    assert frame.label == "original"
+    assert frame.sampling_rate == 3.0
+
+
+def test_internal_xarray_attrs_do_not_own_wandas_metadata() -> None:
+    frame = ChannelFrame.from_numpy(
+        [[1.0, 2.0]],
+        sampling_rate=2.0,
+        label="owned-by-wandas",
+        metadata={"gain": 1.5},
+    )
+
+    frame._xr.attrs["label"] = "not-authoritative"
+    frame._xr.attrs["metadata"] = {"gain": 999}
+
+    assert frame.label == "owned-by-wandas"
+    assert frame.metadata["gain"] == 1.5
+```
+
+- [ ] **Step 2: Run RED tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_xarray_storage_only.py -q
+```
+
+Expected: FAIL because `BaseFrame` does not yet define `_xr`, `_data` is still assignable, and `_replace_data()` does not exist.
+
+- [ ] **Step 3: Commit RED tests**
+
+Run:
+
+```bash
+git add tests/core/test_xarray_storage_only.py
+git commit -m "test: define xarray storage-only expectations"
+```
+
+Expected: commit succeeds with failing tests documented by the previous command output.
+
+---
+
+### Task 3: Implement BaseFrame xarray storage
+
+**Files:**
+- Modify: `wandas/core/base_frame.py`
+
+- [ ] **Step 1: Import xarray and update class annotations**
+
+In `wandas/core/base_frame.py`, add:
+
+```python
+import xarray as xr
+```
+
+Replace the class annotation:
+
+```python
+_data: DaArray
+```
+
+with:
+
+```python
+_xr: xr.DataArray
+```
+
+- [ ] **Step 2: Add helper methods and read-only alias**
+
+Add these methods inside `BaseFrame` after `__init__` and before `_n_channels`:
+
+```python
+    @property
+    def _data(self) -> DaArray:
+        """Compatibility alias for the Dask array stored in ``_xr``."""
+        data = self._xr.data
+        if not isinstance(data, DaArray):
+            raise TypeError(f"Internal xarray data is not a Dask array: {type(data).__name__}")
+        return data
+
+    def _replace_data(self, data: DaArray) -> None:
+        """Replace the internal xarray data container without touching Wandas metadata."""
+        normalized = self._normalize_data(data)
+        self._xr = self._build_xarray(normalized)
+
+    def _normalize_data(self, data: DaArray) -> DaArray:
+        """Normalize Dask data shape and chunks using Wandas channel-wise policy."""
+        try:
+            normalized = data.reshape((1, -1)) if data.ndim == 1 else data
+            if normalized.ndim >= 2:
+                chunks = tuple([1] + [-1] * (normalized.ndim - 1))
+            else:
+                chunks = tuple([-1] * normalized.ndim)
+            return normalized.rechunk(chunks)
+        except Exception as e:
+            logger.warning(f"Rechunk failed: {e!r}. Falling back to chunks=-1.")
+            return data.rechunk(chunks=-1)
+
+    def _build_xarray(self, data: DaArray) -> xr.DataArray:
+        """Build the internal xarray container for frame data, dims, and coords."""
+        return xr.DataArray(
+            data,
+            dims=self._xarray_dims(data),
+            coords=self._xarray_coords(data),
+            name=self.label,
+        )
+
+    def _xarray_dims(self, data: DaArray) -> tuple[str, ...]:
+        """Return conservative dimension names for the internal xarray container."""
+        if data.ndim == 2:
+            return ("channel", "time")
+        if data.ndim == 3:
+            return ("channel", "frequency", "time")
+        if data.ndim >= 1:
+            return tuple(["channel"] + [f"dim_{i}" for i in range(1, data.ndim)])
+        return ()
+
+    def _xarray_coords(self, data: DaArray) -> dict[str, Any]:
+        """Return minimal coordinates that are already owned by the frame."""
+        dims = self._xarray_dims(data)
+        coords: dict[str, Any] = {}
+        if "channel" in dims and data.ndim >= 1:
+            coords["channel"] = [ch.label for ch in self._channel_metadata]
+        if "time" in dims:
+            time_axis = dims.index("time")
+            n_samples = int(data.shape[time_axis])
+            coords["time"] = np.arange(n_samples, dtype=float) / self.sampling_rate
+        return coords
+```
+
+- [ ] **Step 3: Refactor `__init__` to create `_xr`**
+
+In `BaseFrame.__init__`, remove the existing try/except block that assigns `self._data`.
+After `self._channel_metadata` is initialized, add:
+
+```python
+        normalized_data = self._normalize_data(data)
+        self._xr = self._build_xarray(normalized_data)
+```
+
+The order matters: channel metadata must exist before `_build_xarray()` creates channel coords.
+
+Move the Dask graph logging after `_xr` is assigned and keep it using `self._data`.
+
+- [ ] **Step 4: Run storage tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_xarray_storage_only.py -q
+```
+
+Expected: PASS for the storage tests, except failures that point to subclass-specific coord hooks. Fix only minimal hook behavior needed for `ChannelFrame`.
+
+- [ ] **Step 5: Commit BaseFrame storage implementation**
+
+Run:
+
+```bash
+git add wandas/core/base_frame.py tests/core/test_xarray_storage_only.py
+git commit -m "feat: store frame data in xarray containers"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 4: Replace production `_data` assignment
+
+**Files:**
+- Modify: `wandas/frames/channel.py`
+- Test: `tests/core/test_xarray_storage_only.py`
+
+- [ ] **Step 1: Update in-place channel data replacement**
+
+In `wandas/frames/channel.py`, change `_finalize_channel_update()` from:
+
+```python
+        if inplace:
+            self._data = new_data
+            self._channel_metadata = new_chmeta
+            return self
+```
+
+to:
+
+```python
+        if inplace:
+            self._channel_metadata = new_chmeta
+            self._replace_data(new_data)
+            return self
+```
+
+Channel metadata must be updated before `_replace_data()` so the rebuilt xarray channel coord uses the new labels.
+
+- [ ] **Step 2: Add lazy in-place tests**
+
+Append to `tests/core/test_xarray_storage_only.py`:
+
+```python
+def test_add_channel_inplace_updates_xarray_without_compute() -> None:
+    calls: list[str] = []
+
+    def build() -> list[list[float]]:
+        calls.append("computed")
+        return [[1.0, 2.0, 3.0]]
+
+    lazy_data = da.from_delayed(
+        delayed(build)(),
+        shape=(1, 3),
+        dtype=float,
+    )
+    frame = ChannelFrame(data=lazy_data, sampling_rate=3.0)
+
+    result = frame.add_channel([4.0, 5.0, 6.0], label="extra", inplace=True)
+
+    assert result is frame
+    assert calls == []
+    assert frame._data is frame._xr.data
+    assert frame._data.shape == (2, 3)
+    assert list(frame._xr.coords["channel"].values) == ["ch0", "extra"]
+
+
+def test_remove_channel_inplace_updates_xarray_without_compute() -> None:
+    calls: list[str] = []
+
+    def build() -> list[list[float]]:
+        calls.append("computed")
+        return [[1.0, 2.0], [3.0, 4.0]]
+
+    lazy_data = da.from_delayed(
+        delayed(build)(),
+        shape=(2, 2),
+        dtype=float,
+    )
+    frame = ChannelFrame(
+        data=lazy_data,
+        sampling_rate=2.0,
+        channel_metadata=[
+            ChannelMetadata(label="left"),
+            ChannelMetadata(label="right"),
+        ],
+    )
+
+    result = frame.remove_channel("left", inplace=True)
+
+    assert result is frame
+    assert calls == []
+    assert frame._data is frame._xr.data
+    assert frame._data.shape == (1, 2)
+    assert list(frame._xr.coords["channel"].values) == ["right"]
+```
+
+- [ ] **Step 3: Run targeted tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_xarray_storage_only.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Search for production `_data` assignments**
+
+Run:
+
+```bash
+rg -n "self\\._data\\s*=" wandas
+```
+
+Expected: no production matches. If a match remains, replace it with `_replace_data()` only when it is an in-place data replacement. Do not add a `_data` setter.
+
+- [ ] **Step 5: Commit production assignment removal**
+
+Run:
+
+```bash
+git add wandas/frames/channel.py tests/core/test_xarray_storage_only.py
+git commit -m "refactor: replace internal data assignment"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 5: Add public xarray export API
+
+**Files:**
+- Modify: `wandas/core/base_frame.py`
+- Test: `tests/core/test_xarray_storage_only.py`
+
+- [ ] **Step 1: Write RED export tests**
+
+Append to `tests/core/test_xarray_storage_only.py`:
+
+```python
+def test_to_xarray_returns_public_shallow_copy_with_export_attrs() -> None:
+    frame = ChannelFrame.from_numpy(
+        [[1.0, 2.0]],
+        sampling_rate=2.0,
+        label="exported",
+        metadata={"source": "unit-test"},
+    )
+    frame.operation_history.append({"operation": "normalize", "params": {}})
+
+    exported = frame.to_xarray()
+
+    assert isinstance(exported, xr.DataArray)
+    assert exported is not frame._xr
+    assert exported.data is frame._data
+    assert exported.attrs["wandas_frame_type"] == "ChannelFrame"
+    assert exported.attrs["sampling_rate"] == 2.0
+    assert exported.attrs["label"] == "exported"
+    assert exported.attrs["metadata"] == {"source": "unit-test"}
+    assert exported.attrs["operation_history"] == [{"operation": "normalize", "params": {}}]
+
+    exported.attrs["label"] = "changed-export"
+    assert frame.label == "exported"
+
+
+def test_xr_property_matches_to_xarray_contract() -> None:
+    frame = ChannelFrame.from_numpy([1.0, 2.0], sampling_rate=2.0)
+
+    exported = frame.xr
+
+    assert isinstance(exported, xr.DataArray)
+    assert exported is not frame._xr
+    assert exported.data is frame._data
+```
+
+- [ ] **Step 2: Run RED export tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_xarray_storage_only.py::test_to_xarray_returns_public_shallow_copy_with_export_attrs tests/core/test_xarray_storage_only.py::test_xr_property_matches_to_xarray_contract -q
+```
+
+Expected: FAIL because `to_xarray()` and `xr` are not implemented.
+
+- [ ] **Step 3: Implement export API**
+
+Add to `BaseFrame` near `compute()`:
+
+```python
+    def to_xarray(self) -> xr.DataArray:
+        """Return a public xarray view of this frame without changing Wandas ownership."""
+        exported = self._xr.copy(deep=False)
+        exported.attrs = {
+            "wandas_frame_type": type(self).__name__,
+            "sampling_rate": self.sampling_rate,
+            "label": self.label,
+            "metadata": dict(self.metadata),
+            "operation_history": copy.deepcopy(self.operation_history),
+        }
+        return exported
+
+    @property
+    def xr(self) -> xr.DataArray:
+        """Return a public xarray view of this frame."""
+        return self.to_xarray()
+```
+
+- [ ] **Step 4: Run export tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_xarray_storage_only.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit export API**
+
+Run:
+
+```bash
+git add wandas/core/base_frame.py tests/core/test_xarray_storage_only.py
+git commit -m "feat: expose xarray frame views"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 6: Preserve lazy execution through common workflows
+
+**Files:**
+- Test: `tests/core/test_xarray_storage_only.py`
+
+- [ ] **Step 1: Add lazy execution regression tests**
+
+Append to `tests/core/test_xarray_storage_only.py`:
+
+```python
+
+def _lazy_frame_with_counter(calls: list[str]) -> ChannelFrame:
+    def build() -> list[list[float]]:
+        calls.append("computed")
+        return [[1.0, 2.0, 3.0, 4.0]]
+
+    lazy_data = da.from_delayed(delayed(build)(), shape=(1, 4), dtype=float)
+    return ChannelFrame(data=lazy_data, sampling_rate=4.0)
+
+
+def test_construction_and_xarray_export_do_not_compute() -> None:
+    calls: list[str] = []
+    frame = _lazy_frame_with_counter(calls)
+
+    _ = frame._data
+    _ = frame.to_xarray()
+    _ = frame.xr
+
+    assert calls == []
+
+
+def test_selection_and_operation_do_not_compute_until_compute() -> None:
+    calls: list[str] = []
+    frame = _lazy_frame_with_counter(calls)
+
+    selected = frame.get_channel(0)
+    normalized = selected.normalize()
+
+    assert calls == []
+
+    result = normalized.compute()
+
+    assert calls == ["computed"]
+    assert result.shape == (1, 4)
+
+
+def test_transform_methods_remain_lazy() -> None:
+    calls: list[str] = []
+    frame = _lazy_frame_with_counter(calls)
+
+    spectrum = frame.fft()
+    spectrogram = frame.stft(nperseg=4, noverlap=2)
+
+    assert calls == []
+    assert spectrum._data is spectrum._xr.data
+    assert spectrogram._data is spectrogram._xr.data
+```
+
+- [ ] **Step 2: Run lazy tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_xarray_storage_only.py -q
+```
+
+Expected: PASS. If a test computes early, fix the xarray construction/export path. Do not modify operation dispatch.
+
+- [ ] **Step 3: Commit lazy tests**
+
+Run:
+
+```bash
+git add tests/core/test_xarray_storage_only.py
+git commit -m "test: verify xarray storage stays lazy"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 7: Update tests that assign `_data`
+
+**Files:**
+- Modify: `tests/core/test_base_frame.py`
+- Modify: `tests/core/test_base_frame_additional.py`
+- Modify other test files only if `rg` finds direct `_data` assignments.
+
+- [ ] **Step 1: Find direct `_data` assignments in tests**
+
+Run:
+
+```bash
+rg -n "\\._data\\s*=" tests
+```
+
+Expected: a short list of tests that mutate internals.
+
+- [ ] **Step 2: Replace assignment-based tests**
+
+For tests that assign fake objects only to force graph visualization errors, replace direct `_data` mutation with monkeypatching the property target or with a real Dask object.
+
+Example replacement for a visualization failure test:
+
+```python
+def test_visualize_graph_handles_visualize_failure(monkeypatch):
+    frame = make_frame()
+
+    def fail_visualize(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(frame._data, "visualize", fail_visualize)
+
+    assert frame.visualize_graph() is None
+```
+
+For tests that need to replace frame data, use:
+
+```python
+frame._replace_data(new_dask_data)
+```
+
+Do not add a `_data` setter for tests.
+
+- [ ] **Step 3: Run updated test files**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_base_frame.py tests/core/test_base_frame_additional.py tests/core/test_xarray_storage_only.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit test updates**
+
+Run:
+
+```bash
+git add tests/core/test_base_frame.py tests/core/test_base_frame_additional.py tests/core/test_xarray_storage_only.py
+git commit -m "test: stop assigning frame data internals"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 8: Full verification and complexity review
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-09-xarray-storage-only-design.md` only if implementation reveals a needed clarification.
+
+- [ ] **Step 1: Run focused xarray storage tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_xarray_storage_only.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run full test suite**
+
+Run:
+
+```bash
+uv run pytest -q
+```
+
+Expected: all existing tests pass.
+
+- [ ] **Step 3: Run lint and type checks**
+
+Run:
+
+```bash
+uv run ruff check wandas tests
+uv run ty check wandas tests
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 4: Check implementation guardrails**
+
+Run:
+
+```bash
+rg -n "process_xarray|process_dataarray|apply_ufunc|from_xarray|to_netcdf|open_netcdf|to_zarr|open_zarr" wandas tests
+rg -n "self\\._data\\s*=" wandas
+```
+
+Expected:
+
+```text
+No operation-dispatch or storage-I/O symbols were added.
+No production self._data assignment remains.
+```
+
+- [ ] **Step 5: Inspect code size and ownership**
+
+Run:
+
+```bash
+git diff --stat develop...HEAD
+git diff -- wandas/core/base_frame.py wandas/frames/channel.py tests/core/test_xarray_storage_only.py
+```
+
+Expected: changes are concentrated in `BaseFrame`, the single ChannelFrame in-place update path, and focused tests.
+
+- [ ] **Step 6: Write PR complexity summary**
+
+Use this text as the PR body summary and update it with final numbers from verification:
+
+```markdown
+## Summary
+
+This PR restarts the xarray migration as Phase 1 only: xarray is used as an axis-aware data container, not as metadata storage, operation execution, or persistence.
+
+Implemented:
+- Add xarray dependency.
+- Store frame data in `BaseFrame._xr: xr.DataArray`.
+- Keep `_data` as a read-only compatibility alias to `_xr.data`.
+- Replace production `_data` assignment with explicit `_replace_data()`.
+- Add `frame.to_xarray()` and `frame.xr` as public export views.
+- Preserve existing operation execution through `operation.process(self._data)`.
+- Add lazy execution tests to ensure xarray wrapping does not call `compute()`.
+
+Explicitly not included:
+- No attrs-backed metadata.
+- No xarray operation dispatch.
+- No `from_xarray()`.
+- No NetCDF or Zarr.
+- No chunk-policy integration changes.
+
+## Complexity Review
+
+What became simpler:
+- `BaseFrame` has one data owner: `_xr`.
+- Production `_data` assignment is removed.
+- Operation paths remain unchanged.
+
+What became more complex:
+- `BaseFrame` now has small xarray construction/export helpers.
+- Coordinate generation introduces a new hook surface.
+
+Permanent pieces:
+- `_xr` as internal data container.
+- Read-only `_data` compatibility property.
+- `to_xarray()` / `.xr`.
+
+Candidates for later cleanup:
+- Existing operation call sites can continue using `_data` until Phase 3.
+- Coordinate hooks may move to frame-specific schema helpers if they grow.
+
+## Verification
+
+- `uv run pytest -q`: passes
+- `uv run ruff check wandas tests`: passes
+- `uv run ty check wandas tests`: passes
+```
+
+- [ ] **Step 7: Commit any final documentation clarification**
+
+If the design doc needed updates, run:
+
+```bash
+git add docs/superpowers/specs/2026-06-09-xarray-storage-only-design.md
+git commit -m "docs: clarify xarray storage scope"
+```
+
+Expected: no commit is needed unless the implementation forced a real design clarification.

--- a/docs/superpowers/specs/2026-06-09-xarray-storage-only-design.md
+++ b/docs/superpowers/specs/2026-06-09-xarray-storage-only-design.md
@@ -1,0 +1,263 @@
+# Phase 1: xarray-backed storage only
+
+## Purpose
+
+This phase introduces xarray only as an axis-aware data container for Wandas frames.
+It is not an xarray-native execution, metadata, or storage migration.
+
+The goal is to evaluate whether replacing `BaseFrame`'s direct Dask-array ownership with
+`xr.DataArray` reduces long-term complexity without changing the existing Wandas API or
+operation semantics.
+
+## Background
+
+The previous `feat/xarray-bridge` branch grew beyond a bridge. It included authoritative
+xarray storage, attrs-backed metadata, broad `from_xarray()` restoration, NetCDF helpers,
+and xarray-aware operation dispatch. That made the migration hard to review and made it
+unclear whether xarray itself was reducing complexity or adding synchronization work.
+
+This replacement branch starts from `develop` and deliberately limits Phase 1 to:
+
+```text
+xarray as storage, not execution engine.
+```
+
+## Responsibility split
+
+In Phase 1, responsibilities are split as follows:
+
+```text
+xarray:
+  data
+  dims
+  coords
+
+Wandas:
+  sampling_rate
+  label
+  metadata
+  operation_history
+  channel_metadata
+  previous
+  domain API
+```
+
+`xr.DataArray.attrs` may be populated for public export, but attrs are not the internal
+source of truth for Wandas state.
+
+## Architecture
+
+`BaseFrame` owns one internal xarray object:
+
+```python
+class BaseFrame:
+    _xr: xr.DataArray
+
+    @property
+    def _data(self):
+        return self._xr.data
+```
+
+`_data` remains as a read-only compatibility alias for existing operation code.
+There is no `_data` setter.
+
+Production code that currently assigns to `_data` must stop doing so. If an in-place
+method needs to replace frame data, it should call an explicit private method:
+
+```python
+def _replace_data(self, data: DaArray) -> None:
+    self._xr = self._build_xarray(data)
+```
+
+`_replace_data()` updates only the xarray data container. It must not mutate or synchronize
+`sampling_rate`, `label`, `metadata`, `operation_history`, or `_channel_metadata`.
+
+## Data model
+
+`BaseFrame.__init__` keeps the existing Dask normalization and channel-wise rechunk policy:
+
+```text
+1D input:
+  reshape to (1, -1)
+
+2D frame:
+  chunks=(1, -1)
+
+3D+ frame:
+  chunks=(1, -1, -1, ...)
+```
+
+After normalization, the Dask array is wrapped in `xr.DataArray`.
+
+The initial schema is intentionally small. `BaseFrame` may define hooks such as:
+
+```python
+def _xarray_dims(self, data: DaArray) -> tuple[str, ...]: ...
+def _xarray_coords(self, data: DaArray) -> dict[str, Any]: ...
+```
+
+Subclasses can override these hooks only where they already have the required axis
+information:
+
+```text
+ChannelFrame:
+  dims=("channel", "time")
+  coords: channel labels, time seconds
+
+SpectralFrame:
+  dims=("channel", "frequency")
+  coords: channel labels, frequency values
+
+SpectrogramFrame:
+  dims=("channel", "frequency", "time")
+  coords: channel labels, frequency values, time values
+```
+
+If a frame does not have enough domain information for a rich coordinate, the implementation
+should use minimal dimension names instead of adding validation-heavy schema logic.
+
+## Public API
+
+Phase 1 adds:
+
+```python
+frame.to_xarray()
+frame.xr
+```
+
+`to_xarray()` returns a public shallow copy of the internal `DataArray`. It may attach export
+attrs such as:
+
+```text
+wandas_frame_type
+sampling_rate
+label
+metadata
+operation_history
+```
+
+These attrs are export metadata only. They do not back the live Wandas frame state.
+
+`.xr` is a convenience alias for `to_xarray()`.
+
+## Operation execution
+
+Existing operation execution remains unchanged:
+
+```python
+processed_data = operation.process(self._data)
+```
+
+Because `_data` is an alias to `_xr.data`, existing Dask-backed operations should keep the
+same behavior and laziness.
+
+Phase 1 must not add:
+
+```text
+process_xarray()
+process_dataarray()
+xr.apply_ufunc()
+xarray operation dispatch
+blockwise or map_overlap execution modes
+```
+
+## Explicitly out of scope
+
+Phase 1 does not include:
+
+```text
+metadata backed by _xr.attrs
+operation_history backed by _xr.attrs
+channel_metadata backed by _xr.attrs
+sampling_rate or label backed by _xr.attrs
+wd.from_xarray() broad restoration
+NetCDF support
+Zarr support
+xarray accessor API
+operation chunk-policy integration
+```
+
+These are later-phase topics and should not enter this PR.
+
+## Lazy execution requirements
+
+Lazy execution is a core requirement for this phase. The implementation must verify that
+xarray wrapping does not materialize data early.
+
+Required tests:
+
+```text
+BaseFrame construction does not compute.
+Accessing frame._data does not compute.
+Accessing frame.to_xarray() / frame.xr does not compute.
+get_channel() and channel slicing do not compute.
+add_channel() and remove_channel() do not compute.
+apply_operation() does not compute.
+Existing transform methods such as fft() and stft() do not compute.
+compute() and data access are the points that materialize data.
+Dask graph structure remains lazy after wrapping in xarray.
+Default chunks remain channel-wise: channel=1 and signal axes=-1.
+```
+
+Tests should use Dask delayed or mocked compute paths where needed, so they fail if
+construction/export accidentally calls `compute()`.
+
+## Error handling and compatibility
+
+`_data` assignment should fail because `_data` is a read-only property. Existing tests that
+assign fake objects to `_data` should be rewritten to exercise public behavior or
+`_replace_data()` where appropriate.
+
+`_replace_data()` should be private and narrow. It exists for existing in-place frame methods,
+not as a general extension point.
+
+If xarray coord generation fails for a frame, the implementation should prefer a small,
+predictable fallback schema over complex recovery logic.
+
+## Complexity evaluation
+
+This phase succeeds only if the implementation stays simpler than the previous broad branch.
+
+Positive signals:
+
+```text
+BaseFrame has a single data owner: _xr.
+Production code no longer assigns to _data.
+Operation paths do not gain xarray-vs-legacy branching.
+Metadata synchronization code does not appear.
+Added code is mostly small construction/export helpers.
+Existing tests continue to pass with minimal behavioral changes.
+```
+
+Negative signals:
+
+```text
+_data setter returns.
+Metadata attrs become authoritative.
+Subclass schema branching grows large.
+to_xarray() needs complex validation or restoration logic.
+Operation dispatch changes are needed to keep tests passing.
+Production code grows substantially without removing ownership ambiguity.
+```
+
+After implementation, the PR description should include a short complexity review:
+
+```text
+What became simpler?
+What became more complex?
+Which added pieces are permanent?
+Which added pieces are candidates for deletion or Phase 2 replacement?
+```
+
+## Verification
+
+Required verification before opening the PR:
+
+```text
+uv run pytest -q
+uv run ruff check wandas tests
+uv run ty check wandas tests
+```
+
+The PR should also include focused tests for the xarray-backed storage behavior and lazy
+execution requirements above.

--- a/docs/superpowers/specs/2026-06-09-xarray-storage-only-design.md
+++ b/docs/superpowers/specs/2026-06-09-xarray-storage-only-design.md
@@ -97,24 +97,28 @@ def _xarray_coords(self, data: DaArray) -> dict[str, Any]: ...
 ```
 
 Subclasses can override these hooks only where they already have the required axis
-information:
+information. In Phase 1 the concrete schema remains intentionally conservative:
 
 ```text
+BaseFrame default:
+  dims=("dim_0", "dim_1", ...)
+  coords: none
+
 ChannelFrame:
   dims=("channel", "time")
-  coords: channel labels, time seconds
+  coords: channel labels only when metadata length matches the channel count
+  no generated time coordinate
 
 SpectralFrame:
-  dims=("channel", "frequency")
-  coords: channel labels, frequency values
+  BaseFrame default dims/coords in this PR
 
 SpectrogramFrame:
-  dims=("channel", "frequency", "time")
-  coords: channel labels, frequency values, time values
+  BaseFrame default dims/coords in this PR
 ```
 
 If a frame does not have enough domain information for a rich coordinate, the implementation
-should use minimal dimension names instead of adding validation-heavy schema logic.
+should use neutral dimension names instead of adding validation-heavy schema logic.
+Time and frequency coordinates are deferred to a later schema phase.
 
 ## Public API
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "numpy>=2.0.2",
     "scipy>=1.13.0",
     "matplotlib>=3.9.0",
+    "xarray>=2025.6.1",
     "librosa",
     "ipykernel",
     "ipywidgets",

--- a/tests/core/test_base_frame.py
+++ b/tests/core/test_base_frame.py
@@ -463,13 +463,11 @@ def test_visualize_graph_exception_returns_none_and_logs(caplog) -> None:
     dask_data: DaArray = da_from_array(data, chunks=(1, -1))
     cf = ChannelFrame(data=dask_data, sampling_rate=16000)
 
-    cf._data = mock.MagicMock()
-    cf._data.visualize.side_effect = RuntimeError("viz fail")
-
-    with caplog.at_level("WARNING"):
-        res = cf.visualize_graph("out.png")
-        assert res is None
-        assert "Failed to visualize the graph" in caplog.text
+    with mock.patch.object(type(cf._data), "visualize", side_effect=RuntimeError("viz fail")):
+        with caplog.at_level("WARNING"):
+            res = cf.visualize_graph("out.png")
+            assert res is None
+            assert "Failed to visualize the graph" in caplog.text
 
 
 class TestBaseFrameChannelMetadata:

--- a/tests/core/test_base_frame_additional.py
+++ b/tests/core/test_base_frame_additional.py
@@ -175,13 +175,10 @@ def test_compute_non_ndarray_result_raises_value_error():
     arr = np.arange(6).reshape(2, 3)
     f = make_frame(arr)
 
-    class Bad:
-        def compute(self):
-            return [1, 2, 3]
-
-    f._data = Bad()  # ty: ignore[invalid-assignment]
-    with pytest.raises(ValueError, match=r"Computed result is not a np.ndarray"):
-        f.compute()
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(type(f._data), "compute", lambda self: [1, 2, 3])
+        with pytest.raises(ValueError, match=r"Computed result is not a np.ndarray"):
+            f.compute()
 
 
 def test_visualize_graph_failure_logs_warning_returns_none(caplog):
@@ -189,14 +186,14 @@ def test_visualize_graph_failure_logs_warning_returns_none(caplog):
     arr = np.arange(6).reshape(2, 3)
     f = make_frame(arr)
 
-    class BadVis:
-        def visualize(self, filename=None):
-            raise RuntimeError("no graphviz")
-
-    f._data = BadVis()  # ty: ignore[invalid-assignment]
-
-    with caplog.at_level("WARNING"):
-        res = f.visualize_graph()
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            type(f._data),
+            "visualize",
+            lambda self, filename=None: (_ for _ in ()).throw(RuntimeError("no graphviz")),
+        )
+        with caplog.at_level("WARNING"):
+            res = f.visualize_graph()
     assert res is None
     assert "Failed to visualize the graph" in caplog.text
 
@@ -315,27 +312,20 @@ def test_persist_returns_persisted_data():
     """Test persist() calls persist on internal data."""
     arr = np.arange(6).reshape(2, 3)
     f = make_frame(arr)
+    persisted = da_from_array(np.zeros((2, 3)), chunks=(2, 3))
+    calls = {"count": 0}
 
-    class Persister:
-        def __init__(self):
-            self.ndim = 2
-            self.shape = (2, 3)
+    def fake_persist(self):
+        calls["count"] += 1
+        return persisted
 
-        def persist(self):
-            return self
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(type(f._data), "persist", fake_persist)
+        newf = f.persist()
 
-        def rechunk(self, *args, **kwargs):
-            return self
-
-        def compute(self):
-            import numpy as _np
-
-            return _np.zeros(self.shape)
-
-    p = Persister()
-    f._data = p  # ty: ignore[invalid-assignment]
-    newf = f.persist()
-    assert newf._data is p
+    assert calls["count"] == 1
+    assert newf._data is newf._xr.data
+    np.testing.assert_array_equal(newf.compute(), np.zeros((2, 3)))
 
 
 def test_channel_metadata_invalid_dict_raises_value_error():

--- a/tests/core/test_xarray_storage_only.py
+++ b/tests/core/test_xarray_storage_only.py
@@ -5,6 +5,7 @@ from dask import array as da
 from dask import delayed
 
 from wandas import ChannelFrame
+from wandas.core.base_frame import BaseFrame
 from wandas.core.metadata import ChannelMetadata, FrameMetadata
 from wandas.frames.roughness import RoughnessFrame
 from wandas.frames.spectrogram import SpectrogramFrame
@@ -17,6 +18,25 @@ def _lazy_frame_with_counter(calls: list[str]) -> ChannelFrame:
 
     lazy_data = da.from_delayed(delayed(build)(), shape=(1, 4), dtype=float)
     return ChannelFrame(data=lazy_data, sampling_rate=4.0)
+
+
+class AxisOnlyFrame(BaseFrame[np.ndarray]):
+    _channel_axis = -3
+
+    def plot(self, plot_type: str = "default", ax=None, **kwargs):
+        raise NotImplementedError
+
+    def _get_dataframe_index(self):
+        return None
+
+
+def test_base_frame_channel_axis_drives_default_metadata_and_n_channels() -> None:
+    data = da.ones((2, 3, 4), chunks=(1, 3, 4))
+
+    frame = AxisOnlyFrame(data=data, sampling_rate=1.0)
+
+    assert frame.n_channels == 2
+    assert len(frame.channels) == 2
 
 
 def test_base_frame_owns_xarray_dataarray() -> None:

--- a/tests/core/test_xarray_storage_only.py
+++ b/tests/core/test_xarray_storage_only.py
@@ -180,6 +180,20 @@ def test_large_lazy_channel_frame_does_not_create_internal_time_coord() -> None:
     assert "time" not in frame._xr.coords
 
 
+def test_channel_frame_omits_channel_coord_when_metadata_length_differs() -> None:
+    data = da.ones((2, 8), chunks=(1, 8))
+
+    frame = ChannelFrame(
+        data=data,
+        sampling_rate=8.0,
+        channel_metadata=[{"label": "sig", "unit": "", "extra": {}}],
+    )
+
+    assert frame._xr.dims == ("channel", "time")
+    assert frame.labels == ["sig"]
+    assert "channel" not in frame._xr.coords
+
+
 def test_rename_channels_inplace_refreshes_xarray_channel_coord() -> None:
     frame = ChannelFrame.from_numpy(
         np.ones((2, 4)),

--- a/tests/core/test_xarray_storage_only.py
+++ b/tests/core/test_xarray_storage_only.py
@@ -235,3 +235,54 @@ def test_remove_channel_inplace_updates_xarray_without_compute() -> None:
     assert frame._data is frame._xr.data
     assert frame._data.shape == (1, 2)
     assert list(frame._xr.coords["channel"].values) == ["right"]
+
+
+def test_to_xarray_returns_public_shallow_copy_with_export_attrs() -> None:
+    frame = ChannelFrame.from_numpy(
+        np.array([[1.0, 2.0]]),
+        sampling_rate=2.0,
+        label="exported",
+        metadata={"source": "unit-test"},
+    )
+    frame.operation_history.append({"operation": "normalize", "params": {}})
+
+    exported = frame.to_xarray()
+
+    assert isinstance(exported, xr.DataArray)
+    assert exported is not frame._xr
+    assert exported.data is frame._data
+    assert exported.attrs["wandas_frame_type"] == "ChannelFrame"
+    assert exported.attrs["sampling_rate"] == 2.0
+    assert exported.attrs["label"] == "exported"
+    assert exported.attrs["metadata"] == {"source": "unit-test"}
+    assert exported.attrs["operation_history"] == [{"operation": "normalize", "params": {}}]
+
+    exported.attrs["label"] = "changed-export"
+    assert frame.label == "exported"
+
+
+def test_to_xarray_deep_copies_exported_frame_metadata() -> None:
+    metadata = FrameMetadata({"nested": {"x": 1}}, source_file="input.wav")
+    frame = ChannelFrame.from_numpy(
+        np.array([1.0]),
+        sampling_rate=1.0,
+        metadata=metadata,
+    )
+
+    exported = frame.to_xarray()
+
+    assert isinstance(exported.attrs["metadata"], FrameMetadata)
+    assert exported.attrs["metadata"].source_file == "input.wav"
+
+    exported.attrs["metadata"]["nested"]["x"] = 99
+    assert frame.metadata["nested"]["x"] == 1
+
+
+def test_xr_property_matches_to_xarray_contract() -> None:
+    frame = ChannelFrame.from_numpy(np.array([1.0, 2.0]), sampling_rate=2.0)
+
+    exported = frame.xr
+
+    assert isinstance(exported, xr.DataArray)
+    assert exported is not frame._xr
+    assert exported.data is frame._data

--- a/tests/core/test_xarray_storage_only.py
+++ b/tests/core/test_xarray_storage_only.py
@@ -5,6 +5,8 @@ from dask import array as da
 
 from wandas import ChannelFrame
 from wandas.core.metadata import ChannelMetadata, FrameMetadata
+from wandas.frames.roughness import RoughnessFrame
+from wandas.frames.spectrogram import SpectrogramFrame
 
 
 def test_base_frame_owns_xarray_dataarray() -> None:
@@ -19,31 +21,22 @@ def test_base_frame_owns_xarray_dataarray() -> None:
         ],
     )
 
-    assert isinstance(frame._xr, xr.DataArray)  # ty: ignore[unresolved-attribute]
-    assert frame._xr.dims == ("channel", "time")  # ty: ignore[unresolved-attribute]
-    assert frame._data is frame._xr.data  # ty: ignore[unresolved-attribute]
+    assert isinstance(frame._xr, xr.DataArray)
+    assert frame._xr.dims == ("channel", "time")
+    assert frame._data is frame._xr.data
     assert frame._data.chunks == ((1, 1), (8,))
-    assert list(frame._xr.coords["channel"].values) == [  # ty: ignore[unresolved-attribute]
+    assert list(frame._xr.coords["channel"].values) == [
         "left",
         "right",
     ]
-    assert frame._xr.coords["time"].values.tolist() == [  # ty: ignore[unresolved-attribute]
-        0.0,
-        0.25,
-        0.5,
-        0.75,
-        1.0,
-        1.25,
-        1.5,
-        1.75,
-    ]
+    assert "time" not in frame._xr.coords
 
 
 def test_data_alias_is_read_only() -> None:
     frame = ChannelFrame.from_numpy(np.array([1.0, 2.0, 3.0]), sampling_rate=3.0)
 
     with pytest.raises(AttributeError):
-        frame._data = da.zeros((1, 3), chunks=(1, -1))  # type: ignore[misc]
+        setattr(frame, "_data", da.zeros((1, 3), chunks=(1, -1)))
 
 
 def test_replace_data_updates_xarray_container_only() -> None:
@@ -58,9 +51,9 @@ def test_replace_data_updates_xarray_container_only() -> None:
     original_history = frame.operation_history
     replacement = da.full((1, 4), 2.0, chunks=(1, -1))
 
-    frame._replace_data(replacement)  # ty: ignore[unresolved-attribute]
+    frame._replace_data(replacement)
 
-    assert frame._data is frame._xr.data  # ty: ignore[unresolved-attribute]
+    assert frame._data is frame._xr.data
     assert frame._data.shape == (1, 4)
     assert frame._data.chunks == ((1,), (4,))
     assert frame.metadata is original_metadata
@@ -77,8 +70,114 @@ def test_internal_xarray_attrs_do_not_own_wandas_metadata() -> None:
         metadata={"gain": 1.5},
     )
 
-    frame._xr.attrs["label"] = "not-authoritative"  # ty: ignore[unresolved-attribute]
-    frame._xr.attrs["metadata"] = {"gain": 999}  # ty: ignore[unresolved-attribute]
+    frame._xr.attrs["label"] = "not-authoritative"
+    frame._xr.attrs["metadata"] = {"gain": 999}
 
     assert frame.label == "owned-by-wandas"
     assert frame.metadata["gain"] == 1.5
+
+
+def test_base_frame_keeps_roughness_mono_dims_neutral() -> None:
+    bark_axis = np.linspace(0.5, 23.5, 47)
+    data = da.ones((47, 5), chunks=(47, 5))
+
+    frame = RoughnessFrame(
+        data=data,
+        sampling_rate=10.0,
+        bark_axis=bark_axis,
+        overlap=0.5,
+        channel_metadata=[ChannelMetadata(label="mono", unit="asper")],
+    )
+
+    assert frame.n_channels == 1
+    assert frame._xr.dims == ("dim_0", "dim_1")
+    assert "channel" not in frame._xr.coords
+
+
+def test_base_frame_does_not_invent_spectrogram_time_coords() -> None:
+    data = da.ones((513, 6), chunks=(513, 3)) + 0j
+
+    frame = SpectrogramFrame(
+        data=data,
+        sampling_rate=48_000.0,
+        n_fft=1024,
+        hop_length=256,
+    )
+
+    assert frame._xr.dims == ("dim_0", "dim_1", "dim_2")
+    assert "time" not in frame._xr.coords
+
+
+def test_default_spectrogram_channel_metadata_matches_n_channels() -> None:
+    data = da.ones((2, 513, 6), chunks=(1, 513, 3)) + 0j
+
+    frame = SpectrogramFrame(
+        data=data,
+        sampling_rate=48_000.0,
+        n_fft=1024,
+        hop_length=256,
+    )
+
+    assert frame.n_channels == 2
+    assert len(frame.channels) == 2
+
+
+def test_default_roughness_mono_channel_metadata_matches_n_channels() -> None:
+    bark_axis = np.linspace(0.5, 23.5, 47)
+
+    frame = RoughnessFrame(
+        data=da.ones((47, 5), chunks=(47, 5)),
+        sampling_rate=10.0,
+        bark_axis=bark_axis,
+        overlap=0.5,
+    )
+
+    assert frame.n_channels == 1
+    assert len(frame.channels) == 1
+
+
+def test_default_roughness_stereo_channel_metadata_matches_n_channels() -> None:
+    bark_axis = np.linspace(0.5, 23.5, 47)
+
+    frame = RoughnessFrame(
+        data=da.ones((2, 47, 5), chunks=(1, 47, 5)),
+        sampling_rate=10.0,
+        bark_axis=bark_axis,
+        overlap=0.5,
+    )
+
+    assert frame.n_channels == 2
+    assert len(frame.channels) == 2
+
+
+def test_channel_frame_refreshes_xarray_channel_coord_after_label_update() -> None:
+    frame = ChannelFrame.from_numpy(
+        np.ones((2, 4)),
+        sampling_rate=4.0,
+        ch_labels=["L", "R"],
+    )
+
+    assert list(frame._xr.coords["channel"].values) == ["L", "R"]
+
+
+def test_large_lazy_channel_frame_does_not_create_internal_time_coord() -> None:
+    data = da.ones((2, 1_000_000), chunks=(1, 100_000))
+
+    frame = ChannelFrame(data=data, sampling_rate=48_000.0)
+
+    assert frame._xr.dims == ("channel", "time")
+    assert "channel" in frame._xr.coords
+    assert "time" not in frame._xr.coords
+
+
+def test_rename_channels_inplace_refreshes_xarray_channel_coord() -> None:
+    frame = ChannelFrame.from_numpy(
+        np.ones((2, 4)),
+        sampling_rate=4.0,
+        ch_labels=["L", "R"],
+    )
+
+    frame.rename_channels({"L": "Left"}, inplace=True)
+
+    assert frame.labels == ["Left", "R"]
+    assert list(frame._xr.coords["channel"].values) == ["Left", "R"]

--- a/tests/core/test_xarray_storage_only.py
+++ b/tests/core/test_xarray_storage_only.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 from dask import array as da
+from dask import delayed
 
 from wandas import ChannelFrame
 from wandas.core.metadata import ChannelMetadata, FrameMetadata
@@ -181,3 +182,56 @@ def test_rename_channels_inplace_refreshes_xarray_channel_coord() -> None:
 
     assert frame.labels == ["Left", "R"]
     assert list(frame._xr.coords["channel"].values) == ["Left", "R"]
+
+
+def test_add_channel_inplace_updates_xarray_without_compute() -> None:
+    calls: list[str] = []
+
+    def build() -> list[list[float]]:
+        calls.append("computed")
+        return [[1.0, 2.0, 3.0]]
+
+    lazy_data = da.from_delayed(
+        delayed(build)(),
+        shape=(1, 3),
+        dtype=float,
+    )
+    frame = ChannelFrame(data=lazy_data, sampling_rate=3.0)
+
+    result = frame.add_channel(np.array([4.0, 5.0, 6.0]), label="extra", inplace=True)
+
+    assert result is frame
+    assert calls == []
+    assert frame._data is frame._xr.data
+    assert frame._data.shape == (2, 3)
+    assert list(frame._xr.coords["channel"].values) == ["ch0", "extra"]
+
+
+def test_remove_channel_inplace_updates_xarray_without_compute() -> None:
+    calls: list[str] = []
+
+    def build() -> list[list[float]]:
+        calls.append("computed")
+        return [[1.0, 2.0], [3.0, 4.0]]
+
+    lazy_data = da.from_delayed(
+        delayed(build)(),
+        shape=(2, 2),
+        dtype=float,
+    )
+    frame = ChannelFrame(
+        data=lazy_data,
+        sampling_rate=2.0,
+        channel_metadata=[
+            ChannelMetadata(label="left"),
+            ChannelMetadata(label="right"),
+        ],
+    )
+
+    result = frame.remove_channel("left", inplace=True)
+
+    assert result is frame
+    assert calls == []
+    assert frame._data is frame._xr.data
+    assert frame._data.shape == (1, 2)
+    assert list(frame._xr.coords["channel"].values) == ["right"]

--- a/tests/core/test_xarray_storage_only.py
+++ b/tests/core/test_xarray_storage_only.py
@@ -10,6 +10,15 @@ from wandas.frames.roughness import RoughnessFrame
 from wandas.frames.spectrogram import SpectrogramFrame
 
 
+def _lazy_frame_with_counter(calls: list[str]) -> ChannelFrame:
+    def build() -> np.ndarray:
+        calls.append("computed")
+        return np.array([[1.0, 2.0, 3.0, 4.0]])
+
+    lazy_data = da.from_delayed(delayed(build)(), shape=(1, 4), dtype=float)
+    return ChannelFrame(data=lazy_data, sampling_rate=4.0)
+
+
 def test_base_frame_owns_xarray_dataarray() -> None:
     data = da.ones((2, 8), chunks=(2, 4))
     frame = ChannelFrame(
@@ -207,6 +216,45 @@ def test_add_channel_inplace_updates_xarray_without_compute() -> None:
     assert list(frame._xr.coords["channel"].values) == ["ch0", "extra"]
 
 
+def test_construction_and_xarray_export_do_not_compute() -> None:
+    calls: list[str] = []
+    frame = _lazy_frame_with_counter(calls)
+
+    _ = frame._data
+    exported = frame.to_xarray()
+    _ = frame.xr
+
+    assert calls == []
+    assert exported.data is frame._data
+
+
+def test_selection_and_operation_do_not_compute_until_compute() -> None:
+    calls: list[str] = []
+    frame = _lazy_frame_with_counter(calls)
+
+    selected = frame.get_channel(0)
+    normalized = selected.normalize()
+
+    assert calls == []
+
+    result = normalized.compute()
+
+    assert calls == ["computed"]
+    assert result.shape == (1, 4)
+
+
+def test_transform_methods_remain_lazy() -> None:
+    calls: list[str] = []
+    frame = _lazy_frame_with_counter(calls)
+
+    spectrum = frame.fft()
+    spectrogram = frame.stft(n_fft=4, hop_length=2)
+
+    assert calls == []
+    assert spectrum._data is spectrum._xr.data
+    assert spectrogram._data is spectrogram._xr.data
+
+
 def test_remove_channel_inplace_updates_xarray_without_compute() -> None:
     calls: list[str] = []
 
@@ -276,6 +324,16 @@ def test_to_xarray_deep_copies_exported_frame_metadata() -> None:
 
     exported.attrs["metadata"]["nested"]["x"] = 99
     assert frame.metadata["nested"]["x"] == 1
+
+
+def test_to_xarray_deep_copies_exported_operation_history() -> None:
+    frame = ChannelFrame.from_numpy(np.array([1.0, 2.0]), sampling_rate=2.0)
+    frame.operation_history.append({"operation": "gain", "params": {"factor": 2.0}})
+
+    exported = frame.to_xarray()
+    exported.attrs["operation_history"][0]["params"]["factor"] = 99.0
+
+    assert frame.operation_history[0]["params"]["factor"] == 2.0
 
 
 def test_xr_property_matches_to_xarray_contract() -> None:

--- a/tests/core/test_xarray_storage_only.py
+++ b/tests/core/test_xarray_storage_only.py
@@ -1,0 +1,84 @@
+import numpy as np
+import pytest
+import xarray as xr
+from dask import array as da
+
+from wandas import ChannelFrame
+from wandas.core.metadata import ChannelMetadata, FrameMetadata
+
+
+def test_base_frame_owns_xarray_dataarray() -> None:
+    data = da.ones((2, 8), chunks=(2, 4))
+    frame = ChannelFrame(
+        data=data,
+        sampling_rate=4.0,
+        label="signal",
+        channel_metadata=[
+            ChannelMetadata(label="left", unit="Pa"),
+            ChannelMetadata(label="right", unit="Pa"),
+        ],
+    )
+
+    assert isinstance(frame._xr, xr.DataArray)  # ty: ignore[unresolved-attribute]
+    assert frame._xr.dims == ("channel", "time")  # ty: ignore[unresolved-attribute]
+    assert frame._data is frame._xr.data  # ty: ignore[unresolved-attribute]
+    assert frame._data.chunks == ((1, 1), (8,))
+    assert list(frame._xr.coords["channel"].values) == [  # ty: ignore[unresolved-attribute]
+        "left",
+        "right",
+    ]
+    assert frame._xr.coords["time"].values.tolist() == [  # ty: ignore[unresolved-attribute]
+        0.0,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        1.25,
+        1.5,
+        1.75,
+    ]
+
+
+def test_data_alias_is_read_only() -> None:
+    frame = ChannelFrame.from_numpy(np.array([1.0, 2.0, 3.0]), sampling_rate=3.0)
+
+    with pytest.raises(AttributeError):
+        frame._data = da.zeros((1, 3), chunks=(1, -1))  # type: ignore[misc]
+
+
+def test_replace_data_updates_xarray_container_only() -> None:
+    metadata = FrameMetadata({"source": "test"}, source_file="input.wav")
+    frame = ChannelFrame.from_numpy(
+        np.array([[1.0, 2.0, 3.0]]),
+        sampling_rate=3.0,
+        label="original",
+        metadata=metadata,
+    )
+    original_metadata = frame.metadata
+    original_history = frame.operation_history
+    replacement = da.full((1, 4), 2.0, chunks=(1, -1))
+
+    frame._replace_data(replacement)  # ty: ignore[unresolved-attribute]
+
+    assert frame._data is frame._xr.data  # ty: ignore[unresolved-attribute]
+    assert frame._data.shape == (1, 4)
+    assert frame._data.chunks == ((1,), (4,))
+    assert frame.metadata is original_metadata
+    assert frame.operation_history is original_history
+    assert frame.label == "original"
+    assert frame.sampling_rate == 3.0
+
+
+def test_internal_xarray_attrs_do_not_own_wandas_metadata() -> None:
+    frame = ChannelFrame.from_numpy(
+        np.array([[1.0, 2.0]]),
+        sampling_rate=2.0,
+        label="owned-by-wandas",
+        metadata={"gain": 1.5},
+    )
+
+    frame._xr.attrs["label"] = "not-authoritative"  # ty: ignore[unresolved-attribute]
+    frame._xr.attrs["metadata"] = {"gain": 999}  # ty: ignore[unresolved-attribute]
+
+    assert frame.label == "owned-by-wandas"
+    assert frame.metadata["gain"] == 1.5

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -1118,7 +1118,7 @@ def test_reduce_channels_unsupported_op_raises() -> None:
     """_reduce_channels raises ValueError for unsupported operation (line 313)."""
     cf = ChannelFrame.from_numpy(np.random.default_rng(42).random((2, 100)), sampling_rate=1000)
     with pytest.raises(ValueError, match="Unsupported reduction operation"):
-        cf._reduce_channels("median")  # ty: ignore[call-non-callable]
+        cf._reduce_channels("median")
 
 
 def test_roughness_dw_spec_missing_bark_axis() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -4666,6 +4666,8 @@ dependencies = [
     { name = "scipy", version = "1.16.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tqdm" },
     { name = "types-requests" },
+    { name = "xarray", version = "2025.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "xarray", version = "2026.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -4717,6 +4719,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.13.0" },
     { name = "tqdm" },
     { name = "types-requests", specifier = ">=2.32.0.20250328" },
+    { name = "xarray", specifier = ">=2025.6.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -4987,6 +4990,42 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/01/3a/07cd60a9d26fe73efead61c7830af975dfdba8537632d410462672e4432b/wrapt-2.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:61c4956171c7434634401db448371277d07032a81cc21c599c22953374781395", size = 64038, upload-time = "2025-11-07T00:45:00.948Z" },
     { url = "https://files.pythonhosted.org/packages/41/99/8a06b8e17dddbf321325ae4eb12465804120f699cd1b8a355718300c62da/wrapt-2.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:35cdbd478607036fee40273be8ed54a451f5f23121bd9d4be515158f9498f7ad", size = 60634, upload-time = "2025-11-07T00:45:02.087Z" },
     { url = "https://files.pythonhosted.org/packages/15/d1/b51471c11592ff9c012bd3e2f7334a6ff2f42a7aed2caffcf0bdddc9cb89/wrapt-2.0.1-py3-none-any.whl", hash = "sha256:4d2ce1bf1a48c5277d7969259232b57645aae5686dba1eaeade39442277afbca", size = 44046, upload-time = "2025-11-07T00:45:32.116Z" },
+]
+
+[[package]]
+name = "xarray"
+version = "2025.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pandas", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/ec/e50d833518f10b0c24feb184b209bb6856f25b919ba8c1f89678b930b1cd/xarray-2025.6.1.tar.gz", hash = "sha256:a84f3f07544634a130d7dc615ae44175419f4c77957a7255161ed99c69c7c8b0", size = 3003185, upload-time = "2025-06-12T03:04:09.099Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/8a/6b50c1dd2260d407c1a499d47cf829f59f07007e0dcebafdabb24d1d26a5/xarray-2025.6.1-py3-none-any.whl", hash = "sha256:8b988b47f67a383bdc3b04c5db475cd165e580134c1f1943d52aee4a9c97651b", size = 1314739, upload-time = "2025-06-12T03:04:06.708Z" },
+]
+
+[[package]]
+name = "xarray"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pandas", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/a6/6fe936a798a3a38a79c7422d1a31afd2e9a14690fcb0ccff96bc01f04bf2/xarray-2026.4.0.tar.gz", hash = "sha256:c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b", size = 3132311, upload-time = "2026-04-13T19:45:36.688Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/83/6d810a8a9ebc9c307989b418840c20e46907c74d707beb67ab566773e6fc/xarray-2026.4.0-py3-none-any.whl", hash = "sha256:d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08", size = 1414326, upload-time = "2026-04-13T19:45:34.659Z" },
 ]
 
 [[package]]

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -592,6 +592,23 @@ class BaseFrame(ABC, Generic[T]):
         logger.debug(f"Computation complete, result shape: {result.shape}")
         return cast(T, result)
 
+    def to_xarray(self) -> xr.DataArray:
+        """Return a public xarray view of this frame without changing Wandas ownership."""
+        exported = self._xr.copy(deep=False)
+        exported.attrs = {
+            "wandas_frame_type": type(self).__name__,
+            "sampling_rate": self.sampling_rate,
+            "label": self.label,
+            "metadata": copy.deepcopy(self.metadata),
+            "operation_history": copy.deepcopy(self.operation_history),
+        }
+        return exported
+
+    @property
+    def xr(self) -> xr.DataArray:
+        """Return a public xarray view of this frame."""
+        return self.to_xarray()
+
     @abstractmethod
     def plot(self, plot_type: str = "default", ax: Axes | None = None, **kwargs: Any) -> Axes | Iterator[Axes]:
         """Plot the data"""

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+import xarray as xr
 from dask.array.core import Array as DaArray
 from matplotlib.axes import Axes
 from pydantic import ValidationError
@@ -77,7 +78,7 @@ class BaseFrame(ABC, Generic[T]):
         History of operations performed on this frame.
     """
 
-    _data: DaArray
+    _xr: xr.DataArray
     sampling_rate: float
     label: str
     metadata: FrameMetadata
@@ -95,27 +96,7 @@ class BaseFrame(ABC, Generic[T]):
         channel_metadata: list[ChannelMetadata] | list[dict[str, Any]] | None = None,
         previous: "BaseFrame[Any] | None" = None,
     ):
-        # Default rechunk: prefer channel-wise chunking so the 0th axis
-        # (channels) will be processed per-channel for parallelism.
-        # For (channels, samples) arrays use (1, -1). For spectrograms
-        # and higher-dim arrays (channels, ..) we preserve channel-wise
-        # first-axis chunking: (1, -1, -1, ...)
-        try:
-            # Normalize: reshape 1D data to (1, -1)
-            normalized = data.reshape((1, -1)) if data.ndim == 1 else data
-
-            # Chunking: channel-wise on first axis, flat on the rest
-            if normalized.ndim >= 2:
-                chunks = tuple([1] + [-1] * (normalized.ndim - 1))
-            else:
-                chunks = tuple([-1] * normalized.ndim)
-
-            self._data = normalized.rechunk(chunks)
-        except Exception as e:
-            # Fall back to previous behavior if Dask rechunk fails.
-            logger.warning(f"Rechunk failed: {e!r}. Falling back to chunks=-1.")
-            self._data = data.rechunk(chunks=-1)
-
+        normalized_data = self._normalize_data(data)
         self.sampling_rate = sampling_rate
         self.label = label or "unnamed_frame"
         if isinstance(metadata, FrameMetadata):
@@ -157,8 +138,11 @@ class BaseFrame(ABC, Generic[T]):
             ]
         else:
             self._channel_metadata = [
-                ChannelMetadata(label=f"ch{i}", unit="", extra={}) for i in range(self._n_channels)
+                ChannelMetadata(label=f"ch{i}", unit="", extra={})
+                for i in range(self._channel_count_from_data(normalized_data))
             ]
+
+        self._xr = self._build_xarray(normalized_data)
 
         try:
             # Display information for newer dask versions
@@ -166,6 +150,53 @@ class BaseFrame(ABC, Generic[T]):
             logger.debug(f"Dask graph dependencies: {len(self._data.dask.dependencies)}")
         except Exception as e:
             logger.debug(f"Dask graph visualization details unavailable: {e}")
+
+    @property
+    def _data(self) -> DaArray:
+        """Compatibility alias for the Dask array stored in ``_xr``."""
+        data = self._xr.data
+        if not isinstance(data, DaArray):
+            raise TypeError(f"Internal xarray data is not a Dask array: {type(data).__name__}")
+        return data
+
+    def _replace_data(self, data: DaArray) -> None:
+        """Replace the internal xarray data container without touching Wandas metadata."""
+        normalized = self._normalize_data(data)
+        self._xr = self._build_xarray(normalized)
+
+    def _normalize_data(self, data: DaArray) -> DaArray:
+        """Normalize Dask data shape and chunks using Wandas channel-wise policy."""
+        try:
+            normalized = data.reshape((1, -1)) if data.ndim == 1 else data
+            if normalized.ndim >= 2:
+                chunks = tuple([1] + [-1] * (normalized.ndim - 1))
+            else:
+                chunks = tuple([-1] * normalized.ndim)
+            return normalized.rechunk(chunks)
+        except Exception as e:
+            logger.warning(f"Rechunk failed: {e!r}. Falling back to chunks=-1.")
+            return data.rechunk(chunks=-1)
+
+    def _build_xarray(self, data: DaArray) -> xr.DataArray:
+        """Build the internal xarray container for frame data, dims, and coords."""
+        return xr.DataArray(
+            data,
+            dims=self._xarray_dims(data),
+            coords=self._xarray_coords(data),
+            name=self.label,
+        )
+
+    def _xarray_dims(self, data: DaArray) -> tuple[str, ...]:
+        """Return neutral dimension names for the internal xarray container."""
+        return tuple(f"dim_{i}" for i in range(data.ndim))
+
+    def _xarray_coords(self, data: DaArray) -> dict[str, Any]:
+        """Return conservative base coordinates for the internal xarray container."""
+        return {}
+
+    def _channel_count_from_data(self, data: DaArray) -> int:
+        """Return the frame channel count used for default channel metadata."""
+        return int(data.shape[-2])
 
     @property
     def _n_channels(self) -> int:

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -5,7 +5,7 @@ import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator
 from re import Pattern
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar, cast, overload
 
 import numpy as np
 import numpy.typing as npt
@@ -78,6 +78,7 @@ class BaseFrame(ABC, Generic[T]):
         History of operations performed on this frame.
     """
 
+    _channel_axis: ClassVar[int | None] = -2
     _xr: xr.DataArray
     sampling_rate: float
     label: str
@@ -195,18 +196,15 @@ class BaseFrame(ABC, Generic[T]):
         return {}
 
     def _channel_count_from_data(self, data: DaArray) -> int:
-        """Return the frame channel count used for default channel metadata."""
-        return int(data.shape[-2])
+        """Return the frame channel count from the declared channel axis."""
+        if self._channel_axis is None:
+            return 1
+        return int(data.shape[self._channel_axis])
 
     @property
     def _n_channels(self) -> int:
-        """Returns the number of channels.
-
-        Default assumes the channel axis is at position -2.
-        Subclasses with different data layouts (e.g. SpectrogramFrame,
-        RoughnessFrame) should override this.
-        """
-        return int(self._data.shape[-2])
+        """Returns the number of channels from the declared channel axis."""
+        return self._channel_count_from_data(self._data)
 
     @property
     def n_channels(self) -> int:

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -231,6 +231,22 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             previous=previous,
         )
 
+    def _channel_count_from_data(self, data: DaArray) -> int:
+        """Return the number of channels in channel-first data."""
+        return int(data.shape[0])
+
+    def _xarray_dims(self, data: DaArray) -> tuple[str, ...]:
+        """Return ChannelFrame dimension names for the internal xarray container."""
+        return ("channel", "time")
+
+    def _xarray_coords(self, data: DaArray) -> dict[str, Any]:
+        """Return cheap ChannelFrame coordinates owned by the frame."""
+        return {"channel": [ch.label for ch in self._channel_metadata]}
+
+    def _refresh_xarray_channel_coord(self) -> None:
+        """Refresh the internal xarray channel coordinate after label changes."""
+        self._xr = self._xr.assign_coords(channel=[ch.label for ch in self._channel_metadata])
+
     def _set_channel_labels(self, ch_labels: list[str]) -> None:
         """Overwrite channel labels after construction.
 
@@ -240,6 +256,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             raise ValueError("Number of channel labels does not match the number of channels")
         for i, lbl in enumerate(ch_labels):
             self._channel_metadata[i].label = lbl
+        self._refresh_xarray_channel_coord()
 
     def _set_channel_units(self, ch_units: list[str]) -> None:
         """Overwrite channel units after construction.
@@ -259,8 +276,8 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
     ) -> "ChannelFrame":
         """Apply *new_data* and *new_chmeta* either in-place or as a new frame."""
         if inplace:
-            self._data = new_data
             self._channel_metadata = new_chmeta
+            self._replace_data(new_data)
             return self
         return ChannelFrame(
             data=new_data,
@@ -1379,6 +1396,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
 
         if inplace:
             self._channel_metadata = new_chmeta
+            self._refresh_xarray_channel_coord()
             return self
         return self._finalize_channel_update(self._data, new_chmeta, inplace=False)
 

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -241,11 +241,18 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
 
     def _xarray_coords(self, data: DaArray) -> dict[str, Any]:
         """Return cheap ChannelFrame coordinates owned by the frame."""
-        return {"channel": [ch.label for ch in self._channel_metadata]}
+        labels = [ch.label for ch in self._channel_metadata]
+        if len(labels) != self._channel_count_from_data(data):
+            return {}
+        return {"channel": labels}
 
     def _refresh_xarray_channel_coord(self) -> None:
         """Refresh the internal xarray channel coordinate after label changes."""
-        self._xr = self._xr.assign_coords(channel=[ch.label for ch in self._channel_metadata])
+        labels = [ch.label for ch in self._channel_metadata]
+        if len(labels) != self.n_channels:
+            self._xr = self._xr.drop_vars("channel", errors="ignore")
+            return
+        self._xr = self._xr.assign_coords(channel=labels)
 
     def _set_channel_labels(self, ch_labels: list[str]) -> None:
         """Overwrite channel labels after construction.

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -231,10 +231,6 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             previous=previous,
         )
 
-    def _channel_count_from_data(self, data: DaArray) -> int:
-        """Return the number of channels in channel-first data."""
-        return int(data.shape[0])
-
     def _xarray_dims(self, data: DaArray) -> tuple[str, ...]:
         """Return ChannelFrame dimension names for the internal xarray container."""
         return ("channel", "time")

--- a/wandas/frames/roughness.py
+++ b/wandas/frames/roughness.py
@@ -228,6 +228,12 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
         """
         return self._overlap
 
+    def _channel_count_from_data(self, data: DaArray) -> int:
+        """Return the number of channels for mono or channel-first roughness data."""
+        if data.ndim == 2:
+            return 1
+        return int(data.shape[0])
+
     @property
     def _n_channels(self) -> int:
         """

--- a/wandas/frames/roughness.py
+++ b/wandas/frames/roughness.py
@@ -229,24 +229,10 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
         return self._overlap
 
     def _channel_count_from_data(self, data: DaArray) -> int:
-        """Return the number of channels for mono or channel-first roughness data."""
+        """Return the number of channels for mono or channel-bark-time data."""
         if data.ndim == 2:
             return 1
-        return int(data.shape[0])
-
-    @property
-    def _n_channels(self) -> int:
-        """
-        Return the number of channels.
-
-        Returns
-        -------
-        int
-            Number of channels. For 2D data (mono), returns 1.
-        """
-        if self._data.ndim == 2:
-            return 1
-        return int(self._data.shape[0])
+        return int(data.shape[-3])
 
     def _get_additional_init_kwargs(self) -> dict[str, Any]:
         """

--- a/wandas/frames/spectrogram.py
+++ b/wandas/frames/spectrogram.py
@@ -96,6 +96,8 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
     >>> spectrogram.plot()
     """
 
+    _channel_axis = -3
+
     n_fft: int
     hop_length: int
     win_length: int
@@ -146,22 +148,6 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             channel_metadata=channel_metadata,
             previous=previous,
         )
-
-    def _channel_count_from_data(self, data: DaArray) -> int:
-        """Return the number of channels in channel-frequency-time data."""
-        return int(data.shape[-3])
-
-    @property
-    def _n_channels(self) -> int:
-        """
-        Get the number of channels in the data.
-
-        Returns
-        -------
-        int
-            The number of channels.
-        """
-        return int(self._data.shape[-3])
 
     @property
     def n_frames(self) -> int:

--- a/wandas/frames/spectrogram.py
+++ b/wandas/frames/spectrogram.py
@@ -147,6 +147,10 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             previous=previous,
         )
 
+    def _channel_count_from_data(self, data: DaArray) -> int:
+        """Return the number of channels in channel-frequency-time data."""
+        return int(data.shape[-3])
+
     @property
     def _n_channels(self) -> int:
         """


### PR DESCRIPTION
## Summary

Phase 1 of the xarray migration. This intentionally uses xarray only as an axis-aware internal data container.

- add `xarray` dependency
- store `BaseFrame` data in `self._xr: xr.DataArray`
- keep `_data` as a read-only compatibility alias to `self._xr.data`
- keep existing operation execution on Dask arrays unchanged
- centralize channel counting with `BaseFrame._channel_axis` so frame layouts declare channel position once
- expose `frame.to_xarray()` and `frame.xr` as public shallow exports
- keep `sampling_rate`, `label`, `metadata`, `operation_history`, and `channel_metadata` Wandas-owned, not internally backed by `_xr.attrs`
- document the storage-only design and implementation plan

## Explicit Non-Goals

This PR does not add:

- `from_xarray()`
- xarray-native operation dispatch
- `xr.apply_ufunc()` / `map_blocks()` processing
- NetCDF / Zarr support
- xarray accessor APIs
- attrs-backed internal metadata ownership

## Compatibility Notes

- `_data` is now read-only. Production code no longer assigns `self._data = ...`; in-place data replacement uses explicit xarray container refresh instead.
- This may affect external code that relied on private `_data` assignment. Public APIs are expected to keep working.
- `to_xarray()` attaches copied export attrs for interoperability, but internal metadata ownership remains in Wandas. Serialization policy for future NetCDF/Zarr phases is intentionally left out of this PR.
- Channel axis is now declared once via `_channel_axis`; `SpectrogramFrame` uses `-3`, default channel-frequency style frames use `-2`, and `RoughnessFrame` keeps a special count method for mono 2D data.

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check wandas tests`
- `uv run pytest` -> `1454 passed, 3 skipped`

## Review Notes

An independent code review pass found no blocking issues. Remaining risks are intentionally documented: private `_data` setter compatibility and future export attrs serialization design.