### PR TITLE
Phase 1: Add Dask graph operation lineage PoC

### DIFF
--- a/tests/core/test_base_frame_lineage.py
+++ b/tests/core/test_base_frame_lineage.py
@@ -197,6 +197,18 @@ def test_operations_prefers_nested_marker_over_alias() -> None:
     assert [operation.name for operation in operations] == ["normalize", "sum"]
 
 
+def test_operations_preserves_fused_native_markers_before_normalize() -> None:
+    operations = _frame().abs().power(exponent=2.0).normalize().operations
+
+    assert [operation.name for operation in operations] == ["abs", "power", "normalize"]
+
+
+def test_operations_preserves_fused_native_markers_before_stft() -> None:
+    operations = _frame().abs().power(exponent=2.0).stft(n_fft=64, hop_length=16).operations
+
+    assert [operation.name for operation in operations] == ["abs", "power", "stft"]
+
+
 def test_operation_history_public_behavior_is_unchanged() -> None:
     frame = _frame()
     history: list[dict[str, object]] = [{"operation": "load", "params": {"path": "input.wav"}}]

--- a/tests/core/test_base_frame_lineage.py
+++ b/tests/core/test_base_frame_lineage.py
@@ -22,6 +22,16 @@ def _frame() -> ChannelFrame:
     return ChannelFrame(da_from_array(data, chunks=(1, -1)), sampling_rate=16000, label="lineage")
 
 
+def _stereo_frame() -> ChannelFrame:
+    data = np.vstack(
+        [
+            np.linspace(-1.0, 1.0, 4096, dtype=np.float64),
+            np.linspace(1.0, -1.0, 4096, dtype=np.float64),
+        ]
+    )
+    return ChannelFrame(da_from_array(data, chunks=(1, -1)), sampling_rate=16000, label="lineage")
+
+
 class _GraphCollection:
     def __init__(self, graph: dict[object, object]):
         self._graph = graph
@@ -115,6 +125,36 @@ def test_operations_extracts_custom_operation_instance() -> None:
     assert isinstance(operations[0], CustomOperation)
     assert operations[0].func is scale
     assert operations[0].params == {"gain": 2.0}
+
+
+def test_operations_includes_stats_operation_before_normalize() -> None:
+    operations = _frame().abs().normalize().operations
+
+    assert [operation.name for operation in operations] == ["abs", "normalize"]
+
+
+def test_operations_includes_power_params() -> None:
+    operations = _frame().power(exponent=2.0).operations
+
+    assert [operation.name for operation in operations] == ["power"]
+    assert operations[0].params == {"exponent": 2.0}
+
+
+def test_operations_includes_channel_reductions() -> None:
+    summed = _stereo_frame().sum()
+    averaged = _stereo_frame().mean()
+
+    assert [operation.name for operation in summed.operations] == ["sum"]
+    assert [operation.name for operation in averaged.operations] == ["mean"]
+    assert summed.n_channels == 1
+    assert averaged.n_channels == 1
+
+
+def test_operations_includes_channel_difference() -> None:
+    operations = _stereo_frame().channel_difference(other_channel=0).operations
+
+    assert [operation.name for operation in operations] == ["channel_difference"]
+    assert operations[0].params == {"other_channel": 0}
 
 
 def test_operation_history_public_behavior_is_unchanged() -> None:

--- a/tests/core/test_base_frame_lineage.py
+++ b/tests/core/test_base_frame_lineage.py
@@ -1,0 +1,104 @@
+from unittest import mock
+
+import dask.array as da
+import numpy as np
+import pytest
+from dask.delayed import delayed
+
+from wandas.frames.channel import ChannelFrame
+from wandas.processing.custom import CustomOperation
+from wandas.processing.effects import Normalize
+from wandas.processing.filters import HighPassFilter
+from wandas.processing.spectral import STFT
+from wandas.utils.dask_helpers import da_from_array
+from wandas.utils.types import NDArrayReal
+
+
+def _frame() -> ChannelFrame:
+    data = np.linspace(-1.0, 1.0, 4096, dtype=np.float64).reshape(1, -1)
+    return ChannelFrame(da_from_array(data, chunks=(1, -1)), sampling_rate=16000, label="lineage")
+
+
+def test_operations_extracts_serial_chain_in_dependency_order() -> None:
+    result = _frame().high_pass_filter(100).normalize().stft(n_fft=64, hop_length=16)
+
+    operations = result.operations
+
+    assert [operation.name for operation in operations] == ["highpass_filter", "normalize", "stft"]
+    assert isinstance(operations[0], HighPassFilter)
+    assert isinstance(operations[1], Normalize)
+    assert isinstance(operations[2], STFT)
+
+
+def test_operations_keeps_repeated_operations_as_distinct_instances() -> None:
+    result = _frame().normalize().normalize()
+
+    operations = result.operations
+
+    assert [operation.name for operation in operations] == ["normalize", "normalize"]
+    assert operations[0] is not operations[1]
+
+
+def test_operations_ignores_dask_internal_tasks_rechunk_and_from_delayed() -> None:
+    delayed_data = delayed(lambda: np.ones((1, 32), dtype=np.float64))()
+    dask_data = da.from_delayed(delayed_data, shape=(1, 32), dtype=np.float64).rechunk((1, -1))
+    frame = ChannelFrame(dask_data, sampling_rate=16000)
+
+    assert frame.operations == ()
+
+
+def test_operations_stable_after_compute_on_same_frame_graph() -> None:
+    result = _frame().high_pass_filter(100).normalize()
+    before = result.operations
+
+    _ = result.compute()
+
+    assert result.operations == before
+
+
+def test_operations_does_not_compute_data() -> None:
+    result = _frame().normalize()
+
+    with mock.patch("dask.array.core.Array.compute") as compute:
+        operations = result.operations
+
+    compute.assert_not_called()
+    assert [operation.name for operation in operations] == ["normalize"]
+
+
+def test_operations_extracts_custom_operation_instance() -> None:
+    def scale(x: NDArrayReal, gain: float) -> NDArrayReal:
+        return x * gain
+
+    result = _frame().apply(scale, gain=2.0)
+
+    operations = result.operations
+
+    assert len(operations) == 1
+    assert isinstance(operations[0], CustomOperation)
+    assert operations[0].func is scale
+    assert operations[0].params == {"gain": 2.0}
+
+
+def test_operation_history_public_behavior_is_unchanged() -> None:
+    frame = _frame()
+    history: list[dict[str, object]] = [{"operation": "load", "params": {"path": "input.wav"}}]
+    frame.operation_history = history
+    history[0]["operation"] = "mutated"
+
+    assert frame.operation_history == [{"operation": "load", "params": {"path": "input.wav"}}]
+
+    frame.operation_history.append({"operation": "normalize", "params": {}})
+
+    assert frame._xr.attrs["operation_history"] == [
+        {"operation": "load", "params": {"path": "input.wav"}},
+        {"operation": "normalize", "params": {}},
+    ]
+
+
+def test_operations_property_is_read_only_sequence() -> None:
+    result = _frame().normalize()
+
+    assert isinstance(result.operations, tuple)
+    with pytest.raises(AttributeError):
+        result.operations = ()  # ty: ignore[invalid-assignment]

