### PR TITLE
[codex] Fix supported format defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ examples/data/dataset/
 
 # Local/agent-specific settings
 .claude/settings.json
+.worktrees/
 
 # Accidental notebooks (keep repo clean)
 learning-path/06_skill_validation.py

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ signal.describe()
 
 ## What You Can Do / できること
 
-- Read waveform and sensor data from formats such as WAV, CSV, and WDF.
-  WAV、CSV、WDF などから波形やセンサーデータを読み込めます。
+- Read waveform and sensor data from registered reader formats: WAV, FLAC, OGG, AIFF/AIF, SND, and CSV. WDF is available through the separate save/load API.
+  登録済み reader 形式（WAV、FLAC、OGG、AIFF/AIF、SND、CSV）から波形やセンサーデータを読み込めます。WDF は別の save/load API で扱えます。
 - Filter, resample, normalize, and summarize signals with method chaining.
   フィルタ、リサンプリング、正規化、要約をメソッドチェーンで進められます。
 - Run FFT, STFT, Welch, coherence, transfer-function, and octave-style analyses.

--- a/docs/superpowers/specs/2026-06-14-public-api-design.md
+++ b/docs/superpowers/specs/2026-06-14-public-api-design.md
@@ -1,0 +1,132 @@
+# Public API Design for v0.3
+
+## Context
+
+The current top-level `wandas` API exposes convenience constructors such as
+`read_wav`, `read_csv`, `from_numpy`, `from_ndarray`, `generate_sin`, and
+`from_folder`, but the exported names do not describe the stable public surface
+clearly. In particular, `ChannelFrame` is importable as `wandas.ChannelFrame`
+but is missing from `wandas.__all__`.
+
+The documentation also describes the frames module as containing
+`ChannelFrame`, `SpectralFrame`, `SpectrogramFrame`, and `NOctFrame`, while
+`wandas.frames.__all__` currently exports only `ChannelFrame` and
+`RoughnessFrame`. This mismatch makes the public API harder to discover and
+harder to explain.
+
+## Stable Public API
+
+For v0.3, the primary public API is:
+
+```python
+import wandas as wd
+
+wd.read(...)
+wd.read_wav(...)
+wd.read_csv(...)
+wd.load(...)
+wd.from_numpy(...)
+wd.from_folder(...)
+
+wd.ChannelFrame
+wd.SpectralFrame
+wd.SpectrogramFrame
+wd.NOctFrame
+wd.ChannelFrameDataset
+```
+
+`from_ndarray` remains available for backward compatibility, but it stays
+deprecated and is not presented as a primary API in the README or public API
+overview. `generate_sin` remains available as an existing helper, but it is not
+part of the primary v0.3 API list.
+
+## `read` and `load` Responsibilities
+
+`wd.read()` is the standard top-level entry point for creating a
+`ChannelFrame` from external source data handled by `ChannelFrame.from_file()`,
+including WAV, CSV, supported audio files, URLs, bytes, and file-like objects.
+
+`wd.load()` is the standard top-level entry point for loading Wandas native WDF
+files. It delegates to the existing WDF loader and returns a `ChannelFrame`.
+
+WDF is intentionally not handled by `wd.read()`. If a caller passes a `.wdf`
+path to `wd.read()`, Wandas raises a clear `ValueError` that points the
+caller to `wd.load()` instead of falling through to a generic unsupported file
+reader error.
+
+Example error shape:
+
+```text
+WDF files are loaded with wd.load(), not wd.read()
+  Path: example.wdf
+  Use: wd.load("example.wdf")
+```
+
+`ChannelFrame.from_file()` remains the class-level implementation for external
+source data. `wd.read()` is the user-facing top-level wrapper over that
+behavior. `ChannelFrame.load()` and `wd.load()` remain responsible for WDF.
+
+## Exports
+
+`wandas.__all__` includes the primary stable names and retained
+compatibility helpers:
+
+- `ChannelFrame`
+- `SpectralFrame`
+- `SpectrogramFrame`
+- `NOctFrame`
+- `ChannelFrameDataset`
+- `read`
+- `read_wav`
+- `read_csv`
+- `load`
+- `from_numpy`
+- `from_folder`
+- `from_ndarray`
+- `generate_sin`
+
+`wandas.frames.__all__` matches the documented frame classes:
+
+- `ChannelFrame`
+- `SpectralFrame`
+- `SpectrogramFrame`
+- `NOctFrame`
+- `RoughnessFrame`
+
+## Documentation
+
+The README Quick Start uses `wd.read("audio.wav")`, because this is
+the easiest path to explain as stable public API. The README can still
+mention `read_wav` and `read_csv` as explicit-format convenience functions, but
+the first path is `read`.
+
+The API docs describe:
+
+- `wd.read()` for external source data.
+- `wd.load()` for WDF.
+- `wd.read_wav()` and `wd.read_csv()` as explicit-format convenience functions.
+- `from_ndarray()` as deprecated in favor of `from_numpy()`.
+- The same frame classes that `wandas.frames.__all__` exports.
+
+Docs, README, and `__all__` use the same names for the same concepts.
+
+## Testing
+
+Add or update tests to cover:
+
+- `wandas.__all__` contains the stable public names.
+- `wandas.frames.__all__` exports documented frame classes.
+- `wd.ChannelFrame`, `wd.SpectralFrame`, `wd.SpectrogramFrame`,
+  `wd.NOctFrame`, and `wd.ChannelFrameDataset` resolve to the expected classes.
+- `wd.read()` reads WAV and CSV through the existing `ChannelFrame.from_file()`
+  behavior.
+- `wd.read()` rejects `.wdf` paths with an error that mentions `wd.load()`.
+- `wd.load()` loads WDF files through the existing WDF round-trip path.
+- Existing compatibility behavior for `from_ndarray` remains deprecated but
+  functional.
+
+## Acceptance Criteria
+
+The README Quick Start API must be directly explainable as stable public API.
+After this change, the top-level API, frames module exports, README, and docs
+must agree on the v0.3 public names.

