### PR TITLE
[codex] Add source time offset support

### DIFF
--- a/tests/core/test_base_frame.py
+++ b/tests/core/test_base_frame.py
@@ -858,12 +858,12 @@ class TestBaseFrameIndexing:
 
     def test_getitem_with_tuple_list_and_time_preserves_dask(self) -> None:
         """Test __getitem__ with list of channels and time slice."""
-        result = self.channel_frame[[0, 2], ::2]
+        result = self.channel_frame[[0, 2], 100:200]
         assert result is not self.channel_frame
         assert result.n_channels == 2
-        assert result.n_samples == 8000  # Every 2nd sample
+        assert result.n_samples == 100
         assert isinstance(result._data, DaArray)
-        np.testing.assert_array_equal(result.compute(), self.data[[0, 2], ::2])
+        np.testing.assert_array_equal(result.compute(), self.data[[0, 2], 100:200])
 
     def test_getitem_with_tuple_invalid_length(self) -> None:
         """Test __getitem__ with tuple of invalid length raises ValueError."""

--- a/tests/core/test_base_frame.py
+++ b/tests/core/test_base_frame.py
@@ -865,6 +865,10 @@ class TestBaseFrameIndexing:
         assert isinstance(result._data, DaArray)
         np.testing.assert_array_equal(result.compute(), self.data[[0, 2], 100:200])
 
+    def test_source_time_slice_context_without_time_key_returns_none(self) -> None:
+        """No source offset update is needed when tuple indexing omits the time key."""
+        assert self.channel_frame._source_time_slice_context(()) is None
+
     def test_getitem_with_tuple_invalid_length(self) -> None:
         """Test __getitem__ with tuple of invalid length raises ValueError."""
         with pytest.raises(ValueError, match="Invalid key length"):

--- a/tests/core/test_base_frame_additional.py
+++ b/tests/core/test_base_frame_additional.py
@@ -551,6 +551,17 @@ class SingleChannelAxislessFrame(BaseFrame[np.ndarray]):
         return None
 
 
+def test_axisless_frame_stores_source_time_offset_in_attrs() -> None:
+    data = da_from_array(np.arange(4, dtype=float), chunks=(4,))
+    frame = SingleChannelAxislessFrame(data, sampling_rate=100.0, source_time_offset=2.5)
+
+    xr_data = frame.to_xarray()
+
+    assert "source_time_offset" not in xr_data.coords
+    np.testing.assert_array_equal(xr_data.attrs["source_time_offset"], np.array([2.5]))
+    np.testing.assert_array_equal(frame.source_time_offset, np.array([2.5]))
+
+
 def test_data_property_rejects_non_dask_xarray_storage():
     f = make_frame(np.arange(6).reshape(2, 3))
     f._xr = xr.DataArray(np.arange(6).reshape(2, 3), dims=("dim_0", "dim_1"))

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -89,6 +89,17 @@ class TestChannelFrame:
         np.testing.assert_array_equal(cf.source_time, cf.time + 2.5)
         assert cf.to_xarray().attrs["source_time_offset"] == 2.5
 
+    def test_source_time_offset_rejects_non_finite_values(self) -> None:
+        """source_time_offset must remain finite."""
+        cf = ChannelFrame(self.dask_data, self.sample_rate)
+
+        with pytest.raises(ValueError, match="source_time_offset must be finite"):
+            cf.source_time_offset = float("nan")
+        with pytest.raises(ValueError, match="source_time_offset must be finite"):
+            cf.source_time_offset = float("inf")
+        with pytest.raises(TypeError, match="source_time_offset must be a finite numeric value"):
+            cast(Any, cf).source_time_offset = "not-a-number"
+
     def test_time_slice_advances_source_time_offset(self) -> None:
         """Continuous sample slicing advances source-relative time."""
         result = self.channel_frame[:, 500:1500]
@@ -100,6 +111,25 @@ class TestChannelFrame:
         """Stepped sample slicing would make source_time spacing ambiguous."""
         with pytest.raises(ValueError, match="Stepped slicing on the time axis is not supported"):
             _ = self.channel_frame[:, 500::2]
+
+    def test_point_time_selection_raises_for_source_time_offset(self) -> None:
+        """Point time selection is outside the offset-only continuous-slice model."""
+        with pytest.raises(ValueError, match="Only continuous slicing on the time axis is supported"):
+            _ = self.channel_frame[0, 500]
+
+    def test_fancy_time_selection_raises_for_source_time_offset(self) -> None:
+        """Fancy time selection may imply irregular time spacing."""
+        with pytest.raises(ValueError, match="Only continuous slicing on the time axis is supported"):
+            _ = self.channel_frame[:, [500, 700, 900]]
+
+    def test_positional_previous_constructor_argument_remains_compatible(self) -> None:
+        """Adding source_time_offset does not steal the existing positional previous argument."""
+        previous = ChannelFrame(self.dask_data, self.sample_rate)
+
+        cf = ChannelFrame(self.dask_data, self.sample_rate, None, None, None, None, None, previous)
+
+        assert cf.previous is previous
+        assert cf.source_time_offset == 0.0
 
     def test_binary_op_preserves_left_source_time_offset(self) -> None:
         """Frame-frame binary ops use array indices and keep the left timeline."""

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -96,6 +96,13 @@ class TestChannelFrame:
         assert result.source_time_offset == 500 / self.sample_rate
         assert result.source_time[0] == 500 / self.sample_rate
 
+    def test_stepped_time_slice_advances_source_time_offset(self) -> None:
+        """Stepped sample slicing reports the source time of its first sample."""
+        result = self.channel_frame[:, 500::2]
+
+        assert result.source_time_offset == 500 / self.sample_rate
+        assert result.source_time[0] == 500 / self.sample_rate
+
     def test_binary_op_preserves_left_source_time_offset(self) -> None:
         """Frame-frame binary ops use array indices and keep the left timeline."""
         left = ChannelFrame(self.dask_data, self.sample_rate, source_time_offset=2.0)
@@ -468,6 +475,20 @@ def test_add_channel_inplace_updates_original() -> None:
     base.add_channel(np.zeros(6), label="new_ch", inplace=True)
     assert base.n_channels == orig_n + 1
     assert any(ch.label == "new_ch" for ch in base._channel_metadata)
+
+
+def test_channel_update_helpers_preserve_source_time_offset() -> None:
+    base = ChannelFrame(
+        data=_da_from_array(np.zeros((1, 6)), chunks=(1, -1)),
+        sampling_rate=16000,
+        source_time_offset=2.5,
+    )
+
+    added = base.add_channel(np.zeros(6), label="new_ch")
+    removed = added.remove_channel("new_ch")
+
+    assert added.source_time_offset == 2.5
+    assert removed.source_time_offset == 2.5
 
 
 def test_add_channel_unsupported_type_raises() -> None:

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -88,7 +88,9 @@ class TestChannelFrame:
 
         np.testing.assert_array_equal(cf.source_time_offset, np.array([2.5, 2.5]))
         np.testing.assert_array_equal(cf.source_time, cf.time[None, :] + np.array([[2.5], [2.5]]))
-        np.testing.assert_array_equal(cf.to_xarray().attrs["source_time_offset"], np.array([2.5, 2.5]))
+        xr = cf.to_xarray()
+        np.testing.assert_array_equal(xr.coords["source_time_offset"].values, np.array([2.5, 2.5]))
+        assert "source_time_offset" not in xr.attrs
 
     def test_source_time_offset_accepts_per_channel_values(self) -> None:
         """source_time_offset is stored per channel."""
@@ -533,7 +535,7 @@ def test_channel_update_helpers_preserve_source_time_offset() -> None:
     added = base.add_channel(np.zeros(6), label="new_ch")
     removed = added.remove_channel("new_ch")
 
-    np.testing.assert_array_equal(added.source_time_offset, np.array([2.5, 2.5]))
+    np.testing.assert_array_equal(added.source_time_offset, np.array([2.5, 0.0]))
     np.testing.assert_array_equal(removed.source_time_offset, np.array([2.5]))
 
 

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -96,6 +96,15 @@ class TestChannelFrame:
         assert result.source_time_offset == 500 / self.sample_rate
         assert result.source_time[0] == 500 / self.sample_rate
 
+    def test_binary_op_preserves_left_source_time_offset(self) -> None:
+        """Frame-frame binary ops use array indices and keep the left timeline."""
+        left = ChannelFrame(self.dask_data, self.sample_rate, source_time_offset=2.0)
+        right = ChannelFrame(self.dask_data, self.sample_rate, source_time_offset=7.0)
+
+        result = left + right
+
+        assert result.source_time_offset == 2.0
+
     def test_operations_are_lazy(self) -> None:
         """Test that operations don't trigger immediate computation."""
         with mock.patch.object(DaArray, "compute", return_value=self.data) as mock_compute:

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -96,12 +96,10 @@ class TestChannelFrame:
         assert result.source_time_offset == 500 / self.sample_rate
         assert result.source_time[0] == 500 / self.sample_rate
 
-    def test_stepped_time_slice_advances_source_time_offset(self) -> None:
-        """Stepped sample slicing reports the source time of its first sample."""
-        result = self.channel_frame[:, 500::2]
-
-        assert result.source_time_offset == 500 / self.sample_rate
-        assert result.source_time[0] == 500 / self.sample_rate
+    def test_stepped_time_slice_raises_for_source_time_offset(self) -> None:
+        """Stepped sample slicing would make source_time spacing ambiguous."""
+        with pytest.raises(ValueError, match="Stepped slicing on the time axis is not supported"):
+            _ = self.channel_frame[:, 500::2]
 
     def test_binary_op_preserves_left_source_time_offset(self) -> None:
         """Frame-frame binary ops use array indices and keep the left timeline."""
@@ -1576,6 +1574,19 @@ class TestDescribeIntegration:
 
         expected_data = np.loadtxt(io.BytesIO(csv_bytes), delimiter=",", skiprows=1).T
         np.testing.assert_array_equal(cf.data, expected_data[1:])
+
+    def test_from_file_csv_uses_time_column_origin_for_source_time(self) -> None:
+        """CSV source time starts at the selected time-column value."""
+        header = "time,value1,value2\n"
+        data = "\n".join([f"{10 + i / 10},{1.1},{2.2}" for i in range(20)])
+        csv_bytes = (header + data).encode()
+
+        cf = ChannelFrame.from_file(csv_bytes, file_type=".csv", time_column=0, start=0.5)
+
+        assert cf.sampling_rate == 10
+        assert cf.n_samples == 15
+        assert cf.source_time_offset == 10.5
+        assert cf.source_time[0] == 10.5
 
     def test_from_file_bytes_requires_file_type(self) -> None:
         """Test in-memory data requires file_type."""

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -102,6 +102,11 @@ class TestChannelFrame:
         with pytest.raises(ValueError, match="source_time_offset length must match number of channels"):
             ChannelFrame(self.dask_data, self.sample_rate, source_time_offset=[1.0])
 
+    def test_source_time_offset_rejects_multidimensional_values(self) -> None:
+        """source_time_offset must be scalar or channel-wise 1D."""
+        with pytest.raises(ValueError, match="source_time_offset must be a scalar or a 1D array"):
+            ChannelFrame(self.dask_data, self.sample_rate, source_time_offset=np.zeros((2, 1)))
+
     def test_source_time_offset_rejects_non_finite_values(self) -> None:
         """source_time_offset must remain finite."""
         cf = ChannelFrame(self.dask_data, self.sample_rate)

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -86,8 +86,21 @@ class TestChannelFrame:
         """Test source-relative time property."""
         cf = ChannelFrame(self.dask_data, self.sample_rate, source_time_offset=2.5)
 
-        np.testing.assert_array_equal(cf.source_time, cf.time + 2.5)
-        assert cf.to_xarray().attrs["source_time_offset"] == 2.5
+        np.testing.assert_array_equal(cf.source_time_offset, np.array([2.5, 2.5]))
+        np.testing.assert_array_equal(cf.source_time, cf.time[None, :] + np.array([[2.5], [2.5]]))
+        np.testing.assert_array_equal(cf.to_xarray().attrs["source_time_offset"], np.array([2.5, 2.5]))
+
+    def test_source_time_offset_accepts_per_channel_values(self) -> None:
+        """source_time_offset is stored per channel."""
+        cf = ChannelFrame(self.dask_data, self.sample_rate, source_time_offset=[2.5, 7.5])
+
+        np.testing.assert_array_equal(cf.source_time_offset, np.array([2.5, 7.5]))
+        np.testing.assert_array_equal(cf.source_time[:, 0], np.array([2.5, 7.5]))
+
+    def test_source_time_offset_rejects_wrong_channel_count(self) -> None:
+        """source_time_offset arrays must match the channel count."""
+        with pytest.raises(ValueError, match="source_time_offset length must match number of channels"):
+            ChannelFrame(self.dask_data, self.sample_rate, source_time_offset=[1.0])
 
     def test_source_time_offset_rejects_non_finite_values(self) -> None:
         """source_time_offset must remain finite."""
@@ -104,8 +117,8 @@ class TestChannelFrame:
         """Continuous sample slicing advances source-relative time."""
         result = self.channel_frame[:, 500:1500]
 
-        assert result.source_time_offset == 500 / self.sample_rate
-        assert result.source_time[0] == 500 / self.sample_rate
+        np.testing.assert_array_equal(result.source_time_offset, np.array([500 / self.sample_rate] * 2))
+        np.testing.assert_array_equal(result.source_time[:, 0], np.array([500 / self.sample_rate] * 2))
 
     def test_stepped_time_slice_raises_for_source_time_offset(self) -> None:
         """Stepped sample slicing would make source_time spacing ambiguous."""
