### PR TITLE
Phase 3: back frame state with xarray attrs

### DIFF
--- a/docs/superpowers/plans/2026-06-10-xarray-backed-frame-state.md
+++ b/docs/superpowers/plans/2026-06-10-xarray-backed-frame-state.md
@@ -916,7 +916,7 @@ Run:
 rg -n "FrameMetadata|metadata\.source_file|metadata\.merged" docs README.md -g '*.md'
 ```
 
-Expected: no output or only historical design docs under `docs/superpowers/specs`. If user-facing docs mention old API, update them to plain dict metadata and `_source_file`.
+Expected: no output in user-facing docs, or only historical planning/design docs under `docs/superpowers/`. If user-facing docs mention old API, update them to plain dict metadata and `_source_file`.
 
 - [ ] **Step 3: Run type and lint checks**
 

--- a/docs/superpowers/plans/2026-06-10-xarray-backed-frame-state.md
+++ b/docs/superpowers/plans/2026-06-10-xarray-backed-frame-state.md
@@ -1,0 +1,1043 @@
+# Xarray-Backed Frame State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move frame-level state from standalone `BaseFrame` attributes and `FrameMetadata` into `_xr.attrs`, while keeping public property access and leaving `ChannelMetadata` unchanged.
+
+**Architecture:** `BaseFrame._xr` remains the internal data container and becomes the backing store for `sampling_rate`, `label`, `metadata`, and `operation_history`. Wandas properties validate and interpret those attrs; xarray only stores them. `FrameMetadata` is removed instead of bridged for compatibility.
+
+**Tech Stack:** Python 3.10, xarray `DataArray.attrs`, Dask arrays, pytest, ruff, ty, h5py/WDF tests.
+
+---
+
+## File Structure
+
+- Modify: `wandas/core/base_frame.py`
+  - Add property-backed frame state over `_xr.attrs`.
+  - Reorder initialization so `_xr` exists before frame-level setters run.
+  - Preserve attrs in `_replace_data()`.
+  - Deep-copy attrs in `to_xarray()`.
+  - Remove `FrameMetadata` imports and type paths.
+- Modify: `wandas/core/metadata.py`
+  - Remove `FrameMetadata`; keep `ChannelMetadata` unchanged.
+- Modify: `wandas/core/__init__.py`
+  - Stop exporting `FrameMetadata`.
+- Modify: `wandas/frames/channel.py`, `wandas/frames/spectral.py`, `wandas/frames/spectrogram.py`, `wandas/frames/mixins/channel_transform_mixin.py`, `wandas/frames/mixins/channel_processing_mixin.py`, `wandas/frames/mixins/protocols.py`
+  - Replace `FrameMetadata` annotations and `.merged()` calls with `dict[str, Any]` and plain dict merging.
+  - Change WAV source metadata to `{"_source_file": source}`.
+- Modify: `wandas/io/wdf_io.py`
+  - Treat metadata as plain dict.
+  - Store and load `_source_file` as a normal metadata key; read legacy `meta.attrs["source_file"]` into `_source_file` for old WDF files.
+- Modify tests:
+  - `tests/core/test_xarray_storage_only.py`
+  - `tests/core/test_metadata.py`
+  - `tests/core/test_base_frame.py`
+  - `tests/core/test_base_frame_additional.py`
+  - `tests/io/test_wdf_io.py`
+  - `tests/io/test_wav_io.py`
+  - `tests/frames/test_channel_additional.py`
+  - `tests/frames/test_channel_processing.py`
+  - any other tests that still import `FrameMetadata` or assert `.source_file`.
+
+---
+
+### Task 1: Add Failing Tests for Attr-Backed Frame State
+
+**Files:**
+- Modify: `tests/core/test_xarray_storage_only.py`
+
+- [ ] **Step 1: Replace FrameMetadata import in the xarray storage test file**
+
+Change the import near the top of `tests/core/test_xarray_storage_only.py` from:
+
+```python
+from wandas.core.metadata import ChannelMetadata, FrameMetadata
+```
+
+to:
+
+```python
+from wandas.core.metadata import ChannelMetadata
+```
+
+- [ ] **Step 2: Replace `test_replace_data_updates_xarray_container_only` with an attrs preservation test**
+
+Replace the existing function with:
+
+```python
+def test_replace_data_preserves_xarray_attrs_backed_frame_state() -> None:
+    frame = ChannelFrame.from_numpy(
+        np.array([[1.0, 2.0, 3.0]]),
+        sampling_rate=3.0,
+        label="original",
+        metadata={"source": "test", "nested": {"x": 1}},
+    )
+    frame.operation_history = [{"operation": "load", "params": {"path": "input.wav"}}]
+    replacement = da.full((1, 4), 2.0, chunks=(1, -1))
+
+    frame._replace_data(replacement)
+
+    assert frame._data is frame._xr.data
+    assert frame._data.shape == (1, 4)
+    assert frame.sampling_rate == 3.0
+    assert frame.label == "original"
+    assert frame._xr.attrs["sampling_rate"] == 3.0
+    assert frame._xr.attrs["label"] == "original"
+    assert frame.metadata == {"source": "test", "nested": {"x": 1}}
+    assert frame.operation_history == [{"operation": "load", "params": {"path": "input.wav"}}]
+```
+
+- [ ] **Step 3: Replace `test_to_xarray_deep_copies_exported_frame_metadata`**
+
+Replace the function with:
+
+```python
+def test_to_xarray_deep_copies_exported_metadata_dict() -> None:
+    frame = ChannelFrame.from_numpy(
+        np.array([[1.0, 2.0, 3.0]]),
+        sampling_rate=3.0,
+        metadata={"nested": {"x": 1}, "_source_file": "input.wav"},
+    )
+
+    exported = frame.to_xarray()
+    exported.attrs["metadata"]["nested"]["x"] = 99
+    exported.attrs["metadata"]["_source_file"] = "changed.wav"
+
+    assert type(frame.metadata) is dict
+    assert frame.metadata["nested"]["x"] == 1
+    assert frame.metadata["_source_file"] == "input.wav"
+```
+
+- [ ] **Step 4: Add direct attrs-backed property tests**
+
+Add these tests after the existing `to_xarray` tests:
+
+```python
+def test_frame_state_properties_are_backed_by_xarray_attrs() -> None:
+    frame = ChannelFrame.from_numpy(
+        np.array([[1.0, 2.0, 3.0]]),
+        sampling_rate=3.0,
+        label="stateful",
+        metadata={"owner": "attrs"},
+        operation_history=[{"operation": "load", "params": {}}],
+    )
+
+    assert frame._xr.attrs["sampling_rate"] == 3.0
+    assert frame._xr.attrs["label"] == "stateful"
+    assert frame._xr.attrs["metadata"] == {"owner": "attrs"}
+    assert frame._xr.attrs["operation_history"] == [{"operation": "load", "params": {}}]
+
+    frame._xr.attrs["sampling_rate"] = 8.0
+    frame._xr.attrs["label"] = "from-attrs"
+    frame._xr.attrs["metadata"] = {"owner": "mutated"}
+    frame._xr.attrs["operation_history"] = [{"operation": "mutated", "params": {"x": 1}}]
+
+    assert frame.sampling_rate == 8.0
+    assert frame.label == "from-attrs"
+    assert frame.metadata == {"owner": "mutated"}
+    assert frame.operation_history == [{"operation": "mutated", "params": {"x": 1}}]
+
+
+def test_frame_state_property_setters_update_xarray_attrs() -> None:
+    frame = ChannelFrame.from_numpy(np.array([[1.0, 2.0, 3.0]]), sampling_rate=3.0)
+
+    frame.sampling_rate = 6
+    frame.label = "updated"
+    frame.metadata = {"nested": {"x": 1}}
+    frame.operation_history = [{"operation": "gain", "params": {"factor": 2.0}}]
+
+    assert frame._xr.attrs["sampling_rate"] == 6.0
+    assert frame._xr.attrs["label"] == "updated"
+    assert frame._xr.name == "updated"
+    assert frame._xr.attrs["metadata"] == {"nested": {"x": 1}}
+    assert frame._xr.attrs["operation_history"] == [{"operation": "gain", "params": {"factor": 2.0}}]
+
+
+def test_frame_state_property_setters_validate_inputs() -> None:
+    frame = ChannelFrame.from_numpy(np.array([[1.0, 2.0, 3.0]]), sampling_rate=3.0)
+
+    with pytest.raises(ValueError, match="Invalid sampling_rate"):
+        frame.sampling_rate = 0
+
+    with pytest.raises(TypeError, match="Label must be a string or None"):
+        frame.label = 123  # type: ignore[assignment]
+
+    with pytest.raises(TypeError, match="Metadata must be a dictionary"):
+        frame.metadata = "invalid"  # type: ignore[assignment]
+
+    with pytest.raises(TypeError, match="Operation history must be a list"):
+        frame.operation_history = {"operation": "bad"}  # type: ignore[assignment]
+```
+
+- [ ] **Step 5: Run tests and verify they fail for the right reason**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_xarray_storage_only.py -q
+```
+
+Expected: fails because `FrameMetadata` is still imported/used in production or because state is still stored on plain attributes rather than `_xr.attrs`.
+
+- [ ] **Step 6: Commit failing tests**
+
+```bash
+git add tests/core/test_xarray_storage_only.py
+git commit -m "test: define attrs-backed frame state"
+```
+
+---
+
+### Task 2: Implement Attr-Backed State in BaseFrame
+
+**Files:**
+- Modify: `wandas/core/base_frame.py`
+- Test: `tests/core/test_xarray_storage_only.py`
+
+- [ ] **Step 1: Update imports and annotations**
+
+In `wandas/core/base_frame.py`, replace:
+
+```python
+from wandas.utils.types import NDArrayComplex, NDArrayReal
+
+from .metadata import ChannelMetadata, FrameMetadata
+```
+
+with:
+
+```python
+from wandas.utils import validate_sampling_rate
+from wandas.utils.types import NDArrayComplex, NDArrayReal
+
+from .metadata import ChannelMetadata
+```
+
+Update class annotations from:
+
+```python
+sampling_rate: float
+label: str
+metadata: FrameMetadata
+operation_history: list[dict[str, Any]]
+```
+
+to a comment-free removal of those storage annotations. The public properties added below provide the typed interface. Keep `_xr`, `_channel_metadata`, and `_previous` annotations.
+
+- [ ] **Step 2: Reorder `__init__` to build `_xr` before property setters**
+
+Replace the beginning of `BaseFrame.__init__` through `_previous` setup with this structure:
+
+```python
+        normalized_data = self._normalize_data(data)
+        frame_label = label or "unnamed_frame"
+
+        if channel_metadata:
+            def _to_channel_metadata(ch: ChannelMetadata | dict[str, Any], index: int) -> ChannelMetadata:
+                if isinstance(ch, ChannelMetadata):
+                    return copy.deepcopy(ch)
+                if isinstance(ch, dict):
+                    try:
+                        return ChannelMetadata(**ch)
+                    except ValidationError as e:
+                        raise ValueError(
+                            f"Invalid channel_metadata at index {index}\n"
+                            f"  Got: {ch}\n"
+                            f"  Validation error: {e}\n"
+                            f"Ensure all dict keys match ChannelMetadata fields "
+                            f"(label, unit, ref, extra) and have correct types."
+                        ) from e
+                raise TypeError(
+                    f"Invalid type in channel_metadata at index {index}\n"
+                    f"  Got: {type(ch).__name__} ({ch!r})\n"
+                    f"  Expected: ChannelMetadata or dict\n"
+                    f"Use ChannelMetadata objects or dicts with valid fields."
+                )
+
+            self._channel_metadata = [
+                _to_channel_metadata(cast(ChannelMetadata | dict[str, Any], ch), i)
+                for i, ch in enumerate(channel_metadata)
+            ]
+        else:
+            channel_count = self._channel_size_from_xarray_dims(normalized_data)
+            if channel_count is None:
+                channel_count = self._channel_count_from_data(normalized_data)
+            self._channel_metadata = [ChannelMetadata(label=f"ch{i}", unit="", extra={}) for i in range(channel_count)]
+
+        self._xr = self._build_xarray(normalized_data, name=frame_label)
+        self.label = label
+        self.sampling_rate = sampling_rate
+        self.metadata = metadata
+        self.operation_history = operation_history
+        self._previous = previous
+```
+
+- [ ] **Step 3: Change `_build_xarray()` and `_replace_data()`**
+
+Replace `_replace_data()` and `_build_xarray()` with:
+
+```python
+    def _replace_data(self, data: DaArray) -> None:
+        """Replace the internal xarray data container without touching frame state."""
+        normalized = self._normalize_data(data)
+        attrs = copy.deepcopy(self._xr.attrs)
+        self._xr = self._build_xarray(normalized, name=self.label)
+        self._xr.attrs = attrs
+
+    def _build_xarray(self, data: DaArray, *, name: str) -> xr.DataArray:
+        """Build the internal xarray container for frame data, dims, and coords."""
+        return xr.DataArray(
+            data,
+            dims=self._xarray_dims(data),
+            coords=self._xarray_coords(data),
+            name=name,
+        )
+```
+
+- [ ] **Step 4: Add frame state properties after `previous` property**
+
+Add:
+
+```python
+    @property
+    def sampling_rate(self) -> float:
+        """Return the frame sampling rate from xarray attrs."""
+        return float(self._xr.attrs["sampling_rate"])
+
+    @sampling_rate.setter
+    def sampling_rate(self, value: float) -> None:
+        validate_sampling_rate(value)
+        self._xr.attrs["sampling_rate"] = float(value)
+
+    @property
+    def label(self) -> str:
+        """Return the frame label from xarray attrs."""
+        value = self._xr.attrs.get("label", self._xr.name)
+        if value is None or value == "":
+            return "unnamed_frame"
+        return str(value)
+
+    @label.setter
+    def label(self, value: str | None) -> None:
+        if value is not None and not isinstance(value, str):
+            raise TypeError("Label must be a string or None")
+        label = value or "unnamed_frame"
+        self._xr.attrs["label"] = label
+        self._xr.name = label
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Return mutable frame metadata stored in xarray attrs."""
+        value = self._xr.attrs.get("metadata")
+        if value is None:
+            value = {}
+            self._xr.attrs["metadata"] = value
+        if not isinstance(value, dict):
+            raise TypeError(f"Internal metadata attrs must be a dictionary, got {type(value).__name__}")
+        return value
+
+    @metadata.setter
+    def metadata(self, value: dict[str, Any] | None) -> None:
+        if value is None:
+            self._xr.attrs["metadata"] = {}
+            return
+        if not isinstance(value, dict):
+            raise TypeError("Metadata must be a dictionary")
+        self._xr.attrs["metadata"] = dict(value)
+
+    @property
+    def operation_history(self) -> list[dict[str, Any]]:
+        """Return mutable operation history stored in xarray attrs."""
+        value = self._xr.attrs.get("operation_history")
+        if value is None:
+            value = []
+            self._xr.attrs["operation_history"] = value
+        if not isinstance(value, list):
+            raise TypeError(f"Internal operation_history attrs must be a list, got {type(value).__name__}")
+        return value
+
+    @operation_history.setter
+    def operation_history(self, value: list[dict[str, Any]] | None) -> None:
+        if value is None:
+            self._xr.attrs["operation_history"] = []
+            return
+        if not isinstance(value, list):
+            raise TypeError("Operation history must be a list")
+        self._xr.attrs["operation_history"] = copy.deepcopy(value)
+```
+
+- [ ] **Step 5: Update `to_xarray()`**
+
+Replace the method body with:
+
+```python
+        exported = self._xr.copy(deep=False)
+        exported.attrs = copy.deepcopy(self._xr.attrs)
+        exported.attrs["wandas_frame_type"] = type(self).__name__
+        return exported
+```
+
+- [ ] **Step 6: Update `_create_new_instance()` metadata validation**
+
+Replace:
+
+```python
+        metadata = kwargs.pop("metadata", copy.deepcopy(self.metadata))
+        if not isinstance(metadata, (dict, FrameMetadata)):
+            raise TypeError("Metadata must be a dictionary or FrameMetadata")
+```
+
+with:
+
+```python
+        metadata = kwargs.pop("metadata", copy.deepcopy(self.metadata))
+        if not isinstance(metadata, dict):
+            raise TypeError("Metadata must be a dictionary")
+
+        operation_history = kwargs.pop("operation_history", copy.deepcopy(self.operation_history))
+        if not isinstance(operation_history, list):
+            raise TypeError("Operation history must be a list")
+```
+
+And pass `operation_history=operation_history` into `type(self)(...)`.
+
+- [ ] **Step 7: Update `_binary_op()` and `_updated_metadata_and_history()` types**
+
+In `_binary_op()`, replace:
+
+```python
+        metadata: FrameMetadata = self.metadata.copy() if self.metadata is not None else FrameMetadata()
+        operation_history: list[dict[str, Any]] = self.operation_history.copy() if self.operation_history else []
+```
+
+with:
+
+```python
+        metadata = copy.deepcopy(self.metadata)
+        operation_history = copy.deepcopy(self.operation_history)
+```
+
+Change `_updated_metadata_and_history()` return annotation and docstring from `FrameMetadata` to `dict[str, Any]`, and use:
+
+```python
+        new_metadata = copy.deepcopy(self.metadata)
+```
+
+- [ ] **Step 8: Run targeted tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_xarray_storage_only.py -q
+```
+
+Expected: the new attr-backed tests pass, but other repository tests may still fail because `FrameMetadata` remains in other modules.
+
+- [ ] **Step 9: Commit BaseFrame implementation**
+
+```bash
+git add wandas/core/base_frame.py tests/core/test_xarray_storage_only.py
+git commit -m "feat: back frame state with xarray attrs"
+```
+
+---
+
+### Task 3: Remove FrameMetadata From Production Imports and Merges
+
+**Files:**
+- Modify: `wandas/core/metadata.py`
+- Modify: `wandas/core/__init__.py`
+- Modify: `wandas/frames/channel.py`
+- Modify: `wandas/frames/spectral.py`
+- Modify: `wandas/frames/spectrogram.py`
+- Modify: `wandas/frames/mixins/channel_transform_mixin.py`
+- Modify: `wandas/frames/mixins/channel_processing_mixin.py`
+- Modify: `wandas/frames/mixins/protocols.py`
+
+- [ ] **Step 1: Remove FrameMetadata class**
+
+In `wandas/core/metadata.py`, delete the `FrameMetadata` class and the unused import alias:
+
+```python
+import copy as _copy
+```
+
+The file should start with:
+
+```python
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from wandas.utils.util import unit_to_ref
+```
+
+Keep `ChannelMetadata` unchanged.
+
+- [ ] **Step 2: Stop exporting FrameMetadata**
+
+Replace `wandas/core/__init__.py` with:
+
+```python
+from .base_frame import BaseFrame
+
+__all__ = [
+    "BaseFrame",
+]
+```
+
+- [ ] **Step 3: Update frame constructor annotations/imports**
+
+In `wandas/frames/channel.py`, replace:
+
+```python
+from ..core.metadata import ChannelMetadata, FrameMetadata
+```
+
+with:
+
+```python
+from ..core.metadata import ChannelMetadata
+```
+
+Replace each constructor or factory annotation of:
+
+```python
+metadata: "FrameMetadata | dict[str, Any] | None" = None
+```
+
+with:
+
+```python
+metadata: dict[str, Any] | None = None
+```
+
+Do the same replacement in `wandas/frames/spectral.py` and `wandas/frames/spectrogram.py`.
+
+- [ ] **Step 4: Update WAV source metadata**
+
+In `ChannelFrame.from_file()`, replace:
+
+```python
+            metadata=FrameMetadata(source_file=source_file),
+```
+
+with:
+
+```python
+            metadata={"_source_file": source_file} if source_file is not None else None,
+```
+
+- [ ] **Step 5: Replace `.merged()` in transform mixin**
+
+In `wandas/frames/mixins/channel_transform_mixin.py`, replace each occurrence:
+
+```python
+metadata=self.metadata.merged(**params),
+```
+
+with:
+
+```python
+metadata={**self.metadata, **params},
+```
+
+Replace:
+
+```python
+metadata=self.metadata.merged(window=window, n_fft=_n_fft),
+```
+
+with:
+
+```python
+metadata={**self.metadata, "window": window, "n_fft": _n_fft},
+```
+
+- [ ] **Step 6: Replace `.merged()` in processing mixin**
+
+In `wandas/frames/mixins/channel_processing_mixin.py`, replace:
+
+```python
+        new_metadata = self.metadata.merged(**params)
+```
+
+with:
+
+```python
+        new_metadata = {**self.metadata, **params}
+```
+
+- [ ] **Step 7: Update protocols**
+
+In `wandas/frames/mixins/protocols.py`, replace:
+
+```python
+from wandas.core.metadata import ChannelMetadata, FrameMetadata
+```
+
+with:
+
+```python
+from wandas.core.metadata import ChannelMetadata
+```
+
+Replace protocol metadata annotation:
+
+```python
+    metadata: FrameMetadata
+```
+
+with:
+
+```python
+    metadata: dict[str, Any]
+```
+
+Replace `_updated_metadata_and_history()` return annotation:
+
+```python
+    ) -> tuple[FrameMetadata, list[dict[str, Any]]]: ...
+```
+
+with:
+
+```python
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]: ...
+```
+
+- [ ] **Step 8: Search for production FrameMetadata references**
+
+Run:
+
+```bash
+rg -n "FrameMetadata|metadata\.merged|metadata\.source_file" wandas -g '*.py'
+```
+
+Expected: no output.
+
+- [ ] **Step 9: Run focused tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_xarray_storage_only.py tests/frames/test_channel_transform.py tests/frames/test_channel_processing.py -q
+```
+
+Expected: passes or only fails in tests that still import `FrameMetadata`, which Task 5 handles. Production import errors must be fixed in this task before committing.
+
+- [ ] **Step 10: Commit production cleanup**
+
+```bash
+git add wandas/core/metadata.py wandas/core/__init__.py wandas/frames/channel.py wandas/frames/spectral.py wandas/frames/spectrogram.py wandas/frames/mixins/channel_transform_mixin.py wandas/frames/mixins/channel_processing_mixin.py wandas/frames/mixins/protocols.py
+git commit -m "refactor: remove FrameMetadata from production code"
+```
+
+---
+
+### Task 4: Update WDF and Reader Source Metadata
+
+**Files:**
+- Modify: `wandas/io/wdf_io.py`
+- Modify: `tests/io/test_wdf_io.py`
+- Modify: `tests/io/test_wav_io.py`
+- Modify: `tests/frames/test_channel_additional.py`
+
+- [ ] **Step 1: Update WDF source-file tests first**
+
+In `tests/io/test_wdf_io.py`, replace `test_source_file_roundtrip()` with:
+
+```python
+def test_source_file_roundtrip(tmp_path: Path) -> None:
+    """Source file metadata survives a save/load round-trip as a plain dict key."""
+    source = "audio/input.wav"
+    data = np.array([[1, 2, 3]], dtype=np.float32)
+    sr = 16000
+    cf = ChannelFrame.from_numpy(
+        data,
+        sr,
+        metadata={"key": "val", "_source_file": source},
+    )
+    assert type(cf.metadata) is dict
+    assert cf.metadata["_source_file"] == source
+
+    path = tmp_path / "test_source_file.wdf"
+    cf.to_wdf(path)
+    cf2 = ChannelFrame.from_wdf(path)
+
+    assert type(cf2.metadata) is dict
+    assert cf2.metadata["_source_file"] == source
+    assert cf2.metadata["key"] == "val"
+```
+
+Replace `test_source_file_none_roundtrip()` with:
+
+```python
+def test_source_file_absent_roundtrip(tmp_path: Path) -> None:
+    """Round-trip without source file keeps metadata as a plain dict."""
+    data = np.array([[1, 2, 3]], dtype=np.float32)
+    sr = 16000
+    cf = ChannelFrame.from_numpy(data, sr, metadata={"only": "dict"})
+    assert type(cf.metadata) is dict
+    assert "_source_file" not in cf.metadata
+
+    path = tmp_path / "test_no_source_file.wdf"
+    cf.to_wdf(path)
+    cf2 = ChannelFrame.from_wdf(path)
+
+    assert type(cf2.metadata) is dict
+    assert cf2.metadata == {"only": "dict"}
+```
+
+- [ ] **Step 2: Update WAV/URL source tests**
+
+In `tests/io/test_wav_io.py`, replace:
+
+```python
+    assert cf.metadata.source_file == url, "source_file metadata not preserved"
+```
+
+with:
+
+```python
+    assert cf.metadata["_source_file"] == url, "source file metadata not preserved"
+```
+
+In `tests/frames/test_channel_additional.py`, replace:
+
+```python
+    assert cf.metadata.source_file == "my_file.wav"
+```
+
+with:
+
+```python
+    assert cf.metadata["_source_file"] == "my_file.wav"
+```
+
+- [ ] **Step 3: Run source metadata tests and verify failure**
+
+Run:
+
+```bash
+uv run pytest tests/io/test_wdf_io.py::test_source_file_roundtrip tests/io/test_wdf_io.py::test_source_file_absent_roundtrip tests/io/test_wav_io.py::test_read_wav_from_url_sets_source_file tests/frames/test_channel_additional.py::test_read_wav_source_file_metadata -q
+```
+
+Expected: fails until WDF and reader implementation are updated. If exact test names differ, use `rg -n "source_file|_source_file" tests/io tests/frames/test_channel_additional.py` and run the matching node ids.
+
+- [ ] **Step 4: Update WDF writer metadata block**
+
+In `wandas/io/wdf_io.py`, remove `FrameMetadata` import. Replace the frame metadata block with:
+
+```python
+        if frame.metadata:
+            meta_grp = f.create_group("meta")
+            meta_grp.attrs["json"] = json.dumps(dict(frame.metadata))
+
+            for k, v in frame.metadata.items():
+                if isinstance(v, (str, int, float, bool, np.number)):
+                    meta_grp.attrs[k] = v
+```
+
+- [ ] **Step 5: Update WDF reader metadata block**
+
+Replace:
+
+```python
+        frame_metadata = FrameMetadata()
+        if "meta" in f:
+            meta_json = f["meta"].attrs.get("json", "{}")
+            if isinstance(meta_json, (bytes, np.bytes_)):
+                meta_json = _decode_hdf5_str(meta_json)
+            frame_metadata.update(json.loads(meta_json))
+            source_file = f["meta"].attrs.get("source_file", None)
+            if source_file is not None:
+                frame_metadata.source_file = _decode_hdf5_str(source_file)
+```
+
+with:
+
+```python
+        frame_metadata: dict[str, Any] = {}
+        if "meta" in f:
+            meta_json = f["meta"].attrs.get("json", "{}")
+            if isinstance(meta_json, (bytes, np.bytes_)):
+                meta_json = _decode_hdf5_str(meta_json)
+            frame_metadata.update(json.loads(meta_json))
+            legacy_source_file = f["meta"].attrs.get("source_file", None)
+            if legacy_source_file is not None and "_source_file" not in frame_metadata:
+                frame_metadata["_source_file"] = _decode_hdf5_str(legacy_source_file)
+```
+
+Ensure `Any` is imported in `wdf_io.py`; if not present, add:
+
+```python
+from typing import Any
+```
+
+- [ ] **Step 6: Run WDF/WAV source metadata tests**
+
+Run:
+
+```bash
+uv run pytest tests/io/test_wdf_io.py tests/io/test_wav_io.py tests/frames/test_channel_additional.py -q
+```
+
+Expected: passes for source metadata behavior.
+
+- [ ] **Step 7: Commit I/O changes**
+
+```bash
+git add wandas/io/wdf_io.py tests/io/test_wdf_io.py tests/io/test_wav_io.py tests/frames/test_channel_additional.py
+git commit -m "refactor: store source file in metadata dict"
+```
+
+---
+
+### Task 5: Update Metadata Tests and Remaining FrameMetadata Test Usage
+
+**Files:**
+- Modify: `tests/core/test_metadata.py`
+- Modify: `tests/core/test_base_frame.py`
+- Modify: `tests/core/test_base_frame_additional.py`
+- Modify: `tests/frames/test_channel_processing.py`
+- Modify: `tests/core/test_xarray_storage_only.py`
+- Any test found by `rg -n "FrameMetadata|metadata\.source_file|metadata\.merged" tests -g '*.py'`
+
+- [ ] **Step 1: Remove FrameMetadata tests from metadata test file**
+
+In `tests/core/test_metadata.py`, remove `FrameMetadata` from the import:
+
+```python
+from wandas.core.metadata import ChannelMetadata
+```
+
+Delete the entire `TestFrameMetadata` class. Keep all `ChannelMetadata` tests unchanged.
+
+- [ ] **Step 2: Update channel processing metadata preservation test**
+
+In `tests/frames/test_channel_processing.py`, remove `FrameMetadata` import. Replace the test setup around the metadata preservation test with:
+
+```python
+        metadata = {"source": "test", "_source_file": "input.wav"}
+        operation_history = [{"operation": "normalize", "params": {"method": "peak"}}]
+```
+
+Replace assertions:
+
+```python
+        assert result.metadata.source_file == "input.wav"
+        assert frame.metadata.source_file == "input.wav"
+```
+
+with:
+
+```python
+        assert result.metadata["_source_file"] == "input.wav"
+        assert frame.metadata["_source_file"] == "input.wav"
+```
+
+Replace any test assignment:
+
+```python
+        self.channel_frame.metadata = FrameMetadata({"foo": "bar"})
+```
+
+with:
+
+```python
+        self.channel_frame.metadata = {"foo": "bar"}
+```
+
+- [ ] **Step 3: Update invalid metadata error messages**
+
+In tests that assert the old message:
+
+```python
+"Metadata must be a dictionary or FrameMetadata"
+```
+
+replace it with:
+
+```python
+"Metadata must be a dictionary"
+```
+
+- [ ] **Step 4: Search tests for stale FrameMetadata usage**
+
+Run:
+
+```bash
+rg -n "FrameMetadata|metadata\.source_file|metadata\.merged" tests -g '*.py'
+```
+
+Expected: no output. If output remains, replace `FrameMetadata(...)` with plain dict construction, replace `metadata.source_file` assertions with `metadata["_source_file"]`, and replace `metadata.merged(**params)` with `{**metadata, **params}`.
+
+- [ ] **Step 5: Run metadata-focused tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_metadata.py tests/core/test_base_frame.py tests/core/test_base_frame_additional.py tests/frames/test_channel_processing.py tests/core/test_xarray_storage_only.py -q
+```
+
+Expected: passes.
+
+- [ ] **Step 6: Commit test cleanup**
+
+```bash
+git add tests/core/test_metadata.py tests/core/test_base_frame.py tests/core/test_base_frame_additional.py tests/frames/test_channel_processing.py tests/core/test_xarray_storage_only.py
+git commit -m "test: remove FrameMetadata expectations"
+```
+
+---
+
+### Task 6: Repository-Wide Cleanup and Verification
+
+**Files:**
+- Modify any remaining files found by search.
+- No new production abstraction unless a search shows repeated unreadable code.
+
+- [ ] **Step 1: Search production and tests for removed API**
+
+Run:
+
+```bash
+rg -n "FrameMetadata|metadata\.source_file|metadata\.merged" wandas tests -g '*.py'
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Search docs for stale public API examples**
+
+Run:
+
+```bash
+rg -n "FrameMetadata|metadata\.source_file|metadata\.merged" docs README.md -g '*.md'
+```
+
+Expected: no output or only historical design docs under `docs/superpowers/specs`. If user-facing docs mention old API, update them to plain dict metadata and `_source_file`.
+
+- [ ] **Step 3: Run type and lint checks**
+
+Run:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run ty check wandas tests
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Run full test suite**
+
+Run:
+
+```bash
+uv run pytest
+```
+
+Expected: full suite passes. Record the measured pass/skip count for the PR body.
+
+- [ ] **Step 5: Update or add short ADR if implementation changed the spec materially**
+
+If implementation exactly follows the spec, no new ADR is required. If implementation chooses a materially different behavior, add a short ADR under `docs/design/` explaining the final behavior.
+
+- [ ] **Step 6: Commit final cleanup if any**
+
+If Step 1-5 changed files, commit them:
+
+```bash
+git status --short
+git add docs README.md wandas tests
+git commit -m "chore: finalize xarray-backed frame state"
+```
+
+If no files changed, do not create an empty commit.
+
+---
+
+### Task 7: PR Preparation
+
+**Files:**
+- No code files unless PR body template is stored in repo.
+
+- [ ] **Step 1: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat origin/develop...HEAD
+git log --oneline origin/develop..HEAD
+```
+
+Expected: worktree clean; diff shows Phase 3 only.
+
+- [ ] **Step 2: Push branch**
+
+Run:
+
+```bash
+git push -u origin feat/xarray-frame-state
+```
+
+Expected: branch pushed. If Git prints `fatal: could not read Username` but also prints a `To https://github.com/...` update line, treat the push as successful.
+
+- [ ] **Step 3: Create PR body**
+
+Use this body, replacing the test count with the measured result from Task 6:
+
+```markdown
+## Summary
+
+Phase 3 of the xarray migration. This moves frame-level state onto `_xr.attrs` and removes `FrameMetadata` instead of keeping a compatibility adapter.
+
+- store `sampling_rate`, `label`, `metadata`, and `operation_history` in `_xr.attrs`
+- keep public property access for frame state
+- make `frame.metadata` a plain `dict[str, Any]`
+- move source file tracking to `metadata["_source_file"]`
+- remove `FrameMetadata`, `.merged()`, and `.source_file` production paths
+- keep `ChannelMetadata` unchanged
+- keep operation execution, generated coords, from_xarray, NetCDF, and Zarr out of scope
+
+## Compatibility Notes
+
+- This intentionally removes the `FrameMetadata` public API.
+- Code using `frame.metadata.source_file` must use `frame.metadata["_source_file"]`.
+- WDF loading still maps legacy `meta.attrs["source_file"]` to `metadata["_source_file"]` when present.
+
+## Verification
+
+- `uv run ruff check .`
+- `uv run ruff format --check .`
+- `uv run ty check wandas tests`
+- `uv run pytest` -> use the measured pass/skip count printed by Task 6 Step 4, for example `1463 passed, 3 skipped`
+
+## Non-Goals
+
+- no ChannelMetadata migration
+- no unit/ref coords
+- no generated time/frequency/band/bark coords
+- no xarray-native operation dispatch
+- no from_xarray
+- no NetCDF/Zarr
+```
+
+- [ ] **Step 4: Create PR**
+
+Create a PR against `develop` titled:
+
+```text
+Phase 3: back frame state with xarray attrs
+```
+
+- [ ] **Step 5: Report final state**
+
+Report:
+
+- PR URL
+- latest commit SHA
+- verification commands and measured results
+- any intentional breaking changes