--- a/docs/superpowers/specs/2026-06-14-public-api-design.md
+++ b/docs/superpowers/specs/2026-06-14-public-api-design.md
@@ -16,14 +16,12 @@ harder to explain.
 
 ## Stable Public API
 
-For v0.3, the primary public API is:
+For v0.3, the primary public API is intentionally small:
 
 ```python
 import wandas as wd
 
 wd.read(...)
-wd.read_wav(...)
-wd.read_csv(...)
 wd.load(...)
 wd.from_numpy(...)
 wd.from_folder(...)
@@ -35,10 +33,17 @@ wd.NOctFrame
 wd.ChannelFrameDataset
 ```
 
-`from_ndarray` remains available for backward compatibility, but it stays
-deprecated and is not presented as a primary API in the README or public API
-overview. `generate_sin` remains available as an existing helper, but it is not
-part of the primary v0.3 API list.
+These names are the API that README examples and public documentation
+teach first. Format-specific and older constructor aliases remain available for
+backward compatibility, but they are not part of the primary API. This keeps the
+first user decision simple: use `read()` for external source data, `load()` for
+WDF, and `from_numpy()` for arrays.
+
+`read_wav` and `read_csv` remain importable compatibility helpers for existing
+code, but new documentation prefers `read`. `from_ndarray` remains
+available with its existing deprecation warning and is not presented as a
+primary API. `generate_sin` remains available as an existing helper, but it is
+not part of the primary v0.3 API list.
 
 ## `read` and `load` Responsibilities
 
@@ -68,8 +73,8 @@ behavior. `ChannelFrame.load()` and `wd.load()` remain responsible for WDF.
 
 ## Exports
 
-`wandas.__all__` includes the primary stable names and retained
-compatibility helpers:
+`wandas.__all__` is a curated discovery surface and includes only the
+primary names:
 
 - `ChannelFrame`
 - `SpectralFrame`
@@ -77,13 +82,14 @@ compatibility helpers:
 - `NOctFrame`
 - `ChannelFrameDataset`
 - `read`