@@ -129,7 +142,7 @@ class TestChannelFrame:
         cf = ChannelFrame(self.dask_data, self.sample_rate, None, None, None, None, None, previous)
 
         assert cf.previous is previous
-        assert cf.source_time_offset == 0.0
+        np.testing.assert_array_equal(cf.source_time_offset, np.array([0.0, 0.0]))
 
     def test_binary_op_preserves_left_source_time_offset(self) -> None:
         """Frame-frame binary ops use array indices and keep the left timeline."""
@@ -138,7 +151,7 @@ class TestChannelFrame:
 
         result = left + right
 
-        assert result.source_time_offset == 2.0
+        np.testing.assert_array_equal(result.source_time_offset, np.array([2.0, 2.0]))
 
     def test_operations_are_lazy(self) -> None:
         """Test that operations don't trigger immediate computation."""
@@ -515,8 +528,27 @@ def test_channel_update_helpers_preserve_source_time_offset() -> None:
     added = base.add_channel(np.zeros(6), label="new_ch")
     removed = added.remove_channel("new_ch")
 
-    assert added.source_time_offset == 2.5
-    assert removed.source_time_offset == 2.5
+    np.testing.assert_array_equal(added.source_time_offset, np.array([2.5, 2.5]))
+    np.testing.assert_array_equal(removed.source_time_offset, np.array([2.5]))
+
+
+def test_add_channel_frame_preserves_per_channel_source_time_offsets() -> None:
+    base = ChannelFrame(
+        data=_da_from_array(np.zeros((1, 6)), chunks=(1, -1)),
+        sampling_rate=16000,
+        source_time_offset=2.5,
+    )
+    other = ChannelFrame(
+        data=_da_from_array(np.ones((2, 6)), chunks=(1, -1)),
+        sampling_rate=16000,
+        channel_metadata=[{"label": "other0"}, {"label": "other1"}],
+        source_time_offset=[5.0, 8.0],
+    )
+
+    added = base.add_channel(other)
+
+    np.testing.assert_array_equal(added.source_time_offset, np.array([2.5, 5.0, 8.0]))
+    np.testing.assert_array_equal(added.source_time[:, 0], np.array([2.5, 5.0, 8.0]))
 
 
 def test_add_channel_unsupported_type_raises() -> None:
@@ -1127,8 +1159,8 @@ def test_describe_plot_return_type_error() -> None:
                 cf = ChannelFrame.from_file(temp_filename, channel=0, start=0.1, end=0.5)
                 # assert cf.metadata["channels"] == [0]
                 assert cf.channels[0].label == "ch0"
-                assert cf.source_time_offset == 0.1
-                assert cf.source_time[0] == 0.1
+                np.testing.assert_array_equal(cf.source_time_offset, np.array([0.1]))
+                np.testing.assert_array_equal(cf.source_time[:, 0], np.array([0.1]))
                 # Test with multiple channels
                 cf = ChannelFrame.from_file(temp_filename, channel=[0, 1])
                 # assert cf.metadata["channels"] == [0, 1]
@@ -1615,8 +1647,8 @@ class TestDescribeIntegration:
 
         assert cf.sampling_rate == 10
         assert cf.n_samples == 15
-        assert cf.source_time_offset == 10.5
-        assert cf.source_time[0] == 10.5
+        np.testing.assert_array_equal(cf.source_time_offset, np.array([10.5, 10.5]))
+        np.testing.assert_array_equal(cf.source_time[:, 0], np.array([10.5, 10.5]))
 
     def test_from_file_bytes_requires_file_type(self) -> None:
         """Test in-memory data requires file_type."""

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -82,6 +82,20 @@ class TestChannelFrame:
             expected_time = np.arange(16000) / 16000
             np.testing.assert_array_equal(time, expected_time)
 
+    def test_source_time_adds_source_time_offset(self) -> None:
+        """Test source-relative time property."""
+        cf = ChannelFrame(self.dask_data, self.sample_rate, source_time_offset=2.5)
+
+        np.testing.assert_array_equal(cf.source_time, cf.time + 2.5)
+        assert cf.to_xarray().attrs["source_time_offset"] == 2.5
+
+    def test_time_slice_advances_source_time_offset(self) -> None:
+        """Continuous sample slicing advances source-relative time."""
+        result = self.channel_frame[:, 500:1500]
+
+        assert result.source_time_offset == 500 / self.sample_rate
+        assert result.source_time[0] == 500 / self.sample_rate
+
     def test_operations_are_lazy(self) -> None:
         """Test that operations don't trigger immediate computation."""
         with mock.patch.object(DaArray, "compute", return_value=self.data) as mock_compute:
@@ -1055,6 +1069,8 @@ def test_describe_plot_return_type_error() -> None:
                 cf = ChannelFrame.from_file(temp_filename, channel=0, start=0.1, end=0.5)
                 # assert cf.metadata["channels"] == [0]
                 assert cf.channels[0].label == "ch0"
+                assert cf.source_time_offset == 0.1
+                assert cf.source_time[0] == 0.1
                 # Test with multiple channels
                 cf = ChannelFrame.from_file(temp_filename, channel=[0, 1])
                 # assert cf.metadata["channels"] == [0, 1]

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -488,6 +488,13 @@ class TestChannelProcessing:
         assert isinstance(trimmed_frame, ChannelFrame)
         assert trimmed_frame.n_samples == int(0.3 * self.sample_rate)
 
+        # Non-sample-aligned trim starts report the actual sliced sample time.
+        sample_data = _da_from_array(np.arange(1000, dtype=np.float64).reshape(1, -1), chunks=(1, -1))
+        sample_frame = ChannelFrame(sample_data, sampling_rate=1000)
+        trimmed_frame = sample_frame.trim(start=0.1005, end=0.2)
+        assert trimmed_frame.source_time_offset == 0.1
+        assert trimmed_frame.source_time[0] == 0.1
+
         # Test trimming with no start or end (should return the same frame)
         trimmed_frame = self.channel_frame.trim()
         assert isinstance(trimmed_frame, ChannelFrame)

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -474,14 +474,14 @@ class TestChannelProcessing:
         assert isinstance(trimmed_frame, ChannelFrame)
         assert trimmed_frame.n_samples == int(0.4 * self.sample_rate)
         assert trimmed_frame.n_channels == self.channel_frame.n_channels
-        assert trimmed_frame.source_time_offset == 0.1
-        assert trimmed_frame.source_time[0] == 0.1
+        np.testing.assert_array_equal(trimmed_frame.source_time_offset, np.array([0.1, 0.1]))
+        np.testing.assert_array_equal(trimmed_frame.source_time[:, 0], np.array([0.1, 0.1]))
 
         # Test trimming with only start time
         trimmed_frame = self.channel_frame.trim(start=0.2)
         assert isinstance(trimmed_frame, ChannelFrame)
         assert trimmed_frame.n_samples == int(0.8 * self.sample_rate)
-        assert trimmed_frame.source_time_offset == 0.2
+        np.testing.assert_array_equal(trimmed_frame.source_time_offset, np.array([0.2, 0.2]))
 
         # Test trimming with only end time
         trimmed_frame = self.channel_frame.trim(end=0.3)
@@ -492,8 +492,8 @@ class TestChannelProcessing:
         sample_data = _da_from_array(np.arange(1000, dtype=np.float64).reshape(1, -1), chunks=(1, -1))
         sample_frame = ChannelFrame(sample_data, sampling_rate=1000)
         trimmed_frame = sample_frame.trim(start=0.1005, end=0.2)
-        assert trimmed_frame.source_time_offset == 0.1
-        assert trimmed_frame.source_time[0] == 0.1
+        np.testing.assert_array_equal(trimmed_frame.source_time_offset, np.array([0.1]))
+        np.testing.assert_array_equal(trimmed_frame.source_time[:, 0], np.array([0.1]))
 
         # Test trimming with no start or end (should return the same frame)
         trimmed_frame = self.channel_frame.trim()
@@ -1130,7 +1130,7 @@ def test_roughness_dw_spec_preserves_source_channel_metadata_and_ids() -> None:
     assert result.data.ndim == 3
     assert result.data.shape[0] == 2
     assert result.data.shape[1] == 47
-    assert result.source_time_offset == 3.25
+    np.testing.assert_array_equal(result.source_time_offset, np.array([3.25, 3.25]))
     assert result._channel_ids == ["left-id", "right-id"]
     assert result.channels[0].label == "left"
     assert result.channels[0].unit == "Pa"

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -435,6 +435,16 @@ class TestChannelProcessing:
         # Direct numpy mean — decimal=6 default (exact match)
         np.testing.assert_array_almost_equal(mean_data, expected_mean)
 
+    def test_reduce_channels_resets_mismatched_source_time_offsets(self) -> None:
+        """Channel reduction resets source timeline metadata."""
+        self.channel_frame.source_time_offset = [0.0, 5.0]
+
+        sum_cf = self.channel_frame.sum()
+        mean_cf = self.channel_frame.mean()
+
+        np.testing.assert_array_equal(sum_cf.source_time_offset, np.array([0.0]))
+        np.testing.assert_array_equal(mean_cf.source_time_offset, np.array([0.0]))
+
     def test_channel_difference(self) -> None:
         """Test channel_difference method."""
         # Test that channel_difference is lazy
@@ -463,6 +473,16 @@ class TestChannelProcessing:
         # Element-wise subtraction — decimal=6 default (exact match)
         np.testing.assert_array_almost_equal(computed, expected)
 
+    def test_channel_difference_preserves_each_output_source_time_offset(self) -> None:
+        """Channel difference is index-wise and keeps each output channel's timeline."""
+        self.channel_frame.source_time_offset = [0.0, 5.0]
+
+        diff_cf = self.channel_frame.channel_difference(other_channel=0)
+
+        np.testing.assert_array_equal(diff_cf.source_time_offset, np.array([0.0, 5.0]))
+
+    def test_channel_difference_invalid_channel(self) -> None:
+        """Test invalid channel index."""
         # Test invalid channel index
         with pytest.raises(IndexError):
             self.channel_frame.channel_difference(other_channel=10)

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -474,11 +474,14 @@ class TestChannelProcessing:
         assert isinstance(trimmed_frame, ChannelFrame)
         assert trimmed_frame.n_samples == int(0.4 * self.sample_rate)
         assert trimmed_frame.n_channels == self.channel_frame.n_channels
+        assert trimmed_frame.source_time_offset == 0.1
+        assert trimmed_frame.source_time[0] == 0.1
 
         # Test trimming with only start time
         trimmed_frame = self.channel_frame.trim(start=0.2)
         assert isinstance(trimmed_frame, ChannelFrame)
         assert trimmed_frame.n_samples == int(0.8 * self.sample_rate)
+        assert trimmed_frame.source_time_offset == 0.2
 
         # Test trimming with only end time
         trimmed_frame = self.channel_frame.trim(end=0.3)

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -1122,6 +1122,7 @@ def test_roughness_dw_spec_preserves_source_channel_metadata_and_ids() -> None:
             ChannelMetadata(label="right", unit="V", ref=0.5, extra={"gain": 20}),
         ],
         channel_ids=["left-id", "right-id"],
+        source_time_offset=3.25,
     )
 
     result = frame.roughness_dw_spec(overlap=0.5)
@@ -1129,6 +1130,7 @@ def test_roughness_dw_spec_preserves_source_channel_metadata_and_ids() -> None:
     assert result.data.ndim == 3
     assert result.data.shape[0] == 2
     assert result.data.shape[1] == 47
+    assert result.source_time_offset == 3.25
     assert result._channel_ids == ["left-id", "right-id"]
     assert result.channels[0].label == "left"
     assert result.channels[0].unit == "Pa"

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -445,6 +445,16 @@ class TestChannelProcessing:
         np.testing.assert_array_equal(sum_cf.source_time_offset, np.array([0.0]))
         np.testing.assert_array_equal(mean_cf.source_time_offset, np.array([0.0]))
 
+    def test_reduce_channels_preserves_shared_source_time_offset(self) -> None:
+        """Channel reduction preserves a shared source timeline."""
+        self.channel_frame.source_time_offset = [5.0, 5.0]
+
+        sum_cf = self.channel_frame.sum()
+        mean_cf = self.channel_frame.mean()
+
+        np.testing.assert_array_equal(sum_cf.source_time_offset, np.array([5.0]))
+        np.testing.assert_array_equal(mean_cf.source_time_offset, np.array([5.0]))
+
     def test_channel_difference(self) -> None:
         """Test channel_difference method."""
         # Test that channel_difference is lazy

--- a/tests/frames/test_channel_transform.py
+++ b/tests/frames/test_channel_transform.py
@@ -301,6 +301,15 @@ class TestChannelTransform:
         assert abs(ch1_auto[idx_100hz]) > abs(ch1_auto[idx_200hz])
         assert abs(ch1_auto[idx_300hz]) > abs(ch1_auto[idx_200hz])
 
+    def test_cross_channel_transform_uses_input_channel_source_time_offsets(self) -> None:
+        """Pairwise channel transforms use the input-side channel timeline."""
+        cf = ChannelFrame.from_numpy(_DATA, _SAMPLE_RATE)
+        cf.source_time_offset = [0.0, 5.0]
+
+        csd_frame = cf.csd(n_fft=512, win_length=256, hop_length=128)
+
+        np.testing.assert_array_equal(csd_frame.source_time_offset, np.array([0.0, 0.0, 5.0, 5.0]))
+
     def test_transfer_function(self) -> None:
         """伝達関数メソッドのテスト"""
         # 単純なシステム用のテスト信号を作成