--- a/tests/core/test_base_frame_lineage.py
+++ b/tests/core/test_base_frame_lineage.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest import mock
 
 import dask.array as da
@@ -6,6 +7,8 @@ import pytest
 from dask.delayed import delayed
 
 from wandas.frames.channel import ChannelFrame
+from wandas.lineage import extract_operations
+from wandas.processing.base import AudioOperation, _execute_wandas_operation
 from wandas.processing.custom import CustomOperation
 from wandas.processing.effects import Normalize
 from wandas.processing.filters import HighPassFilter
@@ -17,6 +20,21 @@ from wandas.utils.types import NDArrayReal
 def _frame() -> ChannelFrame:
     data = np.linspace(-1.0, 1.0, 4096, dtype=np.float64).reshape(1, -1)
     return ChannelFrame(da_from_array(data, chunks=(1, -1)), sampling_rate=16000, label="lineage")
+
+
+class _GraphCollection:
+    def __init__(self, graph: dict[object, object]):
+        self._graph = graph
+
+    def __dask_graph__(self) -> dict[object, object]:
+        return self._graph
+
+
+class _LineageTestOperation(AudioOperation[NDArrayReal, NDArrayReal]):
+    name = "lineage_test"
+
+    def _process_array(self, x: NDArrayReal) -> NDArrayReal:
+        return x
 
 
 def test_operations_extracts_serial_chain_in_dependency_order() -> None:
@@ -45,6 +63,25 @@ def test_operations_ignores_dask_internal_tasks_rechunk_and_from_delayed() -> No
     frame = ChannelFrame(dask_data, sampling_rate=16000)
 
     assert frame.operations == ()
+
+
+def test_extract_operations_rejects_non_dask_collection() -> None:
+    with pytest.raises(TypeError, match="Expected a Dask collection with __dask_graph__"):
+        extract_operations(object())
+
+
+def test_operations_preserves_tuple_key_dependencies_in_legacy_graph() -> None:
+    first = _LineageTestOperation(16000)
+    second = _LineageTestOperation(16000)
+    first_key = ("first", 0, 0)
+    graph: dict[Any, Any] = {
+        "second": (_execute_wandas_operation, second, first_key),
+        first_key: (_execute_wandas_operation, first, "source"),
+    }
+
+    operations = extract_operations(_GraphCollection(graph))
+
+    assert operations == (first, second)
 
 
 def test_operations_stable_after_compute_on_same_frame_graph() -> None:

--- a/tests/core/test_base_frame_lineage.py
+++ b/tests/core/test_base_frame_lineage.py
@@ -32,6 +32,16 @@ def _stereo_frame() -> ChannelFrame:
     return ChannelFrame(da_from_array(data, chunks=(1, -1)), sampling_rate=16000, label="lineage")
 
 
+def _int_stereo_frame() -> ChannelFrame:
+    data = np.vstack(
+        [
+            np.arange(4096, dtype=np.int16),
+            np.arange(4096, dtype=np.int16) * -1,
+        ]
+    )
+    return ChannelFrame(da_from_array(data, chunks=(1, -1)), sampling_rate=16000, label="lineage")
+
+
 class _GraphCollection:
     def __init__(self, graph: dict[object, object]):
         self._graph = graph
@@ -133,11 +143,27 @@ def test_operations_includes_stats_operation_before_normalize() -> None:
     assert [operation.name for operation in operations] == ["abs", "normalize"]
 
 
+def test_operations_deduplicates_chunked_stats_markers() -> None:
+    operations = _stereo_frame().abs().operations
+
+    assert [operation.name for operation in operations] == ["abs"]
+
+
 def test_operations_includes_power_params() -> None:
     operations = _frame().power(exponent=2.0).operations
 
     assert [operation.name for operation in operations] == ["power"]
     assert operations[0].params == {"exponent": 2.0}
+
+
+def test_stats_operations_keep_dask_native_dtype_and_chunks() -> None:
+    frame = _int_stereo_frame()
+    meaned = frame.mean()
+    absolute = frame.abs()
+
+    assert meaned._data.dtype == np.float64
+    assert meaned.compute().dtype == np.float64
+    assert absolute._data.chunks == frame._data.chunks
 
 
 def test_operations_includes_channel_reductions() -> None:
@@ -155,6 +181,20 @@ def test_operations_includes_channel_difference() -> None:
 
     assert [operation.name for operation in operations] == ["channel_difference"]
     assert operations[0].params == {"other_channel": 0}
+
+
+def test_operations_preserves_negative_channel_difference_indices() -> None:
+    frame = _stereo_frame()
+    result = frame.channel_difference(other_channel=-1)
+
+    assert [operation.name for operation in result.operations] == ["channel_difference"]
+    np.testing.assert_allclose(result.compute(), frame.compute() - frame.compute()[-1])
+
+
+def test_operations_prefers_nested_marker_over_alias() -> None:
+    operations = _stereo_frame().normalize().sum().operations
+
+    assert [operation.name for operation in operations] == ["normalize", "sum"]
 
 
 def test_operation_history_public_behavior_is_unchanged() -> None:

--- a/tests/processing/test_base_operations.py
+++ b/tests/processing/test_base_operations.py
@@ -209,10 +209,11 @@ class TestAudioOperation:
         for pure_val in (True, False):
             op = test_op_cls(16000, pure=pure_val)
             with mock.patch("wandas.processing.base.delayed") as mock_delayed:
-                mock_delayed.return_value = lambda x: mock.MagicMock()
+                mock_delayed.return_value = lambda *args: mock.MagicMock()
                 op.process_array(test_array)
                 _, kwargs = mock_delayed.call_args
                 assert kwargs["pure"] is pure_val