--- a/docs/superpowers/specs/2026-06-10-xarray-backed-frame-state-design.md
+++ b/docs/superpowers/specs/2026-06-10-xarray-backed-frame-state-design.md
@@ -65,7 +65,7 @@ Remove these `FrameMetadata` concepts from the public API and implementation:
 - `FrameMetadata.source_file`
 - WDF special handling for `FrameMetadata.source_file`
 
-Use plain dictionaries for frame metadata. `source_file` moves to a reserved metadata key:
+Use plain dictionaries for frame metadata. This is an intentional breaking change for code importing `FrameMetadata` or using `frame.metadata.source_file`. `source_file` moves to a reserved metadata key:
 
 ```python
 frame.metadata["_source_file"] = "input.wav"

--- a/docs/superpowers/specs/2026-06-10-xarray-backed-frame-state-design.md
+++ b/docs/superpowers/specs/2026-06-10-xarray-backed-frame-state-design.md
@@ -1,0 +1,245 @@
+# Phase 3 Design: Xarray-Backed Frame State
+
+## Status
+
+Proposed. This spec assumes Phase 2 has introduced xarray-backed storage and exact-rank semantic dimensions for target frames.
+
+## Goal
+
+Move frame-level state into the internal `xarray.DataArray.attrs` so Wandas has one storage location for frame state while preserving the public property API.
+
+This phase is intentionally about state ownership, not operation execution or channel metadata migration.
+
+## Motivation
+
+After Phase 1 and Phase 2, `BaseFrame` stores data, dims, and conservative coords in `_xr`, but still stores frame-level state as separate Python attributes:
+
+```text
+BaseFrame
+  _xr
+    data
+    dims
+    coords
+
+  sampling_rate
+  label
+  metadata
+  operation_history
+  _channel_metadata
+```
+
+That split keeps Phase 1/2 safe, but it leaves duplicated state ownership. Phase 3 makes `_xr.attrs` the backing store for frame-level state:
+
+```text
+BaseFrame
+  _xr
+    data
+    dims
+    coords
+    attrs
+      sampling_rate
+      label
+      metadata
+      operation_history
+
+  _channel_metadata
+  _previous
+```
+
+Wandas properties keep the domain semantics. xarray is only the storage location.
+
+## Scope
+
+Move these frame-level fields to `_xr.attrs`:
+
+- `sampling_rate`
+- `label`
+- `metadata`
+- `operation_history`
+
+Remove these `FrameMetadata` concepts from the public API and implementation:
+
+- `FrameMetadata`
+- `FrameMetadata.copy()`
+- `FrameMetadata.merged()`
+- `FrameMetadata.source_file`
+- WDF special handling for `FrameMetadata.source_file`
+
+Use plain dictionaries for frame metadata. `source_file` moves to a reserved metadata key:
+
+```python
+frame.metadata["_source_file"] = "input.wav"
+```
+
+## Non-Goals
+
+Phase 3 does not change:
+
+- `ChannelMetadata` storage or behavior
+- channel `unit`, `ref`, or `extra` handling
+- generated numeric coordinates such as dense time, frequency, band, or bark coordinates
+- operation execution
+- xarray-native operation dispatch
+- `from_xarray`
+- NetCDF or Zarr I/O
+- accepted input shapes
+
+`ChannelMetadata` remains in `wandas/core/metadata.py` for now. Removing Pydantic or moving channel metadata to xarray coords/attrs is a later phase.
+
+## Public API
+
+These existing public attributes remain available as properties:
+
+```python
+frame.sampling_rate
+frame.label
+frame.metadata
+frame.operation_history
+```
+
+Their backing store changes to `_xr.attrs`.
+
+### `sampling_rate`
+
+`sampling_rate` is validated through `validate_sampling_rate()` in the setter and stored as `float`:
+
+```text
+frame.sampling_rate = 0      -> ValueError
+frame.sampling_rate = -1     -> ValueError
+frame.sampling_rate = 48000  -> _xr.attrs["sampling_rate"] = 48000.0
+```
+
+### `label`
+
+`label` is stored in `_xr.attrs["label"]` and mirrored to `_xr.name`. `None` or an empty string becomes `"unnamed_frame"`. Non-string non-`None` values raise `TypeError`.
+
+### `metadata`
+
+`metadata` is a plain `dict[str, Any]`:
+
+```text
+metadata=None        -> {}
+metadata=dict        -> shallow dict copy on set
+metadata=other type  -> TypeError
+```
+
+The getter returns the internal metadata dict so existing mutation patterns continue to work:
+
+```python
+frame.metadata["calibration"] = 1.0
+```
+
+### `operation_history`
+
+`operation_history` is stored as a list of dictionaries. The setter deep-copies incoming history to avoid sharing mutable state between frames.
+
+## Initialization Flow
+
+`BaseFrame.__init__` should build `_xr` before setting frame-level properties because those properties write to `_xr.attrs`.
+
+Order:
+
+1. Normalize data.
+2. Build `_channel_metadata`, because channel coords depend on labels.
+3. Build `_xr` with data, dims, coords, and name.
+4. Set `label`, `sampling_rate`, `metadata`, and `operation_history` through property setters.
+5. Set `_previous`.
+
+`_build_xarray()` must not read `self.label` before `_xr` exists. It should accept a `name` argument or otherwise receive the name explicitly.
+
+## Data Replacement
+
+`_replace_data()` replaces data/dims/coords while preserving frame-level attrs:
+
+```python
+attrs = copy.deepcopy(self._xr.attrs)
+self._xr = self._build_xarray(normalized_data, name=self.label)
+self._xr.attrs = attrs
+```
+
+This keeps metadata and operation history stable across data replacement.
+
+## New Frame Creation
+
+`_create_new_instance()` must keep the current no-shared-mutable-state behavior:
+
+- default `metadata` is `copy.deepcopy(self.metadata)`
+- default `operation_history` is `copy.deepcopy(self.operation_history)`
+- default channel metadata remains `copy.deepcopy(self._channel_metadata)`
+
+Any use of `metadata.merged(...)` must be replaced with plain dict merging, for example:
+
+```python
+metadata={**self.metadata, **params}
+```
+
+or an equivalent local expression. Do not add a broad abstraction unless repeated code becomes hard to read.
+
+## Xarray Export
+
+`to_xarray()` continues to return a public shallow copy of `_xr`, not the internal object. Data remains shallow; attrs are deep-copied:
+
+```python
+exported = self._xr.copy(deep=False)
+exported.attrs = copy.deepcopy(self._xr.attrs)
+return exported
+```
+
+External mutation of `frame.xr.attrs["metadata"]` or `frame.xr.attrs["operation_history"]` must not mutate the frame.
+
+## WDF and File Readers
+
+WDF should store metadata as plain dictionary entries. `_source_file`, when present, is just another metadata key.
+
+WAV and URL readers should populate:
+
+```python
+metadata={"_source_file": source}
+```
+
+Round trips should verify `metadata["_source_file"]`, not `metadata.source_file`.
+
+## Error Handling
+
+- Invalid `metadata` types raise `TypeError`.
+- Invalid `operation_history` types raise `TypeError`.
+- Invalid `sampling_rate` values raise `ValueError` from `validate_sampling_rate()`.
+- Invalid `label` types raise `TypeError`.
+- Missing attrs are repaired lazily by getters where safe: `metadata` becomes `{}` and `operation_history` becomes `[]`. Missing `sampling_rate` should remain an error because a frame without sampling rate is invalid.
+
+## Tests
+
+Add or update tests for:
+
+- `sampling_rate`, `label`, `metadata`, and `operation_history` using `_xr.attrs` as source of truth
+- property setters updating `_xr.attrs` and `_xr.name`
+- invalid `sampling_rate`, `label`, `metadata`, and `operation_history` values
+- `to_xarray()` deep-copying attrs
+- `_replace_data()` preserving attrs
+- `_create_new_instance()` deep-copying metadata and operation history
+- WDF source file round trip through `metadata["_source_file"]`
+- WAV/URL source file metadata through `metadata["_source_file"]`
+- removal of `FrameMetadata` tests while preserving `ChannelMetadata` tests
+
+Run the full verification suite before completion:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run ty check wandas tests
+uv run pytest
+```
+
+## Success Criteria
+
+Phase 3 is complete when:
+
+1. `FrameMetadata` is removed from production code.
+2. `frame.metadata` is a plain dict.
+3. `frame.label`, `frame.sampling_rate`, `frame.metadata`, and `frame.operation_history` are backed by `_xr.attrs`.
+4. Public property access remains available.
+5. `to_xarray()` returns a public copy with deep-copied attrs.
+6. `ChannelMetadata` remains unchanged.
+7. Generated numeric coords are not added.
+8. Operation execution remains unchanged.
+9. Production code removes the FrameMetadata-specific paths instead of adding a compatibility layer.