--- a/tests/frames/test_channel_transform.py
+++ b/tests/frames/test_channel_transform.py
@@ -123,6 +123,8 @@ class TestChannelTransform:
             mock_stft.process.return_value = mock_data
             mock_create_op.return_value = mock_stft
 
+            self.channel_frame.source_time_offset = 2.75
+
             # stftを遅延実行（デフォルト引数）
             result = self.channel_frame.stft()
 
@@ -146,8 +148,9 @@ class TestChannelTransform:
             assert result.hop_length == 512
             assert result.win_length == 2048
             assert result.window == "hann"
-            # Pillar 2: domain transition preserves sampling rate
+            # Pillar 2: domain transition preserves sampling rate and source offset
             assert result.sampling_rate == self.channel_frame.sampling_rate
+            assert result.source_time_offset == 2.75
 
             # カスタムパラメータでテスト
             mock_create_op.reset_mock()

--- a/tests/frames/test_channel_transform.py
+++ b/tests/frames/test_channel_transform.py
@@ -250,6 +250,7 @@ class TestChannelTransform:
 
         # ChannelFrameインスタンスを作成
         cf = ChannelFrame.from_numpy(sigs, sr)
+        cf.source_time_offset = 3.5
 
         # CSD計算のパラメータ
         n_fft = 512
@@ -258,6 +259,7 @@ class TestChannelTransform:
 
         # ChannelFrameメソッドを使用してCSDを計算
         csd_frame = cf.csd(n_fft=n_fft, win_length=win_length, hop_length=hop_length, window="hamming")
+        assert csd_frame.source_time_offset == 3.5
 
         # 実際のデータを取得するために計算
         csd_data = csd_frame.compute()

--- a/tests/frames/test_channel_transform.py
+++ b/tests/frames/test_channel_transform.py
@@ -308,7 +308,44 @@ class TestChannelTransform:
 
         csd_frame = cf.csd(n_fft=512, win_length=256, hop_length=128)
 
-        np.testing.assert_array_equal(csd_frame.source_time_offset, np.array([0.0, 0.0, 5.0, 5.0]))
+        np.testing.assert_array_equal(csd_frame.source_time_offset, np.array([0.0, 5.0, 0.0, 5.0]))
+
+    @pytest.mark.parametrize(
+        ("method_name", "expected_labels"),
+        [
+            ("csd", ["csd(left, left)", "csd(right, left)", "csd(left, right)", "csd(right, right)"]),
+            (
+                "coherence",
+                [
+                    "$\\gamma_{left, left}$",
+                    "$\\gamma_{right, left}$",
+                    "$\\gamma_{left, right}$",
+                    "$\\gamma_{right, right}$",
+                ],
+            ),
+            (
+                "transfer_function",
+                ["$H_{left, left}$", "$H_{right, left}$", "$H_{left, right}$", "$H_{right, right}$"],
+            ),
+        ],
+    )
+    def test_cross_channel_transform_metadata_and_offsets_follow_flattened_order(
+        self,
+        method_name: str,
+        expected_labels: list[str],
+    ) -> None:
+        cf = ChannelFrame.from_numpy(
+            _DATA,
+            _SAMPLE_RATE,
+            ch_labels=["left", "right"],
+        )
+        cf.source_time_offset = [1.0, 9.0]
+
+        transform = getattr(cf, method_name)
+        result = transform(n_fft=512, win_length=256, hop_length=128)
+
+        assert result.labels == expected_labels
+        np.testing.assert_array_equal(result.source_time_offset, np.array([1.0, 9.0, 1.0, 9.0]))
 
     def test_transfer_function(self) -> None:
         """伝達関数メソッドのテスト"""

--- a/tests/frames/test_channel_transform.py
+++ b/tests/frames/test_channel_transform.py
@@ -59,7 +59,7 @@ class TestChannelTransform:
             assert result.previous is self.channel_frame
             # Pillar 2: domain transition preserves sampling rate and source offset
             assert result.sampling_rate == self.channel_frame.sampling_rate
-            assert result.source_time_offset == 2.75
+            np.testing.assert_array_equal(result.source_time_offset, np.array([2.75, 2.75]))
 
     def test_welch_transform(self) -> None:
         """
@@ -113,7 +113,7 @@ class TestChannelTransform:
             assert result.n_fft == 2048
             assert result.window == "blackman"
             assert result.previous is self.channel_frame
-            assert result.source_time_offset == 2.75
+            np.testing.assert_array_equal(result.source_time_offset, np.array([2.75, 2.75]))
 
     def test_stft_transform(self) -> None:
         """Test stft method for lazy short-time Fourier transform."""
@@ -156,7 +156,7 @@ class TestChannelTransform:
             assert result.window == "hann"
             # Pillar 2: domain transition preserves sampling rate and source offset
             assert result.sampling_rate == self.channel_frame.sampling_rate
-            assert result.source_time_offset == 2.75
+            np.testing.assert_array_equal(result.source_time_offset, np.array([2.75, 2.75]))
 
             # カスタムパラメータでテスト
             mock_create_op.reset_mock()
@@ -233,7 +233,7 @@ class TestChannelTransform:
             assert result.G == G
             assert result.fr == fr
             assert result.previous is self.channel_frame
-            assert result.source_time_offset == 2.75
+            np.testing.assert_array_equal(result.source_time_offset, np.array([2.75, 2.75]))
 
     def test_csd(self) -> None:
         """クロススペクトル密度（CSD）メソッドのテスト"""
@@ -259,7 +259,7 @@ class TestChannelTransform:
 
         # ChannelFrameメソッドを使用してCSDを計算
         csd_frame = cf.csd(n_fft=n_fft, win_length=win_length, hop_length=hop_length, window="hamming")
-        assert csd_frame.source_time_offset == 3.5
+        np.testing.assert_array_equal(csd_frame.source_time_offset, np.array([3.5, 3.5, 3.5, 3.5]))
 
         # 実際のデータを取得するために計算
         csd_data = csd_frame.compute()

--- a/tests/frames/test_channel_transform.py
+++ b/tests/frames/test_channel_transform.py
@@ -40,6 +40,8 @@ class TestChannelTransform:
             mock_fft.process.return_value = mock_data
             mock_create_op.return_value = mock_fft
 
+            self.channel_frame.source_time_offset = 2.75
+
             # fftを遅延実行
             result = self.channel_frame.fft(n_fft=4096, window="hamming")
 
@@ -55,8 +57,9 @@ class TestChannelTransform:
             assert result.n_fft == 4096
             assert result.window == "hann"
             assert result.previous is self.channel_frame
-            # Pillar 2: domain transition preserves sampling rate
+            # Pillar 2: domain transition preserves sampling rate and source offset
             assert result.sampling_rate == self.channel_frame.sampling_rate
+            assert result.source_time_offset == 2.75
 
     def test_welch_transform(self) -> None:
         """
@@ -79,6 +82,8 @@ class TestChannelTransform:
             mock_data.rechunk.return_value = mock_data
             mock_welch.process.return_value = mock_data
             mock_create_op.return_value = mock_welch
+
+            self.channel_frame.source_time_offset = 2.75
 
             # welchを遅延実行
             result = self.channel_frame.welch(
@@ -108,6 +113,7 @@ class TestChannelTransform:
             assert result.n_fft == 2048
             assert result.window == "blackman"
             assert result.previous is self.channel_frame
+            assert result.source_time_offset == 2.75
 
     def test_stft_transform(self) -> None:
         """Test stft method for lazy short-time Fourier transform."""
@@ -198,6 +204,8 @@ class TestChannelTransform:
             mock_noct.process.return_value = mock_data
             mock_create_op.return_value = mock_noct
 
+            self.channel_frame.source_time_offset = 2.75
+
             # noct_spectrumを呼び出す
             fmin, fmax, n = 20, 20000, 3
             G, fr = 10, 1000  # noqa: N806
@@ -225,6 +233,7 @@ class TestChannelTransform:
             assert result.G == G
             assert result.fr == fr
             assert result.previous is self.channel_frame
+            assert result.source_time_offset == 2.75
 
     def test_csd(self) -> None:
         """クロススペクトル密度（CSD）メソッドのテスト"""

--- a/tests/frames/test_roughness_frame.py
+++ b/tests/frames/test_roughness_frame.py
@@ -76,6 +76,7 @@ class TestRoughnessFrame:
             sampling_rate=_SAMPLING_RATE,
             bark_axis=_BARK_AXIS,
             overlap=_OVERLAP,
+            source_time_offset=2.25,
         )
 
         assert frame.data.shape == (_N_BARK, _N_TIME)
@@ -358,9 +359,24 @@ class TestRoughnessFrame:
         assert isinstance(result, RoughnessFrame)
         assert result.sampling_rate == frame.sampling_rate
         assert result.overlap == frame.overlap
+        assert result.source_time_offset == frame.source_time_offset
         # Scalar addition — np.allclose default tol (exact match expected)
         assert np.allclose(result.data, original_data + 1.0)
         assert np.allclose(frame.data, original_data)  # Pillar 1: original unchanged
+
+    def test_time_slice_advances_source_time_offset(self) -> None:
+        """RoughnessFrame time slicing advances on the last axis."""
+        frame = RoughnessFrame(
+            data=_DATA_STEREO,
+            sampling_rate=_SAMPLING_RATE,
+            bark_axis=_BARK_AXIS,
+            overlap=_OVERLAP,
+            source_time_offset=4.0,
+        )
+
+        result = frame[:, :, 5:]
+
+        assert result.source_time_offset == 4.0 + 5 / _SAMPLING_RATE
 
     def test_binary_op_with_roughness_frame(self) -> None:
         """Test binary operations between RoughnessFrame instances."""

--- a/tests/frames/test_roughness_frame.py
+++ b/tests/frames/test_roughness_frame.py
@@ -391,6 +391,17 @@ class TestRoughnessFrame:
 
         np.testing.assert_array_equal(frame.source_time, frame.time + 4.0)
 
+    def test_source_time_slice_context_without_time_key_returns_none(self) -> None:
+        """RoughnessFrame source time updates only when its time axis is indexed."""
+        frame = RoughnessFrame(
+            data=_DATA_STEREO,
+            sampling_rate=_SAMPLING_RATE,
+            bark_axis=_BARK_AXIS,
+            overlap=_OVERLAP,
+        )
+
+        assert frame._source_time_slice_context(()) is None
+
     def test_binary_op_with_roughness_frame(self) -> None:
         """Test binary operations between RoughnessFrame instances."""
         frame1 = RoughnessFrame(

--- a/tests/frames/test_roughness_frame.py
+++ b/tests/frames/test_roughness_frame.py
@@ -377,6 +377,19 @@ class TestRoughnessFrame:
         result = frame[:, :, 5:]
 
         assert result.source_time_offset == 4.0 + 5 / _SAMPLING_RATE
+        assert result.source_time[0] == 4.0 + 5 / _SAMPLING_RATE
+
+    def test_source_time_adds_source_time_offset(self) -> None:
+        """RoughnessFrame exposes source-relative analysis times."""
+        frame = RoughnessFrame(
+            data=_DATA_STEREO,
+            sampling_rate=_SAMPLING_RATE,
+            bark_axis=_BARK_AXIS,
+            overlap=_OVERLAP,
+            source_time_offset=4.0,
+        )
+
+        np.testing.assert_array_equal(frame.source_time, frame.time + 4.0)
 
     def test_binary_op_with_roughness_frame(self) -> None:
         """Test binary operations between RoughnessFrame instances."""

--- a/tests/frames/test_roughness_frame.py
+++ b/tests/frames/test_roughness_frame.py
@@ -359,7 +359,7 @@ class TestRoughnessFrame:
         assert isinstance(result, RoughnessFrame)
         assert result.sampling_rate == frame.sampling_rate
         assert result.overlap == frame.overlap
-        assert result.source_time_offset == frame.source_time_offset
+        np.testing.assert_array_equal(result.source_time_offset, frame.source_time_offset)
         # Scalar addition — np.allclose default tol (exact match expected)
         assert np.allclose(result.data, original_data + 1.0)
         assert np.allclose(frame.data, original_data)  # Pillar 1: original unchanged
@@ -376,8 +376,8 @@ class TestRoughnessFrame:
 
         result = frame[:, :, 5:]
 
-        assert result.source_time_offset == 4.0 + 5 / _SAMPLING_RATE
-        assert result.source_time[0] == 4.0 + 5 / _SAMPLING_RATE
+        np.testing.assert_array_equal(result.source_time_offset, np.array([4.0 + 5 / _SAMPLING_RATE] * 2))
+        np.testing.assert_array_equal(result.source_time[:, 0], np.array([4.0 + 5 / _SAMPLING_RATE] * 2))
 
     def test_source_time_adds_source_time_offset(self) -> None:
         """RoughnessFrame exposes source-relative analysis times."""
@@ -389,7 +389,7 @@ class TestRoughnessFrame:
             source_time_offset=4.0,
         )
 
-        np.testing.assert_array_equal(frame.source_time, frame.time + 4.0)
+        np.testing.assert_array_equal(frame.source_time, frame.time[None, :] + np.array([[4.0], [4.0]]))
 
     def test_source_time_slice_context_without_time_key_returns_none(self) -> None:
         """RoughnessFrame source time updates only when its time axis is indexed."""

--- a/tests/frames/test_spectral_frame.py
+++ b/tests/frames/test_spectral_frame.py
@@ -499,6 +499,7 @@ class TestSpectralFrame:
             label="test_frame",
             metadata={"test": "metadata"},
             channel_metadata=self.channel_metadata,