-- `read_wav`
-- `read_csv`
 - `load`
 - `from_numpy`
 - `from_folder`
-- `from_ndarray`
-- `generate_sin`
+
+Compatibility helpers such as `read_wav`, `read_csv`, `from_ndarray`, and
+`generate_sin` remain available as module attributes, but they are omitted from
+`__all__` so wildcard imports and API listings do not promote multiple entry
+points.
 
 `wandas.frames.__all__` matches the documented frame classes:
 
@@ -96,15 +102,15 @@ compatibility helpers:
 ## Documentation
 
 The README Quick Start uses `wd.read("audio.wav")`, because this is
-the easiest path to explain as stable public API. The README can still
-mention `read_wav` and `read_csv` as explicit-format convenience functions, but
-the first path is `read`.
+the easiest path to explain as stable public API. README examples avoid
+`read_wav` and `read_csv` unless documenting compatibility or migration notes.
 
 The API docs describe:
 
 - `wd.read()` for external source data.
 - `wd.load()` for WDF.
-- `wd.read_wav()` and `wd.read_csv()` as explicit-format convenience functions.
+- `read_wav()` and `read_csv()` only as compatibility helpers, not recommended
+  starting points.
 - `from_ndarray()` as deprecated in favor of `from_numpy()`.
 - The same frame classes that `wandas.frames.__all__` exports.
 
@@ -114,19 +120,21 @@ Docs, README, and `__all__` use the same names for the same concepts.
 
 Add or update tests to cover:
 
-- `wandas.__all__` contains the stable public names.
+- `wandas.__all__` contains only the curated primary public names.
 - `wandas.frames.__all__` exports documented frame classes.
 - `wd.ChannelFrame`, `wd.SpectralFrame`, `wd.SpectrogramFrame`,
   `wd.NOctFrame`, and `wd.ChannelFrameDataset` resolve to the expected classes.
 - `wd.read()` reads WAV and CSV through the existing `ChannelFrame.from_file()`
-  behavior.
+  behavior, making `read_wav` and `read_csv` unnecessary for new examples.
 - `wd.read()` rejects `.wdf` paths with an error that mentions `wd.load()`.
 - `wd.load()` loads WDF files through the existing WDF round-trip path.
-- Existing compatibility behavior for `from_ndarray` remains deprecated but
-  functional.
+- Existing compatibility behavior for `read_wav`, `read_csv`, `from_ndarray`,
+  and `generate_sin` remains functional, while those names stay out of the
+  curated primary API.
 
 ## Acceptance Criteria
 
 The README Quick Start API must be directly explainable as stable public API.
-After this change, the top-level API, frames module exports, README, and docs
-must agree on the v0.3 public names.
+After this change, README Quick Start, top-level `__all__`, frames module
+exports, and docs must agree on the small v0.3 primary API. Compatibility
+helpers must not be promoted as alternative starting points.