--- a/tests/core/test_base_frame.py
+++ b/tests/core/test_base_frame.py
@@ -1157,7 +1157,7 @@ class TestBaseFrameInfoAndDataframe:
 
         # Verify all expected information is present
         assert "Channels: 1" in output
-        assert f"Sampling rate: {self.channel_frame.sampling_rate} Hz" in output
+        assert f"Sampling rate: {float(self.sample_rate)} Hz" in output
         assert "Duration: 1.0 s" in output
         assert f"Samples: {self.channel_frame.n_samples}" in output
         assert "Channel labels: ['ch0']" in output

--- a/tests/core/test_base_frame.py
+++ b/tests/core/test_base_frame.py
@@ -1157,7 +1157,7 @@ class TestBaseFrameInfoAndDataframe:
 
         # Verify all expected information is present
         assert "Channels: 1" in output
-        assert f"Sampling rate: {self.sample_rate} Hz" in output
+        assert f"Sampling rate: {self.channel_frame.sampling_rate} Hz" in output
         assert "Duration: 1.0 s" in output
         assert f"Samples: {self.channel_frame.n_samples}" in output
         assert "Channel labels: ['ch0']" in output

--- a/tests/core/test_metadata.py
+++ b/tests/core/test_metadata.py
@@ -1,7 +1,7 @@
 import json
 from typing import Any
 