+            source_time_offset=6.25,
         )
 
         with (
@@ -563,6 +564,7 @@ class TestSpectralFrame:
                 ],
                 channel_metadata=correct_sr_frame.channels.to_list(),
                 channel_ids=correct_sr_frame._channel_ids,
+                source_time_offset=6.25,
                 previous=correct_sr_frame,
             )
 

--- a/tests/frames/test_spectral_frame.py
+++ b/tests/frames/test_spectral_frame.py
@@ -171,6 +171,14 @@ class TestSpectralFrame:
         # Frequency axis from np.fft.rfftfreq — default rtol (exact match)
         np.testing.assert_allclose(freqs, expected)
 
+    def test_frequency_slice_preserves_source_time_offset(self) -> None:
+        """Frequency-axis slicing does not move source-relative time."""
+        self.frame.source_time_offset = 1.25
+
+        result = self.frame[:, 10:20]
+
+        assert result.source_time_offset == 1.25
+
     def test_binary_op_with_spectral_frame(self) -> None:
         """Test _binary_op with another SpectralFrame"""
         other_data: DaArray = _da_from_array(create_complex_data(_SHAPE), chunks=(1, -1))
@@ -395,6 +403,7 @@ class TestSpectralFrame:
             mock_ifft_op.process.return_value = mock_time_series
             mock_result: Any = mock.MagicMock()
             mock_channel_frame.return_value = mock_result
+            self.frame.source_time_offset = 6.25
 
             result = self.frame.ifft()
 
@@ -409,6 +418,7 @@ class TestSpectralFrame:
                 operation_history=self.frame.operation_history,
                 channel_metadata=self.frame.channels.to_list(),
                 channel_ids=self.frame._channel_ids,
+                source_time_offset=6.25,
             )
 
             assert result is mock_result

--- a/tests/frames/test_spectral_frame.py
+++ b/tests/frames/test_spectral_frame.py
@@ -177,7 +177,7 @@ class TestSpectralFrame:
 
         result = self.frame[:, 10:20]
 
-        assert result.source_time_offset == 1.25
+        np.testing.assert_array_equal(result.source_time_offset, np.array([1.25, 1.25]))
 
     def test_binary_op_with_spectral_frame(self) -> None:
         """Test _binary_op with another SpectralFrame"""
@@ -418,7 +418,11 @@ class TestSpectralFrame:
                 operation_history=self.frame.operation_history,
                 channel_metadata=self.frame.channels.to_list(),
                 channel_ids=self.frame._channel_ids,
-                source_time_offset=6.25,
+                source_time_offset=mock.ANY,
+            )
+            np.testing.assert_array_equal(
+                mock_channel_frame.call_args.kwargs["source_time_offset"],
+                np.array([6.25, 6.25]),
             )
 
             assert result is mock_result
@@ -564,8 +568,12 @@ class TestSpectralFrame:
                 ],
                 channel_metadata=correct_sr_frame.channels.to_list(),
                 channel_ids=correct_sr_frame._channel_ids,
-                source_time_offset=6.25,
+                source_time_offset=mock.ANY,
                 previous=correct_sr_frame,
+            )
+            np.testing.assert_array_equal(
+                mock_noct_frame.call_args.kwargs["source_time_offset"],
+                np.array([6.25, 6.25]),
             )
 
             # 結果の検証

--- a/tests/frames/test_spectrogram_frame.py
+++ b/tests/frames/test_spectrogram_frame.py
@@ -158,6 +158,19 @@ class TestSpectrogramFrame:
 
         assert result.source_time_offset == 1.25 + 2 * spec.hop_length / spec.sampling_rate
 
+    def test_stepped_time_slice_advances_source_time_offset_by_hop_length(
+        self, sample_spectrogram: SpectrogramFrame
+    ) -> None:
+        """Stepped spectrogram slicing reports the source time of its first frame."""
+        spec = sample_spectrogram._create_new_instance(
+            data=sample_spectrogram._data,
+            source_time_offset=1.25,
+        )
+
+        result = spec[:, :, 2::2]
+
+        assert result.source_time_offset == 1.25 + 2 * spec.hop_length / spec.sampling_rate
+
     def test_binary_operations(self, sample_spectrogram: SpectrogramFrame) -> None:
         """二項演算子の動作テスト"""
         spec: SpectrogramFrame = sample_spectrogram
@@ -268,11 +281,15 @@ class TestSpectrogramFrame:
 
     def test_get_frame_at(self, sample_spectrogram: SpectrogramFrame) -> None:
         """特定時間フレームの取得テスト"""
-        spec: SpectrogramFrame = sample_spectrogram
+        spec: SpectrogramFrame = sample_spectrogram._create_new_instance(
+            data=sample_spectrogram._data,
+            source_time_offset=3.0,
+        )
 
         # 正常なインデックス
         frame: SpectralFrame = spec.get_frame_at(4)
         assert frame.shape == (2, 65)  # チャネル数 x 周波数ビン数
+        assert frame.source_time_offset == 3.0 + spec.times[4]
 
         # 範囲外インデックス（負の値）
         with pytest.raises(

--- a/tests/frames/test_spectrogram_frame.py
+++ b/tests/frames/test_spectrogram_frame.py
@@ -147,6 +147,17 @@ class TestSpectrogramFrame:
 
         np.testing.assert_array_equal(spec.source_times, spec.times + 1.25)
 
+    def test_time_slice_advances_source_time_offset_by_hop_length(self, sample_spectrogram: SpectrogramFrame) -> None:
+        """Spectrogram time slicing advances by hop_length / sampling_rate."""
+        spec = sample_spectrogram._create_new_instance(
+            data=sample_spectrogram._data,
+            source_time_offset=1.25,
+        )
+
+        result = spec[:, :, 2:]
+
+        assert result.source_time_offset == 1.25 + 2 * spec.hop_length / spec.sampling_rate
+
     def test_binary_operations(self, sample_spectrogram: SpectrogramFrame) -> None:
         """二項演算子の動作テスト"""
         spec: SpectrogramFrame = sample_spectrogram
@@ -295,7 +306,10 @@ class TestSpectrogramFrame:
 
     def test_istft(self, sample_spectrogram: SpectrogramFrame) -> None:
         """istftメソッドがto_channel_frameのエイリアスとして機能することをテスト"""
-        spec: SpectrogramFrame = sample_spectrogram
+        spec: SpectrogramFrame = sample_spectrogram._create_new_instance(
+            data=sample_spectrogram._data,
+            source_time_offset=4.5,
+        )
 
         # istftメソッドを呼び出し
         channel_frame_istft: Any = spec.istft()
@@ -311,8 +325,10 @@ class TestSpectrogramFrame:
         assert channel_frame_istft._n_channels == channel_frame_to._n_channels
         assert channel_frame_istft.shape == channel_frame_to.shape
 
-        # Pillar 2: sampling rate inherited from spectrogram
+        # Pillar 2: sampling rate and source offset inherited from spectrogram
         assert channel_frame_istft.sampling_rate == spec.sampling_rate
+        assert channel_frame_istft.source_time_offset == 4.5
+        assert channel_frame_to.source_time_offset == 4.5
 
         # データが同じであることを確認
         # Same ISTFT algorithm — decimal=6 default (alias, results identical)

--- a/tests/frames/test_spectrogram_frame.py
+++ b/tests/frames/test_spectrogram_frame.py
@@ -158,18 +158,15 @@ class TestSpectrogramFrame:
 
         assert result.source_time_offset == 1.25 + 2 * spec.hop_length / spec.sampling_rate
 
-    def test_stepped_time_slice_advances_source_time_offset_by_hop_length(
-        self, sample_spectrogram: SpectrogramFrame
-    ) -> None:
-        """Stepped spectrogram slicing reports the source time of its first frame."""
+    def test_stepped_time_slice_raises_for_source_time_offset(self, sample_spectrogram: SpectrogramFrame) -> None:
+        """Stepped spectrogram slicing would make source_times spacing ambiguous."""
         spec = sample_spectrogram._create_new_instance(
             data=sample_spectrogram._data,
             source_time_offset=1.25,
         )
 
-        result = spec[:, :, 2::2]
-
-        assert result.source_time_offset == 1.25 + 2 * spec.hop_length / spec.sampling_rate
+        with pytest.raises(ValueError, match="Stepped slicing on the time axis is not supported"):
+            _ = spec[:, :, 2::2]
 
     def test_binary_operations(self, sample_spectrogram: SpectrogramFrame) -> None:
         """二項演算子の動作テスト"""

--- a/tests/frames/test_spectrogram_frame.py
+++ b/tests/frames/test_spectrogram_frame.py
@@ -145,7 +145,8 @@ class TestSpectrogramFrame:
             source_time_offset=1.25,
         )
 
-        np.testing.assert_array_equal(spec.source_times, spec.times + 1.25)
+        np.testing.assert_array_equal(spec.source_time_offset, np.array([1.25, 1.25]))
+        np.testing.assert_array_equal(spec.source_times, spec.times[None, :] + np.array([[1.25], [1.25]]))
 
     def test_time_slice_advances_source_time_offset_by_hop_length(self, sample_spectrogram: SpectrogramFrame) -> None:
         """Spectrogram time slicing advances by hop_length / sampling_rate."""
@@ -156,7 +157,10 @@ class TestSpectrogramFrame:
 
         result = spec[:, :, 2:]
 
-        assert result.source_time_offset == 1.25 + 2 * spec.hop_length / spec.sampling_rate
+        np.testing.assert_array_equal(
+            result.source_time_offset,
+            np.array([1.25 + 2 * spec.hop_length / spec.sampling_rate] * 2),
+        )
 
     def test_stepped_time_slice_raises_for_source_time_offset(self, sample_spectrogram: SpectrogramFrame) -> None:
         """Stepped spectrogram slicing would make source_times spacing ambiguous."""
@@ -291,7 +295,7 @@ class TestSpectrogramFrame:
         # 正常なインデックス
         frame: SpectralFrame = spec.get_frame_at(4)
         assert frame.shape == (2, 65)  # チャネル数 x 周波数ビン数
