### PR TITLE
[codex] Add source_time_offset to raw add_channel input

### DIFF
--- a/tests/frames/test_channel_collection_mixin.py
+++ b/tests/frames/test_channel_collection_mixin.py
@@ -27,6 +27,7 @@ class ConcreteChannelCollection(ChannelCollectionMixin):
         align: Literal["strict", "pad", "truncate"] = "strict",
         suffix_on_dup: Any = None,
         inplace: bool = False,
+        source_time_offset: Any = None,
         **kwargs: Any,
     ) -> Any:
         """Implementation of abstract method for testing"""
@@ -37,6 +38,7 @@ class ConcreteChannelCollection(ChannelCollectionMixin):
             "align": align,
             "suffix_on_dup": suffix_on_dup,
             "inplace": inplace,
+            "source_time_offset": source_time_offset,
             "kwargs": kwargs,
         }
         return self if inplace else MagicMock()
@@ -63,7 +65,17 @@ class TestChannelCollectionMixin:
         assert collection.add_channel_args["align"] == "strict"
         assert collection.add_channel_args["suffix_on_dup"] is None
         assert collection.add_channel_args["inplace"] is False
+        assert collection.add_channel_args["source_time_offset"] is None
         assert isinstance(result, MagicMock)  # Should return a mock since inplace=False
+
+    def test_add_channel_with_source_time_offset(self) -> None:
+        """Test the add_channel method with source_time_offset."""
+        collection = ConcreteChannelCollection()
+        data = np.ones(10)
+        collection.add_channel(data, label="test_channel", source_time_offset=1.25)
+
+        assert collection.add_channel_called
+        assert collection.add_channel_args["source_time_offset"] == 1.25
 
     def test_add_channel_with_inplace(self) -> None:
         """Test the add_channel method with inplace=True"""

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -569,6 +569,57 @@ def test_channel_update_helpers_preserve_source_time_offset() -> None:
     np.testing.assert_array_equal(removed.source_time_offset, np.array([2.5]))
 
 
+def test_add_channel_numpy_raw_uses_explicit_source_time_offset() -> None:
+    base = ChannelFrame(
+        data=_da_from_array(np.zeros((1, 6)), chunks=(1, -1)),
+        sampling_rate=16000,
+        source_time_offset=2.5,
+    )
+
+    added = base.add_channel(np.zeros(6), label="new_ch", source_time_offset=5.0)
+
+    np.testing.assert_array_equal(added.source_time_offset, np.array([2.5, 5.0]))
+    np.testing.assert_array_equal(added.source_time[:, 0], np.array([2.5, 5.0]))
+
+
+def test_add_channel_dask_raw_uses_explicit_source_time_offset_and_stays_lazy() -> None:
+    base = ChannelFrame(
+        data=_da_from_array(np.zeros((1, 6)), chunks=(1, -1)),
+        sampling_rate=16000,
+        source_time_offset=2.5,
+    )
+    raw_channel = _da_from_array(np.ones(6), chunks=3)
+    history_before = list(base.operation_history)
+
+    added = base.add_channel(raw_channel, label="new_ch", source_time_offset=[5.0])
+
+    assert isinstance(added._data, DaArray)
+    assert base.operation_history == history_before
+    assert added.operation_history == history_before
+    np.testing.assert_array_equal(added.source_time_offset, np.array([2.5, 5.0]))
+
+
+@pytest.mark.parametrize(
+    ("source_time_offset", "error_type", "match"),
+    [
+        ([1.0, 2.0], ValueError, "source_time_offset length must match number of channels"),
+        (float("nan"), ValueError, "source_time_offset must be finite"),
+        (float("inf"), ValueError, "source_time_offset must be finite"),
+        ("not-a-number", TypeError, "source_time_offset must be a finite numeric value"),
+        (np.zeros((1, 1)), ValueError, "source_time_offset must be a scalar or a 1D array"),
+    ],
+)
+def test_add_channel_raw_source_time_offset_validation(
+    source_time_offset: Any,
+    error_type: type[Exception],
+    match: str,
+) -> None:
+    base = ChannelFrame(data=_da_from_array(np.zeros((1, 6)), chunks=(1, -1)), sampling_rate=16000)
+
+    with pytest.raises(error_type, match=match):
+        base.add_channel(np.zeros(6), label="new_ch", source_time_offset=source_time_offset)
+
+
 def test_add_channel_frame_preserves_per_channel_source_time_offsets() -> None:
     base = ChannelFrame(
         data=_da_from_array(np.zeros((1, 6)), chunks=(1, -1)),
@@ -586,6 +637,23 @@ def test_add_channel_frame_preserves_per_channel_source_time_offsets() -> None:
 
     np.testing.assert_array_equal(added.source_time_offset, np.array([2.5, 5.0, 8.0]))
     np.testing.assert_array_equal(added.source_time[:, 0], np.array([2.5, 5.0, 8.0]))
+
+
+def test_add_channel_frame_rejects_explicit_source_time_offset() -> None:
+    base = ChannelFrame(
+        data=_da_from_array(np.zeros((1, 6)), chunks=(1, -1)),
+        sampling_rate=16000,
+        source_time_offset=2.5,
+    )
+    other = ChannelFrame(
+        data=_da_from_array(np.ones((1, 6)), chunks=(1, -1)),
+        sampling_rate=16000,
+        channel_metadata=[{"label": "other0"}],
+        source_time_offset=5.0,
+    )
+
+    with pytest.raises(ValueError, match="source_time_offset cannot be used when adding a ChannelFrame"):
+        base.add_channel(other, source_time_offset=9.0)
 
 
 def test_add_channel_unsupported_type_raises() -> None:

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -1262,6 +1262,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         align: str = "strict",
         suffix_on_dup: str | None = None,
         inplace: bool = False,
+        source_time_offset: float | Sequence[float] | NDArrayReal | None = None,
     ) -> "ChannelFrame":
         """Add a new channel to the frame.
 
@@ -1281,6 +1282,9 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             suffix_on_dup: Suffix to add to duplicate labels. If None, raises error.
             inplace: If True, modifies the frame in place.
                 Otherwise returns a new frame.
+            source_time_offset: Offset in seconds for raw numpy or dask input.
+                If None, raw input uses 0.0. When data is a ChannelFrame,
+                offsets are taken from that frame and this argument must be None.
 
         Returns:
             Modified ChannelFrame (self if inplace=True, new frame otherwise).
@@ -1301,6 +1305,12 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         """
         # Handle ndarray/dask/same-type Frame
         if isinstance(data, ChannelFrame):