--- a/docs/superpowers/specs/2026-06-14-source-time-offset-design.md
+++ b/docs/superpowers/specs/2026-06-14-source-time-offset-design.md
@@ -1,0 +1,137 @@
+# Source Time Offset Design
+
+## Purpose
+
+Wandas should preserve signal context across time-domain operations without breaking the existing local time API. Today `ChannelFrame.time` is always derived as `np.arange(n_samples) / sampling_rate`, so a frame created by `x.trim(10.0, 12.0)` cannot directly say that it represents seconds 10.0 through 12.0 of the source signal.
+
+This design adds first-class source-time context using a lightweight offset model:
+
+- `time` and `times` remain local, zero-based axes for backward compatibility.
+- `source_time_offset` records where local time `0.0` sits in the source signal.
+- `source_time` and `source_times` expose source-relative axes by adding the offset to the local axis.
+- `source_time_range` exposes the source-relative time span of a frame.
+
+The accepted behavior is:
+
+```python
+x = wd.read_wav("recording.wav")
+y = x.trim(10.0, 12.0)
+
+y.time[0]        # 0.0
+y.source_time[0] # 10.0
+```
+
+## Public API
+
+All frame types gain:
+
+```python
+frame.source_time_offset: float
+frame.source_time_range: tuple[float, float]
+```
+
+Frames with a local time axis gain a source-time array:
+
+```python
+channel_frame.time          # existing local time axis
+channel_frame.source_time   # channel_frame.time + source_time_offset
+
+roughness_frame.time        # existing local time axis
+roughness_frame.source_time # roughness_frame.time + source_time_offset
+
+spectrogram_frame.times         # existing local spectrogram frame times
+spectrogram_frame.source_times  # spectrogram_frame.times + source_time_offset
+```
+
+`SpectralFrame` and `NOctFrame` keep frequency as their main axis. They preserve `source_time_offset`. Their `source_time_range` is derived from the previous time-domain frame when available, because offset alone is not enough to infer a duration from frequency-bin data.
+
+`to_dataframe()` stays backward compatible. For `ChannelFrame`, the index remains local `time`. Future Analyzer code should use `source_time` or `source_times` when it needs source-relative alignment.
+
+## Internal Model
+
+`BaseFrame.__init__` accepts:
+
+```python
+source_time_offset: float = 0.0
+```
+
+`BaseFrame._create_new_instance()` forwards the current offset unless a caller overrides it. Every concrete frame constructor that calls `BaseFrame.__init__` accepts and forwards the same argument.
+
+The offset is not stored in `metadata`. It is a first-class frame attribute so users and future analyzers can rely on it without parsing mutable metadata.
+
+The offset is measured in seconds and is source-relative, not wall-clock absolute time.
+
+## Operation Rules
+
+`trim(start, end)` keeps `start` and `end` as local-time arguments. The result offset is:
+
+```python
+result.source_time_offset = input.source_time_offset + start
+```
+
+This means:
+
+```python
+x.trim(10.0, 12.0).trim(0.5, 1.0)
+```
+
+represents source seconds 10.5 through 11.0.
+
+`resampling(target_sr)` preserves `source_time_offset`. The output `sampling_rate`, sample count, `duration`, and local `time` must agree with the resampled data shape.
+
+`rms_trend(frame_length, hop_length)` preserves `source_time_offset`. Its local `time` remains based on the output sampling rate created by the operation.
+
+`stft(...)` preserves `source_time_offset`. `SpectrogramFrame.times` remains local STFT frame time, and `SpectrogramFrame.source_times` is `times + source_time_offset`.
+
+Channel selection and channel reduction operations preserve `source_time_offset`.
+
+Frequency-domain transforms preserve `source_time_offset` and keep frequency as their primary data axis. When the output has no time axis, `source_time_range` should delegate to the previous frame source range if that previous frame is available.
+
+## Source Time Range
+
+For frames with a local time axis and known duration:
+
+```python
+source_start = source_time_offset
+source_end = source_time_offset + duration
+```
+
+For `ChannelFrame`, `duration` is `n_samples / sampling_rate`.
+
+For time-frame outputs such as `SpectrogramFrame` and roughness-like frames, `source_time_range` should represent the source span covered by the frame's local duration. The implementation should use the frame's existing local time semantics rather than changing those semantics. For example, `SpectrogramFrame.times` remains based on `hop_length / sampling_rate`.
+
+For frequency-only frames such as `SpectralFrame` and `NOctFrame`, `source_time_range` should return the previous frame source range when `previous` exists. If there is no previous frame and no time-axis duration can be inferred from the frame itself, the range should fall back to a zero-length range at `source_time_offset` instead of inventing a duration from frequency-bin count.
+
+Empty frames should report a valid zero-length range:
+
+```python
+(source_time_offset, source_time_offset)
+```
+
+## Error Handling
+
+`source_time_offset` must be a finite numeric value. Constructors should reject `NaN`, infinity, and non-numeric values with `ValueError` or `TypeError`.
+
+Operations must not silently create a negative sample count or a source range whose end is earlier than its start. Existing trim validation remains local-time validation.
+
+## Tests
+
+Add focused tests for:
+
+- `ChannelFrame.trim(10, 12)` keeps `time[0] == 0.0` and sets `source_time[0] == 10.0`.
+- Chained trim `x.trim(10, 12).trim(0.5, 1.0)` reports source range 10.5 through 11.0.
+- `resampling()` preserves offset and keeps `duration == n_samples / sampling_rate`.
+- `stft()` preserves offset and reports `source_times == times + input.source_time_offset`.
+- `rms_trend()` preserves offset and keeps its local time axis consistent with output sampling rate.
+- `to_dataframe()` keeps local `time` as the index for backward compatibility.
+- Constructor validation rejects invalid offsets.
+
+## Non-Goals
+
+This design does not change `time` or `times` to source-relative axes.
+
+This design does not add wall-clock timestamps or calendar time.
+
+This design does not make `trim(start, end)` accept source-time arguments. Trim arguments remain local time.
+
+This design does not require storing full time arrays on frames.