-        assert frame.source_time_offset == 3.0 + spec.times[4]
+        np.testing.assert_array_equal(frame.source_time_offset, np.array([3.0 + spec.times[4]] * 2))
 
         # 範囲外インデックス（負の値）
         with pytest.raises(
@@ -346,8 +350,8 @@ class TestSpectrogramFrame:
 
         # Pillar 2: sampling rate and source offset inherited from spectrogram
         assert channel_frame_istft.sampling_rate == spec.sampling_rate
-        assert channel_frame_istft.source_time_offset == 4.5
-        assert channel_frame_to.source_time_offset == 4.5
+        np.testing.assert_array_equal(channel_frame_istft.source_time_offset, np.array([4.5, 4.5]))
+        np.testing.assert_array_equal(channel_frame_to.source_time_offset, np.array([4.5, 4.5]))
 
         # データが同じであることを確認
         # Same ISTFT algorithm — decimal=6 default (alias, results identical)

--- a/tests/frames/test_spectrogram_frame.py
+++ b/tests/frames/test_spectrogram_frame.py
@@ -138,6 +138,15 @@ class TestSpectrogramFrame:
         assert len(freqs) == spec.n_freq_bins  # FFTサイズの半分 + 1
         assert len(times) == 5
 
+    def test_source_times_add_source_time_offset(self, sample_spectrogram: SpectrogramFrame) -> None:
+        """source_times returns spectrogram frame times on the source timeline."""
+        spec = sample_spectrogram._create_new_instance(
+            data=sample_spectrogram._data,
+            source_time_offset=1.25,
+        )
+
+        np.testing.assert_array_equal(spec.source_times, spec.times + 1.25)
+
     def test_binary_operations(self, sample_spectrogram: SpectrogramFrame) -> None:
         """二項演算子の動作テスト"""
         spec: SpectrogramFrame = sample_spectrogram

--- a/tests/frames/test_spectrogram_frame.py
+++ b/tests/frames/test_spectrogram_frame.py
@@ -168,6 +168,11 @@ class TestSpectrogramFrame:
         with pytest.raises(ValueError, match="Stepped slicing on the time axis is not supported"):
             _ = spec[:, :, 2::2]
 
+    def test_point_time_selection_raises_for_source_time_offset(self, sample_spectrogram: SpectrogramFrame) -> None:
+        """Point spectrogram time selection is outside the continuous-slice model."""
+        with pytest.raises(ValueError, match="Only continuous slicing on the time axis is supported"):
+            _ = sample_spectrogram[:, :, 2]
+
     def test_binary_operations(self, sample_spectrogram: SpectrogramFrame) -> None:
         """二項演算子の動作テスト"""
         spec: SpectrogramFrame = sample_spectrogram

--- a/tests/io/test_wdf_io.py
+++ b/tests/io/test_wdf_io.py
@@ -49,14 +49,14 @@ def test_wdf_roundtrip_known_signal(known_signal_frame, tmp_path: Path) -> None:
 
 def test_wdf_roundtrip_preserves_source_time_offset(known_signal_frame, tmp_path: Path) -> None:
     """WDF stores and restores source_time_offset as frame state."""
-    known_signal_frame.source_time_offset = 3.25
+    known_signal_frame.source_time_offset = [3.25, 7.5]
     path = tmp_path / "source_time_offset.wdf"
 
     known_signal_frame.save(path)
     loaded = ChannelFrame.load(path)
 
-    assert loaded.source_time_offset == 3.25
-    assert loaded.source_time[0] == 3.25
+    np.testing.assert_array_equal(loaded.source_time_offset, np.array([3.25, 7.5]))
+    np.testing.assert_array_equal(loaded.source_time[:, 0], np.array([3.25, 7.5]))
 
 
 def test_wdf_load_defaults_missing_source_time_offset_to_zero(tmp_path: Path) -> None:
@@ -74,7 +74,7 @@ def test_wdf_load_defaults_missing_source_time_offset_to_zero(tmp_path: Path) ->
 
     loaded = ChannelFrame.load(path)
 
-    assert loaded.source_time_offset == 0.0
+    np.testing.assert_array_equal(loaded.source_time_offset, np.array([0.0]))
 
 
 def test_wdf_load_rejects_non_finite_source_time_offset(tmp_path: Path) -> None:
@@ -92,6 +92,24 @@ def test_wdf_load_rejects_non_finite_source_time_offset(tmp_path: Path) -> None:
         channel.attrs["unit"] = ""
 
     with pytest.raises(ValueError, match="source_time_offset must be finite"):
+        ChannelFrame.load(path)
+
+
+def test_wdf_load_rejects_source_time_offset_length_mismatch(tmp_path: Path) -> None:
+    """Persisted source_time_offset arrays must match WDF channel count."""
+    path = tmp_path / "invalid_offset_length.wdf"
+    with h5py.File(path, "w") as f:
+        f.attrs["version"] = wdf_io.WDF_FORMAT_VERSION
+        f.attrs["sampling_rate"] = 16000.0
+        f.attrs["label"] = ""
+        f.attrs["source_time_offset"] = np.array([1.0, 2.0])
+        channels = f.create_group("channels")
+        channel = channels.create_group("0")
+        channel.create_dataset("data", data=np.zeros(4, dtype=np.float32))
+        channel.attrs["label"] = "mic0"
+        channel.attrs["unit"] = ""
+
+    with pytest.raises(ValueError, match="source_time_offset length must match number of channels"):
         ChannelFrame.load(path)
 
 

--- a/tests/io/test_wdf_io.py
+++ b/tests/io/test_wdf_io.py
@@ -53,10 +53,56 @@ def test_wdf_roundtrip_preserves_source_time_offset(known_signal_frame, tmp_path
     path = tmp_path / "source_time_offset.wdf"
 
     known_signal_frame.save(path)
+    with h5py.File(path, "r") as f:
+        assert "source_time_offset" not in f.attrs
+        assert f["channels"]["0"].attrs["source_time_offset"] == 3.25
+        assert f["channels"]["1"].attrs["source_time_offset"] == 7.5
+
     loaded = ChannelFrame.load(path)
 
     np.testing.assert_array_equal(loaded.source_time_offset, np.array([3.25, 7.5]))
     np.testing.assert_array_equal(loaded.source_time[:, 0], np.array([3.25, 7.5]))
+
+
+def test_wdf_load_channel_source_time_offset_takes_priority_over_root(tmp_path: Path) -> None:
+    """New channel attr offsets take priority over legacy root offsets."""
+    path = tmp_path / "channel_offset_priority.wdf"
+    with h5py.File(path, "w") as f:
+        f.attrs["version"] = wdf_io.WDF_FORMAT_VERSION
+        f.attrs["sampling_rate"] = 16000.0
+        f.attrs["label"] = ""
+        f.attrs["source_time_offset"] = np.array([99.0, 100.0])
+        channels = f.create_group("channels")
+        for i, offset in enumerate([1.25, 2.5]):
+            channel = channels.create_group(str(i))
+            channel.create_dataset("data", data=np.zeros(4, dtype=np.float32))
+            channel.attrs["label"] = f"mic{i}"
+            channel.attrs["unit"] = ""
+            channel.attrs["source_time_offset"] = offset
+
+    loaded = ChannelFrame.load(path)
+
+    np.testing.assert_array_equal(loaded.source_time_offset, np.array([1.25, 2.5]))
+
+
+def test_wdf_load_legacy_root_source_time_offset(tmp_path: Path) -> None:
+    """Legacy root source_time_offset remains readable."""
+    path = tmp_path / "legacy_root_offset.wdf"
+    with h5py.File(path, "w") as f:
+        f.attrs["version"] = wdf_io.WDF_FORMAT_VERSION
+        f.attrs["sampling_rate"] = 16000.0
+        f.attrs["label"] = ""
+        f.attrs["source_time_offset"] = np.array([4.0, 8.0])
+        channels = f.create_group("channels")
+        for i in range(2):
+            channel = channels.create_group(str(i))
+            channel.create_dataset("data", data=np.zeros(4, dtype=np.float32))
+            channel.attrs["label"] = f"mic{i}"
+            channel.attrs["unit"] = ""
+
+    loaded = ChannelFrame.load(path)
+
+    np.testing.assert_array_equal(loaded.source_time_offset, np.array([4.0, 8.0]))
 
 
 def test_wdf_load_defaults_missing_source_time_offset_to_zero(tmp_path: Path) -> None:

--- a/tests/io/test_wdf_io.py
+++ b/tests/io/test_wdf_io.py
@@ -77,6 +77,24 @@ def test_wdf_load_defaults_missing_source_time_offset_to_zero(tmp_path: Path) ->
     assert loaded.source_time_offset == 0.0
 
 
+def test_wdf_load_rejects_non_finite_source_time_offset(tmp_path: Path) -> None:
+    """Invalid persisted source_time_offset values are rejected on load."""
+    path = tmp_path / "invalid_offset.wdf"
+    with h5py.File(path, "w") as f:
+        f.attrs["version"] = wdf_io.WDF_FORMAT_VERSION
+        f.attrs["sampling_rate"] = 16000.0
+        f.attrs["label"] = ""
+        f.attrs["source_time_offset"] = np.nan
+        channels = f.create_group("channels")
+        channel = channels.create_group("0")
+        channel.create_dataset("data", data=np.zeros(4, dtype=np.float32))
+        channel.attrs["label"] = "mic0"
+        channel.attrs["unit"] = ""
+
+    with pytest.raises(ValueError, match="source_time_offset must be finite"):
+        ChannelFrame.load(path)
+
+
 def test_save_load_roundtrip(tmp_path: Path) -> None:
     """Test saving and loading a ChannelFrame with full metadata preservation."""
     # Seeded RNG for reproducibility (Grand Policy: no random data)

--- a/tests/io/test_wdf_io.py
+++ b/tests/io/test_wdf_io.py
@@ -47,6 +47,36 @@ def test_wdf_roundtrip_known_signal(known_signal_frame, tmp_path: Path) -> None:
     assert isinstance(loaded._data, dask.array.core.Array)
 
 
+def test_wdf_roundtrip_preserves_source_time_offset(known_signal_frame, tmp_path: Path) -> None:
+    """WDF stores and restores source_time_offset as frame state."""
+    known_signal_frame.source_time_offset = 3.25
+    path = tmp_path / "source_time_offset.wdf"
+
+    known_signal_frame.save(path)
+    loaded = ChannelFrame.load(path)
+
+    assert loaded.source_time_offset == 3.25
+    assert loaded.source_time[0] == 3.25
+
+
+def test_wdf_load_defaults_missing_source_time_offset_to_zero(tmp_path: Path) -> None:
+    """Legacy WDF files without source_time_offset load with zero offset."""
+    path = tmp_path / "legacy_no_offset.wdf"
+    with h5py.File(path, "w") as f:
+        f.attrs["version"] = wdf_io.WDF_FORMAT_VERSION
+        f.attrs["sampling_rate"] = 16000.0
+        f.attrs["label"] = ""
+        channels = f.create_group("channels")
+        channel = channels.create_group("0")
+        channel.create_dataset("data", data=np.zeros(4, dtype=np.float32))
+        channel.attrs["label"] = "mic0"
+        channel.attrs["unit"] = ""
+
+    loaded = ChannelFrame.load(path)
+
+    assert loaded.source_time_offset == 0.0
+
+
 def test_save_load_roundtrip(tmp_path: Path) -> None:
     """Test saving and loading a ChannelFrame with full metadata preservation."""
     # Seeded RNG for reproducibility (Grand Policy: no random data)

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -755,7 +755,9 @@ class BaseFrame(ABC, Generic[T]):
             time_slice_context = selected._source_time_slice_context(time_keys)
             if time_slice_context is not None:
                 time_axis_key, time_axis_size, time_step = time_slice_context
-                if isinstance(time_axis_key, slice) and (time_axis_key.step is None or time_axis_key.step > 0):
+                if isinstance(time_axis_key, slice):
+                    if time_axis_key.step not in (None, 1):
+                        raise ValueError("Stepped slicing on the time axis is not supported for source time offsets.")
                     start, _, _ = time_axis_key.indices(time_axis_size)
                     source_time_offset += start * time_step
             return selected._create_new_instance(

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -97,7 +97,7 @@ class BaseFrame(ABC, Generic[T]):
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
         previous: "BaseFrame[Any] | None" = None,
-        source_time_offset: float = 0.0,
+        source_time_offset: float | Sequence[float] | NDArrayReal = 0.0,
     ):
         normalized_data = self._normalize_data(data)
         frame_label = label or "unnamed_frame"
@@ -452,19 +452,36 @@ class BaseFrame(ABC, Generic[T]):
         self._xr.attrs["operation_history"] = copy.deepcopy(value)
 
     @property
-    def source_time_offset(self) -> float:
-        """Return the offset from this frame's local time axis to source time."""
-        return float(self._xr.attrs.get("source_time_offset", 0.0))
+    def source_time_offset(self) -> NDArrayReal:
+        """Return each channel's offset from local time axis to source time."""
+        return self._normalize_source_time_offset(self._xr.attrs.get("source_time_offset", 0.0), self.n_channels)
 
     @source_time_offset.setter
-    def source_time_offset(self, value: float) -> None:
+    def source_time_offset(self, value: float | Sequence[float] | NDArrayReal) -> None:
+        self._xr.attrs["source_time_offset"] = self._normalize_source_time_offset(value, self.n_channels)
+
+    @staticmethod
+    def _normalize_source_time_offset(
+        value: object,
+        n_channels: int,
+    ) -> NDArrayReal:
         try:
-            offset = float(value)
+            offsets = np.asarray(value, dtype=float)
         except (TypeError, ValueError) as exc:
             raise TypeError("source_time_offset must be a finite numeric value") from exc
-        if not np.isfinite(offset):
+        if offsets.ndim == 0:
+            offsets = np.full(n_channels, float(offsets), dtype=float)
+        elif offsets.ndim != 1:
+            raise ValueError("source_time_offset must be a scalar or a 1D array")
+        elif len(offsets) != n_channels:
+            raise ValueError(
+                "source_time_offset length must match number of channels\n"
+                f"  Offsets: {len(offsets)}\n"
+                f"  Channels: {n_channels}"
+            )
+        if not np.all(np.isfinite(offsets)):
             raise ValueError("source_time_offset must be finite")
-        self._xr.attrs["source_time_offset"] = offset
+        return offsets.astype(float, copy=True)
 
     def get_channel(
         self: S,
@@ -560,6 +577,7 @@ class BaseFrame(ABC, Generic[T]):
             operation_history=new_history,
             channel_metadata=new_channel_metadata,
             channel_ids=new_channel_ids,
+            source_time_offset=self.source_time_offset[channel_idx_list],
         )
 
     def __len__(self) -> int:
@@ -711,6 +729,7 @@ class BaseFrame(ABC, Generic[T]):
                 operation_history=self.operation_history,
                 channel_metadata=new_channel_metadata,
                 channel_ids=new_channel_ids,
+                source_time_offset=self.source_time_offset[indices],
             )
 
         raise TypeError(f"Invalid key type: {type(key).__name__}. Expected int, str, slice, list, tuple, or ndarray.")
@@ -766,7 +785,7 @@ class BaseFrame(ABC, Generic[T]):
                 if time_axis_key.step not in (None, 1):
                     raise ValueError("Stepped slicing on the time axis is not supported for source time offsets.")
                 start, _, _ = time_axis_key.indices(time_axis_size)
-                source_time_offset += start * time_step
+                source_time_offset = source_time_offset + start * time_step
             return selected._create_new_instance(
                 data=new_data,
                 operation_history=selected.operation_history,

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -118,8 +118,8 @@ class BaseFrame(ABC, Generic[T]):
         self.sampling_rate = sampling_rate
         self.metadata = metadata
         self.operation_history = operation_history
-        self.source_time_offset = source_time_offset
         self._set_channel_metadata(normalized_channel_metadata, self._pending_channel_ids)
+        self.source_time_offset = source_time_offset
         del self._pending_channel_metadata
         del self._pending_channel_ids
         self._previous = previous
@@ -143,12 +143,14 @@ class BaseFrame(ABC, Generic[T]):
         """Replace the internal xarray data container without touching frame state."""
         old_channel_metadata = self.channels.to_list()
         old_channel_ids = self._channel_ids
+        old_source_time_offset = self.source_time_offset
         normalized = self._normalize_data(data)
         attrs = copy.deepcopy(self._xr.attrs)
         self._xr = self._build_xarray(normalized, name=self.label)
         self._xr.attrs = attrs
         if len(old_channel_metadata) == self._n_channels and len(old_channel_ids) == self._n_channels:
             self._set_channel_metadata(old_channel_metadata, old_channel_ids)
+            self.source_time_offset = old_source_time_offset
 
     def _normalize_data(self, data: DaArray) -> DaArray:
         """Normalize Dask data shape and chunks using Wandas channel-wise policy."""
@@ -454,11 +456,20 @@ class BaseFrame(ABC, Generic[T]):
     @property
     def source_time_offset(self) -> NDArrayReal:
         """Return each channel's offset from local time axis to source time."""
-        return self._normalize_source_time_offset(self._xr.attrs.get("source_time_offset", 0.0), self.n_channels)
+        if "source_time_offset" in self._xr.coords:
+            value = self._xr.coords["source_time_offset"].values
+        else:
+            value = self._xr.attrs.get("source_time_offset", 0.0)
+        return self._normalize_source_time_offset(value, self.n_channels)
 
     @source_time_offset.setter
     def source_time_offset(self, value: float | Sequence[float] | NDArrayReal) -> None:
-        self._xr.attrs["source_time_offset"] = self._normalize_source_time_offset(value, self.n_channels)
+        offsets = self._normalize_source_time_offset(value, self.n_channels)
+        if self._CHANNEL_DIM in self._xr.dims:
+            self._xr = self._xr.assign_coords({"source_time_offset": (self._CHANNEL_DIM, offsets)})
+            self._xr.attrs.pop("source_time_offset", None)
+            return
+        self._xr.attrs["source_time_offset"] = offsets
 
     @staticmethod
     def _normalize_source_time_offset(
@@ -882,7 +893,7 @@ class BaseFrame(ABC, Generic[T]):
     def to_xarray(self) -> xr.DataArray:
         """Return a public xarray view of this frame without changing Wandas ownership."""
         exported = self._xr.copy(deep=False)
-        for coord_name in (self._CHANNEL_DIM, "channel_label", "channel_unit", "channel_ref"):
+        for coord_name in (self._CHANNEL_DIM, "channel_label", "channel_unit", "channel_ref", "source_time_offset"):
             if coord_name in exported.coords:
                 coord = exported.coords[coord_name]
                 exported = exported.assign_coords({coord_name: (coord.dims, coord.values.copy())})

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -755,7 +755,7 @@ class BaseFrame(ABC, Generic[T]):
             time_slice_context = selected._source_time_slice_context(time_keys)
             if time_slice_context is not None:
                 time_axis_key, time_axis_size, time_step = time_slice_context
-                if isinstance(time_axis_key, slice) and (time_axis_key.step is None or time_axis_key.step == 1):
+                if isinstance(time_axis_key, slice) and (time_axis_key.step is None or time_axis_key.step > 0):
                     start, _, _ = time_axis_key.indices(time_axis_size)
                     source_time_offset += start * time_step
             return selected._create_new_instance(

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -96,6 +96,7 @@ class BaseFrame(ABC, Generic[T]):
         operation_history: list[dict[str, Any]] | None = None,
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
+        source_time_offset: float = 0.0,
         previous: "BaseFrame[Any] | None" = None,
     ):
         normalized_data = self._normalize_data(data)
@@ -117,6 +118,7 @@ class BaseFrame(ABC, Generic[T]):
         self.sampling_rate = sampling_rate
         self.metadata = metadata
         self.operation_history = operation_history
+        self.source_time_offset = source_time_offset
         self._set_channel_metadata(normalized_channel_metadata, self._pending_channel_ids)
         del self._pending_channel_metadata
         del self._pending_channel_ids
@@ -449,6 +451,15 @@ class BaseFrame(ABC, Generic[T]):
             raise TypeError("Operation history must be a list")
         self._xr.attrs["operation_history"] = copy.deepcopy(value)
 
+    @property
+    def source_time_offset(self) -> float:
+        """Return the offset from this frame's local time axis to source time."""
+        return float(self._xr.attrs.get("source_time_offset", 0.0))
+
+    @source_time_offset.setter
+    def source_time_offset(self, value: float) -> None:
+        self._xr.attrs["source_time_offset"] = float(value)
+
     def get_channel(
         self: S,
         channel_idx: int | list[int] | tuple[int, ...] | npt.NDArray[np.int_] | npt.NDArray[np.bool_] | None = None,
@@ -740,11 +751,17 @@ class BaseFrame(ABC, Generic[T]):
         # Apply time indexing if present
         if time_keys:
             new_data = selected._data[(slice(None),) + time_keys]  # noqa: RUF005
+            source_time_offset = selected.source_time_offset
+            last_key = time_keys[-1]
+            if isinstance(last_key, slice) and (last_key.step is None or last_key.step == 1):
+                start, _, _ = last_key.indices(selected._data.shape[-1])
+                source_time_offset += start / selected.sampling_rate
             return selected._create_new_instance(
                 data=new_data,
                 operation_history=selected.operation_history,
                 channel_metadata=selected.channels.to_list(),
                 channel_ids=selected._channel_ids,
+                source_time_offset=source_time_offset,
             )
 
         return selected
@@ -890,6 +907,8 @@ class BaseFrame(ABC, Generic[T]):
         if not isinstance(channel_ids, list):
             raise TypeError("Channel ids must be a list")
 
+        source_time_offset = kwargs.pop("source_time_offset", self.source_time_offset)
+
         # Get additional initialization arguments from derived classes
         additional_kwargs = self._get_additional_init_kwargs()
         kwargs.update(additional_kwargs)
@@ -902,6 +921,7 @@ class BaseFrame(ABC, Generic[T]):
             operation_history=operation_history,
             channel_metadata=channel_metadata,
             channel_ids=channel_ids,
+            source_time_offset=source_time_offset,
             previous=self,
             **kwargs,
         )
@@ -1192,6 +1212,8 @@ class BaseFrame(ABC, Generic[T]):
         new_metadata, new_history = self._updated_metadata_and_history(operation_name, params)
 
         metadata_updates = operation.get_metadata_updates()
+        if operation_name == "trim":
+            metadata_updates["source_time_offset"] = self.source_time_offset + float(params.get("start", 0.0))
 
         display_name = operation.get_display_name()
         new_channel_metadata = self._relabel_channels(operation_name, display_name)
@@ -1214,6 +1236,7 @@ class BaseFrame(ABC, Generic[T]):
                 "operation_history": new_history,
                 "channel_metadata": new_channel_metadata,
                 "channel_ids": self._channel_ids,
+                "source_time_offset": metadata_updates.pop("source_time_offset", self.source_time_offset),
                 "previous": self,
             }
             kw.update(metadata_updates)

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -752,10 +752,12 @@ class BaseFrame(ABC, Generic[T]):
         if time_keys:
             new_data = selected._data[(slice(None),) + time_keys]  # noqa: RUF005
             source_time_offset = selected.source_time_offset
-            last_key = time_keys[-1]
-            if isinstance(last_key, slice) and (last_key.step is None or last_key.step == 1):
-                start, _, _ = last_key.indices(selected._data.shape[-1])
-                source_time_offset += start / selected.sampling_rate
+            time_slice_context = selected._source_time_slice_context(time_keys)
+            if time_slice_context is not None:
+                time_axis_key, time_axis_size, time_step = time_slice_context
+                if isinstance(time_axis_key, slice) and (time_axis_key.step is None or time_axis_key.step == 1):
+                    start, _, _ = time_axis_key.indices(time_axis_size)
+                    source_time_offset += start * time_step
             return selected._create_new_instance(
                 data=new_data,
                 operation_history=selected.operation_history,
@@ -765,6 +767,18 @@ class BaseFrame(ABC, Generic[T]):
             )
 
         return selected
+
+    def _source_time_slice_context(self, keys: tuple[Any, ...]) -> tuple[Any, int, float] | None:
+        """Return the sliced time-axis key, axis size, and seconds per index."""
+        dims = self._xr.dims
+        if "time" not in dims:
+            return None
+        time_dim_index = dims.index("time")
+        key_index = time_dim_index - 1
+        if key_index < 0 or key_index >= len(keys):
+            return None
+        hop_length = getattr(self, "hop_length", 1)
+        return keys[key_index], self._data.shape[time_dim_index], float(hop_length) / self.sampling_rate
 
     def label2index(self, label: str) -> int:
         """
@@ -996,7 +1010,9 @@ class BaseFrame(ABC, Generic[T]):
         """Default implementation of binary operations using dask's lazy evaluation.
 
         Handles both frame-frame and frame-scalar/array operations with
-        metadata propagation and history tracking.  Uses
+        metadata propagation and history tracking. Frame-frame operations
+        combine current array indices and preserve the left operand's source
+        timeline; no source-time alignment is performed. Uses
         ``_create_new_instance`` so that subclass-specific constructor
         parameters are automatically forwarded.
 
@@ -1213,7 +1229,8 @@ class BaseFrame(ABC, Generic[T]):
 
         metadata_updates = operation.get_metadata_updates()
         if operation_name == "trim":
-            metadata_updates["source_time_offset"] = self.source_time_offset + float(params.get("start", 0.0))
+            start_sample = int(float(params.get("start", 0.0)) * self.sampling_rate)
+            metadata_updates["source_time_offset"] = self.source_time_offset + start_sample / self.sampling_rate
 
         display_name = operation.get_display_name()
         new_channel_metadata = self._relabel_channels(operation_name, display_name)

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -96,8 +96,8 @@ class BaseFrame(ABC, Generic[T]):
         operation_history: list[dict[str, Any]] | None = None,
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
-        source_time_offset: float = 0.0,
         previous: "BaseFrame[Any] | None" = None,
+        source_time_offset: float = 0.0,
     ):
         normalized_data = self._normalize_data(data)
         frame_label = label or "unnamed_frame"
@@ -458,7 +458,13 @@ class BaseFrame(ABC, Generic[T]):
 
     @source_time_offset.setter
     def source_time_offset(self, value: float) -> None:
-        self._xr.attrs["source_time_offset"] = float(value)
+        try:
+            offset = float(value)
+        except (TypeError, ValueError) as exc:
+            raise TypeError("source_time_offset must be a finite numeric value") from exc
+        if not np.isfinite(offset):
+            raise ValueError("source_time_offset must be finite")
+        self._xr.attrs["source_time_offset"] = offset
 
     def get_channel(
         self: S,
@@ -755,11 +761,12 @@ class BaseFrame(ABC, Generic[T]):
             time_slice_context = selected._source_time_slice_context(time_keys)
             if time_slice_context is not None:
                 time_axis_key, time_axis_size, time_step = time_slice_context
-                if isinstance(time_axis_key, slice):
-                    if time_axis_key.step not in (None, 1):
-                        raise ValueError("Stepped slicing on the time axis is not supported for source time offsets.")
-                    start, _, _ = time_axis_key.indices(time_axis_size)
-                    source_time_offset += start * time_step
+                if not isinstance(time_axis_key, slice):
+                    raise ValueError("Only continuous slicing on the time axis is supported for source time offsets.")
+                if time_axis_key.step not in (None, 1):
+                    raise ValueError("Stepped slicing on the time axis is not supported for source time offsets.")
+                start, _, _ = time_axis_key.indices(time_axis_size)
+                source_time_offset += start * time_step
             return selected._create_new_instance(
                 data=new_data,
                 operation_history=selected.operation_history,

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -1346,7 +1346,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
 
         new_ids = [*self._channel_ids, self._next_channel_id()]
         new_chmeta = [*self.channels.to_list(), ChannelMetadata(label=new_label)]
-        new_offsets = np.concatenate([self.source_time_offset, self.source_time_offset[:1]])
+        new_offsets = np.concatenate([self.source_time_offset, np.array([0.0])])
         return self._finalize_channel_update(new_data, new_chmeta, inplace, new_ids, new_offsets)
 
     def remove_channel(self, key: int | str, inplace: bool = False) -> "ChannelFrame":

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -218,7 +218,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
         previous: "BaseFrame[Any] | None" = None,
-        source_time_offset: float = 0.0,
+        source_time_offset: float | Sequence[float] | NDArrayReal = 0.0,
     ) -> None:
         """Initialize a ChannelFrame.
 
@@ -292,11 +292,14 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         new_chmeta: list[ChannelMetadata],
         inplace: bool,
         channel_ids: list[str],
+        source_time_offset: float | Sequence[float] | NDArrayReal | None = None,
     ) -> "ChannelFrame":
         """Apply *new_data* and *new_chmeta* either in-place or as a new frame."""
+        offsets = self.source_time_offset if source_time_offset is None else source_time_offset
         if inplace:
             self._replace_data(new_data)
             self._set_channel_metadata(new_chmeta, channel_ids)
+            self.source_time_offset = cast(Any, offsets)
             return self
         return ChannelFrame(
             data=new_data,
@@ -306,7 +309,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             operation_history=self.operation_history,
             channel_metadata=new_chmeta,
             channel_ids=channel_ids,
-            source_time_offset=self.source_time_offset,
+            source_time_offset=offsets,
             previous=self,
         )
 
@@ -339,7 +342,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
     @property
     def source_time(self) -> NDArrayReal:
         """Get sample times relative to the original source timeline."""
-        return self.time + self.source_time_offset
+        return self.source_time_offset[:, None] + self.time[None, :]
 
     @property
     def n_samples(self) -> int:
@@ -1315,7 +1318,8 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             for _ in new_metadata_list:
                 new_id = self._next_channel_id(new_ids)
                 new_ids.append(new_id)
-            return self._finalize_channel_update(new_data, new_chmeta, inplace, new_ids)
+            new_offsets = np.concatenate([self.source_time_offset, data.source_time_offset])
+            return self._finalize_channel_update(new_data, new_chmeta, inplace, new_ids, new_offsets)
         if isinstance(data, np.ndarray):
             arr = _da_from_array(data.reshape(1, -1), chunks=(1, -1))
         elif isinstance(data, DaArray):
@@ -1342,7 +1346,8 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
 
         new_ids = [*self._channel_ids, self._next_channel_id()]
         new_chmeta = [*self.channels.to_list(), ChannelMetadata(label=new_label)]
-        return self._finalize_channel_update(new_data, new_chmeta, inplace, new_ids)
+        new_offsets = np.concatenate([self.source_time_offset, self.source_time_offset[:1]])
+        return self._finalize_channel_update(new_data, new_chmeta, inplace, new_ids, new_offsets)
 
     def remove_channel(self, key: int | str, inplace: bool = False) -> "ChannelFrame":
         if isinstance(key, int):
@@ -1358,7 +1363,13 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         new_data = self._data[keep_indices, :]
         new_chmeta = [self.channels[i].to_metadata() for i in keep_indices]
         new_ids = [self._channel_ids[i] for i in keep_indices]
-        return self._finalize_channel_update(new_data, new_chmeta, inplace, new_ids)
+        return self._finalize_channel_update(
+            new_data,
+            new_chmeta,
+            inplace,
+            new_ids,
+            self.source_time_offset[keep_indices],
+        )
 
     def rename_channels(
         self,

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -1005,6 +1005,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         n_channels = info["channels"]
         n_frames = info["frames"]
         ch_labels = ch_labels or info.get("ch_labels", None)
+        source_time_start = float(info.get("time_start", 0.0))
 
         logger.debug(f"File info: sr={sr}, channels={n_channels}, frames={n_frames}")
 
@@ -1079,7 +1080,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             sampling_rate=sr,
             label=frame_label,
             metadata={"_source_file": source_file} if source_file is not None else None,
-            source_time_offset=start_idx / sr,
+            source_time_offset=source_time_start + start_idx / sr,
         )
         if ch_labels is not None:
             cf._set_channel_labels(ch_labels)

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -217,8 +217,8 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         operation_history: list[dict[str, Any]] | None = None,
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
-        source_time_offset: float = 0.0,
         previous: "BaseFrame[Any] | None" = None,
+        source_time_offset: float = 0.0,
     ) -> None:
         """Initialize a ChannelFrame.
 

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -217,6 +217,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         operation_history: list[dict[str, Any]] | None = None,
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
+        source_time_offset: float = 0.0,
         previous: "BaseFrame[Any] | None" = None,
     ) -> None:
         """Initialize a ChannelFrame.
@@ -261,6 +262,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             operation_history=operation_history,
             channel_metadata=channel_metadata,
             channel_ids=channel_ids,
+            source_time_offset=source_time_offset,
             previous=previous,
         )
 
@@ -332,6 +334,11 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             >>> print(f"Time step: {time[1] - time[0]:.6f}s")
         """
         return np.arange(self.n_samples) / self.sampling_rate
+
+    @property
+    def source_time(self) -> NDArrayReal:
+        """Get sample times relative to the original source timeline."""
+        return self.time + self.source_time_offset
 
     @property
     def n_samples(self) -> int:
@@ -1071,6 +1078,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             sampling_rate=sr,
             label=frame_label,
             metadata={"_source_file": source_file} if source_file is not None else None,
+            source_time_offset=start_idx / sr,
         )
         if ch_labels is not None:
             cf._set_channel_labels(ch_labels)

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -306,6 +306,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             operation_history=self.operation_history,
             channel_metadata=new_chmeta,
             channel_ids=channel_ids,