-from wandas.core.metadata import ChannelMetadata, FrameMetadata
+from wandas.core.metadata import ChannelMetadata
 from wandas.utils.util import unit_to_ref
 
 
@@ -261,80 +261,3 @@ class TestChannelMetadata:
         assert metadata.unit == "Hz"
         assert metadata.ref == 0.75
         assert metadata.extra["new_key"] == "new_value"
-
-
-class TestFrameMetadata:
-    """Tests for FrameMetadata."""
-
-    def test_init_default_empty_dict_no_source(self) -> None:
-        """Empty FrameMetadata behaves like an empty dict with no source."""
-        meta = FrameMetadata()
-        assert meta.source_file is None
-        assert dict(meta) == {}
-
-    def test_init_source_file_preserved(self) -> None:
-        meta = FrameMetadata(source_file="audio.wav")
-        assert meta.source_file == "audio.wav"
-        assert dict(meta) == {}
-
-    def test_init_dict_content_and_source_file(self) -> None:
-        meta = FrameMetadata({"gain": 0.5, "device": "mic"}, source_file="test.wav")
-        assert meta.source_file == "test.wav"
-        assert meta["gain"] == 0.5
-        assert meta["device"] == "mic"
-
-    def test_dict_operations_setitem_contains_get(self) -> None:
-        meta = FrameMetadata({"a": 1})
-        meta["b"] = 2
-        assert "a" in meta
-        assert "b" in meta
-        assert meta.get("a") == 1
-        assert meta.get("missing") is None
-        assert list(meta.items()) == [("a", 1), ("b", 2)]
-
-    def test_equality_compares_dict_content_only(self) -> None:
-        meta = FrameMetadata({"x": 10}, source_file="file.wav")
-        assert meta == {"x": 10}
-
-    def test_copy_preserves_source_file_independent(self) -> None:
-        meta = FrameMetadata({"key": "val"}, source_file="orig.wav")
-        copied = meta.copy()
-        assert isinstance(copied, FrameMetadata)
-        assert copied.source_file == "orig.wav"
-        assert copied["key"] == "val"
-        # Modifying copy does not affect original
-        copied["key"] = "changed"
-        assert meta["key"] == "val"
-
-    def test_deepcopy_preserves_source_file_independent(self) -> None:
-        import copy
-
-        meta = FrameMetadata({"nested": {"n": 1}}, source_file="deep.wav")
-        cloned = copy.deepcopy(meta)
-        assert isinstance(cloned, FrameMetadata)
-        assert cloned.source_file == "deep.wav"
-        assert cloned["nested"] == {"n": 1}
-        # Modifying nested content in clone does not affect original
-        cloned["nested"]["n"] = 99
-        assert meta["nested"]["n"] == 1
-
-    def test_json_serializable_dict_portion(self) -> None:
-        meta = FrameMetadata({"rate": 44100}, source_file="audio.wav")
-        # json.dumps should only serialize the dict portion
-        data = json.loads(json.dumps(dict(meta)))
-        assert data == {"rate": 44100}
-
-    def test_repr_contains_class_name_and_source(self) -> None:
-        meta = FrameMetadata({"k": 1}, source_file="f.wav")
-        r = repr(meta)
-        assert "FrameMetadata" in r
-        assert "f.wav" in r
-
-    def test_bool_empty_is_falsy_nonempty_is_truthy(self) -> None:
-        assert not FrameMetadata()
-        assert FrameMetadata({"a": 1})
-
-    def test_unpack_operator_merges_with_dict(self) -> None:
-        meta = FrameMetadata({"a": 1, "b": 2}, source_file="s.wav")
-        merged = {**meta, "c": 3}
-        assert merged == {"a": 1, "b": 2, "c": 3}

--- a/tests/core/test_xarray_storage_only.py
+++ b/tests/core/test_xarray_storage_only.py
@@ -518,6 +518,21 @@ def test_to_xarray_returns_public_shallow_copy_with_export_attrs() -> None:
     assert frame.label == "exported"
 
 