--- a/docs/superpowers/specs/2026-06-14-supported-formats-design.md
+++ b/docs/superpowers/specs/2026-06-14-supported-formats-design.md
@@ -1,0 +1,78 @@
+# Supported Formats Consistency Design
+
+## Context
+
+`ChannelFrameDataset` and `wd.from_folder()` currently include `.mp3` in their
+default file extension list. The registered readers do not support `.mp3`:
+
+- `SoundFileReader`: `.wav`, `.flac`, `.ogg`, `.aiff`, `.aif`, `.snd`
+- `CSVFileReader`: `.csv`
+
+This means a default folder scan can collect files that the normal reader
+registry cannot read. The fix should keep `wd.from_folder("data")` from
+including unreadable files by default, and should expose the supported formats
+through the public API.
+
+## Scope
+
+This change will not add MP3 decoding. MP3 can still be requested explicitly
+through `file_extensions=[".mp3"]`, but it will not be part of any default
+format list until a reader that can actually load it is registered.
+
+WDF remains a separate save/load path and is not part of the folder reader
+registry used by `ChannelFrameDataset`.
+
+## Design
+
+Use the reader registry as the single source of truth for default
+`ChannelFrameDataset` file extensions.
+
+Add a helper in `wandas/io/readers.py` that returns supported extensions from
+the registered readers. The helper will:
+
+- inspect `_file_readers`;
+- collect each reader class's `supported_extensions`;
+- normalize extensions to lowercase with a leading dot;
+- de-duplicate extensions;
+- return a stable sorted list.
+
+Add `wd.supported_formats()` in `wandas/__init__.py`. It will delegate to the
+reader helper and return the same extension list used by default folder scans.
+This makes the public API and the registry agree.
+
+Update `ChannelFrameDataset.__init__()` and
+`ChannelFrameDataset.from_folder()` so their default `file_extensions=None`
+path uses the reader helper. Explicit `file_extensions` values remain honored
+unchanged.
+
+Update README/docs wording so the supported folder-reader formats match the
+registry: `.wav`, `.flac`, `.ogg`, `.aiff`, `.aif`, `.snd`, and `.csv`.
+
+## Behavior
+
+`wd.from_folder("data")` will no longer include `.mp3` files by default.
+
+If a caller registers a custom reader with `register_file_reader()`, subsequent
+calls to `wd.supported_formats()` and default dataset construction will include
+that reader's extensions.
+
+If a caller explicitly passes unsupported extensions, Wandas will still scan
+for those paths. Loading may fail as it does today because the explicit request
+overrides the default safety behavior.
+
+## Tests
+
+Add or update focused tests for:
+
+- `wd.supported_formats()` returns registry-backed extensions and excludes
+  `.mp3`;
+- `ChannelFrameDataset.from_folder(tmp_path)` does not include `.mp3` files by
+  default;
+- top-level `wd.from_folder(tmp_path)` has the same default filtering behavior;
+- registering a custom reader updates the supported format helper;
+- explicit `file_extensions=[".mp3"]` remains an override.
+
+## Acceptance Criteria
+
+`wd.from_folder("data")` must not include files by default that the registered
+readers cannot read.