+            source_time_offset=self.source_time_offset,
             previous=self,
         )
 

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -4,6 +4,8 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, SupportsFloat, SupportsIndex, TypeAlias, TypeVar, cast, overload
 
+import numpy as np
+
 from wandas.core.metadata import ChannelMetadata
 from wandas.frames.roughness import RoughnessFrame
 from wandas.processing import create_operation
@@ -324,12 +326,19 @@ class ChannelProcessingMixin:
                 extra=reduced_extra,
             )
         ]
+        source_time_offset = cast(Any, self).source_time_offset
+        if not np.allclose(source_time_offset, source_time_offset[0]):
+            raise ValueError(
+                f"{op} cannot reduce channels with different source_time_offset values. "
+                "Align the channels first or select channels with matching offsets."
+            )
         new_metadata, new_history = self._updated_metadata_and_history(op, {})
         result = self._create_new_instance(
             data=reduced_data,
             metadata=new_metadata,
             operation_history=new_history,
             channel_metadata=new_channel_metadata,
+            source_time_offset=source_time_offset[:1],
         )
         return result
 

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -911,6 +911,7 @@ class ChannelProcessingMixin:
             operation_history=new_history,
             channel_metadata=cast(Any, self).channels.to_list(),
             channel_ids=cast(Any, self)._channel_ids,