+                assert kwargs["name"] == op.name
 
     def test_get_metadata_updates_returns_empty_dict(self) -> None:
         """Base class get_metadata_updates() returns empty dict by default."""

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
     from IPython.display import Image as IPythonImage
     from matplotlib.axes import Axes
 
+    from wandas.processing.base import AudioOperation
+
     VisualizeReturnType: TypeAlias = IPythonImage | None
 else:
     # Use Any at runtime to avoid type checker errors
@@ -452,6 +454,13 @@ class BaseFrame(ABC, Generic[T]):
         if not isinstance(value, list):
             raise TypeError("Operation history must be a list")
         self._xr.attrs["operation_history"] = copy.deepcopy(value)
+
+    @property
+    def operations(self) -> tuple["AudioOperation[Any, Any]", ...]:
+        """Return Wandas operation instances found in the lazy Dask graph."""
+        from wandas.lineage import extract_operations
+
+        return extract_operations(self._data)
 
     @property
     def source_time_offset(self) -> NDArrayReal:

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -304,14 +304,16 @@ class ChannelProcessingMixin:
 
     def _reduce_channels(self: T_Processing, op: str) -> T_Processing:
         """Helper to reduce all channels with the given operation ('sum' or 'mean')."""
+        from wandas.processing import create_operation
+
         if op == "sum":
-            reduced_data = self._data.sum(axis=0, keepdims=True)
             label = "sum"
         elif op == "mean":
-            reduced_data = self._data.mean(axis=0, keepdims=True)
             label = "mean"
         else:
             raise ValueError(f"Unsupported reduction operation: {op}")
+        operation = create_operation(op, self.sampling_rate)
+        reduced_data = operation.process(self._data)
 
         units = [ch.unit for ch in self._channel_metadata]
         reduced_unit = units[0] if all(u == units[0] for u in units) else ""