+def test_to_xarray_uses_attrs_backed_label_for_name() -> None:
+    frame = ChannelFrame.from_numpy(
+        np.array([1.0, 2.0]),
+        sampling_rate=2.0,
+        label="original",
+    )
+    frame._xr.attrs["label"] = "mutated"
+
+    exported = frame.to_xarray()
+
+    assert frame.label == "mutated"
+    assert exported.name == "mutated"
+    assert exported.attrs["label"] == "mutated"
+
+
 def test_to_xarray_deep_copies_exported_metadata_dict() -> None:
     frame = ChannelFrame.from_numpy(
         np.array([[1.0, 2.0, 3.0]]),

--- a/tests/core/test_xarray_storage_only.py
+++ b/tests/core/test_xarray_storage_only.py
@@ -591,13 +591,13 @@ def test_frame_state_property_setters_validate_inputs() -> None:
         frame.sampling_rate = 0
 
     with pytest.raises(TypeError, match="Label must be a string or None"):
-        frame.label = 123  # type: ignore[assignment]
+        frame.label = 123  # ty: ignore[invalid-assignment]
 
     with pytest.raises(TypeError, match="Metadata must be a dictionary"):
-        frame.metadata = "invalid"  # type: ignore[assignment]
+        frame.metadata = "invalid"  # ty: ignore[invalid-assignment]
 
     with pytest.raises(TypeError, match="Operation history must be a list"):
-        frame.operation_history = {"operation": "bad"}  # type: ignore[assignment]
+        frame.operation_history = {"operation": "bad"}  # ty: ignore[invalid-assignment]
 
 
 def test_xr_property_matches_to_xarray_contract() -> None:

--- a/tests/core/test_xarray_storage_only.py
+++ b/tests/core/test_xarray_storage_only.py
@@ -24,6 +24,13 @@ def _lazy_frame_with_counter(calls: list[str]) -> ChannelFrame:
     return ChannelFrame(data=lazy_data, sampling_rate=4.0)
 
 
+class _MergedDict(dict[str, object]):
+    def merged(self, **updates: object) -> dict[str, object]:
+        merged = dict(self)
+        merged.update(updates)
+        return merged
+
+
 class AxisOnlyFrame(BaseFrame[np.ndarray]):
     _channel_axis = -3
 
@@ -455,6 +462,7 @@ def test_selection_and_operation_do_not_compute_until_compute() -> None:
 def test_transform_methods_remain_lazy() -> None:
     calls: list[str] = []
     frame = _lazy_frame_with_counter(calls)
+    frame._xr.attrs["metadata"] = _MergedDict(frame.metadata)
 
     spectrum = frame.fft()
     spectrogram = frame.stft(n_fft=4, hop_length=2)

--- a/tests/core/test_xarray_storage_only.py
+++ b/tests/core/test_xarray_storage_only.py
@@ -533,6 +533,20 @@ def test_to_xarray_uses_attrs_backed_label_for_name() -> None:
     assert exported.attrs["label"] == "mutated"
 
 
+def test_metadata_setter_deep_copies_input_dict() -> None:
+    metadata = {"nested": {"x": 1}, "tags": ["raw"]}
+    frame = ChannelFrame.from_numpy(
+        np.array([1.0, 2.0]),
+        sampling_rate=2.0,
+        metadata=metadata,
+    )
+
+    metadata["nested"]["x"] = 99
+    metadata["tags"].append("mutated")
+
+    assert frame.metadata == {"nested": {"x": 1}, "tags": ["raw"]}
+
+
 def test_to_xarray_deep_copies_exported_metadata_dict() -> None:
     frame = ChannelFrame.from_numpy(
         np.array([[1.0, 2.0, 3.0]]),

--- a/tests/core/test_xarray_storage_only.py
+++ b/tests/core/test_xarray_storage_only.py
@@ -24,13 +24,6 @@ def _lazy_frame_with_counter(calls: list[str]) -> ChannelFrame:
     return ChannelFrame(data=lazy_data, sampling_rate=4.0)
 
 
-class _MergedDict(dict[str, object]):
-    def merged(self, **updates: object) -> dict[str, object]:
-        merged = dict(self)
-        merged.update(updates)
-        return merged
-
-
 class AxisOnlyFrame(BaseFrame[np.ndarray]):
     _channel_axis = -3
 
@@ -462,7 +455,6 @@ def test_selection_and_operation_do_not_compute_until_compute() -> None:
 def test_transform_methods_remain_lazy() -> None:
     calls: list[str] = []
     frame = _lazy_frame_with_counter(calls)
-    frame._xr.attrs["metadata"] = _MergedDict(frame.metadata)
 
     spectrum = frame.fft()
     spectrogram = frame.stft(n_fft=4, hop_length=2)

--- a/tests/core/test_xarray_storage_only.py
+++ b/tests/core/test_xarray_storage_only.py
@@ -8,7 +8,7 @@ from dask import delayed
 
 from wandas import ChannelFrame
 from wandas.core.base_frame import BaseFrame
-from wandas.core.metadata import ChannelMetadata, FrameMetadata
+from wandas.core.metadata import ChannelMetadata
 from wandas.frames.noct import NOctFrame
 from wandas.frames.roughness import RoughnessFrame
 from wandas.frames.spectral import SpectralFrame
@@ -242,27 +242,26 @@ def test_data_alias_is_read_only() -> None:
         setattr(frame, "_data", da.zeros((1, 3), chunks=(1, -1)))
 
 
-def test_replace_data_updates_xarray_container_only() -> None:
-    metadata = FrameMetadata({"source": "test"}, source_file="input.wav")
+def test_replace_data_preserves_xarray_attrs_backed_frame_state() -> None:
     frame = ChannelFrame.from_numpy(
         np.array([[1.0, 2.0, 3.0]]),
         sampling_rate=3.0,
         label="original",
-        metadata=metadata,
+        metadata={"source": "test", "nested": {"x": 1}},
     )
-    original_metadata = frame.metadata
-    original_history = frame.operation_history
+    frame.operation_history = [{"operation": "load", "params": {"path": "input.wav"}}]
     replacement = da.full((1, 4), 2.0, chunks=(1, -1))
 
     frame._replace_data(replacement)
 
     assert frame._data is frame._xr.data
     assert frame._data.shape == (1, 4)
-    assert frame._data.chunks == ((1,), (4,))
-    assert frame.metadata is original_metadata
-    assert frame.operation_history is original_history
-    assert frame.label == "original"
     assert frame.sampling_rate == 3.0
+    assert frame.label == "original"
+    assert frame._xr.attrs["sampling_rate"] == 3.0
+    assert frame._xr.attrs["label"] == "original"
+    assert frame.metadata == {"source": "test", "nested": {"x": 1}}
+    assert frame.operation_history == [{"operation": "load", "params": {"path": "input.wav"}}]
 
 
 def test_internal_xarray_attrs_do_not_own_wandas_metadata() -> None:
@@ -517,21 +516,20 @@ def test_to_xarray_returns_public_shallow_copy_with_export_attrs() -> None:
     assert frame.label == "exported"
 
 
-def test_to_xarray_deep_copies_exported_frame_metadata() -> None:
-    metadata = FrameMetadata({"nested": {"x": 1}}, source_file="input.wav")
+def test_to_xarray_deep_copies_exported_metadata_dict() -> None:
     frame = ChannelFrame.from_numpy(
-        np.array([1.0]),
-        sampling_rate=1.0,
-        metadata=metadata,
+        np.array([[1.0, 2.0, 3.0]]),
+        sampling_rate=3.0,
+        metadata={"nested": {"x": 1}, "_source_file": "input.wav"},
     )
 
     exported = frame.to_xarray()
-
-    assert isinstance(exported.attrs["metadata"], FrameMetadata)
-    assert exported.attrs["metadata"].source_file == "input.wav"
-
     exported.attrs["metadata"]["nested"]["x"] = 99
+    exported.attrs["metadata"]["_source_file"] = "changed.wav"
+
+    assert type(frame.metadata) is dict
     assert frame.metadata["nested"]["x"] == 1
+    assert frame.metadata["_source_file"] == "input.wav"
 
 
 def test_to_xarray_deep_copies_exported_operation_history() -> None:
@@ -542,6 +540,62 @@ def test_to_xarray_deep_copies_exported_operation_history() -> None:
     exported.attrs["operation_history"][0]["params"]["factor"] = 99.0
 
     assert frame.operation_history[0]["params"]["factor"] == 2.0
+
+
+def test_frame_state_properties_are_backed_by_xarray_attrs() -> None:
+    frame = ChannelFrame.from_numpy(
+        np.array([[1.0, 2.0, 3.0]]),
+        sampling_rate=3.0,
+        label="stateful",
+        metadata={"owner": "attrs"},
+        operation_history=[{"operation": "load", "params": {}}],
+    )
+
+    assert frame._xr.attrs["sampling_rate"] == 3.0
+    assert frame._xr.attrs["label"] == "stateful"
+    assert frame._xr.attrs["metadata"] == {"owner": "attrs"}
+    assert frame._xr.attrs["operation_history"] == [{"operation": "load", "params": {}}]
+
+    frame._xr.attrs["sampling_rate"] = 8.0
+    frame._xr.attrs["label"] = "from-attrs"
+    frame._xr.attrs["metadata"] = {"owner": "mutated"}
+    frame._xr.attrs["operation_history"] = [{"operation": "mutated", "params": {"x": 1}}]
+
+    assert frame.sampling_rate == 8.0
+    assert frame.label == "from-attrs"
+    assert frame.metadata == {"owner": "mutated"}
+    assert frame.operation_history == [{"operation": "mutated", "params": {"x": 1}}]
+
+
+def test_frame_state_property_setters_update_xarray_attrs() -> None:
+    frame = ChannelFrame.from_numpy(np.array([[1.0, 2.0, 3.0]]), sampling_rate=3.0)
+
+    frame.sampling_rate = 6
+    frame.label = "updated"
+    frame.metadata = {"nested": {"x": 1}}
+    frame.operation_history = [{"operation": "gain", "params": {"factor": 2.0}}]
+
+    assert frame._xr.attrs["sampling_rate"] == 6.0
+    assert frame._xr.attrs["label"] == "updated"
+    assert frame._xr.name == "updated"
+    assert frame._xr.attrs["metadata"] == {"nested": {"x": 1}}
+    assert frame._xr.attrs["operation_history"] == [{"operation": "gain", "params": {"factor": 2.0}}]
+
+
+def test_frame_state_property_setters_validate_inputs() -> None:
+    frame = ChannelFrame.from_numpy(np.array([[1.0, 2.0, 3.0]]), sampling_rate=3.0)
+
+    with pytest.raises(ValueError, match="Invalid sampling_rate"):
+        frame.sampling_rate = 0
+
+    with pytest.raises(TypeError, match="Label must be a string or None"):
+        frame.label = 123  # type: ignore[assignment]
+
+    with pytest.raises(TypeError, match="Metadata must be a dictionary"):
+        frame.metadata = "invalid"  # type: ignore[assignment]
+
+    with pytest.raises(TypeError, match="Operation history must be a list"):
+        frame.operation_history = {"operation": "bad"}  # type: ignore[assignment]
 
 
 def test_xr_property_matches_to_xarray_contract() -> None:

--- a/tests/core/test_xarray_storage_only.py
+++ b/tests/core/test_xarray_storage_only.py
@@ -266,19 +266,19 @@ def test_replace_data_preserves_xarray_attrs_backed_frame_state() -> None:
     assert frame.operation_history == [{"operation": "load", "params": {"path": "input.wav"}}]
 
 
-def test_internal_xarray_attrs_do_not_own_wandas_metadata() -> None:
+def test_internal_xarray_attrs_are_frame_state_source_of_truth() -> None:
     frame = ChannelFrame.from_numpy(
         np.array([[1.0, 2.0]]),
         sampling_rate=2.0,
-        label="owned-by-wandas",
+        label="owned-by-attrs",
         metadata={"gain": 1.5},
     )
 
-    frame._xr.attrs["label"] = "not-authoritative"
+    frame._xr.attrs["label"] = "authoritative"
     frame._xr.attrs["metadata"] = {"gain": 999}
 
-    assert frame.label == "owned-by-wandas"
-    assert frame.metadata["gain"] == 1.5
+    assert frame.label == "authoritative"
+    assert frame.metadata["gain"] == 999
 
 
 def test_base_frame_keeps_roughness_mono_dims_neutral() -> None:

--- a/tests/core/test_xarray_storage_only.py
+++ b/tests/core/test_xarray_storage_only.py
@@ -260,6 +260,8 @@ def test_replace_data_preserves_xarray_attrs_backed_frame_state() -> None:
     assert frame.label == "original"
     assert frame._xr.attrs["sampling_rate"] == 3.0
     assert frame._xr.attrs["label"] == "original"
+    assert frame._xr.attrs["metadata"] == {"source": "test", "nested": {"x": 1}}
+    assert frame._xr.attrs["operation_history"] == [{"operation": "load", "params": {"path": "input.wav"}}]
     assert frame.metadata == {"source": "test", "nested": {"x": 1}}
     assert frame.operation_history == [{"operation": "load", "params": {"path": "input.wav"}}]
 
@@ -548,8 +550,8 @@ def test_frame_state_properties_are_backed_by_xarray_attrs() -> None:
         sampling_rate=3.0,
         label="stateful",
         metadata={"owner": "attrs"},
-        operation_history=[{"operation": "load", "params": {}}],
     )
+    frame.operation_history = [{"operation": "load", "params": {}}]
 
     assert frame._xr.attrs["sampling_rate"] == 3.0
     assert frame._xr.attrs["label"] == "stateful"

--- a/tests/frames/test_channel_additional.py
+++ b/tests/frames/test_channel_additional.py
@@ -83,7 +83,7 @@ def test_from_file_in_memory_and_source_name_and_ch_labels_and_header_and_csv_kw
     )
     assert isinstance(cf, ChannelFrame)
     assert cf.sampling_rate == 44100