+            source_time_offset=cast(Any, self).source_time_offset,
             previous=cast("BaseFrame[NDArrayReal]", self),
         )
 

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -4,8 +4,6 @@ import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, SupportsFloat, SupportsIndex, TypeAlias, TypeVar, cast, overload
 
-import numpy as np
-
 from wandas.core.metadata import ChannelMetadata
 from wandas.frames.roughness import RoughnessFrame
 from wandas.processing import create_operation
@@ -326,19 +324,13 @@ class ChannelProcessingMixin:
                 extra=reduced_extra,
             )
         ]
-        source_time_offset = cast(Any, self).source_time_offset
-        if not np.allclose(source_time_offset, source_time_offset[0]):
-            raise ValueError(
-                f"{op} cannot reduce channels with different source_time_offset values. "
-                "Align the channels first or select channels with matching offsets."
-            )
         new_metadata, new_history = self._updated_metadata_and_history(op, {})
         result = self._create_new_instance(
             data=reduced_data,
             metadata=new_metadata,
             operation_history=new_history,
             channel_metadata=new_channel_metadata,
-            source_time_offset=source_time_offset[:1],
+            source_time_offset=0.0,
         )
         return result
 

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -324,13 +324,17 @@ class ChannelProcessingMixin:
                 extra=reduced_extra,
             )
         ]
+        source_time_offset = cast(Any, self).source_time_offset
+        reduced_source_time_offset = (
+            source_time_offset[:1] if (source_time_offset == source_time_offset[0]).all() else 0.0
+        )
         new_metadata, new_history = self._updated_metadata_and_history(op, {})
         result = self._create_new_instance(
             data=reduced_data,
             metadata=new_metadata,
             operation_history=new_history,
             channel_metadata=new_channel_metadata,
-            source_time_offset=0.0,
+            source_time_offset=reduced_source_time_offset,
         )
         return result
 

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -335,6 +335,7 @@ class ChannelTransformMixin:
             operation_history=self.operation_history,
             channel_metadata=cast(Any, self).channels.to_list(),
             channel_ids=cast(Any, self)._channel_ids,
+            source_time_offset=cast(Any, self).source_time_offset,
             previous=self._as_base_frame,
         )
 

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -110,6 +110,7 @@ class ChannelTransformMixin:
                 {"operation": operation_name, "params": params},
             ],
             channel_metadata=channel_metadata,
+            source_time_offset=cast(Any, self).source_time_offset,
             previous=self._as_base_frame,
         )
 

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -37,8 +37,8 @@ def _build_cross_channel_metadata(
     from wandas.core.metadata import ChannelMetadata
 
     result = []
-    for in_ch in channel_metadata:
-        for out_ch in channel_metadata:
+    for out_ch in channel_metadata:
+        for in_ch in channel_metadata:
             meta = ChannelMetadata()
             meta.label = label_template.format(in_label=in_ch.label, out_label=out_ch.label)
             meta.unit = ""
@@ -52,8 +52,8 @@ def _build_cross_channel_source_time_offsets(source_time_offset: Any) -> Any:
     """Build pairwise source offsets for cross-channel spectral outputs."""
     offsets = np.asarray(source_time_offset, dtype=float)
     result: list[float] = []
-    for in_offset in offsets:
-        for _out_offset in offsets:
+    for _out_offset in offsets:
+        for in_offset in offsets:
             result.append(float(in_offset))
     return np.asarray(result, dtype=float)
 

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -158,6 +158,7 @@ class ChannelTransformMixin:
             ],
             channel_metadata=cast(Any, self).channels.to_list(),
             channel_ids=cast(Any, self)._channel_ids,
+            source_time_offset=cast(Any, self).source_time_offset,
             previous=self._as_base_frame,
         )
 
@@ -216,6 +217,7 @@ class ChannelTransformMixin:
             ],
             channel_metadata=cast(Any, self).channels.to_list(),
             channel_ids=cast(Any, self)._channel_ids,
+            source_time_offset=cast(Any, self).source_time_offset,
             previous=self._as_base_frame,
         )
 
@@ -274,6 +276,7 @@ class ChannelTransformMixin:
             ],
             channel_metadata=cast(Any, self).channels.to_list(),
             channel_ids=cast(Any, self)._channel_ids,
+            source_time_offset=cast(Any, self).source_time_offset,
             previous=self._as_base_frame,
         )
 

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -53,12 +53,7 @@ def _build_cross_channel_source_time_offsets(source_time_offset: Any) -> Any:
     offsets = np.asarray(source_time_offset, dtype=float)
     result: list[float] = []
     for in_offset in offsets:
-        for out_offset in offsets:
-            if not np.isclose(in_offset, out_offset):
-                raise ValueError(
-                    "Cross-channel transforms require matching source_time_offset values. "
-                    "Align the channels first or select channels with matching offsets."
-                )
+        for _out_offset in offsets:
             result.append(float(in_offset))
     return np.asarray(result, dtype=float)
 

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -4,6 +4,8 @@ operations."""
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
+import numpy as np
+
 from ...core.base_frame import BaseFrame
 from .protocols import TransformFrameProtocol
 
@@ -44,6 +46,21 @@ def _build_cross_channel_metadata(
             meta["metadata"] = {"in_ch": in_ch["metadata"], "out_ch": out_ch["metadata"]}
             result.append(meta)
     return result
+
+
+def _build_cross_channel_source_time_offsets(source_time_offset: Any) -> Any:
+    """Build pairwise source offsets for cross-channel spectral outputs."""
+    offsets = np.asarray(source_time_offset, dtype=float)
+    result: list[float] = []
+    for in_offset in offsets:
+        for out_offset in offsets:
+            if not np.isclose(in_offset, out_offset):
+                raise ValueError(
+                    "Cross-channel transforms require matching source_time_offset values. "
+                    "Align the channels first or select channels with matching offsets."
+                )
+            result.append(float(in_offset))
+    return np.asarray(result, dtype=float)
 
 
 class ChannelTransformMixin:
@@ -110,7 +127,7 @@ class ChannelTransformMixin:
                 {"operation": operation_name, "params": params},
             ],
             channel_metadata=channel_metadata,
-            source_time_offset=cast(Any, self).source_time_offset,
+            source_time_offset=_build_cross_channel_source_time_offsets(cast(Any, self).source_time_offset),
             previous=self._as_base_frame,
         )
 

--- a/wandas/frames/noct.py
+++ b/wandas/frames/noct.py
@@ -135,8 +135,8 @@ class NOctFrame(BaseFrame[NDArrayReal]):
         operation_history: list[dict[str, Any]] | None = None,
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
-        source_time_offset: float = 0.0,
         previous: "BaseFrame[Any] | None" = None,
+        source_time_offset: float = 0.0,
     ) -> None:
         """
         Initialize a NOctFrame instance.

--- a/wandas/frames/noct.py
+++ b/wandas/frames/noct.py
@@ -135,6 +135,7 @@ class NOctFrame(BaseFrame[NDArrayReal]):
         operation_history: list[dict[str, Any]] | None = None,
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
+        source_time_offset: float = 0.0,
         previous: "BaseFrame[Any] | None" = None,
     ) -> None:
         """
@@ -159,6 +160,7 @@ class NOctFrame(BaseFrame[NDArrayReal]):
             operation_history=operation_history,
             channel_metadata=channel_metadata,
             channel_ids=channel_ids,
+            source_time_offset=source_time_offset,
             previous=previous,
         )
 

--- a/wandas/frames/noct.py
+++ b/wandas/frames/noct.py
@@ -136,7 +136,7 @@ class NOctFrame(BaseFrame[NDArrayReal]):
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
         previous: "BaseFrame[Any] | None" = None,
-        source_time_offset: float = 0.0,
+        source_time_offset: float | Sequence[float] | NDArrayReal = 0.0,
     ) -> None:
         """
         Initialize a NOctFrame instance.

--- a/wandas/frames/roughness.py
+++ b/wandas/frames/roughness.py
@@ -119,6 +119,7 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
         operation_history: list[dict[str, Any]] | None = None,
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
+        source_time_offset: float = 0.0,
         previous: "BaseFrame[Any] | None" = None,
     ) -> None:
         """Initialize a RoughnessFrame."""
@@ -153,6 +154,7 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
             operation_history=operation_history,
             channel_metadata=channel_metadata,
             channel_ids=channel_ids,
+            source_time_offset=source_time_offset,
             previous=previous,
         )
 

--- a/wandas/frames/roughness.py
+++ b/wandas/frames/roughness.py
@@ -120,7 +120,7 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
         previous: "BaseFrame[Any] | None" = None,
-        source_time_offset: float = 0.0,
+        source_time_offset: float | Sequence[float] | NDArrayReal = 0.0,
     ) -> None:
         """Initialize a RoughnessFrame."""
         # Validate dimensions
@@ -224,7 +224,7 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
     @property
     def source_time(self) -> NDArrayReal:
         """Return roughness analysis time points on the source timeline."""
-        return self.time + self.source_time_offset
+        return self.source_time_offset[:, None] + self.time[None, :]
 
     @property
     def overlap(self) -> float:

--- a/wandas/frames/roughness.py
+++ b/wandas/frames/roughness.py
@@ -119,8 +119,8 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
         operation_history: list[dict[str, Any]] | None = None,
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
-        source_time_offset: float = 0.0,
         previous: "BaseFrame[Any] | None" = None,