--- a/wandas/lineage.py
+++ b/wandas/lineage.py
@@ -1,0 +1,214 @@
+"""Extract Wandas operation lineage from lazy Dask graphs."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from wandas.processing.base import AudioOperation, _execute_wandas_operation
+
+
+@dataclass(frozen=True)
+class _OperationNode:
+    key: Any
+    operation: AudioOperation[Any, Any]
+    dependencies: frozenset[Any]
+
+
+def extract_operations(collection: Any) -> tuple[AudioOperation[Any, Any], ...]:
+    """Return Wandas operations embedded in an unoptimized Dask collection graph."""
+    graph = _collection_graph(collection)
+    nodes = _operation_nodes(graph)
+    if not nodes:
+        return ()
+    return tuple(node.operation for node in _ordered_operation_nodes(nodes, graph))
+
+
+def _collection_graph(collection: Any) -> Mapping[Any, Any]:
+    dask_graph = collection.__dask_graph__()
+    if hasattr(dask_graph, "to_dict"):
+        graph = dask_graph.to_dict()
+    else:
+        graph = dict(dask_graph)
+    if not isinstance(graph, Mapping):
+        raise TypeError(f"Dask graph must be a mapping, got {type(graph).__name__}")
+    return _flatten_graph(graph)
+
+
+def _flatten_graph(graph: Mapping[Any, Any]) -> Mapping[Any, Any]:
+    flattened: dict[Any, Any] = dict(graph)
+    stack = list(graph.values())
+    seen_tasks = {id(task) for task in stack}
+    while stack:
+        task = stack.pop()
+        _, args = _task_func_and_args(task)
+        for value in _walk_values(args, include_containers=True):
+            if _looks_like_dask_task(value) and id(value) not in seen_tasks:
+                seen_tasks.add(id(value))
+                stack.append(value)
+            if not _is_graph_mapping(value):
+                continue
+            for key, nested_task in value.items():
+                if key not in flattened:
+                    flattened[key] = nested_task
+                    stack.append(nested_task)
+    return flattened
+
+
+def _is_graph_mapping(value: Any) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    return any(_looks_like_dask_task(item) for item in value.values())
+
+
+def _looks_like_dask_task(value: Any) -> bool:
+    return (
+        hasattr(value, "func")
+        or hasattr(value, "target")
+        or value.__class__.__module__.startswith("dask.")
+        or isinstance(value, tuple)
+    )
+
+
+def _operation_nodes(graph: Mapping[Any, Any]) -> dict[Any, _OperationNode]:
+    nodes: dict[Any, _OperationNode] = {}
+    for key, task in graph.items():
+        marker = _operation_marker(task)
+        if marker is None:
+            continue
+        nodes[key] = _OperationNode(
+            key=key,
+            operation=marker,
+            dependencies=frozenset(_task_dependencies(task, graph)),
+        )
+    return nodes
+
+
+def _operation_marker(task: Any) -> AudioOperation[Any, Any] | None:
+    func, args = _task_func_and_args(task)
+    if func is not _execute_wandas_operation:
+        return None
+    for arg in args:
+        if isinstance(arg, AudioOperation):
+            return arg
+    return None
+
+
+def _task_func_and_args(task: Any) -> tuple[Any, tuple[Any, ...]]:
+    func = getattr(task, "func", None)
+    args = getattr(task, "args", None)
+    if func is not None and args is not None:
+        return func, tuple(args)
+    if isinstance(task, tuple) and task:
+        return task[0], tuple(task[1:])
+    return None, ()
+
+
+def _task_dependencies(task: Any, graph: Mapping[Any, Any]) -> set[Any]:
+    graph_keys = set(graph)
+    discovered = {
+        key
+        for key in (_reference_key(value, graph_keys) for value in _walk_values(_task_func_and_args(task)[1]))
+        if key is not None
+    }
+    discovered.update(_inline_task_output_dependencies(task, graph_keys))
+
+    dependencies = getattr(task, "dependencies", None)
+    if dependencies is not None:
+        return {_dependency_key(dep) for dep in dependencies} | discovered
+
+    return discovered
+
+
+def _inline_task_output_dependencies(task: Any, graph_keys: set[Any]) -> set[Any]:
+    dependencies: set[Any] = set()
+    for value in _walk_values(_task_func_and_args(task)[1]):
+        if not _looks_like_dask_task(value):
+            continue
+        func, args = _task_func_and_args(value)
+        if getattr(func, "__name__", None) != "_execute_subgraph" or len(args) < 2:
+            continue
+        output_key = _reference_key(args[1], graph_keys)
+        if output_key is not None:
+            dependencies.add(output_key)
+    return dependencies
+
+
+def _ordered_operation_nodes(
+    nodes: Mapping[Any, _OperationNode],
+    graph: Mapping[Any, Any],
+) -> list[_OperationNode]:
+    direct_operation_deps = {
+        key: _reachable_operation_dependencies(node.dependencies, nodes, graph) for key, node in nodes.items()
+    }
+
+    ordered: list[_OperationNode] = []
+    remaining = dict(nodes)
+    while remaining:
+        progressed = False
+        for key, node in list(remaining.items()):
+            if direct_operation_deps[key].isdisjoint(remaining):
+                ordered.append(node)
+                del remaining[key]
+                progressed = True
+        if not progressed:
+            ordered.extend(remaining.values())
+            break
+    return ordered
+
+
+def _reachable_operation_dependencies(
+    start_keys: Iterable[Any],
+    nodes: Mapping[Any, _OperationNode],
+    graph: Mapping[Any, Any],
+) -> set[Any]:
+    found: set[Any] = set()
+    seen: set[Any] = set()
+    stack = list(start_keys)
+    while stack:
+        key = stack.pop()
+        if key in seen:
+            continue
+        seen.add(key)
+        if key in nodes:
+            found.add(key)
+            continue
+        task = graph.get(key)
+        if task is not None:
+            stack.extend(_task_dependencies(task, graph))
+    return found
+
+
+def _dependency_key(value: Any) -> Any:
+    return getattr(value, "key", value)
+
+
+def _reference_key(value: Any, graph_keys: set[Any]) -> Any | None:
+    try:
+        if value in graph_keys:
+            return value
+    except TypeError:
+        pass
+    key = getattr(value, "key", None)
+    try:
+        if key in graph_keys:
+            return key
+    except TypeError:
+        pass
+    return None
+
+
+def _walk_values(values: Any, *, include_containers: bool = False) -> Iterable[Any]:
+    if include_containers:
+        yield values
+    if isinstance(values, Mapping):
+        for key, value in values.items():
+            yield key
+            yield from _walk_values(value, include_containers=include_containers)
+        return
+    if isinstance(values, tuple | list | set | frozenset):
+        for value in values:
+            yield from _walk_values(value, include_containers=include_containers)
+        return
+    yield values

--- a/wandas/lineage.py
+++ b/wandas/lineage.py
@@ -18,6 +18,38 @@ class _OperationNode:
     dependencies: frozenset[Any]
 
 
+@dataclass(frozen=True)
+class _SubgraphTask:
+    task: Any
+    substitutions: Mapping[Any, Any]
+    key_map: Mapping[Any, Any]
+
+    @property
+    def dependencies(self) -> frozenset[Any]:
+        dependencies = getattr(self.task, "dependencies", None)
+        if dependencies is None:
+            return frozenset()
+        resolved: set[Any] = set()
+        for dependency in dependencies:
+            value = _resolve_subgraph_value(dependency, self.substitutions, self.key_map)
+            try:
+                hash(value)
+            except TypeError:
+                continue
+            resolved.add(value)
+        return frozenset(resolved)
+
+
+@dataclass(frozen=True)
+class _SubgraphOutputTask:
+    task: Any
+    output_dependency: Any
+
+    @property
+    def dependencies(self) -> frozenset[Any]:
+        return frozenset({self.output_dependency})
+
+
 def extract_operations(collection: Any) -> tuple[AudioOperation[Any, Any], ...]:
     """Return Wandas operations embedded in an unoptimized Dask collection graph."""
     graph = _collection_graph(collection)
@@ -43,22 +75,46 @@ def _collection_graph(collection: Any) -> Mapping[Any, Any]:
 
 def _flatten_graph(graph: Mapping[Any, Any]) -> Mapping[Any, Any]:
     flattened: dict[Any, Any] = dict(graph)
-    stack = list(graph.values())
-    seen_tasks = {id(task) for task in stack}
+    stack = list(graph.items())
+    seen_tasks = {id(task) for task in graph.values()}
     while stack:
-        task = stack.pop()
+        key, task = stack.pop()
+        subgraph_tasks, output_dependency = _subgraph_tasks(key, task)
+        if output_dependency is not None:
+            flattened[key] = _SubgraphOutputTask(task, output_dependency)
+        for nested_key, nested_task in subgraph_tasks.items():
+            if nested_key not in flattened or _prefers_nested_task(flattened[nested_key], nested_task):
+                flattened[nested_key] = nested_task
+                stack.append((nested_key, nested_task))
+        if output_dependency is not None:
+            continue
+
         _, args = _task_func_and_args(task)
         for value in _walk_values(args, include_containers=True):
             if _looks_like_dask_task(value) and id(value) not in seen_tasks:
                 seen_tasks.add(id(value))
-                stack.append(value)
+                stack.append((_dependency_key(value), value))
             if not _is_graph_mapping(value):
                 continue
             for key, nested_task in value.items():
                 if key not in flattened or _prefers_nested_task(flattened[key], nested_task):
                     flattened[key] = nested_task
-                    stack.append(nested_task)
+                    stack.append((key, nested_task))
     return flattened
+
+
+def _subgraph_tasks(parent_key: Any, task: Any) -> tuple[Mapping[Any, _SubgraphTask], Any | None]:
+    func, args = _task_func_and_args(task)
+    if getattr(func, "__name__", None) != "_execute_subgraph" or len(args) < 2 or not isinstance(args[0], Mapping):
+        return {}, None
+    subgraph = args[0]
+    key_map = {key: (parent_key, key) for key in subgraph}
+    substitutions = _subgraph_substitutions(args)
+    output_dependency = key_map.get(_dependency_key(args[1]))
+    return {
+        key_map[key]: _SubgraphTask(nested_task, substitutions=substitutions, key_map=key_map)
+        for key, nested_task in subgraph.items()
+    }, output_dependency
 
 
 def _prefers_nested_task(existing_task: Any, nested_task: Any) -> bool:
@@ -91,12 +147,6 @@ def _operation_nodes(graph: Mapping[Any, Any]) -> dict[Any, _OperationNode]:
         operation_id = id(marker)
         existing_key = operation_keys.get(operation_id)
         if existing_key is not None:
-            existing_node = nodes[existing_key]
-            nodes[existing_key] = _OperationNode(
-                key=existing_node.key,
-                operation=existing_node.operation,
-                dependencies=existing_node.dependencies | dependencies,
-            )
             continue
         operation_keys[operation_id] = key
         nodes[key] = _OperationNode(key=key, operation=marker, dependencies=dependencies)
@@ -106,24 +156,10 @@ def _operation_nodes(graph: Mapping[Any, Any]) -> dict[Any, _OperationNode]:
 def _operation_marker(task: Any) -> AudioOperation[Any, Any] | None:
     func, args = _task_func_and_args(task)
     if getattr(func, "__name__", None) == "_execute_subgraph":
-        return _subgraph_operation_marker(args)
+        return None
     if not any(func is marker_func for marker_func in _OPERATION_MARKER_FUNCTIONS):
         return None
     return _operation_from_args(args)
-
-
-def _subgraph_operation_marker(args: tuple[Any, ...]) -> AudioOperation[Any, Any] | None:
-    if len(args) < 2 or not isinstance(args[0], Mapping):
-        return None
-    subgraph = args[0]
-    output_task = subgraph.get(_dependency_key(args[1]))
-    if output_task is None:
-        return None
-    func, output_args = _task_func_and_args(output_task)
-    if not any(func is marker_func for marker_func in _OPERATION_MARKER_FUNCTIONS):
-        return None
-    substitutions = _subgraph_substitutions(args)
-    return _operation_from_args(output_args, substitutions)
 
 
 def _subgraph_substitutions(args: tuple[Any, ...]) -> dict[Any, Any]:
@@ -151,6 +187,12 @@ def _literal_value(value: Any) -> Any:
 
 
 def _task_func_and_args(task: Any) -> tuple[Any, tuple[Any, ...]]:
+    if isinstance(task, _SubgraphTask):
+        func, args = _task_func_and_args(task.task)
+        return (
+            func,
+            tuple(_resolve_subgraph_value(arg, task.substitutions, task.key_map) for arg in args),
+        )
     func = getattr(task, "func", None)
     args = getattr(task, "args", None)
     if func is not None and args is not None:
@@ -162,9 +204,10 @@ def _task_func_and_args(task: Any) -> tuple[Any, tuple[Any, ...]]:
 
 def _task_dependencies(task: Any, graph: Mapping[Any, Any]) -> set[Any]:
     graph_keys = set(graph)
+    task_args = _task_func_and_args(task)[1]
     discovered = {
         key
-        for key in (_reference_key(value, graph_keys) for value in _walk_values(_task_func_and_args(task)[1]))
+        for key in (_reference_key(value, graph_keys) for value in _walk_references(task_args, graph_keys))
         if key is not None
     }
     discovered.update(_inline_task_output_dependencies(task, graph_keys))
@@ -195,7 +238,7 @@ def _ordered_operation_nodes(
     graph: Mapping[Any, Any],
 ) -> list[_OperationNode]:
     direct_operation_deps = {
-        key: _reachable_operation_dependencies(node.dependencies, nodes, graph) for key, node in nodes.items()
+        key: _reachable_operation_dependencies(node.dependencies, nodes, graph) - {key} for key, node in nodes.items()
     }
 
     ordered: list[_OperationNode] = []
@@ -239,6 +282,18 @@ def _dependency_key(value: Any) -> Any:
     return getattr(value, "key", value)
 
 
+def _resolve_subgraph_value(value: Any, substitutions: Mapping[Any, Any], key_map: Mapping[Any, Any]) -> Any:
+    key = _dependency_key(value)
+    try:
+        if key in substitutions:
+            return substitutions[key]
+        if key in key_map:
+            return key_map[key]
+    except TypeError:
+        pass
+    return value
+
+
 def _reference_key(value: Any, graph_keys: set[Any]) -> Any | None:
     try:
         if value in graph_keys:
@@ -252,6 +307,22 @@ def _reference_key(value: Any, graph_keys: set[Any]) -> Any | None:
     except TypeError:
         pass
     return None
+
+
+def _walk_references(values: Any, graph_keys: set[Any]) -> Iterable[Any]:
+    if _reference_key(values, graph_keys) is not None:
+        yield values
+        return
+    if isinstance(values, Mapping):
+        for key, value in values.items():
+            yield from _walk_references(key, graph_keys)
+            yield from _walk_references(value, graph_keys)
+        return
+    if isinstance(values, (tuple, list, set, frozenset)):
+        for value in values:
+            yield from _walk_references(value, graph_keys)
+        return
+    yield values
 
 
 def _walk_values(values: Any, *, include_containers: bool = False) -> Iterable[Any]:

--- a/wandas/lineage.py
+++ b/wandas/lineage.py
@@ -26,7 +26,10 @@ def extract_operations(collection: Any) -> tuple[AudioOperation[Any, Any], ...]:
 
 
 def _collection_graph(collection: Any) -> Mapping[Any, Any]:
-    dask_graph = collection.__dask_graph__()
+    dask_graph_method = getattr(collection, "__dask_graph__", None)
+    if not callable(dask_graph_method):
+        raise TypeError(f"Expected a Dask collection with __dask_graph__(), got {type(collection).__name__}")
+    dask_graph = dask_graph_method()
     if hasattr(dask_graph, "to_dict"):
         graph = dask_graph.to_dict()
     else:
@@ -207,7 +210,9 @@ def _walk_values(values: Any, *, include_containers: bool = False) -> Iterable[A
             yield key
             yield from _walk_values(value, include_containers=include_containers)
         return
-    if isinstance(values, tuple | list | set | frozenset):
+    if isinstance(values, (tuple, list, set, frozenset)):
+        if isinstance(values, tuple):
+            yield values
         for value in values:
             yield from _walk_values(value, include_containers=include_containers)
         return

--- a/wandas/lineage.py
+++ b/wandas/lineage.py
@@ -6,7 +6,9 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
-from wandas.processing.base import AudioOperation, _execute_wandas_operation
+from wandas.processing.base import AudioOperation, _execute_wandas_operation, _mark_wandas_operation
+
+_OPERATION_MARKER_FUNCTIONS = {_execute_wandas_operation, _mark_wandas_operation}
 
 
 @dataclass(frozen=True)
@@ -53,10 +55,14 @@ def _flatten_graph(graph: Mapping[Any, Any]) -> Mapping[Any, Any]:
             if not _is_graph_mapping(value):
                 continue
             for key, nested_task in value.items():
-                if key not in flattened:
+                if key not in flattened or _prefers_nested_task(flattened[key], nested_task):
                     flattened[key] = nested_task
                     stack.append(nested_task)
     return flattened
+
+
+def _prefers_nested_task(existing_task: Any, nested_task: Any) -> bool:
+    return _operation_marker(existing_task) is None and _operation_marker(nested_task) is not None
 
 
 def _is_graph_mapping(value: Any) -> bool:
@@ -76,26 +82,72 @@ def _looks_like_dask_task(value: Any) -> bool:
 
 def _operation_nodes(graph: Mapping[Any, Any]) -> dict[Any, _OperationNode]:
     nodes: dict[Any, _OperationNode] = {}
+    operation_keys: dict[int, Any] = {}
     for key, task in graph.items():
         marker = _operation_marker(task)
         if marker is None:
             continue
-        nodes[key] = _OperationNode(
-            key=key,
-            operation=marker,
-            dependencies=frozenset(_task_dependencies(task, graph)),
-        )
+        dependencies = frozenset(_task_dependencies(task, graph))
+        operation_id = id(marker)
+        existing_key = operation_keys.get(operation_id)
+        if existing_key is not None:
+            existing_node = nodes[existing_key]
+            nodes[existing_key] = _OperationNode(
+                key=existing_node.key,
+                operation=existing_node.operation,
+                dependencies=existing_node.dependencies | dependencies,
+            )
+            continue
+        operation_keys[operation_id] = key
+        nodes[key] = _OperationNode(key=key, operation=marker, dependencies=dependencies)
     return nodes
 
 
 def _operation_marker(task: Any) -> AudioOperation[Any, Any] | None:
     func, args = _task_func_and_args(task)
-    if func is not _execute_wandas_operation:
+    if getattr(func, "__name__", None) == "_execute_subgraph":
+        return _subgraph_operation_marker(args)
+    if not any(func is marker_func for marker_func in _OPERATION_MARKER_FUNCTIONS):
         return None
+    return _operation_from_args(args)
+
+
+def _subgraph_operation_marker(args: tuple[Any, ...]) -> AudioOperation[Any, Any] | None:
+    if len(args) < 2 or not isinstance(args[0], Mapping):
+        return None
+    subgraph = args[0]
+    output_task = subgraph.get(_dependency_key(args[1]))
+    if output_task is None:
+        return None
+    func, output_args = _task_func_and_args(output_task)
+    if not any(func is marker_func for marker_func in _OPERATION_MARKER_FUNCTIONS):
+        return None
+    substitutions = _subgraph_substitutions(args)
+    return _operation_from_args(output_args, substitutions)
+
+
+def _subgraph_substitutions(args: tuple[Any, ...]) -> dict[Any, Any]:
+    if len(args) < 3 or not isinstance(args[2], tuple):
+        return {}
+    return dict(zip(args[2], args[3:], strict=False))
+
+
+def _operation_from_args(
+    args: tuple[Any, ...],
+    substitutions: Mapping[Any, Any] | None = None,
+) -> AudioOperation[Any, Any] | None:
+    substitutions = substitutions or {}
     for arg in args:
-        if isinstance(arg, AudioOperation):
-            return arg
+        value = _literal_value(arg)
+        if not isinstance(value, AudioOperation):
+            value = _literal_value(substitutions.get(_dependency_key(arg), value))
+        if isinstance(value, AudioOperation):
+            return value
     return None
+
+
+def _literal_value(value: Any) -> Any:
+    return getattr(value, "value", value)
 
 
 def _task_func_and_args(task: Any) -> tuple[Any, tuple[Any, ...]]:

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -18,6 +18,11 @@ InputArrayType = TypeVar("InputArrayType", NDArrayReal, NDArrayComplex)
 OutputArrayType = TypeVar("OutputArrayType", NDArrayReal, NDArrayComplex)
 
 
+def _execute_wandas_operation(operation: "AudioOperation[Any, Any]", data: Any) -> Any:
+    """Execute a Wandas operation from a Dask task."""
+    return operation._process_array(data)
+
+
 class AudioOperation(Generic[InputArrayType, OutputArrayType]):
     """Abstract base class for audio processing operations."""
 
@@ -113,27 +118,9 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
         # Default is no-op function
         raise NotImplementedError("Subclasses must implement this method.")
 
-    def _create_named_wrapper(self) -> Any:
-        """
-        Create a named wrapper function for better Dask graph visualization.
-
-        Returns
-        -------
-        callable
-            A wrapper function with the operation name set as __name__.
-        """
-
-        def operation_wrapper(x: InputArrayType) -> OutputArrayType:
-            return self._process_array(x)
-
-        # Set the function name to the operation name for better visualization
-        operation_wrapper.__name__ = self.name
-        return operation_wrapper
-
     def _delayed(self, data: Any) -> Any:
-        """Create a ``dask.delayed`` result for *data* using the named wrapper."""
-        wrapper = self._create_named_wrapper()
-        return delayed(wrapper, pure=self.pure)(data)
+        """Create a ``dask.delayed`` result for *data* with an explicit operation marker."""
+        return delayed(_execute_wandas_operation, name=self.name, pure=self.pure)(self, data)
 
     def process_array(self, x: Any) -> Any:
         """

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -1,7 +1,7 @@
 import importlib
 import inspect
 import logging