-    assert cf.metadata.source_file == "my_file.wav"
+    assert cf.metadata["_source_file"] == "my_file.wav"
     assert cf.labels == ["L", "R"]
     assert cap.get("time_column") == 1
     assert cap.get("delimiter") == ";"

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -5,7 +5,6 @@ import numpy as np
 import pytest
 from dask.array.core import Array as DaArray
 
-from wandas.core.metadata import FrameMetadata
 from wandas.frames.channel import ChannelFrame, ChannelMetadata
 from wandas.frames.spectral import SpectralFrame
 from wandas.utils.util import calculate_rms
@@ -212,7 +211,7 @@ class TestChannelProcessing:
         def rfft_transform(x: np.ndarray) -> np.ndarray:
             return np.fft.rfft(x, axis=-1)
 
-        metadata = FrameMetadata({"source": "test"}, source_file="input.wav")
+        metadata = {"source": "test", "_source_file": "input.wav"}
         operation_history = [{"operation": "normalize", "params": {"method": "peak"}}]
 
         frame = ChannelFrame(
@@ -239,9 +238,9 @@ class TestChannelProcessing:
         assert result.label == frame.label
         assert frame.labels == ["sig0", "sig1"]
         assert result.labels == ["rfft_transform(sig0)", "rfft_transform(sig1)"]
-        assert result.metadata == {"source": "test", "custom": {}}
-        assert result.metadata.source_file == "input.wav"
-        assert frame.metadata.source_file == "input.wav"
+        assert result.metadata == {"source": "test", "_source_file": "input.wav", "custom": {}}
+        assert result.metadata["_source_file"] == "input.wav"
+        assert frame.metadata["_source_file"] == "input.wav"
         assert frame.operation_history == operation_history
         assert result.operation_history == [
             {"operation": "normalize", "params": {"method": "peak"}},
@@ -723,7 +722,7 @@ class TestChannelProcessing:
         """rms_trend後のChannelFrame属性を確認するテスト"""
         # 事前に属性をセット
         self.channel_frame.label = "test_label"
-        self.channel_frame.metadata = FrameMetadata({"foo": "bar"})
+        self.channel_frame.metadata = {"foo": "bar"}
         self.channel_frame._channel_metadata = [
             ChannelMetadata(label="test_ch0", unit="", ref=1.0, extra={"foo": 123}),
             ChannelMetadata(label="test_ch1", unit="Pa", extra={"bar": "baz"}),
@@ -773,7 +772,7 @@ class TestChannelProcessing:
         the frame label, metadata, and channel metadata in place.
         """
         self.channel_frame.label = "test_label"
-        self.channel_frame.metadata = FrameMetadata({"foo": "bar"})
+        self.channel_frame.metadata = {"foo": "bar"}
         self.channel_frame._channel_metadata = [
             ChannelMetadata(label="test_ch0", unit="", ref=1.0, extra={"foo": 123}),
             ChannelMetadata(label="test_ch1", unit="Pa", extra={"bar": "baz"}),

--- a/tests/io/test_wav_io.py
+++ b/tests/io/test_wav_io.py
@@ -211,7 +211,7 @@ def test_from_file_url_wav() -> None:
     np.testing.assert_allclose(computed[0], data_left, rtol=1e-5)
     np.testing.assert_allclose(computed[1], data_right, rtol=1e-5)
     # Provenance metadata (Pillar 2)
-    assert cf.metadata.source_file == url, "source_file metadata not preserved"
+    assert cf.metadata["_source_file"] == url, "source file metadata not preserved"
     assert cf.label == "sample"
 
 

--- a/tests/io/test_wdf_io.py
+++ b/tests/io/test_wdf_io.py
@@ -367,6 +367,27 @@ def test_from_wdf_legacy_source_file_attr_maps_to_metadata_key(tmp_path: Path) -
     assert loaded.metadata["_source_file"] == "legacy/input.wav"
 
 
+def test_load_wdf_rejects_non_object_metadata_json(tmp_path: Path) -> None:
+    """Malformed WDF metadata JSON fails with an actionable error."""
+    path = tmp_path / "array_metadata.wdf"
+    with h5py.File(path, "w") as f:
+        f.attrs["version"] = wdf_io.WDF_FORMAT_VERSION
+        f.attrs["sampling_rate"] = 16000.0
+        f.attrs["label"] = ""
+
+        channels = f.create_group("channels")
+        channel = channels.create_group("0")
+        channel.create_dataset("data", data=np.array([1.0, 2.0, 3.0], dtype=np.float32))
+        channel.attrs["label"] = ""
+        channel.attrs["unit"] = ""
+
+        meta = f.create_group("meta")
+        meta.attrs["json"] = json.dumps(["not", "a", "dict"])
+
+    with pytest.raises(ValueError, match="WDF meta/json must decode to a JSON object"):
+        ChannelFrame.load(path)
+
+
 def test_load_wdf_from_url(tmp_path: Path) -> None:
     """Test WDF load from mocked URL preserves data and metadata (Pillar 2, 4).
 

--- a/tests/io/test_wdf_io.py
+++ b/tests/io/test_wdf_io.py
@@ -313,6 +313,13 @@ def test_source_file_roundtrip(tmp_path: Path) -> None:
 
     path = tmp_path / "test_source_file.wdf"
     cf.save(path)
+    with h5py.File(path, "r") as f:
+        meta = f["meta"]
+        saved_metadata = json.loads(meta.attrs["json"])
+        assert saved_metadata["_source_file"] == source
+        assert meta.attrs["_source_file"] == source
+        assert "source_file" not in meta.attrs
+
     cf2 = ChannelFrame.load(path)
 
     assert type(cf2.metadata) is dict

--- a/tests/io/test_wdf_io.py
+++ b/tests/io/test_wdf_io.py
@@ -1,5 +1,6 @@
 """Tests for WDF (Wandas Data File) I/O functionality."""
 
+import json
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -298,47 +299,65 @@ def test_load_file_not_found(tmp_path: Path) -> None:
 
 
 def test_source_file_roundtrip(tmp_path: Path) -> None:
-    """Test that source_file in FrameMetadata survives a save/load round-trip."""
-    from wandas.core.metadata import FrameMetadata
-
-    rng = np.random.default_rng(8)
+    """Source file metadata survives a save/load round-trip as a plain dict key."""
+    source = "audio/input.wav"
+    data = np.array([[1, 2, 3]], dtype=np.float32)
     sr = 16000
-    data = rng.standard_normal((1, sr))
-    source = "/data/recordings/audio.wav"
     cf = ChannelFrame.from_numpy(
         data,
         sr,
-        metadata=FrameMetadata({"key": "val"}, source_file=source),
+        metadata={"key": "val", "_source_file": source},
     )
-    assert isinstance(cf.metadata, FrameMetadata)
-    assert cf.metadata.source_file == source
+    assert type(cf.metadata) is dict
+    assert cf.metadata["_source_file"] == source
 
     path = tmp_path / "test_source_file.wdf"
     cf.save(path)
-
     cf2 = ChannelFrame.load(path)
-    assert isinstance(cf2.metadata, FrameMetadata)
-    assert cf2.metadata.source_file == source
-    assert cf2.metadata.get("key") == "val"
+
+    assert type(cf2.metadata) is dict
+    assert cf2.metadata["_source_file"] == source
+    assert cf2.metadata["key"] == "val"
 
 
-def test_source_file_none_roundtrip(tmp_path: Path) -> None:
-    """Test round-trip when source_file is None."""
-    from wandas.core.metadata import FrameMetadata
-
-    rng = np.random.default_rng(9)
+def test_source_file_absent_roundtrip(tmp_path: Path) -> None:
+    """Round-trip without source file keeps metadata as a plain dict."""
+    data = np.array([[1, 2, 3]], dtype=np.float32)
     sr = 16000
-    data = rng.standard_normal((1, sr))
-    cf = ChannelFrame.from_numpy(data, sr, metadata=FrameMetadata({"only": "dict"}))
-    assert cf.metadata.source_file is None
+    cf = ChannelFrame.from_numpy(data, sr, metadata={"only": "dict"})
+    assert type(cf.metadata) is dict
+    assert "_source_file" not in cf.metadata
 
     path = tmp_path / "test_no_source_file.wdf"
     cf.save(path)
-
     cf2 = ChannelFrame.load(path)
-    assert isinstance(cf2.metadata, FrameMetadata)
-    assert cf2.metadata.source_file is None
-    assert cf2.metadata.get("only") == "dict"
+
+    assert type(cf2.metadata) is dict
+    assert cf2.metadata == {"only": "dict"}
+
+
+def test_from_wdf_legacy_source_file_attr_maps_to_metadata_key(tmp_path: Path) -> None:
+    """Legacy meta/source_file attrs populate _source_file when JSON lacks it."""
+    path = tmp_path / "legacy_source_file.wdf"
+    with h5py.File(path, "w") as f:
+        f.attrs["version"] = wdf_io.WDF_FORMAT_VERSION
+        f.attrs["sampling_rate"] = 16000.0
+        f.attrs["label"] = ""
+
+        channels = f.create_group("channels")
+        channel = channels.create_group("0")
+        channel.create_dataset("data", data=np.array([1.0, 2.0, 3.0], dtype=np.float32))
+        channel.attrs["label"] = ""
+        channel.attrs["unit"] = ""
+
+        meta = f.create_group("meta")
+        meta.attrs["json"] = json.dumps({"key": "val"})
+        meta.attrs["source_file"] = "legacy/input.wav"
+
+    loaded = ChannelFrame.load(path)
+    assert type(loaded.metadata) is dict
+    assert loaded.metadata["key"] == "val"
+    assert loaded.metadata["_source_file"] == "legacy/input.wav"
 
 
 def test_load_wdf_from_url(tmp_path: Path) -> None:

--- a/wandas/core/__init__.py
+++ b/wandas/core/__init__.py
@@ -1,7 +1,5 @@
 from .base_frame import BaseFrame
-from .metadata import FrameMetadata
 
 __all__ = [
     "BaseFrame",
-    "FrameMetadata",
 ]

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -15,9 +15,10 @@ from dask.array.core import Array as DaArray
 from matplotlib.axes import Axes
 from pydantic import ValidationError
 
+from wandas.utils import validate_sampling_rate
 from wandas.utils.types import NDArrayComplex, NDArrayReal
 
-from .metadata import ChannelMetadata, FrameMetadata
+from .metadata import ChannelMetadata
 
 # IPython display types for visualize_graph return type
 # Define as type alias under TYPE_CHECKING; use Any at runtime
@@ -55,9 +56,8 @@ class BaseFrame(ABC, Generic[T]):
         The sampling rate of the signal in Hz.
     label : str, optional
         A label for the frame. If not provided, defaults to "unnamed_frame".
-    metadata : FrameMetadata | dict, optional
-        Additional metadata for the frame. Plain dicts are automatically
-        converted to FrameMetadata.
+    metadata : dict, optional
+        Additional metadata for the frame.
     operation_history : list[dict], optional
         History of operations performed on this frame.
     channel_metadata : list[ChannelMetadata | dict], optional
@@ -72,7 +72,7 @@ class BaseFrame(ABC, Generic[T]):
         The sampling rate of the signal in Hz.
     label : str
         The label of the frame.
-    metadata : FrameMetadata
+    metadata : dict
         Additional metadata for the frame.
     operation_history : list[dict]
         History of operations performed on this frame.
@@ -84,10 +84,6 @@ class BaseFrame(ABC, Generic[T]):
     _channel_axis: ClassVar[int | None] = -2
     _xarray_dim_suffix: ClassVar[tuple[str, ...]] = ()
     _xr: xr.DataArray
-    sampling_rate: float
-    label: str
-    metadata: FrameMetadata
-    operation_history: list[dict[str, Any]]
     _channel_metadata: list[ChannelMetadata]
     _previous: "BaseFrame[Any] | None"
 
@@ -96,25 +92,16 @@ class BaseFrame(ABC, Generic[T]):
         data: DaArray,
         sampling_rate: float,
         label: str | None = None,
-        metadata: "FrameMetadata | dict[str, Any] | None" = None,
+        metadata: dict[str, Any] | None = None,
         operation_history: list[dict[str, Any]] | None = None,
         channel_metadata: list[ChannelMetadata] | list[dict[str, Any]] | None = None,
         previous: "BaseFrame[Any] | None" = None,
     ):
         normalized_data = self._normalize_data(data)
-        self.sampling_rate = sampling_rate
-        self.label = label or "unnamed_frame"
-        if isinstance(metadata, FrameMetadata):
-            self.metadata = metadata
-        elif metadata is not None:
-            self.metadata = FrameMetadata(metadata)
-        else:
-            self.metadata = FrameMetadata()
-        self.operation_history = operation_history or []
-        self._previous = previous
+        frame_label = label or "unnamed_frame"
 
         if channel_metadata:
-            # Pydantic handles both ChannelMetadata objects and dicts
+
             def _to_channel_metadata(ch: ChannelMetadata | dict[str, Any], index: int) -> ChannelMetadata:
                 if isinstance(ch, ChannelMetadata):
                     return copy.deepcopy(ch)
@@ -129,13 +116,12 @@ class BaseFrame(ABC, Generic[T]):
                             f"Ensure all dict keys match ChannelMetadata fields "
                             f"(label, unit, ref, extra) and have correct types."
                         ) from e
-                else:
-                    raise TypeError(
-                        f"Invalid type in channel_metadata at index {index}\n"
-                        f"  Got: {type(ch).__name__} ({ch!r})\n"
-                        f"  Expected: ChannelMetadata or dict\n"
-                        f"Use ChannelMetadata objects or dicts with valid fields."
-                    )
+                raise TypeError(
+                    f"Invalid type in channel_metadata at index {index}\n"
+                    f"  Got: {type(ch).__name__} ({ch!r})\n"
+                    f"  Expected: ChannelMetadata or dict\n"
+                    f"Use ChannelMetadata objects or dicts with valid fields."
+                )
 
             self._channel_metadata = [
                 _to_channel_metadata(cast(ChannelMetadata | dict[str, Any], ch), i)
@@ -147,7 +133,12 @@ class BaseFrame(ABC, Generic[T]):
                 channel_count = self._channel_count_from_data(normalized_data)
             self._channel_metadata = [ChannelMetadata(label=f"ch{i}", unit="", extra={}) for i in range(channel_count)]
 
-        self._xr = self._build_xarray(normalized_data)
+        self._xr = self._build_xarray(normalized_data, name=frame_label)
+        self.label = label
+        self.sampling_rate = sampling_rate
+        self.metadata = metadata
+        self.operation_history = operation_history
+        self._previous = previous
 
         try:
             # Display information for newer dask versions
@@ -165,9 +156,11 @@ class BaseFrame(ABC, Generic[T]):
         return data
 
     def _replace_data(self, data: DaArray) -> None:
-        """Replace the internal xarray data container without touching Wandas metadata."""
+        """Replace the internal xarray data container without touching frame state."""
         normalized = self._normalize_data(data)
-        self._xr = self._build_xarray(normalized)
+        attrs = copy.deepcopy(self._xr.attrs)
+        self._xr = self._build_xarray(normalized, name=self.label)
+        self._xr.attrs = attrs
 
     def _normalize_data(self, data: DaArray) -> DaArray:
         """Normalize Dask data shape and chunks using Wandas channel-wise policy."""
@@ -182,13 +175,13 @@ class BaseFrame(ABC, Generic[T]):
             logger.warning(f"Rechunk failed: {e!r}. Falling back to chunks=-1.")
             return data.rechunk(chunks=-1)
 
-    def _build_xarray(self, data: DaArray) -> xr.DataArray:
+    def _build_xarray(self, data: DaArray, *, name: str) -> xr.DataArray:
         """Build the internal xarray container for frame data, dims, and coords."""
         return xr.DataArray(
             data,
             dims=self._xarray_dims(data),
             coords=self._xarray_coords(data),
-            name=self.label,
+            name=name,
         )
 
     def _xarray_dims(self, data: DaArray) -> tuple[str, ...]:
@@ -257,6 +250,72 @@ class BaseFrame(ABC, Generic[T]):
         Returns the previous frame.
         """
         return self._previous
+
+    @property
+    def sampling_rate(self) -> float:
+        """Return the frame sampling rate from xarray attrs."""
+        return float(self._xr.attrs["sampling_rate"])
+
+    @sampling_rate.setter
+    def sampling_rate(self, value: float) -> None:
+        validate_sampling_rate(value)
+        self._xr.attrs["sampling_rate"] = float(value)
+
+    @property
+    def label(self) -> str:
+        """Return the frame label from xarray attrs."""
+        value = self._xr.attrs.get("label", self._xr.name)
+        if value is None or value == "":
+            return "unnamed_frame"
+        return str(value)
+
+    @label.setter
+    def label(self, value: str | None) -> None:
+        if value is not None and not isinstance(value, str):
+            raise TypeError("Label must be a string or None")
+        label = value or "unnamed_frame"
+        self._xr.attrs["label"] = label
+        self._xr.name = label
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Return mutable frame metadata stored in xarray attrs."""
+        value = self._xr.attrs.get("metadata")
+        if value is None:
+            value = {}
+            self._xr.attrs["metadata"] = value
+        if not isinstance(value, dict):
+            raise TypeError(f"Internal metadata attrs must be a dictionary, got {type(value).__name__}")
+        return value
+
+    @metadata.setter
+    def metadata(self, value: dict[str, Any] | None) -> None:
+        if value is None:
+            self._xr.attrs["metadata"] = {}
+            return
+        if not isinstance(value, dict):
+            raise TypeError("Metadata must be a dictionary")
+        self._xr.attrs["metadata"] = dict(value)
+
+    @property
+    def operation_history(self) -> list[dict[str, Any]]:
+        """Return mutable operation history stored in xarray attrs."""
+        value = self._xr.attrs.get("operation_history")
+        if value is None:
+            value = []
+            self._xr.attrs["operation_history"] = value
+        if not isinstance(value, list):
+            raise TypeError(f"Internal operation_history attrs must be a list, got {type(value).__name__}")
+        return value
+
+    @operation_history.setter
+    def operation_history(self, value: list[dict[str, Any]] | None) -> None:
+        if value is None:
+            self._xr.attrs["operation_history"] = []
+            return
+        if not isinstance(value, list):
+            raise TypeError("Operation history must be a list")
+        self._xr.attrs["operation_history"] = copy.deepcopy(value)
 
     def get_channel(
         self: S,
@@ -628,13 +687,8 @@ class BaseFrame(ABC, Generic[T]):
     def to_xarray(self) -> xr.DataArray:
         """Return a public xarray view of this frame without changing Wandas ownership."""
         exported = self._xr.copy(deep=False)
-        exported.attrs = {
-            "wandas_frame_type": type(self).__name__,
-            "sampling_rate": self.sampling_rate,
-            "label": self.label,
-            "metadata": copy.deepcopy(self.metadata),
-            "operation_history": copy.deepcopy(self.operation_history),
-        }
+        exported.attrs = copy.deepcopy(self._xr.attrs)
+        exported.attrs["wandas_frame_type"] = type(self).__name__
         return exported
 
     @property
@@ -674,8 +728,12 @@ class BaseFrame(ABC, Generic[T]):
             raise TypeError("Label must be a string")
 
         metadata = kwargs.pop("metadata", copy.deepcopy(self.metadata))
-        if not isinstance(metadata, (dict, FrameMetadata)):
-            raise TypeError("Metadata must be a dictionary or FrameMetadata")
+        if not isinstance(metadata, dict):
+            raise TypeError("Metadata must be a dictionary")
+
+        operation_history = kwargs.pop("operation_history", copy.deepcopy(self.operation_history))
+        if not isinstance(operation_history, list):
+            raise TypeError("Operation history must be a list")
 
         channel_metadata = kwargs.pop("channel_metadata", copy.deepcopy(self._channel_metadata))
         if not isinstance(channel_metadata, list):
@@ -690,6 +748,7 @@ class BaseFrame(ABC, Generic[T]):
             sampling_rate=sampling_rate,
             label=label,
             metadata=metadata,
+            operation_history=operation_history,
             channel_metadata=channel_metadata,
             previous=self,
             **kwargs,
@@ -773,8 +832,8 @@ class BaseFrame(ABC, Generic[T]):
         """
         logger.debug(f"Setting up {symbol} operation (lazy)")
 
-        metadata: FrameMetadata = self.metadata.copy() if self.metadata is not None else FrameMetadata()
-        operation_history: list[dict[str, Any]] = self.operation_history.copy() if self.operation_history else []
+        metadata = copy.deepcopy(self.metadata)
+        operation_history = copy.deepcopy(self.operation_history)
         if isinstance(other, type(self)):
             if self.sampling_rate != other.sampling_rate:
                 raise ValueError(
@@ -885,15 +944,15 @@ class BaseFrame(ABC, Generic[T]):
         self,
         operation_name: str,
         params: dict[str, Any],
-    ) -> tuple[FrameMetadata, list[dict[str, Any]]]:
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
         """Build new metadata dict and operation history after an operation.
 
         Returns
         -------
-        tuple[FrameMetadata, list[dict[str, Any]]]
+        tuple[dict[str, Any], list[dict[str, Any]]]
             (new_metadata, new_history) ready to pass to ``_create_new_instance``.
         """
-        new_metadata = self.metadata.copy()
+        new_metadata = copy.deepcopy(self.metadata)
         new_metadata[operation_name] = params
         new_history = [*self.operation_history, {"operation": operation_name, "params": params}]
         return new_metadata, new_history

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -295,7 +295,7 @@ class BaseFrame(ABC, Generic[T]):
             return
         if not isinstance(value, dict):
             raise TypeError("Metadata must be a dictionary")
-        self._xr.attrs["metadata"] = dict(value)
+        self._xr.attrs["metadata"] = copy.deepcopy(value)
 
     @property
     def operation_history(self) -> list[dict[str, Any]]:

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -687,6 +687,7 @@ class BaseFrame(ABC, Generic[T]):
     def to_xarray(self) -> xr.DataArray:
         """Return a public xarray view of this frame without changing Wandas ownership."""
         exported = self._xr.copy(deep=False)
+        exported.name = self.label
         exported.attrs = copy.deepcopy(self._xr.attrs)
         exported.attrs["wandas_frame_type"] = type(self).__name__
         return exported

--- a/wandas/core/metadata.py
+++ b/wandas/core/metadata.py
@@ -1,69 +1,8 @@
-import copy as _copy
 from typing import Any
 
-from pydantic import BaseModel, Field  # Direct import from pydantic
+from pydantic import BaseModel, Field
 
 from wandas.utils.util import unit_to_ref
-
-
-class FrameMetadata(dict[str, Any]):
-    """
-    Frame-level metadata with explicit source file tracking.
-
-    Behaves like a regular dict for backward compatibility while also
-    storing the path or name of the file the frame was loaded from.
-
-    Parameters
-    ----------
-    *args : Any
-        Positional arguments forwarded to :class:`dict`.
-    source_file : str | None, optional
-        Path or name of the source file.
-    **kwargs : Any
-        Keyword arguments forwarded to :class:`dict`.
-
-    Examples
-    --------
-    >>> meta = FrameMetadata({"gain": 0.5}, source_file="audio.wav")
-    >>> meta.source_file
-    'audio.wav'
-    >>> meta["gain"]
-    0.5
-    """
-
-    source_file: str | None
-
-    def __init__(
-        self,
-        *args: Any,
-        source_file: str | None = None,
-        **kwargs: Any,
-    ) -> None:
-        super().__init__(*args, **kwargs)
-        self.source_file = source_file
-
-    def copy(self) -> "FrameMetadata":
-        """Return a shallow copy that preserves *source_file*."""
-        result = FrameMetadata(super().copy())
-        result.source_file = self.source_file
-        return result
-
-    def merged(self, **kwargs: Any) -> "FrameMetadata":
-        """Return a copy with additional key-value pairs merged in."""
-        result = self.copy()
-        result.update(kwargs)
-        return result
-
-    def __copy__(self) -> "FrameMetadata":
-        return self.copy()
-
-    def __deepcopy__(self, memo: dict[int, Any]) -> "FrameMetadata":
-        result = FrameMetadata(_copy.deepcopy(dict(self), memo))
-        result.source_file = _copy.deepcopy(self.source_file, memo)
-        return result
-
-    def __repr__(self) -> str:
-        return f"FrameMetadata({dict.__repr__(self)}, source_file={self.source_file!r})"
 
 
 class ChannelMetadata(BaseModel):

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -20,7 +20,7 @@ from wandas.utils.dask_helpers import da_from_array as _da_from_array
 from wandas.utils.types import NDArrayReal
 
 from ..core.base_frame import BaseFrame
-from ..core.metadata import ChannelMetadata, FrameMetadata
+from ..core.metadata import ChannelMetadata
 from ..io.readers import get_file_reader
 from .mixins import ChannelProcessingMixin, ChannelTransformMixin
 
@@ -184,7 +184,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         data: DaArray,
         sampling_rate: float,
         label: str | None = None,
-        metadata: "FrameMetadata | dict[str, Any] | None" = None,
+        metadata: dict[str, Any] | None = None,
         operation_history: list[dict[str, Any]] | None = None,
         channel_metadata: list[ChannelMetadata] | list[dict[str, Any]] | None = None,
         previous: "BaseFrame[Any] | None" = None,
@@ -770,7 +770,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         data: NDArrayReal,
         sampling_rate: float,
         label: str | None = None,
-        metadata: "FrameMetadata | dict[str, Any] | None" = None,
+        metadata: dict[str, Any] | None = None,
         ch_labels: list[str] | None = None,
         ch_units: list[str] | str | None = None,
     ) -> "ChannelFrame":
@@ -819,7 +819,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         labels: list[str] | None = None,
         unit: list[str] | str | None = None,
         frame_label: str | None = None,
-        metadata: "FrameMetadata | dict[str, Any] | None" = None,
+        metadata: dict[str, Any] | None = None,
     ) -> "ChannelFrame":
         """Create a ChannelFrame from a NumPy array.
 
@@ -1019,7 +1019,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             data=dask_array,
             sampling_rate=sr,
             label=frame_label,
-            metadata=FrameMetadata(source_file=source_file),
+            metadata={"_source_file": source_file} if source_file is not None else None,
         )
         if ch_labels is not None:
             cf._set_channel_labels(ch_labels)

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -887,7 +887,7 @@ class ChannelProcessingMixin:
         metadata_updates = operation.get_metadata_updates()
 
         # Build metadata and history
-        new_metadata = self.metadata.merged(**params)
+        new_metadata = {**self.metadata, **params}
         new_history = [
             *self.operation_history,
             {"operation": operation_name, "params": params},

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -104,7 +104,7 @@ class ChannelTransformMixin:
             n_fft=n_fft,
             window=operation.window,
             label=f"{label_prefix} {self.label}",
-            metadata=self.metadata.merged(**params),
+            metadata={**self.metadata, **params},
             operation_history=[
                 *self.operation_history,
                 {"operation": operation_name, "params": params},
@@ -151,7 +151,7 @@ class ChannelTransformMixin:
             n_fft=_n_fft,
             window=operation.window,
             label=f"Spectrum of {self.label}",
-            metadata=self.metadata.merged(window=window, n_fft=_n_fft),
+            metadata={**self.metadata, "window": window, "n_fft": _n_fft},
             operation_history=[
                 *self.operation_history,
                 {"operation": "fft", "params": {"n_fft": _n_fft, "window": window}},
@@ -208,7 +208,7 @@ class ChannelTransformMixin:
             n_fft=operation.n_fft,
             window=operation.window,
             label=f"Spectrum of {self.label}",
-            metadata=self.metadata.merged(**params),
+            metadata={**self.metadata, **params},
             operation_history=[
                 *self.operation_history,
                 {"operation": "welch", "params": params},
@@ -262,7 +262,7 @@ class ChannelTransformMixin:
             G=G,
             fr=fr,
             label=f"1/{n}Oct of {self.label}",
-            metadata=self.metadata.merged(**params),
+            metadata={**self.metadata, **params},
             operation_history=[
                 *self.operation_history,
                 {

--- a/wandas/frames/mixins/protocols.py
+++ b/wandas/frames/mixins/protocols.py
@@ -8,7 +8,7 @@ from typing import Any, Protocol, TypeVar, runtime_checkable
 
 from dask.array.core import Array as DaArray
 
-from wandas.core.metadata import ChannelMetadata, FrameMetadata
+from wandas.core.metadata import ChannelMetadata
 from wandas.utils.types import NDArrayReal
 
 logger = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ class BaseFrameProtocol(Protocol):
     _data: DaArray
     sampling_rate: float
     _channel_metadata: list[ChannelMetadata]
-    metadata: FrameMetadata
+    metadata: dict[str, Any]
     operation_history: list[dict[str, Any]]
     label: str
 
@@ -97,7 +97,7 @@ class ProcessingFrameProtocol(BaseFrameProtocol, Protocol):
         self,
         operation_name: str,
         params: dict[str, Any],
-    ) -> tuple[FrameMetadata, list[dict[str, Any]]]: ...
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]: ...
 
     def _get_ref_values(self, *, require_non_default: bool = False) -> list[float]: ...
 

--- a/wandas/frames/spectral.py
+++ b/wandas/frames/spectral.py
@@ -12,7 +12,7 @@ from dask.array.core import Array as DaArray
 from wandas.utils.types import NDArrayComplex, NDArrayReal
 
 from ..core.base_frame import BaseFrame
-from ..core.metadata import ChannelMetadata, FrameMetadata
+from ..core.metadata import ChannelMetadata
 from .mixins.spectral_properties_mixin import SpectralPropertiesMixin
 
 if TYPE_CHECKING:
@@ -113,7 +113,7 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         n_fft: int,
         window: str = "hann",
         label: str | None = None,
-        metadata: FrameMetadata | dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
         operation_history: list[dict[str, Any]] | None = None,
         channel_metadata: list[ChannelMetadata] | list[dict[str, Any]] | None = None,
         previous: BaseFrame[Any] | None = None,
@@ -378,7 +378,7 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             G=G,
             fr=fr,
             label=f"1/{n}Oct of {self.label}",
-            metadata=self.metadata.merged(**params),
+            metadata={**self.metadata, **params},
             operation_history=[
                 *self.operation_history,
                 {

--- a/wandas/frames/spectrogram.py
+++ b/wandas/frames/spectrogram.py
@@ -8,7 +8,7 @@ import pandas as pd
 from dask.array.core import Array as DaArray
 
 from wandas.core.base_frame import BaseFrame
-from wandas.core.metadata import ChannelMetadata, FrameMetadata
+from wandas.core.metadata import ChannelMetadata
 from wandas.frames.mixins.spectral_properties_mixin import SpectralPropertiesMixin
 from wandas.utils.types import NDArrayComplex, NDArrayReal
 
@@ -112,7 +112,7 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         win_length: int | None = None,
         window: str = "hann",
         label: str | None = None,
-        metadata: "FrameMetadata | dict[str, Any] | None" = None,
+        metadata: dict[str, Any] | None = None,
         operation_history: list[dict[str, Any]] | None = None,
         channel_metadata: list[ChannelMetadata] | list[dict[str, Any]] | None = None,
         previous: "BaseFrame[Any] | None" = None,

--- a/wandas/io/wdf_io.py
+++ b/wandas/io/wdf_io.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
 from wandas.utils.dask_helpers import da_from_array as _da_from_array
 
 from ..core.base_frame import BaseFrame
-from ..core.metadata import FrameMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -136,7 +135,8 @@ def save(
 
         # Store frame metadata
         dict_is_nonempty = bool(frame.metadata)
-        has_source_file = isinstance(frame.metadata, FrameMetadata) and frame.metadata.source_file is not None
+        source_file = frame.metadata.get("_source_file")
+        has_source_file = source_file is not None
         if dict_is_nonempty or has_source_file:
             meta_grp = f.create_group("meta")
             # Store metadata dict content as JSON
@@ -144,7 +144,7 @@ def save(
 
             # Store source_file separately if present
             if has_source_file:
-                meta_grp.attrs["source_file"] = str(frame.metadata.source_file)
+                meta_grp.attrs["source_file"] = str(source_file)
 
             # Also store individual metadata items as attributes for compatibility
             for k, v in frame.metadata.items():
@@ -222,15 +222,15 @@ def load(path: str | Path, *, format: str = "hdf5", timeout: float = 10.0) -> "C
         frame_label = f.attrs.get("label", "")
 
         # Get frame metadata
-        frame_metadata = FrameMetadata()
+        frame_metadata: dict[str, Any] = {}
         if "meta" in f:
             meta_json = f["meta"].attrs.get("json", "{}")
             if isinstance(meta_json, (bytes, np.bytes_)):
                 meta_json = _decode_hdf5_str(meta_json)
-            frame_metadata.update(json.loads(meta_json))
+            frame_metadata = json.loads(meta_json)
             source_file = f["meta"].attrs.get("source_file", None)
             if source_file is not None:
-                frame_metadata.source_file = _decode_hdf5_str(source_file)
+                frame_metadata.setdefault("_source_file", _decode_hdf5_str(source_file))
 
         # Load operation history
         operation_history = []

--- a/wandas/io/wdf_io.py
+++ b/wandas/io/wdf_io.py
@@ -134,17 +134,10 @@ def save(
                             op_sub_grp.attrs[k] = str(v)
 
         # Store frame metadata
-        dict_is_nonempty = bool(frame.metadata)
-        source_file = frame.metadata.get("_source_file")
-        has_source_file = source_file is not None
-        if dict_is_nonempty or has_source_file:
+        if frame.metadata:
             meta_grp = f.create_group("meta")
             # Store metadata dict content as JSON
             meta_grp.attrs["json"] = json.dumps(dict(frame.metadata))
-
-            # Store source_file separately if present
-            if has_source_file:
-                meta_grp.attrs["source_file"] = str(source_file)
 
             # Also store individual metadata items as attributes for compatibility
             for k, v in frame.metadata.items():

--- a/wandas/io/wdf_io.py
+++ b/wandas/io/wdf_io.py
@@ -220,7 +220,10 @@ def load(path: str | Path, *, format: str = "hdf5", timeout: float = 10.0) -> "C
             meta_json = f["meta"].attrs.get("json", "{}")
             if isinstance(meta_json, (bytes, np.bytes_)):
                 meta_json = _decode_hdf5_str(meta_json)
-            frame_metadata = json.loads(meta_json)
+            parsed_metadata = json.loads(meta_json)
+            if not isinstance(parsed_metadata, dict):
+                raise ValueError("WDF meta/json must decode to a JSON object")
+            frame_metadata = parsed_metadata
             source_file = f["meta"].attrs.get("source_file", None)
             if source_file is not None:
                 frame_metadata.setdefault("_source_file", _decode_hdf5_str(source_file))


### PR DESCRIPTION
## Summary
- Move frame-level state (`sampling_rate`, `label`, `metadata`, `operation_history`) onto `BaseFrame._xr.attrs` while preserving the public property API.
- Remove `FrameMetadata` from production/public paths; `frame.metadata` is now a plain dict and source-file metadata uses `metadata["_source_file"]`.
- Keep `ChannelMetadata`, operation execution, generated coords, `from_xarray`, and NetCDF/Zarr out of scope.
- Update WDF compatibility so legacy `meta.attrs["source_file"]` is read into `_source_file`, while newly saved WDF files no longer emit the legacy attr.

## Verification
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check wandas tests`
- `uv run pytest` -> 1457 passed, 3 skipped
- `rg -n "FrameMetadata|metadata\.source_file|metadata\.merged" wandas tests -g '*.py'` -> no matches

## Compatibility Notes
- This intentionally removes the `FrameMetadata` public API.
- Code using `frame.metadata.source_file` should use `frame.metadata["_source_file"]`.
- WDF load keeps migration compatibility for legacy `source_file` attrs.