--- a/tests/io/test_file_readers.py
+++ b/tests/io/test_file_readers.py
@@ -312,6 +312,9 @@ class TestFileReaderHelpers:
 
             assert ".custom" in formats
             assert formats.count(".wav") == 1
+
+            reader = get_file_reader("test.custom")
+            assert isinstance(reader, CustomFileReader)
         finally:
             del _file_readers[original_count:]
 

--- a/tests/io/test_file_readers.py
+++ b/tests/io/test_file_readers.py
@@ -318,6 +318,14 @@ class TestFileReaderHelpers:
         finally:
             del _file_readers[original_count:]
 
+    def test_can_read_uses_normalized_supported_extensions(self) -> None:
+        class CustomFileReader(SoundFileReader):
+            supported_extensions: list[str] = ["custom"]
+
+        assert CustomFileReader.can_read("test.custom") is True
+        assert CustomFileReader.can_read("test.wav") is False
+        assert CustomFileReader.can_read("test") is False
+
 
 class TestGetFileReader:
     def test_get_file_reader_wav(self) -> None:

--- a/tests/io/test_file_readers.py
+++ b/tests/io/test_file_readers.py
@@ -15,6 +15,7 @@ from wandas.io.readers import (
     _prepare_file_source,
     get_file_reader,
     register_file_reader,
+    supported_formats,
 )
 from wandas.utils.types import NDArrayReal
 
@@ -293,6 +294,27 @@ class TestFileReaderHelpers:
 
         assert prepared is stream
 
+    def test_supported_formats_returns_registered_reader_extensions(self) -> None:
+        formats = supported_formats()
+
+        assert formats == [".aif", ".aiff", ".csv", ".flac", ".ogg", ".snd", ".wav"]
+        assert ".mp3" not in formats
+
+    def test_supported_formats_reflects_custom_reader_registration(self) -> None:
+        class CustomFileReader(SoundFileReader):
+            supported_extensions: list[str] = ["custom", ".WAV"]
+
+        original_count = len(_file_readers)
+        try:
+            register_file_reader(CustomFileReader)
+
+            formats = supported_formats()
+
+            assert ".custom" in formats
+            assert formats.count(".wav") == 1
+        finally:
+            del _file_readers[original_count:]
+
 
 class TestGetFileReader:
     def test_get_file_reader_wav(self) -> None:
@@ -327,8 +349,11 @@ class TestRegisterFileReader:
             supported_extensions: list[str] = [".custom"]
 
         original_count: int = len(_file_readers)
-        register_file_reader(CustomFileReader)
+        try:
+            register_file_reader(CustomFileReader)
 
-        assert len(_file_readers) == original_count + 1
-        reader = get_file_reader("test.custom")
-        assert isinstance(reader, CustomFileReader)
+            assert len(_file_readers) == original_count + 1
+            reader = get_file_reader("test.custom")
+            assert isinstance(reader, CustomFileReader)
+        finally:
+            del _file_readers[original_count:]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -69,6 +69,13 @@ def test_no_handler():
     assert len(logger.handlers) == 0
 
 
+def test_supported_formats_public_api() -> None:
+    formats = wandas.supported_formats()
+
+    assert formats == [".aif", ".aiff", ".csv", ".flac", ".ogg", ".snd", ".wav"]
+    assert ".mp3" not in formats
+
+
 def test_existing_handler():
     """すでにハンドラーがある場合、新しいハンドラーは追加されない"""
     # 事前にハンドラーを追加

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -119,6 +119,17 @@ def test_from_folder(tmp_path: Path) -> None:
     assert len(dataset) == 1
 
 
+def test_from_folder_default_extensions_exclude_mp3(tmp_path: Path) -> None:
+    (tmp_path / "readable.csv").write_text("time,ch1\n0.0,1.0\n", encoding="utf-8")
+    (tmp_path / "ignored.mp3").write_bytes(b"")
+
+    dataset = wandas.from_folder(str(tmp_path))
+
+    names = [lazy_frame.file_path.name for lazy_frame in dataset._lazy_frames]
+    assert names == ["readable.csv"]
+    assert ".mp3" not in dataset.file_extensions
+
+
 def test_from_folder_same_as_class_method(tmp_path: Path) -> None:
     """wd.from_folder が ChannelFrameDataset.from_folder と同じ結果を返すことを確認"""
     from wandas.utils.frame_dataset import ChannelFrameDataset

