### PR TITLE
[codex] Add custom operation dask_pure API

### DIFF
--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -152,6 +152,37 @@ class TestChannelProcessing:
         with pytest.raises(ValueError, match="Parameter name conflict"):
             frame.apply(add_for_pure_arg, output_shape_func=lambda shape: shape, pure=False)
 
+    def test_apply_custom_function_defaults_to_dask_pure(self) -> None:
+        frame = ChannelFrame(
+            data=self.dask_data,
+            sampling_rate=self.sample_rate,
+            channel_metadata=[{"label": "ch0", "unit": "", "extra": {}}],
+        )
+
+        result = frame.apply(lambda x: x, output_shape_func=lambda shape: shape)
+
+        assert result.lineage is not None
+        assert result.lineage.operation.pure is True
+
+    def test_apply_custom_function_dask_pure_controls_operation_not_history_params(self) -> None:
+        frame = ChannelFrame(
+            data=self.dask_data,
+            sampling_rate=self.sample_rate,
+            channel_metadata=[{"label": "ch0", "unit": "", "extra": {}}],
+        )
+
+        result = frame.apply(
+            lambda x, user_param: x + user_param,
+            output_shape_func=lambda shape: shape,
+            dask_pure=False,
+            user_param=1.5,
+        )
+
+        assert result.lineage is not None
+        assert result.lineage.operation.pure is False
+        assert result.lineage.operation.params == {"user_param": 1.5}
+        assert result.operation_history[-1]["params"] == {"user_param": 1.5}
+
     def test_apply_custom_function_params_copy_mutation_does_not_change_history_or_compute(self) -> None:
         """Custom operation params are defensive views for history and compute."""
         frame = ChannelFrame(

--- a/tests/processing/test_custom_operation.py
+++ b/tests/processing/test_custom_operation.py
@@ -135,6 +135,18 @@ class TestCustomOperation:
 
         assert op.params["config"]["gain"] == 2.0
 
+    def test_custom_operation_defaults_to_dask_pure(self) -> None:
+        op = CustomOperation(16000, func=lambda x: x)
+
+        assert op.pure is True
+
+    def test_custom_operation_dask_pure_controls_dask_purity_not_params(self) -> None:
+        op = CustomOperation(16000, func=lambda x, gain: x * gain, dask_pure=False, gain=2.0)
+
+        assert op.pure is False
+        assert op.params == {"gain": 2.0}
+        assert "dask_pure" not in op.to_params()
+
     def test_custom_operation_does_not_expose_pure_constructor_option(self) -> None:
         def my_func(x: np.ndarray, pure: bool) -> np.ndarray:
             return x + (1.0 if pure else 2.0)

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -81,6 +81,8 @@ class ChannelProcessingMixin:
         output_shape_func: Callable[[tuple[int, ...]], tuple[int, ...]] | None = ...,
         output_frame_class: None = ...,
         output_frame_kwargs: dict[str, Any] | None = ...,
+        *,
+        dask_pure: bool = ...,
         **kwargs: Any,
     ) -> T_Processing: ...
 
@@ -93,14 +95,19 @@ class ChannelProcessingMixin:
         output_shape_func: Callable[[tuple[int, ...]], tuple[int, ...]] | None = ...,
         output_frame_class: type[T_OutputFrame] = ...,
         output_frame_kwargs: dict[str, Any] | None = ...,
+        *,
+        dask_pure: bool = ...,
         **kwargs: Any,
     ) -> T_OutputFrame: ...
+
     def apply(
         self: T_Processing,
         func: Callable[..., Any],
         output_shape_func: Callable[[tuple[int, ...]], tuple[int, ...]] | None = None,
         output_frame_class: type[T_OutputFrame] | None = None,
         output_frame_kwargs: dict[str, Any] | None = None,
+        *,
+        dask_pure: bool = True,
         **kwargs: Any,
     ) -> Any:
         """Apply a custom function to the signal.
@@ -114,6 +121,10 @@ class ChannelProcessingMixin:
                 ``ChannelFrame`` -> ``SpectralFrame``).
             output_frame_kwargs: Extra constructor keyword arguments required
                 by *output_frame_class* (e.g. ``{"n_fft": 1024}``).
+            dask_pure: Dask execution-control flag for delayed custom
+                operations. Set to ``False`` for non-deterministic or
+                side-effecting functions. This value is not forwarded to
+                *func* or recorded in operation history.
             **kwargs: Additional arguments for the function.
 
         Returns:
@@ -143,6 +154,7 @@ class ChannelProcessingMixin:
             sampling_rate=self.sampling_rate,
             func=func,
             output_shape_func=output_shape_func,
+            dask_pure=dask_pure,
             **kwargs,
         )
 

--- a/wandas/processing/custom.py
+++ b/wandas/processing/custom.py
@@ -19,6 +19,8 @@ class CustomOperation(AudioOperation[InputArrayType, OutputArrayType]):
         sampling_rate: float,
         func: Callable[..., OutputArrayType],
         output_shape_func: Callable[[tuple[int, ...]], tuple[int, ...]] | None = None,
+        *,
+        dask_pure: bool = True,
         **params: Any,
     ):
         """
@@ -32,16 +34,21 @@ class CustomOperation(AudioOperation[InputArrayType, OutputArrayType]):
             Function to apply to the data.
         output_shape_func : Callable, optional
             Function to calculate output shape from input shape.
+        dask_pure : bool, default=True
+            Dask execution-control flag for the delayed task. Set to ``False``
+            for non-deterministic or side-effecting custom functions. This is
+            not forwarded to the custom function or recorded in lineage params.
         **params : Any
-            Additional parameters to pass to the function. ``pure`` is reserved
-            for operation purity and Dask task semantics; use a different
-            custom parameter name such as ``is_pure``.
+            Additional parameters to pass to the function. ``pure`` and
+            ``dask_pure`` are reserved for operation purity and Dask task
+            semantics; use different custom parameter names such as
+            ``is_pure``.
         """
         # Store callables privately so a frame lineage operation cannot alter a
         # pending Dask graph by reassigning public attributes before compute.
         self._func: Callable[..., OutputArrayType] = func
         self._output_shape_func = output_shape_func
-        super().__init__(sampling_rate, pure=True, **params)
+        super().__init__(sampling_rate, pure=dask_pure, **params)
 
     @property
     def func(self) -> Callable[..., OutputArrayType]:


### PR DESCRIPTION
## Summary

Closes #239.

- Add `dask_pure` to `CustomOperation` and `ChannelFrame.apply()` as the explicit Dask delayed purity control.
- Keep `pure` reserved and unavailable as a custom function kwarg.
- Ensure `dask_pure` affects `operation.pure` but is not forwarded to custom functions or recorded in lineage/history params.

## Validation

- `uv run pytest tests/processing/test_custom_operation.py tests/frames/test_channel_processing.py`
- `uv run ruff check wandas tests --config=pyproject.toml -v`
- `uv run ty check wandas tests`