+        source_time_offset: float = 0.0,
     ) -> None:
         """Initialize a RoughnessFrame."""
         # Validate dimensions
@@ -220,6 +220,11 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
             Time values in seconds for each frame.
         """
         return np.arange(self.n_time_points) / self.sampling_rate
+
+    @property
+    def source_time(self) -> NDArrayReal:
+        """Return roughness analysis time points on the source timeline."""
+        return self.time + self.source_time_offset
 
     @property
     def overlap(self) -> float:

--- a/wandas/frames/roughness.py
+++ b/wandas/frames/roughness.py
@@ -257,6 +257,13 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
         """DataFrame index is not supported for RoughnessFrame."""
         raise NotImplementedError("DataFrame index is not supported for RoughnessFrame.")
 
+    def _source_time_slice_context(self, keys: tuple[Any, ...]) -> tuple[Any, int, float] | None:
+        """Roughness time is stored on the last data axis."""
+        key_index = self._data.ndim - 2
+        if key_index < 0 or key_index >= len(keys):
+            return None
+        return keys[key_index], self._data.shape[-1], 1.0 / self.sampling_rate
+
     def to_dataframe(self) -> "pd.DataFrame":
         """DataFrame conversion is not supported for RoughnessFrame.
 
@@ -337,6 +344,7 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
             operation_history=operation_history,
             channel_metadata=self.channels.to_list(),
             channel_ids=self._channel_ids,
+            source_time_offset=self.source_time_offset,
             previous=self,
         )
 

--- a/wandas/frames/spectral.py
+++ b/wandas/frames/spectral.py
@@ -396,6 +396,7 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             ],
             channel_metadata=self.channels.to_list(),
             channel_ids=self._channel_ids,
+            source_time_offset=self.source_time_offset,
             previous=self,
         )
 

--- a/wandas/frames/spectral.py
+++ b/wandas/frames/spectral.py
@@ -299,6 +299,7 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             operation_history=self.operation_history,
             channel_metadata=self.channels.to_list(),
             channel_ids=self._channel_ids,
+            source_time_offset=self.source_time_offset,
         )
 
     def _get_additional_init_kwargs(self) -> dict[str, Any]:

--- a/wandas/frames/spectral.py
+++ b/wandas/frames/spectral.py
@@ -119,7 +119,7 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
         previous: BaseFrame[Any] | None = None,
-        source_time_offset: float = 0.0,
+        source_time_offset: float | Sequence[float] | NDArrayReal = 0.0,
     ) -> None:
         if data.ndim == 1:
             data = data.reshape(1, -1)

--- a/wandas/frames/spectral.py
+++ b/wandas/frames/spectral.py
@@ -118,8 +118,8 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         operation_history: list[dict[str, Any]] | None = None,
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
-        source_time_offset: float = 0.0,
         previous: BaseFrame[Any] | None = None,
+        source_time_offset: float = 0.0,
     ) -> None:
         if data.ndim == 1:
             data = data.reshape(1, -1)

--- a/wandas/frames/spectral.py
+++ b/wandas/frames/spectral.py
@@ -118,6 +118,7 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         operation_history: list[dict[str, Any]] | None = None,
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
+        source_time_offset: float = 0.0,
         previous: BaseFrame[Any] | None = None,
     ) -> None:
         if data.ndim == 1:
@@ -134,6 +135,7 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             operation_history=operation_history,
             channel_metadata=channel_metadata,
             channel_ids=channel_ids,
+            source_time_offset=source_time_offset,
             previous=previous,
         )
 

--- a/wandas/frames/spectrogram.py
+++ b/wandas/frames/spectrogram.py
@@ -461,6 +461,7 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             operation_history=self.operation_history,
             channel_metadata=self.channels.to_list(),
             channel_ids=self._channel_ids,
+            source_time_offset=self.source_time_offset,
         )
 
     def istft(self) -> "ChannelFrame":

--- a/wandas/frames/spectrogram.py
+++ b/wandas/frames/spectrogram.py
@@ -414,6 +414,7 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             operation_history=self.operation_history,
             channel_metadata=self.channels.to_list(),
             channel_ids=self._channel_ids,
+            source_time_offset=self.source_time_offset + float(self.times[time_idx]),
         )
 
     def to_channel_frame(self) -> "ChannelFrame":

--- a/wandas/frames/spectrogram.py
+++ b/wandas/frames/spectrogram.py
@@ -116,6 +116,7 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         operation_history: list[dict[str, Any]] | None = None,
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
+        source_time_offset: float = 0.0,
         previous: "BaseFrame[Any] | None" = None,
     ) -> None:
         if data.ndim == 2:
@@ -148,6 +149,7 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             operation_history=operation_history,
             channel_metadata=channel_metadata,
             channel_ids=channel_ids,
+            source_time_offset=source_time_offset,
             previous=previous,
         )
 
@@ -198,6 +200,11 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             Array of time values corresponding to each time frame.
         """
         return np.arange(self.n_frames) * self.hop_length / self.sampling_rate
+
+    @property
+    def source_times(self) -> NDArrayReal:
+        """Get frame times relative to the original source timeline."""
+        return self.times + self.source_time_offset
 
     def plot(
         self,

--- a/wandas/frames/spectrogram.py
+++ b/wandas/frames/spectrogram.py
@@ -116,8 +116,8 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         operation_history: list[dict[str, Any]] | None = None,
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
-        source_time_offset: float = 0.0,
         previous: "BaseFrame[Any] | None" = None,
+        source_time_offset: float = 0.0,
     ) -> None:
         if data.ndim == 2:
             data = da.expand_dims(data, axis=0)

--- a/wandas/frames/spectrogram.py
+++ b/wandas/frames/spectrogram.py
@@ -117,7 +117,7 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
         channel_ids: list[str] | None = None,
         previous: "BaseFrame[Any] | None" = None,
-        source_time_offset: float = 0.0,
+        source_time_offset: float | Sequence[float] | NDArrayReal = 0.0,
     ) -> None:
         if data.ndim == 2:
             data = da.expand_dims(data, axis=0)
@@ -204,7 +204,7 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
     @property
     def source_times(self) -> NDArrayReal:
         """Get frame times relative to the original source timeline."""
-        return self.times + self.source_time_offset
+        return self.source_time_offset[:, None] + self.times[None, :]
 
     def plot(
         self,

--- a/wandas/io/readers.py
+++ b/wandas/io/readers.py
@@ -263,6 +263,7 @@ class CSVFileReader(FileReader):
             # Get time column as Series
             time_series = df[time_column] if isinstance(time_column, str) else df.iloc[:, time_column]
             time_values = np.array(time_series.values)
+            time_start = float(time_values[0]) if len(time_values) > 0 else 0.0
             if len(time_values) > 1:
                 # Use round() instead of int() to handle floating-point precision issues
                 estimated_sr = round(1 / np.mean(np.diff(time_values)))
@@ -270,6 +271,7 @@ class CSVFileReader(FileReader):
                 estimated_sr = 0  # Cannot determine from single row
         except Exception:
             estimated_sr = 0  # Default if can't calculate
+            time_start = 0.0
 
         frames = df.shape[0]
         duration = frames / estimated_sr if estimated_sr else None
@@ -282,6 +284,7 @@ class CSVFileReader(FileReader):
             "format": "CSV",
             "duration": duration,
             "ch_labels": df.columns[1:].tolist(),  # Assuming first column is time
+            "time_start": time_start,
         }
 
     @classmethod

--- a/wandas/io/wdf_io.py
+++ b/wandas/io/wdf_io.py
@@ -221,7 +221,7 @@ def load(path: str | Path, *, format: str = "hdf5", timeout: float = 10.0) -> "C
         # Get global attributes
         sampling_rate = float(f.attrs["sampling_rate"])
         frame_label = _decode_hdf5_str(f.attrs.get("label", ""))
-        source_time_offset = float(f.attrs.get("source_time_offset", 0.0))
+        source_time_offset = f.attrs.get("source_time_offset", 0.0)
 
         # Get frame metadata
         frame_metadata: dict[str, Any] = {}

--- a/wandas/io/wdf_io.py
+++ b/wandas/io/wdf_io.py
@@ -96,7 +96,6 @@ def save(
         f.attrs["sampling_rate"] = frame.sampling_rate
         f.attrs["label"] = frame.label or ""
         f.attrs["frame_type"] = type(frame).__name__
-        f.attrs["source_time_offset"] = frame.source_time_offset
         f.attrs["channel_ids_json"] = json.dumps(frame._channel_ids)
 
         # Create channels group
@@ -116,6 +115,7 @@ def save(
             ch_grp.attrs["label"] = ch_meta.label
             ch_grp.attrs["unit"] = ch_meta.unit
             ch_grp.attrs["ref"] = ch_meta.ref
+            ch_grp.attrs["source_time_offset"] = frame.source_time_offset[i]
 
             # Store extra metadata as JSON
             if ch_meta.extra:
@@ -221,7 +221,7 @@ def load(path: str | Path, *, format: str = "hdf5", timeout: float = 10.0) -> "C
         # Get global attributes
         sampling_rate = float(f.attrs["sampling_rate"])
         frame_label = _decode_hdf5_str(f.attrs.get("label", ""))
-        source_time_offset = f.attrs.get("source_time_offset", 0.0)
+        legacy_source_time_offset = f.attrs.get("source_time_offset", None)
 
         # Get frame metadata
         frame_metadata: dict[str, Any] = {}
@@ -259,6 +259,7 @@ def load(path: str | Path, *, format: str = "hdf5", timeout: float = 10.0) -> "C
         # Load channel data and metadata
         all_channel_data = []
         channel_metadata_list = []
+        channel_source_time_offsets = []
         channel_ids = None
         if "channel_ids_json" in f.attrs:
             parsed_channel_ids = json.loads(_decode_hdf5_str(f.attrs["channel_ids_json"]))
@@ -283,6 +284,8 @@ def load(path: str | Path, *, format: str = "hdf5", timeout: float = 10.0) -> "C
                 label = _decode_hdf5_str(ch_group.attrs.get("label", f"Ch{idx}"))
                 unit = _decode_hdf5_str(ch_group.attrs.get("unit", ""))
                 ref = float(ch_group.attrs["ref"]) if "ref" in ch_group.attrs else None
+                if "source_time_offset" in ch_group.attrs:
+                    channel_source_time_offsets.append(float(ch_group.attrs["source_time_offset"]))
 
                 # Load additional metadata if present
                 ch_extra = {}
@@ -301,6 +304,13 @@ def load(path: str | Path, *, format: str = "hdf5", timeout: float = 10.0) -> "C
             combined_data = np.stack(all_channel_data, axis=0)
         else:
             raise ValueError("No channel data found in the file")
+
+        if channel_source_time_offsets:
+            source_time_offset = channel_source_time_offsets
+        elif legacy_source_time_offset is not None:
+            source_time_offset = legacy_source_time_offset
+        else:
+            source_time_offset = 0.0
 
         # Create a new ChannelFrame
         # Use channel-wise chunking: 1 for channel axis and -1 for samples

--- a/wandas/io/wdf_io.py
+++ b/wandas/io/wdf_io.py
@@ -96,6 +96,7 @@ def save(
         f.attrs["sampling_rate"] = frame.sampling_rate
         f.attrs["label"] = frame.label or ""
         f.attrs["frame_type"] = type(frame).__name__
+        f.attrs["source_time_offset"] = frame.source_time_offset
         f.attrs["channel_ids_json"] = json.dumps(frame._channel_ids)
 
         # Create channels group
@@ -220,6 +221,7 @@ def load(path: str | Path, *, format: str = "hdf5", timeout: float = 10.0) -> "C
         # Get global attributes
         sampling_rate = float(f.attrs["sampling_rate"])
         frame_label = _decode_hdf5_str(f.attrs.get("label", ""))
+        source_time_offset = float(f.attrs.get("source_time_offset", 0.0))
 
         # Get frame metadata
         frame_metadata: dict[str, Any] = {}
@@ -312,6 +314,7 @@ def load(path: str | Path, *, format: str = "hdf5", timeout: float = 10.0) -> "C
             operation_history=operation_history,
             channel_metadata=channel_metadata_list,
             channel_ids=channel_ids,
+            source_time_offset=source_time_offset,
         )
 
         logger.debug(f"ChannelFrame loaded from {path}: {len(cf)} channels, {cf.n_samples} samples")


### PR DESCRIPTION
## Summary
- Add `source_time_offset` as channel-wise BaseFrame state stored in xarray attrs.
- Keep the API offset-only: scalar inputs are broadcast to all channels, and per-channel arrays are preserved through channel operations.
- Add source-relative time accessors for `ChannelFrame.source_time`, `SpectrogramFrame.source_times`, and roughness analysis time.
- Advance offsets for `from_file(start=...)`, `trim()`, and continuous time slicing.
- Persist and restore channel-wise `source_time_offset` in WDF files, with legacy scalar/missing attrs broadcast on load.

This intentionally stays in the simpler offset-only scope. It does not introduce `source_time_range`, range comparisons, `source_time_window_length`, resampling/realignment, or range propagation APIs.

## Notes
- `add_channel(ChannelFrame)` now preserves different channel source offsets by concatenating the incoming frame's per-channel offsets.
- Operations that combine channels into a single derived channel, or pair channels for cross-channel spectra, require compatible source offsets because a single output channel cannot represent mixed source timelines without alignment.

## Test plan
- `python -m pytest`
- `ruff check`
- `ruff format --check`
- `ty check`