-from typing import Any, ClassVar, Generic, TypeVar
+from typing import Any, ClassVar, Generic, TypeVar, cast
 
 import dask.array as da
 from dask.array.core import Array as DaArray
@@ -21,6 +21,11 @@ OutputArrayType = TypeVar("OutputArrayType", NDArrayReal, NDArrayComplex)
 def _execute_wandas_operation(operation: "AudioOperation[Any, Any]", data: Any) -> Any:
     """Execute a Wandas operation from a Dask task."""
     return operation._process_array(data)
+
+
+def _mark_wandas_operation(data: Any, operation: "AudioOperation[Any, Any]") -> Any:
+    """Mark a Dask-native task as a Wandas operation without changing the data."""
+    return data
 
 
 class AudioOperation(Generic[InputArrayType, OutputArrayType]):
@@ -121,6 +126,11 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
     def _delayed(self, data: Any) -> Any:
         """Create a ``dask.delayed`` result for *data* with an explicit operation marker."""
         return delayed(_execute_wandas_operation, name=self.name, pure=self.pure)(self, data)
+
+    def _mark_array(self, data: DaArray) -> DaArray:
+        """Attach an explicit operation marker to a Dask-native array result."""
+        marker = cast(Any, _mark_wandas_operation)
+        return data.map_blocks(marker, self, dtype=data.dtype)
 
     def process_array(self, x: Any) -> Any:
         """

--- a/wandas/processing/effects.py
+++ b/wandas/processing/effects.py
@@ -4,7 +4,6 @@ from typing import Any
 import dask.array as da
 import numpy as np
 from dask.array.core import Array as DaArray
-from dask.delayed import delayed
 from scipy.signal import windows as sp_windows
 
 from wandas.processing.base import AudioOperation, register_operation
@@ -201,8 +200,7 @@ class Normalize(AudioOperation[NDArrayReal, NDArrayReal]):
     def process(self, data: DaArray) -> DaArray:
         """Execute normalization with accurate floating output dtype metadata."""
         logger.debug("Adding delayed normalize operation to computation graph")
-        wrapper = self._create_named_wrapper()
-        delayed_result = delayed(wrapper, pure=self.pure)(data)
+        delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)
         return da.from_delayed(delayed_result, shape=output_shape, dtype=self._output_dtype(data.dtype, self.norm))
 

--- a/wandas/processing/stats.py
+++ b/wandas/processing/stats.py
@@ -1,6 +1,6 @@
 import logging
 
-import numpy as np
+import dask.array as da
 from dask.array.core import Array as DaArray
 
 from wandas.processing.base import AudioOperation, register_operation
@@ -26,9 +26,8 @@ class ABS(AudioOperation[NDArrayReal, NDArrayReal]):
         """
         super().__init__(sampling_rate)
 
