### PR TITLE
[codex] Canonicalize audio operation config

### DIFF
--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -139,6 +139,21 @@ class TestChannelProcessing:
 
         np.testing.assert_array_equal(result.compute(), self.data + 1.0)
 
+    def test_apply_custom_function_accepts_pure_named_argument(self) -> None:
+        frame = ChannelFrame(
+            data=self.dask_data,
+            sampling_rate=self.sample_rate,
+            channel_metadata=[{"label": "ch0", "unit": "", "extra": {}}],
+        )
+
+        def add_for_pure_arg(x: np.ndarray, pure: bool) -> np.ndarray:
+            return x + (1.0 if pure else 2.0)
+
+        result = frame.apply(add_for_pure_arg, output_shape_func=lambda shape: shape, pure=False)
+
+        np.testing.assert_array_equal(result.compute(), self.data + 2.0)
+        assert result.operation_history[-1]["params"] == {"pure": False}
+
     def test_apply_custom_function_params_copy_mutation_does_not_change_history_or_compute(self) -> None:
         """Custom operation params are defensive views for history and compute."""
         frame = ChannelFrame(

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -169,6 +169,25 @@ class TestChannelProcessing:
         np.testing.assert_array_equal(result.compute(), self.data * 2.0)
         assert result.operation_history[-1]["params"] == {"gain": 2.0}
 
+    def test_apply_custom_function_mutating_nested_param_does_not_change_history_or_compute(self) -> None:
+        """Custom functions receive per-call config snapshots for mutable kwargs."""
+        frame = ChannelFrame(
+            data=self.dask_data,
+            sampling_rate=self.sample_rate,
+            channel_metadata=[{"label": "ch0", "unit": "", "extra": {}}],
+        )
+
+        def mutating_scale(x: np.ndarray, config: dict[str, float]) -> np.ndarray:
+            gain = config["gain"]
+            config["gain"] = 99.0
+            return x * gain
+
+        result = frame.apply(mutating_scale, output_shape_func=lambda shape: shape, config={"gain": 2.0})
+
+        np.testing.assert_array_equal(result.compute(), self.data * 2.0)
+        np.testing.assert_array_equal(result.compute(), self.data * 2.0)
+        assert result.operation_history[-1]["params"] == {"config": {"gain": 2.0}}
+
     def test_registered_operation_params_copy_mutation_does_not_change_history_or_compute(self) -> None:
         """Registered operation params are defensive views for history and compute."""
 

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -139,7 +139,7 @@ class TestChannelProcessing:
 
         np.testing.assert_array_equal(result.compute(), self.data + 1.0)
 
-    def test_apply_custom_function_accepts_pure_named_argument(self) -> None:
+    def test_apply_custom_function_rejects_pure_reserved_argument(self) -> None:
         frame = ChannelFrame(
             data=self.dask_data,
             sampling_rate=self.sample_rate,
@@ -149,10 +149,8 @@ class TestChannelProcessing:
         def add_for_pure_arg(x: np.ndarray, pure: bool) -> np.ndarray:
             return x + (1.0 if pure else 2.0)
 
-        result = frame.apply(add_for_pure_arg, output_shape_func=lambda shape: shape, pure=False)
-
-        np.testing.assert_array_equal(result.compute(), self.data + 2.0)
-        assert result.operation_history[-1]["params"] == {"pure": False}
+        with pytest.raises(ValueError, match="Parameter name conflict"):
+            frame.apply(add_for_pure_arg, output_shape_func=lambda shape: shape, pure=False)
 
     def test_apply_custom_function_params_copy_mutation_does_not_change_history_or_compute(self) -> None:
         """Custom operation params are defensive views for history and compute."""

--- a/tests/frames/test_channel_transform.py
+++ b/tests/frames/test_channel_transform.py
@@ -692,7 +692,7 @@ def test_cross_channel_spectral_transform_n_fft_not_int():
 
     mock_op = MagicMock()
     mock_op.process.return_value = _da_from_array(np.random.default_rng(42).random((3, 513)), chunks=(3, 513))
-    mock_op.n_fft = "not_an_int"  # non-int value
+    mock_op.to_params.return_value = {"n_fft": "not_an_int", "window": "hann"}
 
     with patch("wandas.processing.create_operation", return_value=mock_op):
         with pytest.raises(TypeError, match="must provide a positive integer n_fft"):
@@ -708,7 +708,7 @@ def test_cross_channel_spectral_transform_n_fft_non_positive():
 
     mock_op = MagicMock()
     mock_op.process.return_value = _da_from_array(np.random.default_rng(42).random((3, 513)), chunks=(3, 513))
-    mock_op.n_fft = 0  # non-positive int
+    mock_op.to_params.return_value = {"n_fft": 0, "window": "hann"}
 
     with patch("wandas.processing.create_operation", return_value=mock_op):
         with pytest.raises(ValueError, match="must provide a positive integer n_fft"):

--- a/tests/processing/test_base_operations.py
+++ b/tests/processing/test_base_operations.py
@@ -10,6 +10,7 @@ from dask.array.core import Array as DaArray
 from dask.base import tokenize
 
 from wandas.frames.channel import ChannelFrame
+from wandas.processing import base as base_module
 from wandas.processing.base import (
     _OPERATION_MODULES,
     _OPERATION_REGISTRY,
@@ -587,6 +588,41 @@ class TestAudioOperation:
         dask_array = da_from_array(np.array([1.0]), chunks=(1,))
 
         assert _snapshot_config_value(dask_array) is dask_array
+
+    def test_snapshot_config_value_returns_immutable_scalars_without_deepcopy(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def fail_deepcopy(value: object) -> object:
+            raise AssertionError(f"deepcopy should not run for {value!r}")
+
+        monkeypatch.setattr("wandas.processing.base.copy.deepcopy", fail_deepcopy)
+
+        for value in [None, True, 1, 1.5, "gain", b"gain", 1 + 2j]:
+            assert _snapshot_config_value(value) is value
+
+    def test_config_value_snapshots_only_requested_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        test_op_cls = self._make_test_op_class()
+        target = {"gain": 2.0}
+        untouched = {"bias": 1.0}
+        op = test_op_cls(16000, target=target, untouched=untouched)
+        config = object.__getattribute__(op, "_config")
+        calls: list[object] = []
+        real_snapshot = base_module._snapshot_config_value
+
+        def record_snapshot(value: object) -> object:
+            calls.append(value)
+            return real_snapshot(value)
+
+        monkeypatch.setattr(base_module, "_snapshot_config_value", record_snapshot)
+
+        snapshot = op._config_value("target")
+
+        assert snapshot == {"gain": 2.0}
+        assert calls[0] is config["target"]
+        assert config["untouched"] not in calls
+        snapshot["gain"] = 99.0
+        assert op._config["target"] == {"gain": 2.0}
 
     def test_config_values_equal_handles_non_matching_containers(self) -> None:
         assert not _config_values_equal({"left": 1}, {"right": 1})

--- a/tests/processing/test_base_operations.py
+++ b/tests/processing/test_base_operations.py
@@ -9,6 +9,7 @@ import pytest
 from dask.array.core import Array as DaArray
 from dask.base import tokenize
 
+from wandas.frames.channel import ChannelFrame
 from wandas.processing.base import (
     _OPERATION_MODULES,
     _OPERATION_REGISTRY,
@@ -217,6 +218,81 @@ class TestAudioOperation:
             _ = result.compute()
             mock_compute.assert_called_once()
 
+    def test_super_only_config_operation_exposes_base_params_through_lineage_and_compute(self) -> None:
+        class SuperOnlyGainOperation(AudioOperation[NDArrayReal, NDArrayReal]):
+            name = "super_only_gain_op"
+
+            def __init__(self, sampling_rate: float, gain: float):
+                super().__init__(sampling_rate, gain=gain)
+
+            def _process_array(self, x: NDArrayReal) -> NDArrayReal:
+                return x * self._config_snapshot()["gain"]
+
+        try:
+            register_operation(SuperOnlyGainOperation)
+            op = create_operation("super_only_gain_op", 16000, gain=2.0)
+            data = da_from_array(np.array([[1.0, 2.0]]), chunks=(1, -1))
+            frame = ChannelFrame(data, sampling_rate=16000)
+            result = ChannelFrame(
+                op.process(data),
+                sampling_rate=16000,
+                lineage=frame._lineage_with_operation(op, frame.lineage),
+            )
+
+            assert op.params == {"gain": 2.0}
+            assert op.to_params() == {"gain": 2.0}
+            assert result.operation_history == [{"operation": "super_only_gain_op", "params": {"gain": 2.0}}]
+            np.testing.assert_array_equal(result.compute(), np.array([[2.0, 4.0]]))
+        finally:
+            _OPERATION_REGISTRY.pop("super_only_gain_op", None)
+
+    def test_base_config_snapshots_constructor_inputs_for_params_compute_and_history(self) -> None:
+        class BaseConfigOperation(AudioOperation[NDArrayReal, NDArrayReal]):
+            name = "base_config_snapshot_op"
+
+            def __init__(self, sampling_rate: float, config: dict[str, float]):
+                super().__init__(sampling_rate, config=config)
+
+            def _process_array(self, x: NDArrayReal) -> NDArrayReal:
+                return x * self._config_snapshot()["config"]["gain"]
+
+        config = {"gain": 2.0}
+        op = BaseConfigOperation(16000, config=config)
+        data = da_from_array(np.array([[1.0, 2.0]]), chunks=(1, -1))
+        frame = ChannelFrame(data, sampling_rate=16000)
+        result = ChannelFrame(
+            op.process(data),
+            sampling_rate=16000,
+            lineage=frame._lineage_with_operation(op, frame.lineage),
+        )
+
+        config["gain"] = 99.0
+
+        assert op.params["config"] == {"gain": 2.0}
+        assert op.to_params()["config"] == {"gain": 2.0}
+        assert result.operation_history[-1]["params"] == {"config": {"gain": 2.0}}
+        np.testing.assert_array_equal(result.compute(), np.array([[2.0, 4.0]]))
+
+    def test_base_config_returned_nested_values_do_not_change_pending_compute(self) -> None:
+        class BaseConfigOperation(AudioOperation[NDArrayReal, NDArrayReal]):
+            name = "base_config_pending_op"
+
+            def __init__(self, sampling_rate: float, config: dict[str, float]):
+                super().__init__(sampling_rate, config=config)
+
+            def _process_array(self, x: NDArrayReal) -> NDArrayReal:
+                return x * self._config_snapshot()["config"]["gain"]
+
+        op = BaseConfigOperation(16000, config={"gain": 2.0})
+        data = da_from_array(np.array([[1.0, 2.0]]), chunks=(1, -1))
+        result = op.process(data)
+
+        op.params["config"]["gain"] = 99.0
+        op.to_params()["config"]["gain"] = 99.0
+
+        assert op.params["config"] == {"gain": 2.0}
+        np.testing.assert_array_equal(result.compute(), np.array([[2.0, 4.0]]))
+
     def test_validate_params_raises_on_invalid(self) -> None:
         """validate_params() raises ValueError for invalid parameters in __init__."""
 
@@ -350,11 +426,11 @@ class TestAudioOperation:
             name = "nested_params_op"
 
             def __init__(self, sampling_rate: float, config: dict[str, float]):
-                self._config = _snapshot_config_value(config)
+                self._test_config = _snapshot_config_value(config)
                 super().__init__(sampling_rate, config=config)
 
             def to_params(self) -> dict[str, Any]:
-                return {"config": self._config}
+                return {"config": self._test_config}
 
             def _process_array(self, x: NDArrayReal) -> NDArrayReal:
                 return x
@@ -382,14 +458,14 @@ class TestAudioOperation:
             name = "private_config_op"
 
             def __init__(self, sampling_rate: float, config: dict[str, float]):
-                self._config = _snapshot_config_value(config)
+                self._test_config = _snapshot_config_value(config)
                 super().__init__(sampling_rate, config=config)
 
             def to_params(self) -> dict[str, Any]:
-                return {"config": self._config}
+                return {"config": self._test_config}
 
             def _process_array(self, x: NDArrayReal) -> NDArrayReal:
-                return x * self._config["gain"]
+                return x * self._test_config["gain"]
 
         config = {"gain": 2.0}
         op = PrivateConfigOperation(16000, config=config)
@@ -491,11 +567,11 @@ class TestAudioOperation:
 
             def __init__(self, sampling_rate: float, reference: NDArrayReal):
                 self._reference = _snapshot_config_value(reference)
-                self._config = {"weights": _snapshot_config_value(reference)}
+                self._test_config = {"weights": _snapshot_config_value(reference)}
                 super().__init__(sampling_rate, reference=reference, config={"weights": reference})
 
             def to_params(self) -> dict[str, Any]:
-                return {"reference": self._reference, "config": self._config}
+                return {"reference": self._reference, "config": self._test_config}
 
             def _process_array(self, x: NDArrayReal) -> NDArrayReal:
                 return x
@@ -559,11 +635,11 @@ class TestAudioOperation:
             name = "ambiguous_params_op"
 
             def __init__(self, sampling_rate: float, config: object):
-                self._config = config
+                self._test_config = config
                 super().__init__(sampling_rate, config=config)
 
             def to_params(self) -> dict[str, object]:
-                return {"config": self._config}
+                return {"config": self._test_config}
 
             def _process_array(self, x: NDArrayReal) -> NDArrayReal:
                 return x

--- a/tests/processing/test_custom_operation.py
+++ b/tests/processing/test_custom_operation.py
@@ -29,42 +29,6 @@ class TestCustomOperation:
 
         np.testing.assert_array_equal(op._process_array(data), data * 2.0)
 
-    def test_custom_operation_copies_nested_params_for_each_delayed_execution(self) -> None:
-        data = np.array([[1.0, 2.0, 3.0]])
-        dask_data = da_from_array(data, chunks=(1, -1))
-
-        def mutating_scale(x: np.ndarray, config: dict[str, float]) -> np.ndarray:
-            gain = config["gain"]
-            config["gain"] += 1.0
-            return x * gain
-
-        op = CustomOperation(16000, func=mutating_scale, config={"gain": 2.0})
-        result = op.process(dask_data)
-
-        np.testing.assert_array_equal(result.compute(), data * 2.0)
-        np.testing.assert_array_equal(result.compute(), data * 2.0)
-        assert op.params["config"]["gain"] == 2.0
-
-    def test_custom_operation_uses_base_config_snapshot_for_repeated_delayed_compute(self) -> None:
-        data = np.array([[1.0, 2.0, 3.0]])
-        dask_data = da_from_array(data, chunks=(1, -1))
-
-        def mutating_scale(x: np.ndarray, config: dict[str, float]) -> np.ndarray:
-            gain = config["gain"]
-            config["gain"] = 99.0
-            return x * gain
-
-        config = {"gain": 2.0}
-        op = CustomOperation(16000, func=mutating_scale, config=config)
-        result = op.process(dask_data)
-        config["gain"] = 10.0
-        op.params["config"]["gain"] = 11.0
-        op.to_params()["config"]["gain"] = 12.0
-
-        np.testing.assert_array_equal(result.compute(), data * 2.0)
-        np.testing.assert_array_equal(result.compute(), data * 2.0)
-        assert op.params["config"] == {"gain": 2.0}
-
     def test_custom_operation_subclass_delayed_wrapper_uses_process_array_hook(self) -> None:
         class HookedCustomOperation(CustomOperation):
             def _process_array(self, x: np.ndarray) -> np.ndarray:
@@ -155,18 +119,12 @@ class TestCustomOperation:
 
         assert op.params["config"]["gain"] == 2.0
 
-    def test_custom_operation_accepts_pure_named_function_argument(self) -> None:
-        data = np.array([[1.0, 2.0]])
-        dask_data = da_from_array(data, chunks=(1, -1))
-
+    def test_custom_operation_does_not_expose_pure_constructor_option(self) -> None:
         def my_func(x: np.ndarray, pure: bool) -> np.ndarray:
             return x + (1.0 if pure else 2.0)
 
-        op = CustomOperation(16000, func=my_func, pure=False)
-
-        assert op.params["pure"] is False
-        assert op.to_params()["pure"] is False
-        np.testing.assert_array_equal(op.process(dask_data).compute(), data + 2.0)
+        with pytest.raises(TypeError, match="multiple values"):
+            CustomOperation(16000, func=my_func, pure=False)
 
     def test_custom_operation_accepts_params_named_function_argument(self) -> None:
         data = np.array([[1.0, 2.0]])

--- a/tests/processing/test_custom_operation.py
+++ b/tests/processing/test_custom_operation.py
@@ -29,6 +29,22 @@ class TestCustomOperation:
 
         np.testing.assert_array_equal(op._process_array(data), data * 2.0)
 
+    def test_custom_operation_copies_nested_params_for_each_delayed_execution(self) -> None:
+        data = np.array([[1.0, 2.0, 3.0]])
+        dask_data = da_from_array(data, chunks=(1, -1))
+
+        def mutating_scale(x: np.ndarray, config: dict[str, float]) -> np.ndarray:
+            gain = config["gain"]
+            config["gain"] = 99.0
+            return x * gain
+
+        op = CustomOperation(16000, func=mutating_scale, config={"gain": 2.0})
+        result = op.process(dask_data)
+
+        np.testing.assert_array_equal(result.compute(), data * 2.0)
+        np.testing.assert_array_equal(result.compute(), data * 2.0)
+        assert op.params["config"] == {"gain": 2.0}
+
     def test_custom_operation_subclass_delayed_wrapper_uses_process_array_hook(self) -> None:
         class HookedCustomOperation(CustomOperation):
             def _process_array(self, x: np.ndarray) -> np.ndarray:

--- a/tests/processing/test_custom_operation.py
+++ b/tests/processing/test_custom_operation.py
@@ -155,6 +155,19 @@ class TestCustomOperation:
 
         assert op.params["config"]["gain"] == 2.0
 
+    def test_custom_operation_accepts_pure_named_function_argument(self) -> None:
+        data = np.array([[1.0, 2.0]])
+        dask_data = da_from_array(data, chunks=(1, -1))
+
+        def my_func(x: np.ndarray, pure: bool) -> np.ndarray:
+            return x + (1.0 if pure else 2.0)
+
+        op = CustomOperation(16000, func=my_func, pure=False)
+
+        assert op.params["pure"] is False
+        assert op.to_params()["pure"] is False
+        np.testing.assert_array_equal(op.process(dask_data).compute(), data + 2.0)
+
     def test_custom_operation_accepts_params_named_function_argument(self) -> None:
         data = np.array([[1.0, 2.0]])
         dask_data = da_from_array(data, chunks=(1, -1))

--- a/tests/processing/test_custom_operation.py
+++ b/tests/processing/test_custom_operation.py
@@ -45,6 +45,26 @@ class TestCustomOperation:
         np.testing.assert_array_equal(result.compute(), data * 2.0)
         assert op.params["config"]["gain"] == 2.0
 
+    def test_custom_operation_uses_base_config_snapshot_for_repeated_delayed_compute(self) -> None:
+        data = np.array([[1.0, 2.0, 3.0]])
+        dask_data = da_from_array(data, chunks=(1, -1))
+
+        def mutating_scale(x: np.ndarray, config: dict[str, float]) -> np.ndarray:
+            gain = config["gain"]
+            config["gain"] = 99.0
+            return x * gain
+
+        config = {"gain": 2.0}
+        op = CustomOperation(16000, func=mutating_scale, config=config)
+        result = op.process(dask_data)
+        config["gain"] = 10.0
+        op.params["config"]["gain"] = 11.0
+        op.to_params()["config"]["gain"] = 12.0
+
+        np.testing.assert_array_equal(result.compute(), data * 2.0)
+        np.testing.assert_array_equal(result.compute(), data * 2.0)
+        assert op.params["config"] == {"gain": 2.0}
+
     def test_custom_operation_subclass_delayed_wrapper_uses_process_array_hook(self) -> None:
         class HookedCustomOperation(CustomOperation):
             def _process_array(self, x: np.ndarray) -> np.ndarray:

--- a/tests/processing/test_effect_operations.py
+++ b/tests/processing/test_effect_operations.py
@@ -226,11 +226,9 @@ def test_add_with_snr_and_fade_expose_lineage_parameters() -> None:
     add = AddWithSNR(_SR, other=noise, snr=12.0)
     fade = Fade(_SR, fade_ms=25)
 
-    assert add.other is noise
     assert add.snr == 12.0
     assert add.to_params() == {"other": noise, "snr": 12.0}
     assert fade.fade_ms == 25.0
-    assert fade.fade_len == 400
     assert fade.to_params() == {"fade_ms": 25.0}
 
 

--- a/tests/processing/test_effect_operations.py
+++ b/tests/processing/test_effect_operations.py
@@ -83,6 +83,17 @@ class TestHpssHarmonic:
 
         assert hpss.to_params()["margin"] == [2.0, 3.0]
 
+    def test_hpss_harmonic_params_and_kwargs_share_defensive_base_config(self) -> None:
+        hpss = HpssHarmonic(_SR, margin=[2.0, 3.0], kernel_size={"harmonic": 31})
+
+        hpss.params["margin"][0] = 8.0
+        hpss.to_params()["kernel_size"]["harmonic"] = 99
+        hpss.kwargs["margin"][1] = 9.0
+
+        assert hpss.params["margin"] == [2.0, 3.0]
+        assert hpss.to_params()["kernel_size"] == {"harmonic": 31}
+        assert hpss.kwargs == {"margin": [2.0, 3.0], "kernel_size": {"harmonic": 31}}
+
     def test_hpss_harmonic_registry_returns_correct_class(self) -> None:
         """Test HpssHarmonic is registered as 'hpss_harmonic'."""
         assert get_operation("hpss_harmonic") == HpssHarmonic

--- a/tests/processing/test_fade_operation.py
+++ b/tests/processing/test_fade_operation.py
@@ -103,7 +103,7 @@ class TestFade:
             atol=1e-12,  # float64 window multiplication precision
         )
 
-    def test_frame_fade_lineage_exposes_read_only_fade_len(self) -> None:
+    def test_frame_fade_lineage_records_fade_parameters(self) -> None:
         sig = np.ones((1, 200), dtype=float)
         frame = ChannelFrame(da_from_array(sig, chunks=(1, -1)), sampling_rate=_SR)
 
@@ -112,9 +112,7 @@ class TestFade:
         op = result.lineage.operation
         assert isinstance(op, Fade)
 
-        assert op.fade_len == 20
-        with pytest.raises(AttributeError):
-            setattr(op, "fade_len", 0)
+        assert op.to_params() == {"fade_ms": 20.0}
 
         expected = sp_windows.tukey(200, alpha=Fade.calculate_tukey_alpha(20, 200)).reshape(1, -1)
         np.testing.assert_allclose(result.compute(), expected, rtol=1e-10, atol=1e-12)

--- a/tests/processing/test_temporal_operations.py
+++ b/tests/processing/test_temporal_operations.py
@@ -334,6 +334,20 @@ class TestRmsTrend:
         assert rms.dB is True
         assert rms.Aw is True
 
+    def test_rms_trend_ref_params_are_defensive_for_pending_compute(self) -> None:
+        data = np.ones((1, 8), dtype=float)
+        dask_data = da_from_array(data, chunks=(1, -1))
+        rms = RmsTrend(_SR, frame_length=4, hop_length=2, dB=True, ref=[1.0])
+        result = rms.process(dask_data)
+
+        rms.params["ref"][0] = 100.0
+        rms.to_params()["ref"][0] = 100.0
+
+        assert rms.params["ref"].tolist() == [1.0]
+        np.testing.assert_allclose(
+            result.compute(), np.array([[-3.010299956639812, 0.0, 0.0, 0.0, -3.010299956639812]])
+        )
+
     def test_rms_trend_registry_returns_correct_class(self) -> None:
         """Test that RmsTrend is registered as 'rms_trend'."""
         assert get_operation("rms_trend") == RmsTrend

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -130,6 +130,14 @@ class ChannelProcessingMixin:
                 "  Suggested alternatives: 'sr', 'sample_rate', or 'fs'\n"
                 f"  Received params: {list(kwargs.keys())}"
             )
+        if "pure" in kwargs:
+            raise ValueError(
+                "Parameter name conflict\n"
+                "  Cannot use 'pure' as a parameter in apply().\n"
+                "  'pure' is reserved for operation purity and Dask task semantics.\n"
+                "  Suggested alternative: rename the function argument to 'is_pure'.\n"
+                f"  Received params: {list(kwargs.keys())}"
+            )
 
         operation = CustomOperation(
             sampling_rate=self.sampling_rate,

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -98,7 +98,8 @@ class ChannelTransformMixin:
             label_template,
         )
 
-        n_fft = operation.n_fft
+        operation_params = operation.to_params()
+        n_fft = operation_params["n_fft"]
         if isinstance(n_fft, bool) or not isinstance(n_fft, int):
             raise TypeError(
                 f"Operation '{operation_name}' must provide a positive integer n_fft "
@@ -113,7 +114,7 @@ class ChannelTransformMixin:
             data=result_data,
             sampling_rate=self.sampling_rate,
             n_fft=n_fft,
-            window=operation.window,
+            window=operation_params["window"],
             label=f"{label_prefix} {self.label}",
             metadata=self.metadata,
             channel_metadata=channel_metadata,

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -210,9 +210,9 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
 
     Operation parameters are captured as operation-owned snapshots for lineage
     metadata. ``params`` is a read-only defensive snapshot; create a new
-    operation when configuration needs to change. Subclasses should store
-    execution config in private attributes and expose lineage through
-    ``to_params()``.
+    operation when configuration needs to change. Subclasses can rely on the
+    default ``to_params()`` when lineage parameters match constructor
+    parameters.
     """
 
     # Class variable: operation name
@@ -238,6 +238,11 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
             Operation-specific parameters
         """
         object.__setattr__(self, "_sampling_rate", float(sampling_rate))
+        object.__setattr__(
+            self,
+            "_config",
+            {key: _snapshot_config_value(value) for key, value in params.items()},
+        )
         self.pure = pure
 
         # Validate parameters during initialization
@@ -260,7 +265,12 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
 
     def to_params(self) -> Mapping[str, Any]:
         """Return operation parameters used for lineage and display."""
-        return {}
+        return self._config_snapshot()
+
+    def _config_snapshot(self) -> dict[str, Any]:
+        """Return a defensive copy of base-managed constructor config."""
+        config = object.__getattribute__(self, "_config")
+        return {key: _snapshot_config_value(value) for key, value in config.items()}
 
     def validate_params(self) -> None:
         """Validate parameters (raises exception if invalid)"""

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -99,6 +99,8 @@ class BinaryOperation:
 
 def _snapshot_config_value(value: Any) -> Any:
     """Return an operation-owned snapshot of user supplied config values."""
+    if value is None or isinstance(value, bool | int | float | str | bytes | complex):
+        return value
     if isinstance(value, DaArray):
         return value
     if isinstance(value, np.ndarray):
@@ -218,9 +220,7 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
     # Class variable: operation name
     name: ClassVar[str]
 
-    # Optional attributes used by some subclasses (e.g., FFT)
-    n_fft: int | None
-    window: str
+    _config: dict[str, Any]
 
     def __init__(self, sampling_rate: float, *, pure: bool = True, **params: Any):
         """
@@ -269,8 +269,11 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
 
     def _config_snapshot(self) -> dict[str, Any]:
         """Return a defensive copy of base-managed constructor config."""
-        config = object.__getattribute__(self, "_config")
-        return {key: _snapshot_config_value(value) for key, value in config.items()}
+        return {key: _snapshot_config_value(value) for key, value in self._config.items()}
+
+    def _config_value(self, key: str) -> Any:
+        """Return a defensive snapshot for one base-managed config value."""
+        return _snapshot_config_value(self._config[key])
 
     def validate_params(self) -> None:
         """Validate parameters (raises exception if invalid)"""

--- a/wandas/processing/custom.py
+++ b/wandas/processing/custom.py
@@ -5,6 +5,7 @@ from wandas.processing.base import (
     AudioOperation,
     InputArrayType,
     OutputArrayType,
+    _snapshot_config_value,
     register_operation,
 )
 
@@ -39,6 +40,7 @@ class CustomOperation(AudioOperation[InputArrayType, OutputArrayType]):
         # pending Dask graph by reassigning public attributes before compute.
         self._func: Callable[..., OutputArrayType] = func
         self._output_shape_func = output_shape_func
+        self._custom_params = {key: _snapshot_config_value(value) for key, value in params.items()}
         super().__init__(sampling_rate, **params)
 
     @property
@@ -51,9 +53,13 @@ class CustomOperation(AudioOperation[InputArrayType, OutputArrayType]):
         """Output shape function captured at operation construction time."""
         return self._output_shape_func
 
+    def to_params(self) -> dict[str, Any]:
+        return {key: _snapshot_config_value(value) for key, value in self._custom_params.items()}
+
     def _process_array(self, x: InputArrayType) -> OutputArrayType:
         """Apply custom function."""
-        return self._func(x, **self._config_snapshot())
+        params = {key: _snapshot_config_value(value) for key, value in self._custom_params.items()}
+        return self._func(x, **params)
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
         """Calculate output shape."""

--- a/wandas/processing/custom.py
+++ b/wandas/processing/custom.py
@@ -5,7 +5,6 @@ from wandas.processing.base import (
     AudioOperation,
     InputArrayType,
     OutputArrayType,
-    _snapshot_config_value,
     register_operation,
 )
 
@@ -40,7 +39,6 @@ class CustomOperation(AudioOperation[InputArrayType, OutputArrayType]):
         # pending Dask graph by reassigning public attributes before compute.
         self._func: Callable[..., OutputArrayType] = func
         self._output_shape_func = output_shape_func
-        self._custom_params = {key: _snapshot_config_value(value) for key, value in params.items()}
         super().__init__(sampling_rate, **params)
 
     @property
@@ -53,13 +51,9 @@ class CustomOperation(AudioOperation[InputArrayType, OutputArrayType]):
         """Output shape function captured at operation construction time."""
         return self._output_shape_func
 
-    def to_params(self) -> dict[str, Any]:
-        return {key: _snapshot_config_value(value) for key, value in self._custom_params.items()}
-
     def _process_array(self, x: InputArrayType) -> OutputArrayType:
         """Apply custom function."""
-        params = {key: _snapshot_config_value(value) for key, value in self._custom_params.items()}
-        return self._func(x, **params)
+        return self._func(x, **self._config_snapshot())
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
         """Calculate output shape."""

--- a/wandas/processing/custom.py
+++ b/wandas/processing/custom.py
@@ -5,7 +5,6 @@ from wandas.processing.base import (
     AudioOperation,
     InputArrayType,
     OutputArrayType,
-    _snapshot_config_value,
     register_operation,
 )
 
@@ -34,14 +33,15 @@ class CustomOperation(AudioOperation[InputArrayType, OutputArrayType]):
         output_shape_func : Callable, optional
             Function to calculate output shape from input shape.
         **params : Any
-            Additional parameters to pass to the function.
+            Additional parameters to pass to the function. ``pure`` is reserved
+            for operation purity and Dask task semantics; use a different
+            custom parameter name such as ``is_pure``.
         """
         # Store callables privately so a frame lineage operation cannot alter a
         # pending Dask graph by reassigning public attributes before compute.
         self._func: Callable[..., OutputArrayType] = func
         self._output_shape_func = output_shape_func
-        self._custom_params = {key: _snapshot_config_value(value) for key, value in params.items()}
-        super().__init__(sampling_rate, **params)
+        super().__init__(sampling_rate, pure=True, **params)
 
     @property
     def func(self) -> Callable[..., OutputArrayType]:
@@ -53,13 +53,9 @@ class CustomOperation(AudioOperation[InputArrayType, OutputArrayType]):
         """Output shape function captured at operation construction time."""
         return self._output_shape_func
 
-    def to_params(self) -> dict[str, Any]:
-        return {key: _snapshot_config_value(value) for key, value in self._custom_params.items()}
-
     def _process_array(self, x: InputArrayType) -> OutputArrayType:
         """Apply custom function."""
-        params = {key: _snapshot_config_value(value) for key, value in self._custom_params.items()}
-        return self._func(x, **params)
+        return self._func(x, **self._config)
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
         """Calculate output shape."""

--- a/wandas/processing/custom.py
+++ b/wandas/processing/custom.py
@@ -55,7 +55,7 @@ class CustomOperation(AudioOperation[InputArrayType, OutputArrayType]):
 
     def _process_array(self, x: InputArrayType) -> OutputArrayType:
         """Apply custom function."""
-        return self._func(x, **self._config)
+        return self._func(x, **self._config_snapshot())
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
         """Calculate output shape."""

--- a/wandas/processing/effects.py
+++ b/wandas/processing/effects.py
@@ -76,7 +76,7 @@ class _HpssBase(AudioOperation[NDArrayReal, NDArrayReal]):
     def _process_array(self, x: NDArrayReal) -> NDArrayReal:
         logger.debug(f"Applying HPSS {self._extract_func} to array with shape: {x.shape}")
         func = getattr(self._effects, self._extract_func)
-        result: NDArrayReal = func(x, **self._config_snapshot())
+        result: NDArrayReal = func(x, **self._config)
         logger.debug(f"HPSS {self._extract_func} applied, returning result with shape: {result.shape}")
         return result
 
@@ -183,10 +183,6 @@ class Normalize(AudioOperation[NDArrayReal, NDArrayReal]):
                 f"Typical values: 1e-10 (small threshold), 1e-6 (larger threshold)"
             )
 
-        self._norm = norm
-        self._axis = axis
-        self._threshold = threshold
-        self._fill = fill
         super().__init__(sampling_rate, norm=norm, axis=axis, threshold=threshold, fill=fill)
         logger.debug(
             f"Initialized Normalize operation with norm={norm}, axis={axis}, threshold={threshold}, fill={fill}"
@@ -195,28 +191,34 @@ class Normalize(AudioOperation[NDArrayReal, NDArrayReal]):
     @property
     def norm(self) -> float | None:
         """Norm captured at operation construction time."""
-        return self._config_snapshot()["norm"]
+        return self._config_value("norm")
 
     @property
     def axis(self) -> int | None:
         """Axis captured at operation construction time."""
-        return self._config_snapshot()["axis"]
+        return self._config_value("axis")
 
     @property
     def threshold(self) -> float | None:
         """Threshold captured at operation construction time."""
-        return self._config_snapshot()["threshold"]
+        return self._config_value("threshold")
 
     @property
     def fill(self) -> bool | None:
         """Fill behavior captured at operation construction time."""
-        return self._config_snapshot()["fill"]
+        return self._config_value("fill")
 
     def _process_array(self, x: NDArrayReal) -> NDArrayReal:
         """Perform normalization processing"""
-        logger.debug(f"Applying normalization to array with shape: {x.shape}, norm={self._norm}, axis={self._axis}")
+        logger.debug(f"Applying normalization to array with shape: {x.shape}, norm={self.norm}, axis={self.axis}")
 
-        result = _normalize_array(x, norm=self._norm, axis=self._axis, threshold=self._threshold, fill=self._fill)
+        result = _normalize_array(
+            x,
+            norm=self.norm,
+            axis=self.axis,
+            threshold=self.threshold,
+            fill=self.fill,
+        )
 
         logger.debug(f"Normalization applied, returning result with shape: {result.shape}")
         return result
@@ -226,7 +228,11 @@ class Normalize(AudioOperation[NDArrayReal, NDArrayReal]):
         logger.debug("Adding delayed normalize operation to computation graph")
         delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)
-        return da.from_delayed(delayed_result, shape=output_shape, dtype=self._output_dtype(data.dtype, self._norm))
+        return da.from_delayed(
+            delayed_result,
+            shape=output_shape,
+            dtype=self._output_dtype(data.dtype, self.norm),
+        )
 
 
 class RemoveDC(AudioOperation[NDArrayReal, NDArrayReal]):
@@ -292,35 +298,25 @@ class AddWithSNR(AudioOperation[NDArrayReal, NDArrayReal]):
         snr : float
             Signal-to-noise ratio (dB)
         """
-        self._other = other
-        self._snr = snr
         super().__init__(sampling_rate, other=other, snr=snr)
         logger.debug(f"Initialized AddWithSNR operation with SNR: {snr} dB")
 
     @property
-    def other(self) -> DaArray:
-        """Noise signal captured at operation construction time."""
-        return self._other
-
-    @property
     def snr(self) -> float:
         """Signal-to-noise ratio captured at operation construction time."""
-        return self._snr
-
-    def to_params(self) -> dict[str, Any]:
-        return {"other": self._other, "snr": self._snr}
+        return self._config_value("snr")
 
     def _process_array(self, x: NDArrayReal) -> NDArrayReal:
         """Perform addition processing considering SNR"""
         logger.debug(f"Applying SNR-based addition with shape: {x.shape}")
-        other: NDArrayReal = self._other.compute()
+        other: NDArrayReal = self._config["other"].compute()
 
         # Use multi-channel versions of calculate_rms and calculate_desired_noise_rms
         clean_rms = util.calculate_rms(x)
         other_rms = util.calculate_rms(other)
 
         # Adjust noise gain based on specified SNR (apply per channel)
-        desired_noise_rms = util.calculate_desired_noise_rms(clean_rms, self._snr)
+        desired_noise_rms = util.calculate_desired_noise_rms(clean_rms, self.snr)
 
         # Apply gain per channel using broadcasting
         gain = desired_noise_rms / other_rms
@@ -342,27 +338,20 @@ class Fade(AudioOperation[NDArrayReal, NDArrayReal]):
     _display = "fade"
 
     def __init__(self, sampling_rate: float, fade_ms: float = 50) -> None:
-        self._fade_ms = float(fade_ms)
-        # Precompute fade length in samples at construction time
-        self._fade_len = round(self._fade_ms * float(sampling_rate) / 1000.0)
+        fade_ms = float(fade_ms)
         super().__init__(sampling_rate, fade_ms=fade_ms)
 
     @property
     def fade_ms(self) -> float:
         """Fade duration captured at operation construction time."""
-        return self._fade_ms
-
-    @property
-    def fade_len(self) -> int:
-        """Fade length in samples."""
-        return self._fade_len
-
-    def to_params(self) -> dict[str, float]:
-        return {"fade_ms": self._fade_ms}
+        return self._config_value("fade_ms")
 
     def validate_params(self) -> None:
-        if self._fade_ms < 0:
+        if self.fade_ms < 0:
             raise ValueError("fade_ms must be non-negative")
+
+    def _fade_len_for_sampling_rate(self) -> int:
+        return round(self.fade_ms * self.sampling_rate / 1000.0)
 
     @staticmethod
     def calculate_tukey_alpha(fade_len: int, n_samples: int) -> float:
@@ -404,14 +393,16 @@ class Fade(AudioOperation[NDArrayReal, NDArrayReal]):
         n_samples = int(arr.shape[-1])
 
         # If no fade requested, return input
-        if self._fade_len <= 0:
+        fade_len = self._fade_len_for_sampling_rate()
+
+        if fade_len <= 0:
             return arr
 
-        if 2 * self._fade_len >= n_samples:
+        if 2 * fade_len >= n_samples:
             raise ValueError("Fade length too long: 2*fade_ms must be less than signal length")
 
         # Calculate Tukey window alpha parameter
-        alpha = self.calculate_tukey_alpha(self._fade_len, n_samples)
+        alpha = self.calculate_tukey_alpha(fade_len, n_samples)
 
         # Create tukey window (numpy) and apply
         env = sp_windows.tukey(n_samples, alpha=alpha)

--- a/wandas/processing/effects.py
+++ b/wandas/processing/effects.py
@@ -6,7 +6,7 @@ import numpy as np
 from dask.array.core import Array as DaArray
 from scipy.signal import windows as sp_windows
 
-from wandas.processing.base import AudioOperation, _snapshot_config_value, register_operation
+from wandas.processing.base import AudioOperation, register_operation
 from wandas.utils import util
 from wandas.utils.optional_imports import require_librosa_effects
 from wandas.utils.types import NDArrayReal
@@ -65,22 +65,18 @@ class _HpssBase(AudioOperation[NDArrayReal, NDArrayReal]):
     _display: str  # set by subclasses
 
     def __init__(self, sampling_rate: float, **kwargs: Any):
-        self._kwargs = {key: _snapshot_config_value(value) for key, value in kwargs.items()}
         self._effects = require_librosa_effects(self.name)
         super().__init__(sampling_rate, **kwargs)
 
     @property
     def kwargs(self) -> dict[str, Any]:
         """Keyword arguments captured at operation construction time."""
-        return {key: _snapshot_config_value(value) for key, value in self._kwargs.items()}
-
-    def to_params(self) -> dict[str, Any]:
-        return {key: _snapshot_config_value(value) for key, value in self._kwargs.items()}
+        return self._config_snapshot()
 
     def _process_array(self, x: NDArrayReal) -> NDArrayReal:
         logger.debug(f"Applying HPSS {self._extract_func} to array with shape: {x.shape}")
         func = getattr(self._effects, self._extract_func)
-        result: NDArrayReal = func(x, **self._kwargs)
+        result: NDArrayReal = func(x, **self._config_snapshot())
         logger.debug(f"HPSS {self._extract_func} applied, returning result with shape: {result.shape}")
         return result
 
@@ -199,25 +195,22 @@ class Normalize(AudioOperation[NDArrayReal, NDArrayReal]):
     @property
     def norm(self) -> float | None:
         """Norm captured at operation construction time."""
-        return self._norm
+        return self._config_snapshot()["norm"]
 
     @property
     def axis(self) -> int | None:
         """Axis captured at operation construction time."""
-        return self._axis
+        return self._config_snapshot()["axis"]
 
     @property
     def threshold(self) -> float | None:
         """Threshold captured at operation construction time."""
-        return self._threshold
+        return self._config_snapshot()["threshold"]
 
     @property
     def fill(self) -> bool | None:
         """Fill behavior captured at operation construction time."""
-        return self._fill
-
-    def to_params(self) -> dict[str, float | int | bool | None]:
-        return {"norm": self._norm, "axis": self._axis, "threshold": self._threshold, "fill": self._fill}
+        return self._config_snapshot()["fill"]
 
     def _process_array(self, x: NDArrayReal) -> NDArrayReal:
         """Perform normalization processing"""

--- a/wandas/processing/filters.py
+++ b/wandas/processing/filters.py
@@ -59,15 +59,12 @@ class _ButterworthFilter(AudioOperation[NDArrayReal, NDArrayReal]):
     @property
     def cutoff(self) -> float:
         """Cutoff frequency captured at operation construction time."""
-        return self._cutoff
+        return self._config_snapshot()["cutoff"]
 
     @property
     def order(self) -> int:
         """Filter order captured at operation construction time."""
-        return self._order
-
-    def to_params(self) -> dict[str, float | int]:
-        return {"cutoff": self._cutoff, "order": self._order}
+        return self._config_snapshot()["order"]
 
     def validate_params(self) -> None:
         _validate_cutoff(self._cutoff, self.sampling_rate, "Cutoff")
@@ -154,15 +151,12 @@ class BandPassFilter(_ButterworthFilter):
     @property
     def low_cutoff(self) -> float:
         """Lower cutoff frequency captured at operation construction time."""
-        return self._low_cutoff
+        return self._config_snapshot()["low_cutoff"]
 
     @property
     def high_cutoff(self) -> float:
         """Higher cutoff frequency captured at operation construction time."""
-        return self._high_cutoff
-
-    def to_params(self) -> dict[str, float | int]:
-        return {"low_cutoff": self._low_cutoff, "high_cutoff": self._high_cutoff, "order": self._order}
+        return self._config_snapshot()["high_cutoff"]
 
     def validate_params(self) -> None:
         """Validate parameters"""

--- a/wandas/processing/filters.py
+++ b/wandas/processing/filters.py
@@ -52,26 +52,24 @@ class _ButterworthFilter(AudioOperation[NDArrayReal, NDArrayReal]):
     _b: NDArrayReal
 
     def __init__(self, sampling_rate: float, cutoff: float, order: int = 4):
-        self._cutoff = cutoff
-        self._order = order
         super().__init__(sampling_rate, cutoff=cutoff, order=order)
 
     @property
     def cutoff(self) -> float:
         """Cutoff frequency captured at operation construction time."""
-        return self._config_snapshot()["cutoff"]
+        return self._config_value("cutoff")
 
     @property
     def order(self) -> int:
         """Filter order captured at operation construction time."""
-        return self._config_snapshot()["order"]
+        return self._config_value("order")
 
     def validate_params(self) -> None:
-        _validate_cutoff(self._cutoff, self.sampling_rate, "Cutoff")
+        _validate_cutoff(self.cutoff, self.sampling_rate, "Cutoff")
 
     def _setup_processor(self) -> None:
-        normal_cutoff = self._cutoff / (0.5 * self.sampling_rate)
-        self._b, self._a = signal.butter(self._order, normal_cutoff, btype=self._btype)
+        normal_cutoff = self.cutoff / (0.5 * self.sampling_rate)
+        self._b, self._a = signal.butter(self.order, normal_cutoff, btype=self._btype)
         logger.debug(f"{self._display} filter coefficients calculated: b={self._b}, a={self._a}")
 
     @property
@@ -142,31 +140,30 @@ class BandPassFilter(_ButterworthFilter):
             If either cutoff frequency is not within valid range (0 < cutoff < Nyquist),
             or if low_cutoff >= high_cutoff
         """
-        self._low_cutoff = low_cutoff
-        self._high_cutoff = high_cutoff
-        self._order = order
         # Skip single-cutoff _ButterworthFilter.__init__
         AudioOperation.__init__(self, sampling_rate, low_cutoff=low_cutoff, high_cutoff=high_cutoff, order=order)
 
     @property
     def low_cutoff(self) -> float:
         """Lower cutoff frequency captured at operation construction time."""
-        return self._config_snapshot()["low_cutoff"]
+        return self._config_value("low_cutoff")
 
     @property
     def high_cutoff(self) -> float:
         """Higher cutoff frequency captured at operation construction time."""
-        return self._config_snapshot()["high_cutoff"]
+        return self._config_value("high_cutoff")
 
     def validate_params(self) -> None:
         """Validate parameters"""
-        _validate_cutoff(self._low_cutoff, self.sampling_rate, "Lower cutoff")
-        _validate_cutoff(self._high_cutoff, self.sampling_rate, "Higher cutoff")
-        if self._low_cutoff >= self._high_cutoff:
+        low_cutoff = self.low_cutoff
+        high_cutoff = self.high_cutoff
+        _validate_cutoff(low_cutoff, self.sampling_rate, "Lower cutoff")
+        _validate_cutoff(high_cutoff, self.sampling_rate, "Higher cutoff")
+        if low_cutoff >= high_cutoff:
             raise ValueError(
                 f"Invalid bandpass filter cutoff frequencies\n"
-                f"  Lower cutoff: {self._low_cutoff} Hz\n"
-                f"  Higher cutoff: {self._high_cutoff} Hz\n"
+                f"  Lower cutoff: {low_cutoff} Hz\n"
+                f"  Higher cutoff: {high_cutoff} Hz\n"
                 f"  Problem: Lower cutoff must be less than higher cutoff\n"
                 f"A bandpass filter passes frequencies between low and high\n"
                 f"  cutoffs.\n"
@@ -177,11 +174,15 @@ class BandPassFilter(_ButterworthFilter):
     def _setup_processor(self) -> None:
         """Set up band-pass filter processor"""
         nyquist = 0.5 * self.sampling_rate
-        low_normal_cutoff = self._low_cutoff / nyquist
-        high_normal_cutoff = self._high_cutoff / nyquist
+        low_normal_cutoff = self.low_cutoff / nyquist
+        high_normal_cutoff = self.high_cutoff / nyquist
 
         # Precompute and save filter coefficients
-        self._b, self._a = signal.butter(self._order, [low_normal_cutoff, high_normal_cutoff], btype="band")
+        self._b, self._a = signal.butter(
+            self.order,
+            [low_normal_cutoff, high_normal_cutoff],
+            btype="band",
+        )
         logger.debug(f"Bandpass filter coefficients calculated: b={self._b}, a={self._a}")
 
 

--- a/wandas/processing/spectral.py
+++ b/wandas/processing/spectral.py
@@ -130,8 +130,6 @@ class FFT(AudioOperation[NDArrayReal, NDArrayComplex]):
 
     name = "fft"
     _display = "FFT"
-    n_fft: int | None
-    window: str
 
     def __init__(self, sampling_rate: float, n_fft: int | None = None, window: str = "hann"):
         """
@@ -162,22 +160,17 @@ class FFT(AudioOperation[NDArrayReal, NDArrayComplex]):
                 f"8192 (powers of 2 are most efficient)"
             )
 
-        self._n_fft = n_fft
-        self._window = window
         super().__init__(sampling_rate, n_fft=n_fft, window=window)
 
     @property
     def n_fft(self) -> int | None:
         """FFT size captured at operation construction time."""
-        return self._n_fft
+        return self._config_value("n_fft")
 
     @property
     def window(self) -> str:
         """Window name captured at operation construction time."""
-        return self._window
-
-    def to_params(self) -> dict[str, int | str | None]:
-        return {"n_fft": self._n_fft, "window": self._window}
+        return self._config_value("window")
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
         """
@@ -193,20 +186,22 @@ class FFT(AudioOperation[NDArrayReal, NDArrayComplex]):
         tuple
             Output data shape (channels, freqs).
         """
-        n_freqs = self._n_fft // 2 + 1 if self._n_fft else input_shape[-1] // 2 + 1
+        n_fft = self.n_fft
+        n_freqs = n_fft // 2 + 1 if n_fft else input_shape[-1] // 2 + 1
         return (*input_shape[:-1], n_freqs)
 
     def _process_array(self, x: NDArrayReal) -> NDArrayComplex:
         """Apply FFT to the input array."""
         from scipy.signal import get_window
 
-        if self._n_fft is not None and x.shape[-1] > self._n_fft:
+        n_fft = self.n_fft
+        if n_fft is not None and x.shape[-1] > n_fft:
             # If n_fft is specified and input length exceeds it, truncate
-            x = x[..., : self._n_fft]
+            x = x[..., :n_fft]
 
-        win = get_window(self._window, x.shape[-1])
+        win = get_window(self.window, x.shape[-1])
         x = x * win
-        result: NDArrayComplex = np.fft.rfft(x, n=self._n_fft, axis=-1)
+        result: NDArrayComplex = np.fft.rfft(x, n=n_fft, axis=-1)
         result[..., 1:-1] *= 2.0
         # Window function scaling correction
         scaling_factor = np.sum(win)
@@ -219,8 +214,6 @@ class IFFT(AudioOperation[NDArrayComplex, NDArrayReal]):
 
     name = "ifft"
     _display = "iFFT"
-    n_fft: int | None
-    window: str
 
     def __init__(self, sampling_rate: float, n_fft: int | None = None, window: str = "hann"):
         """
@@ -235,22 +228,17 @@ class IFFT(AudioOperation[NDArrayComplex, NDArrayReal]):
         window : str, optional
             Window function type, default is 'hann'
         """
-        self._n_fft = n_fft
-        self._window = window
         super().__init__(sampling_rate, n_fft=n_fft, window=window)
 
     @property
     def n_fft(self) -> int | None:
         """IFFT size captured at operation construction time."""
-        return self._n_fft
+        return self._config_value("n_fft")
 
     @property
     def window(self) -> str:
         """Window name captured at operation construction time."""
-        return self._window
-
-    def to_params(self) -> dict[str, int | str | None]:
-        return {"n_fft": self._n_fft, "window": self._window}
+        return self._config_value("window")
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
         """
@@ -266,7 +254,8 @@ class IFFT(AudioOperation[NDArrayComplex, NDArrayReal]):
         tuple
             Output data shape (channels, samples)
         """
-        n_samples = 2 * (input_shape[-1] - 1) if self._n_fft is None else self._n_fft
+        n_fft = self.n_fft
+        n_samples = 2 * (input_shape[-1] - 1) if n_fft is None else n_fft
         return (*input_shape[:-1], n_samples)
 
     def _process_array(self, x: NDArrayComplex) -> NDArrayReal:
@@ -278,12 +267,12 @@ class IFFT(AudioOperation[NDArrayComplex, NDArrayReal]):
         _x[..., 1:-1] /= 2.0
 
         # Execute IFFT
-        result: NDArrayReal = np.fft.irfft(_x, n=self._n_fft, axis=-1)
+        result: NDArrayReal = np.fft.irfft(_x, n=self.n_fft, axis=-1)
 
         # Window function correction (inverse of FFT operation)
         from scipy.signal import get_window
 
-        win = get_window(self._window, result.shape[-1])
+        win = get_window(self.window, result.shape[-1])
 
         # Correct the FFT window function scaling
         scaling_factor = np.sum(win) / result.shape[-1]
@@ -331,45 +320,40 @@ class STFT(AudioOperation[NDArrayReal, NDArrayComplex]):
         # Validate and compute parameters
         actual_win_length, actual_hop_length = _validate_spectral_params(n_fft, win_length, hop_length, "STFT")
 
-        self._n_fft = n_fft
-        self._win_length = actual_win_length
-        self._hop_length = actual_hop_length
-        self._window = window
-
         self._SFT = ShortTimeFFT(
-            win=get_window(window, self._win_length),
-            hop=self._hop_length,
+            win=get_window(window, actual_win_length),
+            hop=actual_hop_length,
             fs=sampling_rate,
-            mfft=self._n_fft,
+            mfft=n_fft,
             scale_to="magnitude",
         )
         super().__init__(
             sampling_rate,
             n_fft=n_fft,
-            win_length=self._win_length,
-            hop_length=self._hop_length,
+            win_length=actual_win_length,
+            hop_length=actual_hop_length,
             window=window,
         )
 
     @property
     def n_fft(self) -> int:
         """FFT size captured at operation construction time."""
-        return self._config_snapshot()["n_fft"]
+        return self._config_value("n_fft")
 
     @property
     def win_length(self) -> int:
         """Window length captured at operation construction time."""
-        return self._config_snapshot()["win_length"]
+        return self._config_value("win_length")
 
     @property
     def hop_length(self) -> int:
         """Hop length captured at operation construction time."""
-        return self._config_snapshot()["hop_length"]
+        return self._config_value("hop_length")
 
     @property
     def window(self) -> str:
         """Window name captured at operation construction time."""
-        return self._config_snapshot()["window"]
+        return self._config_value("window")
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
         """
@@ -446,26 +430,20 @@ class ISTFT(AudioOperation[NDArrayComplex, NDArrayReal]):
         # Validate and compute parameters
         actual_win_length, actual_hop_length = _validate_spectral_params(n_fft, win_length, hop_length, "ISTFT")
 
-        self._n_fft = n_fft
-        self._win_length = actual_win_length
-        self._hop_length = actual_hop_length
-        self._window = window
-        self._length = length
-
         # Instantiate ShortTimeFFT for ISTFT calculation
         self._SFT = ShortTimeFFT(
-            win=get_window(window, self._win_length),
-            hop=self._hop_length,
+            win=get_window(window, actual_win_length),
+            hop=actual_hop_length,
             fs=sampling_rate,
-            mfft=self._n_fft,
+            mfft=n_fft,
             scale_to="magnitude",  # Consistent scaling with STFT
         )
 
         super().__init__(
             sampling_rate,
             n_fft=n_fft,
-            win_length=self._win_length,
-            hop_length=self._hop_length,
+            win_length=actual_win_length,
+            hop_length=actual_hop_length,
             window=window,
             length=length,
         )
@@ -473,36 +451,27 @@ class ISTFT(AudioOperation[NDArrayComplex, NDArrayReal]):
     @property
     def n_fft(self) -> int:
         """FFT size captured at operation construction time."""
-        return self._n_fft
+        return self._config_value("n_fft")
 
     @property
     def win_length(self) -> int:
         """Window length captured at operation construction time."""
-        return self._win_length
+        return self._config_value("win_length")
 
     @property
     def hop_length(self) -> int:
         """Hop length captured at operation construction time."""
-        return self._hop_length
+        return self._config_value("hop_length")
 
     @property
     def window(self) -> str:
         """Window name captured at operation construction time."""
-        return self._window
+        return self._config_value("window")
 
     @property
     def length(self) -> int | None:
         """Output length captured at operation construction time."""
-        return self._length
-
-    def to_params(self) -> dict[str, int | str | None]:
-        return {
-            "n_fft": self._n_fft,
-            "win_length": self._win_length,
-            "hop_length": self._hop_length,
-            "window": self._window,
-            "length": self._length,
-        }
+        return self._config_value("length")
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
         """
@@ -550,7 +519,7 @@ class ISTFT(AudioOperation[NDArrayComplex, NDArrayReal]):
         - hop: hop length (samples between frames)
         - m_num: window length
         - m_num_mid: window midpoint position
-        - self._length: optional length override (if set, limits output)
+        - length: optional length override (if set, limits output)
 
         References
         ----------
@@ -571,9 +540,10 @@ class ISTFT(AudioOperation[NDArrayComplex, NDArrayReal]):
         k0 = 0
         k1 = k_max
 
-        # If self._length is specified, it acts as an override to limit the output
-        if self._length is not None:
-            k1 = min(self._length, k1)
+        # If length is specified, it acts as an override to limit the output
+        length = self.length
+        if length is not None:
+            k1 = min(length, k1)
 
         output_samples = k1 - k0
 
@@ -596,8 +566,9 @@ class ISTFT(AudioOperation[NDArrayComplex, NDArrayReal]):
         result: NDArrayReal = self._SFT.istft(_x)
 
         # Trim to desired length if specified
-        if self._length is not None:
-            result = result[..., : self._length]
+        length = self.length
+        if length is not None:
+            result = result[..., :length]
 
         logger.debug(f"ShortTimeFFT applied, returning result with shape: {result.shape}")
         return result
@@ -620,13 +591,6 @@ class Welch(AudioOperation[NDArrayReal, NDArrayReal]):
 
     name = "welch"
     _display = "Welch"
-    n_fft: int
-    window: str
-    hop_length: int | None
-    _noverlap: int
-    win_length: int | None
-    average: str
-    detrend: str
 
     def __init__(
         self,
@@ -666,18 +630,11 @@ class Welch(AudioOperation[NDArrayReal, NDArrayReal]):
         # Validate and compute parameters
         actual_win_length, actual_hop_length = _validate_spectral_params(n_fft, win_length, hop_length, "Welch method")
 
-        self._n_fft = n_fft
-        self._win_length = actual_win_length
-        self._hop_length = actual_hop_length
-        self._noverlap = self._win_length - self._hop_length
-        self._window = window
-        self._average = average
-        self._detrend = detrend
         super().__init__(
             sampling_rate,
             n_fft=n_fft,
-            win_length=self._win_length,
-            hop_length=self._hop_length,
+            win_length=actual_win_length,
+            hop_length=actual_hop_length,
             window=window,
             average=average,
             detrend=detrend,
@@ -686,47 +643,37 @@ class Welch(AudioOperation[NDArrayReal, NDArrayReal]):
     @property
     def n_fft(self) -> int:
         """FFT size captured at operation construction time."""
-        return self._n_fft
+        return self._config_value("n_fft")
 
     @property
     def win_length(self) -> int:
         """Window length captured at operation construction time."""
-        return self._win_length
+        return self._config_value("win_length")
 
     @property
     def hop_length(self) -> int:
         """Hop length captured at operation construction time."""
-        return self._hop_length
+        return self._config_value("hop_length")
 
     @property
     def window(self) -> str:
         """Window name captured at operation construction time."""
-        return self._window
+        return self._config_value("window")
 
     @property
     def average(self) -> str:
         """Averaging method captured at operation construction time."""
-        return self._average
+        return self._config_value("average")
 
     @property
     def detrend(self) -> str:
         """Detrend method captured at operation construction time."""
-        return self._detrend
+        return self._config_value("detrend")
 
     @property
     def noverlap(self) -> int:
         """Overlap captured at operation construction time."""
-        return self._noverlap
-
-    def to_params(self) -> dict[str, int | str | None]:
-        return {
-            "n_fft": self._n_fft,
-            "win_length": self._win_length,
-            "hop_length": self._hop_length,
-            "window": self._window,
-            "average": self._average,
-            "detrend": self._detrend,
-        }
+        return self.win_length - self.hop_length
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
         """
@@ -742,7 +689,7 @@ class Welch(AudioOperation[NDArrayReal, NDArrayReal]):
         tuple
             Output data shape (channels, freqs)
         """
-        n_freqs = self._n_fft // 2 + 1
+        n_freqs = self.n_fft // 2 + 1
         return (*input_shape[:-1], n_freqs)
 
     def _process_array(self, x: NDArrayReal) -> NDArrayReal:
@@ -758,12 +705,12 @@ class Welch(AudioOperation[NDArrayReal, NDArrayReal]):
 
         _, result = ss.welch(
             x,
-            nperseg=self._win_length,
-            noverlap=self._noverlap,
-            nfft=self._n_fft,
-            window=self._window,
-            average=self._average,
-            detrend=self._detrend,
+            nperseg=self.win_length,
+            noverlap=self.noverlap,
+            nfft=self.n_fft,
+            window=self.window,
+            average=self.average,
+            detrend=self.detrend,
             scaling="spectrum",
         )
 
@@ -799,40 +746,32 @@ class _NOctBase(AudioOperation[NDArrayReal, NDArrayReal]):
         G: int = 10,
         fr: int = 1000,
     ):
-        self._fmin = fmin
-        self._fmax = fmax
-        self._n = n
-        self._G = G
-        self._fr = fr
         super().__init__(sampling_rate, fmin=fmin, fmax=fmax, n=n, G=G, fr=fr)
 
     @property
     def fmin(self) -> float:
         """Minimum band frequency captured at operation construction time."""
-        return self._fmin
+        return self._config_value("fmin")
 
     @property
     def fmax(self) -> float:
         """Maximum band frequency captured at operation construction time."""
-        return self._fmax
+        return self._config_value("fmax")
 
     @property
     def n(self) -> int:
         """Fractional octave denominator captured at operation construction time."""
-        return self._n
+        return self._config_value("n")
 
     @property
     def G(self) -> int:  # noqa: N802
         """Octave ratio base captured at operation construction time."""
-        return self._G
+        return self._config_value("G")
 
     @property
     def fr(self) -> int:
         """Reference frequency captured at operation construction time."""
-        return self._fr
-
-    def to_params(self) -> dict[str, float | int]:
-        return {"fmin": self._fmin, "fmax": self._fmax, "n": self._n, "G": self._G, "fr": self._fr}
+        return self._config_value("fr")
 
     def ensure_dependencies(self) -> None:
         require_mosqito_center_freq("NOctFrame")
@@ -846,7 +785,13 @@ class _NOctBase(AudioOperation[NDArrayReal, NDArrayReal]):
         return super().process(data)
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
-        _, fpref = _center_freq(fmin=self._fmin, fmax=self._fmax, n=self._n, G=self._G, fr=self._fr)
+        _, fpref = _center_freq(
+            fmin=self.fmin,
+            fmax=self.fmax,
+            n=self.n,
+            G=self.G,
+            fr=self.fr,
+        )
         return (input_shape[0], fpref.shape[0])
 
 
@@ -862,11 +807,11 @@ class NOctSpectrum(_NOctBase):
         spec, _ = noct_spectrum(
             sig=x.T,
             fs=self.sampling_rate,
-            fmin=self._fmin,
-            fmax=self._fmax,
-            n=self._n,
-            G=self._G,
-            fr=self._fr,
+            fmin=self.fmin,
+            fmax=self.fmax,
+            n=self.n,
+            G=self.G,
+            fr=self.fr,
         )
         spec = np.expand_dims(spec, axis=0) if spec.ndim == 1 else spec.T
         logger.debug(f"NoctSpectrum applied, returning result with shape: {spec.shape}")
@@ -889,11 +834,11 @@ class NOctSynthesis(_NOctBase):
         result, _ = noct_synthesis(
             spectrum=np.abs(x).T,
             freqs=freqs,
-            fmin=self._fmin,
-            fmax=self._fmax,
-            n=self._n,
-            G=self._G,
-            fr=self._fr,
+            fmin=self.fmin,
+            fmax=self.fmax,
+            n=self.n,
+            G=self.G,
+            fr=self.fr,
         )
         result = result.T
         logger.debug(f"NoctSynthesis applied, returning result with shape: {result.shape}")
@@ -909,8 +854,6 @@ class _CrossSpectralBase(AudioOperation[NDArrayReal, NDArrayReal]):
 
     _method_label: str  # human-readable label for _validate_spectral_params
     _display: str  # set by subclasses
-    n_fft: int
-    _noverlap: int
 
     def __init__(
         self,
@@ -925,17 +868,11 @@ class _CrossSpectralBase(AudioOperation[NDArrayReal, NDArrayReal]):
         actual_win_length, actual_hop_length = _validate_spectral_params(
             n_fft, win_length, hop_length, self._method_label
         )
-        self._n_fft = n_fft
-        self._win_length = actual_win_length
-        self._hop_length = actual_hop_length
-        self._noverlap = self._win_length - self._hop_length
-        self._window = window
-        self._detrend = detrend
         super().__init__(
             sampling_rate,
             n_fft=n_fft,
-            hop_length=self._hop_length,
-            win_length=self._win_length,
+            hop_length=actual_hop_length,
+            win_length=actual_win_length,
             window=window,
             detrend=detrend,
             **extra_kwargs,
@@ -944,45 +881,36 @@ class _CrossSpectralBase(AudioOperation[NDArrayReal, NDArrayReal]):
     @property
     def n_fft(self) -> int:
         """FFT size captured at operation construction time."""
-        return self._n_fft
+        return self._config_value("n_fft")
 
     @property
     def win_length(self) -> int:
         """Window length captured at operation construction time."""
-        return self._win_length
+        return self._config_value("win_length")
 
     @property
     def hop_length(self) -> int:
         """Hop length captured at operation construction time."""
-        return self._hop_length
+        return self._config_value("hop_length")
 
     @property
     def window(self) -> str:
         """Window name captured at operation construction time."""
-        return self._window
+        return self._config_value("window")
 
     @property
     def detrend(self) -> str:
         """Detrend method captured at operation construction time."""
-        return self._detrend
+        return self._config_value("detrend")
 
     @property
     def noverlap(self) -> int:
         """Overlap captured at operation construction time."""
-        return self._noverlap
-
-    def to_params(self) -> dict[str, int | str]:
-        return {
-            "n_fft": self._n_fft,
-            "hop_length": self._hop_length,
-            "win_length": self._win_length,
-            "window": self._window,
-            "detrend": self._detrend,
-        }
+        return self.win_length - self.hop_length
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
         n_channels = input_shape[0]
-        n_freqs = self._n_fft // 2 + 1
+        n_freqs = self.n_fft // 2 + 1
         return (n_channels * n_channels, n_freqs)
 
 
@@ -1002,11 +930,11 @@ class Coherence(_CrossSpectralBase):
             x=x[:, np.newaxis],
             y=x[np.newaxis, :],
             fs=self.sampling_rate,
-            nperseg=self._win_length,
-            noverlap=self._noverlap,
-            nfft=self._n_fft,
-            window=self._window,
-            detrend=self._detrend,
+            nperseg=self.win_length,
+            noverlap=self.noverlap,
+            nfft=self.n_fft,
+            window=self.window,
+            detrend=self.detrend,
         )
 
         # Reshape result to (n_channels * n_channels, n_freqs)
@@ -1034,8 +962,6 @@ class _ScaledCrossSpectralBase(_CrossSpectralBase):
         scaling: str = "spectrum",
         average: str = "mean",
     ):
-        self._scaling = scaling
-        self._average = average
         super().__init__(
             sampling_rate,
             n_fft=n_fft,
@@ -1050,17 +976,12 @@ class _ScaledCrossSpectralBase(_CrossSpectralBase):
     @property
     def scaling(self) -> str:
         """Scaling mode captured at operation construction time."""
-        return self._scaling
+        return self._config_value("scaling")
 
     @property
     def average(self) -> str:
         """Averaging method captured at operation construction time."""
-        return self._average
-
-    def to_params(self) -> dict[str, int | str]:
-        params = super().to_params()
-        params.update({"scaling": self._scaling, "average": self._average})
-        return params
+        return self._config_value("average")
 
 
 class CSD(_ScaledCrossSpectralBase):
@@ -1080,13 +1001,13 @@ class CSD(_ScaledCrossSpectralBase):
             x=x[:, np.newaxis],
             y=x[np.newaxis, :],
             fs=self.sampling_rate,
-            nperseg=self._win_length,
-            noverlap=self._noverlap,
-            nfft=self._n_fft,
-            window=self._window,
-            detrend=self._detrend,
-            scaling=self._scaling,
-            average=self._average,
+            nperseg=self.win_length,
+            noverlap=self.noverlap,
+            nfft=self.n_fft,
+            window=self.window,
+            detrend=self.detrend,
+            scaling=self.scaling,
+            average=self.average,
         )
 
         # Reshape result to (n_channels * n_channels, n_freqs)
@@ -1113,13 +1034,13 @@ class TransferFunction(_ScaledCrossSpectralBase):
             x=x[:, np.newaxis, :],
             y=x[np.newaxis, :, :],
             fs=self.sampling_rate,
-            nperseg=self._win_length,
-            noverlap=self._noverlap,
-            nfft=self._n_fft,
-            window=self._window,
-            detrend=self._detrend,
-            scaling=self._scaling,
-            average=self._average,
+            nperseg=self.win_length,
+            noverlap=self.noverlap,
+            nfft=self.n_fft,
+            window=self.window,
+            detrend=self.detrend,
+            scaling=self.scaling,
+            average=self.average,
             axis=-1,
         )
         # p_yx shape: (num_channels, num_channels, num_frequencies)
@@ -1128,13 +1049,13 @@ class TransferFunction(_ScaledCrossSpectralBase):
         _f, p_xx = ss.welch(
             x=x,
             fs=self.sampling_rate,
-            nperseg=self._win_length,
-            noverlap=self._noverlap,
-            nfft=self._n_fft,
-            window=self._window,
-            detrend=self._detrend,
-            scaling=self._scaling,
-            average=self._average,
+            nperseg=self.win_length,
+            noverlap=self.noverlap,
+            nfft=self.n_fft,
+            window=self.window,
+            detrend=self.detrend,
+            scaling=self.scaling,
+            average=self.average,
             axis=-1,
         )
         # p_xx shape: (num_channels, num_frequencies)

--- a/wandas/processing/spectral.py
+++ b/wandas/processing/spectral.py
@@ -354,30 +354,22 @@ class STFT(AudioOperation[NDArrayReal, NDArrayComplex]):
     @property
     def n_fft(self) -> int:
         """FFT size captured at operation construction time."""
-        return self._n_fft
+        return self._config_snapshot()["n_fft"]
 
     @property
     def win_length(self) -> int:
         """Window length captured at operation construction time."""
-        return self._win_length
+        return self._config_snapshot()["win_length"]
 
     @property
     def hop_length(self) -> int:
         """Hop length captured at operation construction time."""
-        return self._hop_length
+        return self._config_snapshot()["hop_length"]
 
     @property
     def window(self) -> str:
         """Window name captured at operation construction time."""
-        return self._window
-
-    def to_params(self) -> dict[str, int | str | None]:
-        return {
-            "n_fft": self._n_fft,
-            "win_length": self._win_length,
-            "hop_length": self._hop_length,
-            "window": self._window,
-        }
+        return self._config_snapshot()["window"]
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
         """

--- a/wandas/processing/stats.py
+++ b/wandas/processing/stats.py
@@ -47,13 +47,12 @@ class Power(AudioOperation[NDArrayReal, NDArrayReal]):
         exponent : float
             Power exponent
         """
-        self._exponent = exponent
         super().__init__(sampling_rate, exponent=exponent)
 
     @property
     def exponent(self) -> float:
         """Exponent captured at operation construction time."""
-        return self._config_snapshot()["exponent"]
+        return self._config_value("exponent")
 
     @property
     def exp(self) -> float:
@@ -61,7 +60,7 @@ class Power(AudioOperation[NDArrayReal, NDArrayReal]):
         return self.exponent
 
     def process(self, data: DaArray) -> DaArray:
-        return self._mark_array(da.power(data, self._exponent))
+        return self._mark_array(da.power(data, self.exponent))
 
 
 class Sum(AudioOperation[NDArrayReal, NDArrayReal]):
@@ -89,7 +88,6 @@ class ChannelDifference(AudioOperation[NDArrayReal, NDArrayReal]):
 
     name = "channel_difference"
     _display = "diff"
-    other_channel: int
 
     def __init__(self, sampling_rate: float, other_channel: int = 0):
         """
@@ -102,18 +100,18 @@ class ChannelDifference(AudioOperation[NDArrayReal, NDArrayReal]):
         other_channel : int
             Channel to calculate difference with, default is 0
         """
-        self._other_channel = other_channel
         super().__init__(sampling_rate, other_channel=other_channel)
 
     @property
     def other_channel(self) -> int:
         """Other channel index captured at operation construction time."""
-        return self._config_snapshot()["other_channel"]
+        return self._config_value("other_channel")
 
     def process(self, data: DaArray) -> DaArray:
-        if not -data.shape[0] <= self._other_channel < data.shape[0]:
+        other_channel = self.other_channel
+        if not -data.shape[0] <= other_channel < data.shape[0]:
             raise IndexError("Channel index out of range")
-        return self._mark_array(data - data[self._other_channel])
+        return self._mark_array(data - data[other_channel])
 
 
 # Register all operations

--- a/wandas/processing/stats.py
+++ b/wandas/processing/stats.py
@@ -53,15 +53,12 @@ class Power(AudioOperation[NDArrayReal, NDArrayReal]):
     @property
     def exponent(self) -> float:
         """Exponent captured at operation construction time."""
-        return self._exponent
+        return self._config_snapshot()["exponent"]
 
     @property
     def exp(self) -> float:
         """Backward-compatible read-only alias for the captured exponent."""
-        return self._exponent
-
-    def to_params(self) -> dict[str, float]:
-        return {"exponent": self._exponent}
+        return self.exponent
 
     def process(self, data: DaArray) -> DaArray:
         return self._mark_array(da.power(data, self._exponent))
@@ -111,10 +108,7 @@ class ChannelDifference(AudioOperation[NDArrayReal, NDArrayReal]):
     @property
     def other_channel(self) -> int:
         """Other channel index captured at operation construction time."""
-        return self._other_channel
-
-    def to_params(self) -> dict[str, int]:
-        return {"other_channel": self._other_channel}
+        return self._config_snapshot()["other_channel"]
 
     def process(self, data: DaArray) -> DaArray:
         if not -data.shape[0] <= self._other_channel < data.shape[0]:

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -76,16 +76,12 @@ class ReSampling(AudioOperation[NDArrayReal, NDArrayReal]):
         """
         validate_sampling_rate(sampling_rate, "source sampling rate")
         validate_sampling_rate(target_sr, "target sampling rate")
-        self._target_sr = target_sr
         super().__init__(sampling_rate, target_sr=target_sr)
 
     @property
     def target_sr(self) -> float:
         """Target sampling rate captured at operation construction time."""
-        return self._target_sr
-
-    def to_params(self) -> dict[str, float]:
-        return {"target_sr": self._target_sr}
+        return self._config_value("target_sr")
 
     def get_metadata_updates(self) -> dict[str, Any]:
         """
@@ -101,7 +97,7 @@ class ReSampling(AudioOperation[NDArrayReal, NDArrayReal]):
         Resampling always produces output at target_sr, regardless of input
         sampling rate. All necessary parameters are provided at initialization.
         """
-        return {"sampling_rate": self._target_sr}
+        return {"sampling_rate": self.target_sr}
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
         """
@@ -118,7 +114,7 @@ class ReSampling(AudioOperation[NDArrayReal, NDArrayReal]):
             Output data shape
         """
         # Calculate length after resampling using exact decimal sampling-rate ratio.
-        ratio = _resampling_fraction(self.sampling_rate, self._target_sr)
+        ratio = _resampling_fraction(self.sampling_rate, self.target_sr)
         n_samples = _ceil_resampled_length(input_shape[-1], ratio)
         return (*input_shape[:-1], n_samples)
 
@@ -132,7 +128,7 @@ class ReSampling(AudioOperation[NDArrayReal, NDArrayReal]):
     def _process_array(self, x: NDArrayReal) -> NDArrayReal:
         """Create processor function for resampling operation"""
         logger.debug(f"Applying resampling to array with shape: {x.shape}")
-        up, down = _resampling_ratio(self.sampling_rate, self._target_sr)
+        up, down = _resampling_ratio(self.sampling_rate, self.target_sr)
         target_len = self.calculate_output_shape(x.shape)[-1]
         poly_len = _ceil_resampled_length(x.shape[-1], Fraction(up, down))
         if poly_len == target_len:
@@ -174,35 +170,28 @@ class Trim(AudioOperation[NDArrayReal, NDArrayReal]):
         end : float
             End time for trimming (seconds)
         """
-        self._start = start
-        self._end = end
-        self._start_sample = int(start * sampling_rate)
-        self._end_sample = int(end * sampling_rate)
         super().__init__(sampling_rate, start=start, end=end)
-        logger.debug(f"Initialized Trim operation with start: {self._start}, end: {self._end}")
+        logger.debug(f"Initialized Trim operation with start: {start}, end: {end}")
 
     @property
     def start(self) -> float:
         """Start time captured at operation construction time."""
-        return self._start
+        return self._config_value("start")
 
     @property
     def end(self) -> float:
         """End time captured at operation construction time."""
-        return self._end
+        return self._config_value("end")
 
     @property
     def start_sample(self) -> int:
         """Start sample index derived from the captured start time."""
-        return self._start_sample
+        return int(self.start * self.sampling_rate)
 
     @property
     def end_sample(self) -> int:
         """End sample index derived from the captured end time."""
-        return self._end_sample
-
-    def to_params(self) -> dict[str, float]:
-        return {"start": self._start, "end": self._end}
+        return int(self.end * self.sampling_rate)
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
         """
@@ -220,15 +209,15 @@ class Trim(AudioOperation[NDArrayReal, NDArrayReal]):
         """
         # Calculate length after trimming
         # Exclude parts where there is no signal
-        end_sample = min(self._end_sample, input_shape[-1])
-        n_samples = end_sample - self._start_sample
+        end_sample = min(self.end_sample, input_shape[-1])
+        n_samples = end_sample - self.start_sample
         return (*input_shape[:-1], n_samples)
 
     def _process_array(self, x: NDArrayReal) -> NDArrayReal:
         """Create processor function for trimming operation"""
         logger.debug(f"Applying trim to array with shape: {x.shape}")
         # Apply trimming
-        result = x[..., self._start_sample : self._end_sample]
+        result = x[..., self.start_sample : self.end_sample]
         logger.debug(f"Trim applied, returning result with shape: {result.shape}")
         return result
 
@@ -261,17 +250,12 @@ class FixLength(AudioOperation[NDArrayReal, NDArrayReal]):
             if duration is None:
                 raise ValueError("Either length or duration must be provided.")
             length = int(duration * sampling_rate)
-        self._target_length = length
-
-        super().__init__(sampling_rate, target_length=self._target_length)
+        super().__init__(sampling_rate, target_length=length)
 
     @property
     def target_length(self) -> int:
         """Target length captured at operation construction time."""
-        return self._target_length
-
-    def to_params(self) -> dict[str, int]:
-        return {"target_length": self._target_length}
+        return self._config_value("target_length")
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
         """
@@ -287,17 +271,17 @@ class FixLength(AudioOperation[NDArrayReal, NDArrayReal]):
         tuple
             Output data shape
         """
-        return (*input_shape[:-1], self._target_length)
+        return (*input_shape[:-1], self.target_length)
 
     def _process_array(self, x: NDArrayReal) -> NDArrayReal:
         """Create processor function for padding operation"""
         logger.debug(f"Applying padding to array with shape: {x.shape}")
         # Apply padding
-        pad_width = self._target_length - x.shape[-1]
+        pad_width = self.target_length - x.shape[-1]
         if pad_width > 0:
             result = np.pad(x, ((0, 0), (0, pad_width)), mode="constant")
         else:
-            result = x[..., : self._target_length]
+            result = x[..., : self.target_length]
         logger.debug(f"Padding applied, returning result with shape: {result.shape}")
         return result
 
@@ -307,9 +291,6 @@ class RmsTrend(AudioOperation[NDArrayReal, NDArrayReal]):
 
     name = "rms_trend"
     _display = "RMS"
-    frame_length: int
-    hop_length: int
-    Aw: bool
 
     def __init__(
         self,
@@ -338,44 +319,40 @@ class RmsTrend(AudioOperation[NDArrayReal, NDArrayReal]):
         Aw : bool
             Whether to apply A-weighting before RMS calculation
         """
-        self._frame_length = frame_length
-        self._hop_length = hop_length
-        self._dB = dB
-        self._Aw = Aw
-        self._ref = np.array(ref if isinstance(ref, list) else [ref])
+        ref_array = np.array(ref if isinstance(ref, list) else [ref])
         super().__init__(
             sampling_rate,
             frame_length=frame_length,
             hop_length=hop_length,
             dB=dB,
             Aw=Aw,
-            ref=self._ref,
+            ref=ref_array,
         )
 
     @property
     def frame_length(self) -> int:
         """Frame length captured at operation construction time."""
-        return self._config_snapshot()["frame_length"]
+        return self._config_value("frame_length")
 
     @property
     def hop_length(self) -> int:
         """Hop length captured at operation construction time."""
-        return self._config_snapshot()["hop_length"]
+        return self._config_value("hop_length")
 
     @property
     def dB(self) -> bool:  # noqa: N802
         """Whether output is converted to decibels."""
-        return self._config_snapshot()["dB"]
+        return self._config_value("dB")
 
     @property
     def Aw(self) -> bool:  # noqa: N802
         """Whether A-weighting is applied before RMS calculation."""
-        return self._config_snapshot()["Aw"]
+        return self._config_value("Aw")
 
     @property
     def ref(self) -> NDArrayReal:
         """Reference values captured at operation construction time."""
-        return self._config_snapshot()["ref"]
+        return self._config_value("ref")
 
     def get_metadata_updates(self) -> dict[str, Any]:
         """
@@ -391,7 +368,7 @@ class RmsTrend(AudioOperation[NDArrayReal, NDArrayReal]):
         The output sampling rate is determined by downsampling the input
         by hop_length. All necessary parameters are provided at initialization.
         """
-        new_sr = self.sampling_rate / self._hop_length
+        new_sr = self.sampling_rate / self.hop_length
         return {"sampling_rate": new_sr}
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
@@ -408,7 +385,11 @@ class RmsTrend(AudioOperation[NDArrayReal, NDArrayReal]):
         tuple
             Output data shape (channels, frames)
         """
-        n_frames = _centered_frame_count(input_shape[-1], self._frame_length, self._hop_length)
+        n_frames = _centered_frame_count(
+            input_shape[-1],
+            self.frame_length,
+            self.hop_length,
+        )
         return (*input_shape[:-1], n_frames)
 
     @staticmethod
@@ -419,7 +400,7 @@ class RmsTrend(AudioOperation[NDArrayReal, NDArrayReal]):
         """Create processor function for RMS calculation"""
         logger.debug(f"Applying RMS to array with shape: {x.shape}")
 
-        if self._Aw:
+        if self.Aw:
             # Apply A-weighting
             _x = A_weight(x, self.sampling_rate)
             if isinstance(_x, np.ndarray):
@@ -432,11 +413,15 @@ class RmsTrend(AudioOperation[NDArrayReal, NDArrayReal]):
                 raise ValueError("A_weighting returned an unexpected type.")
 
         # Calculate RMS
-        result: NDArrayReal = _frame_rms(x, frame_length=self._frame_length, hop_length=self._hop_length)
+        result: NDArrayReal = _frame_rms(
+            x,
+            frame_length=self.frame_length,
+            hop_length=self.hop_length,
+        )
 
-        if self._dB:
+        if self.dB:
             # Convert to dB
-            result = 20 * np.log10(np.maximum(result / self._ref[..., np.newaxis], DB_FLOOR))
+            result = 20 * np.log10(np.maximum(result / self._config["ref"][..., np.newaxis], DB_FLOOR))
         logger.debug(f"RMS applied, returning result with shape: {result.shape}")
         return result
 
@@ -462,22 +447,21 @@ class SoundLevel(AudioOperation[NDArrayReal, NDArrayReal]):
         dB: bool = False,
     ) -> None:
         validate_sampling_rate(sampling_rate)
-        self._ref = np.atleast_1d(np.array(ref, dtype=float, copy=True))
-        if np.any(self._ref <= 0):
+        ref_array = np.atleast_1d(np.array(ref, dtype=float, copy=True))
+        if np.any(ref_array <= 0):
             raise ValueError(
                 "Invalid sound level reference\n"
-                f"  Got: {self._ref.tolist()}\n"
+                f"  Got: {ref_array.tolist()}\n"
                 "  Expected: Positive reference values\n"
                 "Sound pressure level requires a positive reference pressure."
             )
-        self._freq_weighting = self._normalize_freq_weighting(freq_weighting)
-        self._time_weighting = self._normalize_time_weighting(time_weighting)
-        self._dB = dB
+        normalized_freq_weighting = self._normalize_freq_weighting(freq_weighting)
+        normalized_time_weighting = self._normalize_time_weighting(time_weighting)
         super().__init__(
             sampling_rate,
-            ref=self._ref,
-            freq_weighting=self._freq_weighting,
-            time_weighting=self._time_weighting,
+            ref=ref_array,
+            freq_weighting=normalized_freq_weighting,
+            time_weighting=normalized_time_weighting,
             dB=dB,
         )
 
@@ -510,27 +494,27 @@ class SoundLevel(AudioOperation[NDArrayReal, NDArrayReal]):
     @property
     def ref(self) -> NDArrayReal:
         """Reference values captured at operation construction time."""
-        return self._config_snapshot()["ref"]
+        return self._config_value("ref")
 
     @property
     def freq_weighting(self) -> str:
         """Frequency weighting captured at operation construction time."""
-        return self._config_snapshot()["freq_weighting"]
+        return self._config_value("freq_weighting")
 
     @property
     def time_weighting(self) -> str:
         """Time weighting captured at operation construction time."""
-        return self._config_snapshot()["time_weighting"]
+        return self._config_value("time_weighting")
 
     @property
     def dB(self) -> bool:  # noqa: N802
         """Whether output is converted to decibels."""
-        return self._config_snapshot()["dB"]
+        return self._config_value("dB")
 
     @property
     def time_constant(self) -> float:
         """Return the RC time constant in seconds."""
-        return 0.125 if self._time_weighting == "Fast" else 1.0
+        return 0.125 if self.time_weighting == "Fast" else 1.0
 
     @staticmethod
     def _output_dtype(
@@ -543,20 +527,23 @@ class SoundLevel(AudioOperation[NDArrayReal, NDArrayReal]):
 
     def get_display_name(self) -> str:
         """Get display name for the operation for use in channel labels."""
-        if self._dB:
-            return f"L{self._freq_weighting}{self._time_weighting[0]}"
-        return f"{self._freq_weighting}{self._time_weighting[0]}RMS"
+        freq_weighting = self.freq_weighting
+        time_weighting = self.time_weighting
+        if self.dB:
+            return f"L{freq_weighting}{time_weighting[0]}"
+        return f"{freq_weighting}{time_weighting[0]}RMS"
 
     def _reference_squared(self, n_channels: int) -> NDArrayReal:
         """Return squared reference pressure for each channel."""
-        if self._ref.size == 1:
-            ref = np.repeat(self._ref, n_channels)
-        elif self._ref.size == n_channels:
-            ref = self._ref
+        ref_config = self._config["ref"]
+        if ref_config.size == 1:
+            ref = np.repeat(ref_config, n_channels)
+        elif ref_config.size == n_channels:
+            ref = ref_config
         else:
             raise ValueError(
                 "Reference count mismatch\n"
-                f"  Got: {self._ref.size} reference values for {n_channels} channels\n"
+                f"  Got: {ref_config.size} reference values for {n_channels} channels\n"
                 "  Expected: One shared reference or one reference per channel\n"
                 "Provide ref as a scalar or a list matching the number of channels."
             )
@@ -567,19 +554,20 @@ class SoundLevel(AudioOperation[NDArrayReal, NDArrayReal]):
         logger.debug(
             "Applying sound level to array with shape %s using %s/%s weighting",
             x.shape,
-            self._freq_weighting,
-            self._time_weighting,
+            self.freq_weighting,
+            self.time_weighting,
         )
         output_dtype = self._output_dtype(x.dtype)
         weighted_input = x if x.dtype == np.float64 else np.asarray(x, dtype=np.float64)
-        if self._freq_weighting == "Z":
+        freq_weighting = self.freq_weighting
+        if freq_weighting == "Z":
             weighted = weighted_input
         else:
-            weighted = frequency_weight(weighted_input, self.sampling_rate, curve=self._freq_weighting)
+            weighted = frequency_weight(weighted_input, self.sampling_rate, curve=freq_weighting)
         squared = np.square(weighted)
         alpha = np.asarray(np.exp(-1.0 / (self.sampling_rate * self.time_constant)), dtype=np.float64).item()
         smoothed = lfilter([1.0 - alpha], [1.0, -alpha], squared, axis=-1)
-        if self._dB:
+        if self.dB:
             ref_squared_broadcast = self._reference_squared(smoothed.shape[0])[:, np.newaxis]
             result = 10.0 * np.log10(np.maximum(smoothed / ref_squared_broadcast, MIN_SOUND_LEVEL_POWER_RATIO))
         else:

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -355,36 +355,27 @@ class RmsTrend(AudioOperation[NDArrayReal, NDArrayReal]):
     @property
     def frame_length(self) -> int:
         """Frame length captured at operation construction time."""
-        return self._frame_length
+        return self._config_snapshot()["frame_length"]
 
     @property
     def hop_length(self) -> int:
         """Hop length captured at operation construction time."""
-        return self._hop_length
+        return self._config_snapshot()["hop_length"]
 
     @property
     def dB(self) -> bool:  # noqa: N802
         """Whether output is converted to decibels."""
-        return self._dB
+        return self._config_snapshot()["dB"]
 
     @property
     def Aw(self) -> bool:  # noqa: N802
         """Whether A-weighting is applied before RMS calculation."""
-        return self._Aw
+        return self._config_snapshot()["Aw"]
 
     @property
     def ref(self) -> NDArrayReal:
         """Reference values captured at operation construction time."""
-        return self._ref.copy()
-
-    def to_params(self) -> dict[str, Any]:
-        return {
-            "frame_length": self._frame_length,
-            "hop_length": self._hop_length,
-            "dB": self._dB,
-            "Aw": self._Aw,
-            "ref": self._ref,
-        }
+        return self._config_snapshot()["ref"]
 
     def get_metadata_updates(self) -> dict[str, Any]:
         """
@@ -519,30 +510,22 @@ class SoundLevel(AudioOperation[NDArrayReal, NDArrayReal]):
     @property
     def ref(self) -> NDArrayReal:
         """Reference values captured at operation construction time."""
-        return self._ref.copy()
+        return self._config_snapshot()["ref"]
 
     @property
     def freq_weighting(self) -> str:
         """Frequency weighting captured at operation construction time."""
-        return self._freq_weighting
+        return self._config_snapshot()["freq_weighting"]
 
     @property
     def time_weighting(self) -> str:
         """Time weighting captured at operation construction time."""
-        return self._time_weighting
+        return self._config_snapshot()["time_weighting"]
 
     @property
     def dB(self) -> bool:  # noqa: N802
         """Whether output is converted to decibels."""
-        return self._dB
-
-    def to_params(self) -> dict[str, Any]:
-        return {
-            "ref": self._ref,
-            "freq_weighting": self._freq_weighting,
-            "time_weighting": self._time_weighting,
-            "dB": self._dB,
-        }
+        return self._config_snapshot()["dB"]
 
     @property
     def time_constant(self) -> float:


### PR DESCRIPTION
## Summary

- Make `AudioOperation` snapshot constructor params into a base-owned canonical `_config` dict.
- Have default `to_params()` and `params` expose defensive snapshots from that canonical config.
- Migrate representative operations to rely on the base config path where lineage params match constructor params.
- Add regression coverage for lineage/history exposure, defensive nested config, Dask pending compute stability, HPSS kwargs, RMS refs, and custom operation repeated delayed computes.

## Impact

This removes duplicated operation config state for the migrated operations and makes simple subclasses automatically expose constructor params through lineage, display, and history without overriding `to_params()`.

## Validation

- `uv run pytest tests/processing/test_base_operations.py tests/processing/test_custom_operation.py tests/processing/test_temporal_operations.py tests/processing/test_effect_operations.py tests/core/test_base_frame_lineage.py tests/core/test_base_frame_additional.py`
- `uv run pytest`
- `uv run ruff check wandas tests --config=pyproject.toml`
- `uv run ty check wandas tests`
- Commit hook: `ruff check`, `ruff format`, `ty`