### PR TITLE
[codex] Document Codex worktree workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,10 +15,12 @@ These instructions are for Wandas custom agents. For substantive implementation,
 ## 2. Development Workflow & Commands
 - **Environment**: use `uv` for all Python commands (see `pyproject.toml`).
 - **Git worktrees for Codex work**:
-  - For substantive code changes, create or switch to a dedicated Git worktree under `.worktrees/` before editing, unless the user explicitly asks to use the current checkout.
-  - Use a descriptive branch/worktree name that matches the task, such as `.worktrees/fix-issue-123` or `.worktrees/feat-custom-operation-api`.
+  - For substantive code changes, create or switch to a dedicated Git worktree under `.worktrees/` before editing when the active agent has a tool path for `git worktree`, unless the user explicitly asks to use the current checkout.
+  - Keep branch names and checkout paths separate. Use a valid Git branch name such as `codex/fix-issue-123` or `codex/feat-custom-operation-api` with a checkout path such as `.worktrees/fix-issue-123` or `.worktrees/feat-custom-operation-api`.
   - Before creating a worktree, inspect `git status --short` and do not move, stage, revert, or overwrite uncommitted changes from the current checkout.
+  - If the current checkout has uncommitted changes related to the task, continue in that checkout or ask the user before creating a fresh worktree. If the changes are unrelated, leave them untouched and use a separate worktree. If the relationship is unclear, ask before editing.
   - If the current checkout already appears to be the intended task worktree, continue there and state that assumption.
+  - If a role is required to edit files but lacks any tool path to create or switch worktrees, stop before editing and ask the user or a tool-capable role to prepare the worktree.
   - Keep commits, staging, pushes, and PR publication in the publisher workflow unless the user explicitly requests them.
 - **Setup**:
   - If a `.venv` virtual environment is missing, run the VS Code task "Create Virtual Environment" (see `.vscode/tasks.json`) which executes:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,6 +14,12 @@ These instructions are for Wandas custom agents. For substantive implementation,
 
 ## 2. Development Workflow & Commands
 - **Environment**: use `uv` for all Python commands (see `pyproject.toml`).
+- **Git worktrees for Codex work**:
+  - For substantive code changes, create or switch to a dedicated Git worktree under `.worktrees/` before editing, unless the user explicitly asks to use the current checkout.
+  - Use a descriptive branch/worktree name that matches the task, such as `.worktrees/fix-issue-123` or `.worktrees/feat-custom-operation-api`.
+  - Before creating a worktree, inspect `git status --short` and do not move, stage, revert, or overwrite uncommitted changes from the current checkout.
+  - If the current checkout already appears to be the intended task worktree, continue there and state that assumption.
+  - Keep commits, staging, pushes, and PR publication in the publisher workflow unless the user explicitly requests them.
 - **Setup**:
   - If a `.venv` virtual environment is missing, run the VS Code task "Create Virtual Environment" (see `.vscode/tasks.json`) which executes:
     - `uv venv --allow-existing .venv && uv sync --frozen --all-groups`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Follow `.github/copilot-instructions.md` for the full Wandas repository conventi
 Core rules:
 
 - Use `uv` for Python commands.
-- For substantive code changes, use a dedicated Git worktree under `.worktrees/` before editing unless the user explicitly asks to work in the current checkout.
+- For substantive code changes, use a dedicated Git worktree under `.worktrees/` when available and appropriate; follow `.github/copilot-instructions.md` for dirty-checkout and tool-availability rules.
 - Preserve frame immutability, metadata/history, and Dask laziness.
 - Keep frame methods thin; numerical logic belongs in `wandas/processing`.
 - Prefer small, explicit contracts over compatibility layers for undocumented or ambiguous behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ Follow `.github/copilot-instructions.md` for the full Wandas repository conventi
 Core rules:
 
 - Use `uv` for Python commands.
+- For substantive code changes, use a dedicated Git worktree under `.worktrees/` before editing unless the user explicitly asks to work in the current checkout.
 - Preserve frame immutability, metadata/history, and Dask laziness.
 - Keep frame methods thin; numerical logic belongs in `wandas/processing`.
 - Prefer small, explicit contracts over compatibility layers for undocumented or ambiguous behavior.


### PR DESCRIPTION
## Summary

- Add a Codex-facing core rule to use dedicated Git worktrees for substantive code changes.
- Document the detailed `.worktrees/` workflow in the repository instructions.
- Clarify that existing uncommitted checkout changes should not be moved, staged, reverted, or overwritten.

## Validation

- `git diff --check`
- Commit hooks ran and skipped code-only checks because only Markdown instruction files changed.