-    def _process_array(self, x: NDArrayReal) -> NDArrayReal:
-        result: NDArrayReal = np.abs(x)
-        return result
+    def process(self, data: DaArray) -> DaArray:
+        return self._mark_array(da.abs(data))
 
 
 class Power(AudioOperation[NDArrayReal, NDArrayReal]):
@@ -51,9 +50,8 @@ class Power(AudioOperation[NDArrayReal, NDArrayReal]):
         self.exp = exponent
         super().__init__(sampling_rate, exponent=exponent)
 
-    def _process_array(self, x: NDArrayReal) -> NDArrayReal:
-        result: NDArrayReal = np.power(x, self.exp)
-        return result
+    def process(self, data: DaArray) -> DaArray:
+        return self._mark_array(da.power(data, self.exp))
 
 
 class Sum(AudioOperation[NDArrayReal, NDArrayReal]):
@@ -62,12 +60,8 @@ class Sum(AudioOperation[NDArrayReal, NDArrayReal]):
     name = "sum"
     _display = "sum"
 
-    def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
-        return (1, *input_shape[1:])
-
-    def _process_array(self, x: NDArrayReal) -> NDArrayReal:
-        result: NDArrayReal = x.sum(axis=0, keepdims=True)
-        return result
+    def process(self, data: DaArray) -> DaArray:
+        return self._mark_array(data.sum(axis=0, keepdims=True))
 
 
 class Mean(AudioOperation[NDArrayReal, NDArrayReal]):