+            if source_time_offset is not None:
+                raise ValueError(
+                    "source_time_offset cannot be used when adding a ChannelFrame\n"
+                    "  ChannelFrame input already carries per-channel offsets.\n"
+                    "Pass raw ndarray or dask data to set an explicit offset."
+                )
             if self.sampling_rate != data.sampling_rate:
                 raise ValueError("sampling_rate mismatch")
             arr = _align_to_length(data._data, self.n_samples, align, data.n_samples)
@@ -1360,7 +1370,9 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
 
         new_ids = [*self._channel_ids, self._next_channel_id()]
         new_chmeta = [*self.channels.to_list(), ChannelMetadata(label=new_label)]
-        new_offsets = np.concatenate([self.source_time_offset, np.array([0.0])])
+        raw_source_time_offset = 0.0 if source_time_offset is None else source_time_offset
+        new_channel_offsets = self._normalize_source_time_offset(raw_source_time_offset, arr.shape[0])
+        new_offsets = np.concatenate([self.source_time_offset, new_channel_offsets])
         return self._finalize_channel_update(new_data, new_chmeta, inplace, new_ids, new_offsets)
 
     def remove_channel(self, key: int | str, inplace: bool = False) -> "ChannelFrame":

--- a/wandas/frames/mixins/channel_collection_mixin.py
+++ b/wandas/frames/mixins/channel_collection_mixin.py
@@ -3,10 +3,13 @@ ChannelCollectionMixin: Common functionality for adding/removing channels in
 ChannelFrame
 """
 
+from collections.abc import Sequence
 from typing import Any, Literal, TypeVar
 
 import dask.array as da
 import numpy as np
+
+from wandas.utils.types import NDArrayReal
 
 T = TypeVar("T", bound="ChannelCollectionMixin")
 
@@ -19,6 +22,7 @@ class ChannelCollectionMixin:
         align: Literal["strict", "pad", "truncate"] = "strict",
         suffix_on_dup: str | None = None,
         inplace: bool = False,
+        source_time_offset: float | Sequence[float] | NDArrayReal | None = None,
         **kwargs: Any,
     ) -> T:
         """
@@ -29,6 +33,7 @@ class ChannelCollectionMixin:
             align: Behavior when lengths don't match
             suffix_on_dup: Suffix when label is duplicated
             inplace: True for self-modification
+            source_time_offset: Offset for raw ndarray/dask input
         Returns:
             New Frame or self
         Raises:


### PR DESCRIPTION
## Summary
- add source_time_offset to ChannelFrame.add_channel for raw numpy and dask input
- preserve ChannelFrame input offsets and reject explicit overrides
- cover raw numpy, raw dask laziness/history, validation, and mixin signature behavior

## Validation
- UV_PROJECT_ENVIRONMENT=/workspaces/wandas/.venv uv run pytest tests/frames/test_channel_frame.py tests/frames/test_channel_collection.py -q
- UV_PROJECT_ENVIRONMENT=/workspaces/wandas/.venv uv run ruff check wandas tests --config=pyproject.toml -v
- UV_PROJECT_ENVIRONMENT=/workspaces/wandas/.venv uv run ty check wandas tests
- pre-commit hook: ruff check, ruff format, ty