--- a/tests/utils/test_frame_dataset.py
+++ b/tests/utils/test_frame_dataset.py
@@ -87,6 +87,29 @@ def create_test_files(
     return tmp_path
 
 
+def test_channel_frame_dataset_default_extensions_exclude_mp3(tmp_path: Path) -> None:
+    (tmp_path / "readable.wav").write_bytes(b"")
+    (tmp_path / "ignored.mp3").write_bytes(b"")
+    (tmp_path / "readable.csv").write_text("time,ch1\n0.0,1.0\n", encoding="utf-8")
+
+    dataset = ChannelFrameDataset.from_folder(str(tmp_path))
+
+    names = [lazy_frame.file_path.name for lazy_frame in dataset._lazy_frames]
+    assert names == ["readable.csv", "readable.wav"]
+    assert dataset.file_extensions == [".aif", ".aiff", ".csv", ".flac", ".ogg", ".snd", ".wav"]
+
+
+def test_channel_frame_dataset_explicit_extensions_can_include_mp3(tmp_path: Path) -> None:
+    (tmp_path / "explicit.mp3").write_bytes(b"")
+    (tmp_path / "ignored.wav").write_bytes(b"")
+
+    dataset = ChannelFrameDataset.from_folder(str(tmp_path), file_extensions=[".mp3"])
+
+    names = [lazy_frame.file_path.name for lazy_frame in dataset._lazy_frames]
+    assert names == ["explicit.mp3"]
+    assert dataset.file_extensions == [".mp3"]
+
+
 # --- Test LazyFrame ---
 
 
@@ -212,7 +235,15 @@ class TestChannelFrameDataset:
         assert all(not lf.is_loaded for lf in dataset._lazy_frames)
         assert all(lf.frame is None for lf in dataset._lazy_frames)
         assert dataset.folder_path == folder_path
-        assert dataset.file_extensions == [".wav", ".mp3", ".flac", ".csv"]  # Default extensions
+        assert dataset.file_extensions == [
+            ".aif",
+            ".aiff",
+            ".csv",
+            ".flac",
+            ".ogg",
+            ".snd",
+            ".wav",
+        ]  # Default extensions
         assert dataset._recursive is False
 
     def test_init_eager_loads_all_frames(self, create_test_files: Path) -> None:

--- a/wandas/__init__.py
+++ b/wandas/__init__.py
@@ -18,7 +18,22 @@ from_numpy = ChannelFrame.from_numpy
 from_ndarray = ChannelFrame.from_ndarray
 
 generate_sin = generate_sample.generate_sin_lazy
-__all__ = ["ChannelFrameDataset", "from_folder", "from_ndarray", "generate_sin", "read_csv", "read_wav"]
+__all__ = [
+    "ChannelFrameDataset",
+    "from_folder",
+    "from_ndarray",
+    "generate_sin",
+    "read_csv",
+    "read_wav",
+    "supported_formats",
+]
+
+
+def supported_formats() -> list[str]:
+    """Return file extensions supported by the registered readers."""
+    from .io.readers import supported_formats as _supported_formats
+
+    return _supported_formats()
 
 
 def from_folder(

--- a/wandas/io/readers.py
+++ b/wandas/io/readers.py
@@ -104,10 +104,22 @@ class FileReader(ABC):
         # pragma: no cover
 
     @classmethod
+    def _normalize_supported_extensions(cls) -> list[str]:
+        """Return normalized reader extensions in lowercase dot form."""
+        normalized_extensions: list[str] = []
+        for extension in cls.supported_extensions:
+            normalized_extension = _normalize_extension(extension)
+            if normalized_extension is not None:
+                normalized_extensions.append(normalized_extension)
+        return normalized_extensions
+
+    @classmethod
     def can_read(cls, path: str | Path) -> bool:
         """Check if this reader can handle the file based on extension."""
-        ext = Path(path).suffix.lower()
-        return ext in cls.supported_extensions
+        ext = _normalize_extension(Path(path).suffix)
+        if ext is None:
+            return False
+        return ext in cls._normalize_supported_extensions()
 
 
 class SoundFileReader(FileReader):
@@ -365,10 +377,7 @@ def supported_formats() -> list[str]:
     """Return file extensions supported by the registered readers."""
     extensions: set[str] = set()
     for reader in _file_readers:
-        for extension in reader.__class__.supported_extensions:
-            normalized = _normalize_extension(extension)
-            if normalized is not None:
-                extensions.add(normalized)
+        extensions.update(reader.__class__._normalize_supported_extensions())
     return sorted(extensions)
 
 
@@ -411,7 +420,7 @@ def get_file_reader(
 
     # Try each reader in order
     for reader in _file_readers:
-        if ext in reader.__class__.supported_extensions:
+        if ext in reader.__class__._normalize_supported_extensions():
             logger.debug(f"Using {reader.__class__.__name__} for {path_str}")
             return reader
 

--- a/wandas/io/readers.py
+++ b/wandas/io/readers.py
@@ -361,6 +361,17 @@ def _normalize_extension(file_type: str | None) -> str | None:
     return ext
 
 
+def supported_formats() -> list[str]:
+    """Return file extensions supported by the registered readers."""
+    extensions: set[str] = set()
+    for reader in _file_readers:
+        for extension in reader.__class__.supported_extensions:
+            normalized = _normalize_extension(extension)
+            if normalized is not None:
+                extensions.add(normalized)
+    return sorted(extensions)
+
+
 def _prepare_file_source(
     source: str | Path | bytes | bytearray | memoryview | BinaryIO,
 ) -> str | BinaryIO:

--- a/wandas/utils/frame_dataset.py
+++ b/wandas/utils/frame_dataset.py
@@ -11,6 +11,7 @@ from tqdm.auto import tqdm
 
 from wandas.frames.channel import ChannelFrame
 from wandas.frames.spectrogram import SpectrogramFrame
+from wandas.io.readers import supported_formats
 
 logger = logging.getLogger(__name__)
 
@@ -531,12 +532,7 @@ class ChannelFrameDataset(FrameDataset[ChannelFrame]):
         source_dataset: "FrameDataset[Any] | None" = None,
         transform: Callable[[Any], ChannelFrame | None] | None = None,
     ):
-        _file_extensions = file_extensions or [
-            ".wav",
-            ".mp3",
-            ".flac",
-            ".csv",
-        ]
+        _file_extensions = file_extensions if file_extensions is not None else supported_formats()
 
         super().__init__(
             folder_path=folder_path,
@@ -652,7 +648,7 @@ class ChannelFrameDataset(FrameDataset[ChannelFrame]):
         lazy_loading: bool = True,
     ) -> "ChannelFrameDataset":
         """Class method to create a ChannelFrameDataset from a folder."""
-        extensions = file_extensions if file_extensions is not None else [".wav", ".mp3", ".flac", ".csv"]
+        extensions = file_extensions if file_extensions is not None else supported_formats()
 
         return cls(
             folder_path,


### PR DESCRIPTION
## Summary
- Derive folder-reader supported formats from the registered reader registry and expose `wd.supported_formats()`.
- Remove `.mp3` from default `wd.from_folder()` / `ChannelFrameDataset` discovery unless explicitly requested.
- Normalize custom reader extension matching and align README wording with actual supported formats.

## Test Plan
- `uv run ruff check wandas/io/readers.py wandas/utils/frame_dataset.py wandas/__init__.py tests/io/test_file_readers.py tests/utils/test_frame_dataset.py tests/test_init.py`
- `uv run ty check wandas/io/readers.py wandas/utils/frame_dataset.py wandas/__init__.py`
- `uv run pytest tests/io/test_file_readers.py tests/utils/test_frame_dataset.py tests/test_init.py -v`
- `uv run pytest -v`