@@ -76,12 +70,8 @@ class Mean(AudioOperation[NDArrayReal, NDArrayReal]):
     name = "mean"
     _display = "mean"
 
-    def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
-        return (1, *input_shape[1:])
-
-    def _process_array(self, x: NDArrayReal) -> NDArrayReal:
-        result: NDArrayReal = x.mean(axis=0, keepdims=True)
-        return result
+    def process(self, data: DaArray) -> DaArray:
+        return self._mark_array(data.mean(axis=0, keepdims=True))
 
 
 class ChannelDifference(AudioOperation[NDArrayReal, NDArrayReal]):
@@ -106,13 +96,9 @@ class ChannelDifference(AudioOperation[NDArrayReal, NDArrayReal]):
         super().__init__(sampling_rate, other_channel=other_channel)
 
     def process(self, data: DaArray) -> DaArray:
-        if self.other_channel < 0 or self.other_channel >= data.shape[0]:
+        if not -data.shape[0] <= self.other_channel < data.shape[0]:
             raise IndexError("Channel index out of range")
-        return super().process(data)
-
-    def _process_array(self, x: NDArrayReal) -> NDArrayReal:
-        result: NDArrayReal = x - x[self.other_channel]
-        return result
+        return self._mark_array(data - data[self.other_channel])
 
 
 # Register all operations

--- a/wandas/processing/stats.py
+++ b/wandas/processing/stats.py
@@ -1,6 +1,6 @@
 import logging
 
-import dask.array as da
+import numpy as np
 from dask.array.core import Array as DaArray
 
 from wandas.processing.base import AudioOperation, register_operation
@@ -26,9 +26,9 @@ class ABS(AudioOperation[NDArrayReal, NDArrayReal]):
         """
         super().__init__(sampling_rate)
 
-    def process(self, data: DaArray) -> DaArray:
-        # Use Dask's aggregate function directly without map_blocks
-        return da.abs(data)
+    def _process_array(self, x: NDArrayReal) -> NDArrayReal:
+        result: NDArrayReal = np.abs(x)
+        return result
 
 
 class Power(AudioOperation[NDArrayReal, NDArrayReal]):
@@ -48,12 +48,12 @@ class Power(AudioOperation[NDArrayReal, NDArrayReal]):
         exponent : float
             Power exponent
         """
-        super().__init__(sampling_rate)
         self.exp = exponent
+        super().__init__(sampling_rate, exponent=exponent)
 
-    def process(self, data: DaArray) -> DaArray:
-        # Use Dask's aggregate function directly without map_blocks
-        return da.power(data, self.exp)
+    def _process_array(self, x: NDArrayReal) -> NDArrayReal:
+        result: NDArrayReal = np.power(x, self.exp)
+        return result
 
 
 class Sum(AudioOperation[NDArrayReal, NDArrayReal]):
@@ -62,9 +62,12 @@ class Sum(AudioOperation[NDArrayReal, NDArrayReal]):
     name = "sum"
     _display = "sum"
 
-    def process(self, data: DaArray) -> DaArray:
-        # Use Dask's aggregate function directly without map_blocks
-        return data.sum(axis=0, keepdims=True)
+    def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
+        return (1, *input_shape[1:])
+
+    def _process_array(self, x: NDArrayReal) -> NDArrayReal:
+        result: NDArrayReal = x.sum(axis=0, keepdims=True)
+        return result
 
 
 class Mean(AudioOperation[NDArrayReal, NDArrayReal]):
@@ -73,9 +76,12 @@ class Mean(AudioOperation[NDArrayReal, NDArrayReal]):
     name = "mean"
     _display = "mean"
 
