### PR TITLE
[codex] Bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wandas"
-version = "0.2.0"
+version = "0.3.0"
 description = "Wandas is an open source library for efficient signal analysis in Python"
 authors = [{name = "kasahart", email="kasahart66@gmail.com"}]
 maintainers = [

--- a/uv.lock
+++ b/uv.lock
@@ -3919,7 +3919,7 @@ wheels = [
 
 [[package]]
 name = "wandas"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "cattrs" },


### PR DESCRIPTION
## Summary

- Bump the project version from `0.2.0` to `0.3.0` in `pyproject.toml`.
- Sync the editable package version in `uv.lock`.

## Validation

- `uv lock`
- `uv run python -c "import wandas; print(wandas.__version__)"` returned `0.3.0`.