-    def process(self, data: DaArray) -> DaArray:
-        # Use Dask's aggregate function directly without map_blocks
-        return data.mean(axis=0, keepdims=True)
+    def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
+        return (1, *input_shape[1:])
+
+    def _process_array(self, x: NDArrayReal) -> NDArrayReal:
+        result: NDArrayReal = x.mean(axis=0, keepdims=True)
+        return result
 
 
 class ChannelDifference(AudioOperation[NDArrayReal, NDArrayReal]):
@@ -100,8 +106,12 @@ class ChannelDifference(AudioOperation[NDArrayReal, NDArrayReal]):
         super().__init__(sampling_rate, other_channel=other_channel)
 
     def process(self, data: DaArray) -> DaArray:
-        # Use Dask's aggregate function directly without map_blocks
-        result = data - data[self.other_channel]
+        if self.other_channel < 0 or self.other_channel >= data.shape[0]:
+            raise IndexError("Channel index out of range")
+        return super().process(data)
+
+    def _process_array(self, x: NDArrayReal) -> NDArrayReal:
+        result: NDArrayReal = x - x[self.other_channel]
         return result
 
 

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -5,7 +5,6 @@ from typing import Any
 import dask.array as da
 import numpy as np
 from dask.array.core import Array as DaArray
-from dask.delayed import delayed
 from scipy.signal import lfilter, resample, resample_poly
 
 from wandas.processing.base import AudioOperation, register_operation
@@ -138,8 +137,7 @@ class ReSampling(AudioOperation[NDArrayReal, NDArrayReal]):
     def process(self, data: DaArray) -> DaArray:
         """Execute resampling with accurate floating output dtype metadata."""
         logger.debug("Adding delayed resampling operation to computation graph")
-        wrapper = self._create_named_wrapper()
-        delayed_result = delayed(wrapper, pure=self.pure)(data)
+        delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)
         return da.from_delayed(delayed_result, shape=output_shape, dtype=self._output_dtype(data.dtype))
 
@@ -381,8 +379,7 @@ class RmsTrend(AudioOperation[NDArrayReal, NDArrayReal]):
     def process(self, data: DaArray) -> DaArray:
         """Execute RMS trend with accurate floating output dtype metadata."""
         logger.debug("Adding delayed RMS trend operation to computation graph")
-        wrapper = self._create_named_wrapper()
-        delayed_result = delayed(wrapper, pure=self.pure)(data)
+        delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)
         return da.from_delayed(delayed_result, shape=output_shape, dtype=self._output_dtype())
 
@@ -509,8 +506,7 @@ class SoundLevel(AudioOperation[NDArrayReal, NDArrayReal]):
     def process(self, data: DaArray) -> DaArray:
         """Execute sound level with floating output dtype metadata."""
         logger.debug("Adding delayed sound level operation to computation graph")
-        wrapper = self._create_named_wrapper()
-        delayed_result = delayed(wrapper, pure=self.pure)(data)
+        delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)
         return da.from_delayed(delayed_result, shape=output_shape, dtype=self._output_dtype(data.dtype))
 


### PR DESCRIPTION
Closes #234
Part of #232
Follow-up: #235 tracks the AudioOperation immutability/read-only contract raised during review.

## Summary
- Implements Phase 1 only for Dask graph operation markers and lineage extraction.
- Adds `_execute_wandas_operation(operation, data)` as the explicit Dask task marker and routes `AudioOperation._delayed()` through it.
- Adds identity marker tasks for Dask-native stats operations so `abs`, `power`, `sum`, `mean`, and `channel_difference` keep Dask's native dtype/chunk/reduction behavior while still appearing in lineage.
- Adds `wandas.lineage.extract_operations()` and `BaseFrame.operations` as a read-only tuple of `AudioOperation` instances.
- Keeps existing `operation_history` behavior unchanged and does not implement Phase 2 items such as multi-input AddWithSNR, WDF/persist boundaries, operation summaries, or legacy history cleanup.

## Design Notes
- Marker detection does not inspect task key strings. It requires the task function to be `_execute_wandas_operation` or the Dask-native identity marker and the task args, including duck-typed literal wrappers, to contain an `AudioOperation` instance.
- Extraction reads the unoptimized collection graph via public `__dask_graph__()` and `HighLevelGraph.to_dict()`.
- Dask TaskSpec, legacy tuple tasks, Alias-like task refs, and nested `_execute_subgraph` mappings are adapted inside `wandas.lineage`.
- Nested marker tasks are expanded with subgraph-local substitutions so fused native chains such as `abs -> power -> normalize` preserve every marker.
- Nested marker tasks are preferred over outer aliases when a subgraph uses the same key, and repeated chunk marker tasks for the same operation instance are deduplicated.
- Phase 1 returns a single-input serial chain in dependency order, while internally preserving operation nodes keyed by graph key plus dependencies for future DAG expansion.
- `AudioOperation` immutability is not implemented in this PoC; #235 tracks that contract separately.

## PoC Results
- Dask 2025.11 TaskSpec marker extraction works for `high_pass_filter -> normalize -> stft`.
- Stats-style operations such as `abs`, `power`, `sum`, `mean`, and `channel_difference` now emit lineage markers without replacing Dask-native array operations.
- Fused native marker chains before whole-array delayed operations are preserved, including `abs -> power -> normalize` and `abs -> power -> stft`.
- Negative channel indices continue to work for `channel_difference`.
- No broader private Dask API dependency was needed beyond duck-typed task adapters and public graph conversion.
- `frame.operations` does not call `compute()`.
- `dask.base.tokenize(operation)` and `cloudpickle.dumps(operation)` succeeded for `HighPassFilter`, `Normalize`, `STFT`, and `CustomOperation`.
- `distributed` is not installed in this environment, so LocalCluster smoke was not run.

## Validation
- `uv run ruff check wandas tests` passed.
- `uv run ty check wandas tests` passed.
- `uv run pytest tests/core/test_base_frame_lineage.py tests/processing/test_stats_operations.py tests/frames/test_channel_processing.py` passed: 105 passed.
- `uv run pytest tests/core/test_base_frame_lineage.py tests/core/test_base_frame.py tests/core/test_base_frame_additional.py tests/processing/test_base_operations.py tests/processing/test_effect_operations.py tests/processing/test_spectral_operations.py` passed: 361 passed, 2 warnings.
- `uv run pytest` passed: 1701 passed, 3 skipped, 39 warnings.