### PR TITLE
[codex] Implement multi-input SNR add lineage

### DIFF
--- a/tests/core/test_base_frame_additional.py
+++ b/tests/core/test_base_frame_additional.py
@@ -910,6 +910,26 @@ def test_apply_operation_helpers_update_metadata_and_history(monkeypatch):
     assert dependency_calls == 4
 
 
+def test_apply_operation_instance_rejects_multi_input_operation_before_processing():
+    f = make_frame(np.arange(6).reshape(2, 3).astype(float))
+    process_calls = 0
+
+    class MultiInputOperation:
+        name = "multi_input"
+        params = {}
+        _expected_input_count = 2
+
+        def process(self, data):
+            nonlocal process_calls
+            process_calls += 1
+            return data
+
+    with pytest.raises(ValueError, match="Operation requires multiple runtime inputs"):
+        f._apply_operation_instance(MultiInputOperation())
+
+    assert process_calls == 0
+
+
 def test_mutable_config_value_converts_containers_for_history():
     source_array = np.array([1.0, 2.0])
     dask_array = da_from_array(source_array.reshape(1, 2), chunks=(1, -1))

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -78,7 +78,8 @@ class TestChannelFrame:
             def ensure_dependencies(self) -> None:
                 calls.append("ensure")
 
-            def process(self, data: DaArray) -> DaArray:
+            def process(self, data: DaArray, noise: DaArray) -> DaArray:
+                assert noise is other._data
                 calls.append("process")
                 return data
 

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -945,6 +945,11 @@ class TestChannelProcessing:
         assert np.all(computed[:, :8000] > 1.0)
         np.testing.assert_allclose(computed[:, 8000:], 1.0)  # Exact: zero-padded region unchanged
 
+    def test_apply_operation_rejects_add_with_snr_without_runtime_noise_input(self) -> None:
+        """Generic apply_operation cannot supply AddWithSNR's second runtime input."""
+        with pytest.raises(ValueError, match="Operation requires multiple runtime inputs"):
+            self.channel_frame.apply_operation("add_with_snr", snr=6.0)
+
     def test_add_with_different_lengths(self) -> None:
         """異なる長さの信号を加算するテスト。"""
         # 標準の長さのフレーム（self.channel_frame）

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -798,13 +798,7 @@ class TestChannelProcessing:
 
         result = signal_cf.add(noise_cf, snr=10.0)
 
-        noise_param = result.operation_history[-1]["params"]["other"]
-        assert noise_param == {
-            "type": "dask.array",
-            "shape": [1, 16000],
-            "dtype": "float64",
-            "chunks": [[1], [16000]],
-        }
+        assert result.operation_history[-1]["params"] == {"snr": 10.0}
         json.dumps(result.operation_history)
         json.dumps(dict(result.metadata))
         assert result.lineage is not None
@@ -859,7 +853,7 @@ class TestChannelProcessing:
         assert result.sampling_rate == self.sample_rate
         assert result.n_channels == 2
         assert result.n_samples == 16000
-        assert len(result.operation_history) > len(signal_cf.operation_history)
+        assert result.operation_history[-1] == {"operation": "add_with_snr", "params": {"snr": snr_db}}
         computed = result.compute()
         added_noise = computed - signal_data
         added_noise_rms = calculate_rms(added_noise)
@@ -869,6 +863,44 @@ class TestChannelProcessing:
 
         # atol=1e-3: SNR estimation from computed noise has small float64 rounding
         np.testing.assert_allclose(actual_snr, np.full_like(actual_snr, snr_db), atol=1e-3)
+
+    def test_add_with_snr_matches_processing_formula_and_two_parent_lineage(self) -> None:
+        """Frame SNR add delegates noise as a Dask input and records both parent branches."""
+        t = np.linspace(0, 1, 16000, endpoint=False)
+        clean = np.sin(2 * np.pi * 440 * t).reshape(1, -1)
+        noise = np.cos(2 * np.pi * 880 * t).reshape(1, -1)
+        signal_cf = ChannelFrame(_da_from_array(clean, chunks=(1, -1)), self.sample_rate)
+        noise_cf = ChannelFrame(_da_from_array(noise, chunks=(1, -1)), self.sample_rate)
+
+        signal = signal_cf.normalize()
+        noise_branch = noise_cf.low_pass_filter(cutoff=1200)
+        result = signal.add(noise_branch, snr=6.0)
+
+        clean_input = signal.compute()
+        noise_input = noise_branch.compute()
+        desired_noise_rms = calculate_rms(clean_input) / (10 ** (6.0 / 20))
+        expected = clean_input + noise_input * (desired_noise_rms / calculate_rms(noise_input))
+
+        np.testing.assert_allclose(result.compute(), expected)
+        assert result.operation_history[-1] == {"operation": "add_with_snr", "params": {"snr": 6.0}}
+        assert result.operation_graph is not None
+        assert [node["operation"] for node in result.operation_graph["inputs"]] == ["normalize", "lowpass_filter"]
+
+    def test_add_with_snr_shared_input_graph_keeps_shared_branch_once_per_parent_path(self) -> None:
+        data = _da_from_array(np.linspace(0.1, 1.0, 16000).reshape(1, -1), chunks=(1, -1))
+        base = ChannelFrame(data, self.sample_rate)
+        shared = base.normalize()
+        signal = shared.low_pass_filter(cutoff=3000)
+        noise = shared.high_pass_filter(cutoff=300)
+
+        result = signal.add(noise, snr=3.0)
+
+        operations = [record["operation"] for record in result.operation_history]
+        assert operations == ["normalize", "lowpass_filter", "normalize", "highpass_filter", "add_with_snr"]
+        assert result.operation_graph is not None
+        assert [node["operation"] for node in result.operation_graph["inputs"]] == ["lowpass_filter", "highpass_filter"]
+        shared_parents = [node["inputs"][0]["operation"] for node in result.operation_graph["inputs"]]
+        assert shared_parents == ["normalize", "normalize"]
 
     def test_add_with_snr_scalar_returns_direct_addition(self) -> None:
         """Scalar inputs should follow the direct-addition branch even when snr is provided."""

--- a/tests/processing/test_base_operations.py
+++ b/tests/processing/test_base_operations.py
@@ -859,6 +859,7 @@ class TestAudioOperation:
 
         class AddInputs(AudioOperation[NDArrayReal, NDArrayReal]):
             name = "add_inputs_op"
+            _expected_input_count = 2
 
             def _process_inputs(self, *inputs: NDArrayReal) -> NDArrayReal:
                 left, right = inputs
@@ -879,6 +880,7 @@ class TestAudioOperation:
 
         class AddInputs(AudioOperation[NDArrayReal, NDArrayReal]):
             name = "add_inputs_dtype_op"
+            _expected_input_count = 2
 
             def _process_inputs(self, *inputs: NDArrayReal) -> NDArrayReal:
                 left, right = inputs
@@ -893,6 +895,22 @@ class TestAudioOperation:
         expected_dtype = np.result_type(left.dtype, right.dtype)
         assert result.dtype == expected_dtype
         assert result.compute().dtype == expected_dtype
+
+    def test_process_rejects_extra_inputs_before_dask_compute(self) -> None:
+        """Base process validates input arity when building the Dask graph."""
+
+        class DoubleOp(AudioOperation[NDArrayReal, NDArrayReal]):
+            name = "double_early_reject_op"
+
+            def _process_array(self, x: NDArrayReal) -> NDArrayReal:
+                return x * 2.0
+
+        first = da_from_array(np.array([[1.0, 2.0, 3.0]]), chunks=(1, -1))
+        second = da_from_array(np.array([[4.0, 5.0, 6.0]]), chunks=(1, -1))
+        op = DoubleOp(16000)
+
+        with pytest.raises(ValueError, match="Expected exactly one input"):
+            op.process(first, second)
 
     def test_default_process_rejects_extra_inputs(self) -> None:
         """Single-input operations fail clearly when called with multiple inputs."""

--- a/tests/processing/test_base_operations.py
+++ b/tests/processing/test_base_operations.py
@@ -854,6 +854,42 @@ class TestAudioOperation:
         with pytest.raises(NotImplementedError, match="Subclasses must implement"):
             op._process_array(np.array([[1.0, 2.0, 3.0]]))
 
+    def test_process_accepts_variadic_inputs_for_multi_input_subclass(self) -> None:
+        """A subclass can process multiple Dask inputs lazily."""
+
+        class AddInputs(AudioOperation[NDArrayReal, NDArrayReal]):
+            name = "add_inputs_op"
+
+            def _process_inputs(self, *inputs: NDArrayReal) -> NDArrayReal:
+                left, right = inputs
+                return left + right
+
+        left = da_from_array(np.array([[1.0, 2.0, 3.0]]), chunks=(1, -1))
+        right = da_from_array(np.array([[0.5, 0.25, 0.125]]), chunks=(1, -1))
+        op = AddInputs(16000)
+
+        result = op.process(left, right)
+
+        assert isinstance(result, DaArray)
+        assert result.shape == left.shape
+        np.testing.assert_allclose(result.compute(), np.array([[1.5, 2.25, 3.125]]))
+
+    def test_default_process_rejects_extra_inputs(self) -> None:
+        """Single-input operations fail clearly when called with multiple inputs."""
+
+        class DoubleOp(AudioOperation[NDArrayReal, NDArrayReal]):
+            name = "double_single_input_op"
+
+            def _process_array(self, x: NDArrayReal) -> NDArrayReal:
+                return x * 2.0
+
+        first = da_from_array(np.array([[1.0, 2.0, 3.0]]), chunks=(1, -1))
+        second = da_from_array(np.array([[4.0, 5.0, 6.0]]), chunks=(1, -1))
+        op = DoubleOp(16000)
+
+        with pytest.raises(ValueError, match="Expected exactly one input"):
+            op.process(first, second).compute()
+
     def test_calculate_output_shape_default_returns_input(self) -> None:
         """Default calculate_output_shape() returns input shape unchanged."""
 

--- a/tests/processing/test_base_operations.py
+++ b/tests/processing/test_base_operations.py
@@ -912,6 +912,22 @@ class TestAudioOperation:
         with pytest.raises(ValueError, match="Expected exactly one input"):
             op.process(first, second)
 
+    def test_process_override_rejects_extra_inputs_without_manual_validation(self) -> None:
+        """Subclass process overrides are wrapped with base arity validation."""
+
+        class OverrideProcessOp(AudioOperation[NDArrayReal, NDArrayReal]):
+            name = "override_process_early_reject_op"
+
+            def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
+                return self._mark_array(data)
+
+        first = da_from_array(np.array([[1.0, 2.0, 3.0]]), chunks=(1, -1))
+        second = da_from_array(np.array([[4.0, 5.0, 6.0]]), chunks=(1, -1))
+        op = OverrideProcessOp(16000)
+
+        with pytest.raises(ValueError, match="Expected exactly one input"):
+            op.process(first, second)
+
     def test_default_process_rejects_extra_inputs(self) -> None:
         """Single-input operations fail clearly when called with multiple inputs."""
 

--- a/tests/processing/test_base_operations.py
+++ b/tests/processing/test_base_operations.py
@@ -874,6 +874,26 @@ class TestAudioOperation:
         assert result.shape == left.shape
         np.testing.assert_allclose(result.compute(), np.array([[1.5, 2.25, 3.125]]))
 
+    def test_process_uses_result_type_metadata_for_multi_input_subclass(self) -> None:
+        """Default multi-input metadata dtype follows NumPy result type."""
+
+        class AddInputs(AudioOperation[NDArrayReal, NDArrayReal]):
+            name = "add_inputs_dtype_op"
+
+            def _process_inputs(self, *inputs: NDArrayReal) -> NDArrayReal:
+                left, right = inputs
+                return left + right
+
+        left = da_from_array(np.array([[1, 2, 3]], dtype=np.int16), chunks=(1, -1))
+        right = da_from_array(np.array([[0.5, 0.25, 0.125]], dtype=np.float32), chunks=(1, -1))
+        op = AddInputs(16000)
+
+        result = op.process(left, right)
+
+        expected_dtype = np.result_type(left.dtype, right.dtype)
+        assert result.dtype == expected_dtype
+        assert result.compute().dtype == expected_dtype
+
     def test_default_process_rejects_extra_inputs(self) -> None:
         """Single-input operations fail clearly when called with multiple inputs."""
 

--- a/tests/processing/test_display_names.py
+++ b/tests/processing/test_display_names.py
@@ -1,7 +1,5 @@
 """Tests for display names in all audio operations."""
 
-import numpy as np
-
 from wandas.processing.effects import (
     AddWithSNR,
     Fade,
@@ -30,7 +28,6 @@ from wandas.processing.spectral import (
 )
 from wandas.processing.stats import ABS, ChannelDifference, Mean, Power, Sum
 from wandas.processing.temporal import FixLength, ReSampling, RmsTrend, SoundLevel, Trim
-from wandas.utils.dask_helpers import da_from_array
 
 
 class TestFilterDisplayNames:
@@ -159,10 +156,7 @@ class TestEffectDisplayNames:
 
     def test_add_with_snr_display_name(self) -> None:
         """Test that AddWithSNR returns '+SNR' as display name."""
-
-        # Deterministic dummy noise signal (values irrelevant for display name test)
-        noise = da_from_array(np.ones((1, 1000)), chunks=(1, 1000))
-        op = AddWithSNR(sampling_rate=44100, other=noise, snr=10.0)
+        op = AddWithSNR(sampling_rate=44100, snr=10.0)
         assert op.get_display_name() == "+SNR"
 
     def test_fade_display_name(self) -> None:

--- a/tests/processing/test_effect_operations.py
+++ b/tests/processing/test_effect_operations.py
@@ -222,12 +222,11 @@ def test_normalize_stores_all_lineage_parameters() -> None:
 
 
 def test_add_with_snr_and_fade_expose_lineage_parameters() -> None:
-    noise = da_from_array(np.ones((1, 8)), chunks=(1, -1))
-    add = AddWithSNR(_SR, other=noise, snr=12.0)
+    add = AddWithSNR(_SR, snr=12.0)
     fade = Fade(_SR, fade_ms=25)
 
     assert add.snr == 12.0
-    assert add.to_params() == {"other": noise, "snr": 12.0}
+    assert add.to_params() == {"snr": 12.0}
     assert fade.fade_ms == 25.0
     assert fade.to_params() == {"fade_ms": 25.0}
 
@@ -239,11 +238,11 @@ class TestAddWithSNR:
 
     def test_add_with_snr_init_stores_params(self) -> None:
         """Test AddWithSNR stores sampling rate and SNR."""
-        rng = np.random.default_rng(42)
-        noise = da_from_array(rng.standard_normal((1, _SR)), chunks=(1, -1))
-        op = AddWithSNR(_SR, noise, 10.0)
+        op = AddWithSNR(_SR, 10.0)
         assert op.sampling_rate == _SR
         assert op.snr == 10.0
+        assert op.params == {"snr": 10.0}
+        assert not any(isinstance(value, DaArray) for value in op._config.values())
 
     def test_add_with_snr_registry_returns_correct_class(self) -> None:
         """Test AddWithSNR is registered as 'add_with_snr'."""
@@ -256,11 +255,11 @@ class TestAddWithSNR:
         dask_input, sr = pure_sine_440hz_dask
         rng = np.random.default_rng(42)
         noise = da_from_array(rng.standard_normal((1, sr)), chunks=(1, -1))
-        op = AddWithSNR(sr, noise, 10.0)
+        op = AddWithSNR(sr, 10.0)
         input_copy = dask_input.compute().copy()
 
         # Act
-        result_da = op.process(dask_input)
+        result_da = op.process(dask_input, noise)
 
         # Assert 1: Immutability
         assert result_da is not dask_input
@@ -284,10 +283,10 @@ class TestAddWithSNR:
         target_snr = 10.0
         rng = np.random.default_rng(42)
         noise = da_from_array(rng.standard_normal((1, sr)), chunks=(1, -1))
-        op = AddWithSNR(sr, noise, target_snr)
+        op = AddWithSNR(sr, target_snr)
 
         clean = dask_input.compute()
-        result = op.process(dask_input).compute()
+        result = op.process(dask_input, noise).compute()
 
         clean_power = util.calculate_rms(clean) ** 2
         noise_component = result - clean
@@ -309,9 +308,9 @@ class TestAddWithSNR:
 
         dask_clean = da_from_array(clean, chunks=(1, -1))
         dask_noise = da_from_array(noise, chunks=(1, -1))
-        op = AddWithSNR(_SR, dask_noise, 10.0)
+        op = AddWithSNR(_SR, 10.0)
 
-        result_da = op.process(dask_clean)
+        result_da = op.process(dask_clean, dask_noise)
         assert isinstance(result_da, DaArray)  # Pillar 1: Dask graph preserved
         result = result_da.compute()
         assert result.shape == clean.shape

--- a/tests/processing/test_effect_operations.py
+++ b/tests/processing/test_effect_operations.py
@@ -272,6 +272,30 @@ class TestAddWithSNR:
         result = result_da.compute()
         assert result.shape == input_copy.shape
 
+    def test_add_with_snr_int16_clean_float32_noise_uses_float32_dtype(self) -> None:
+        """Integer clean data is promoted to at least float32 for SNR math."""
+        clean = da_from_array(np.array([[1000, -1000, 500, -500]], dtype=np.int16), chunks=(1, -1))
+        noise = da_from_array(np.array([[0.5, -0.25, 0.125, -0.5]], dtype=np.float32), chunks=(1, -1))
+        op = AddWithSNR(_SR, 10.0)
+
+        result_da = op.process(clean, noise)
+
+        assert isinstance(result_da, DaArray)
+        assert result_da.dtype == np.float32
+        assert result_da.compute().dtype == np.float32
+
+    def test_add_with_snr_float32_clean_float64_noise_uses_float64_dtype(self) -> None:
+        """Float64 input preserves float64 precision in SNR math."""
+        clean = da_from_array(np.array([[1.0, -1.0, 0.5, -0.5]], dtype=np.float32), chunks=(1, -1))
+        noise = da_from_array(np.array([[0.5, -0.25, 0.125, -0.5]], dtype=np.float64), chunks=(1, -1))
+        op = AddWithSNR(_SR, 10.0)
+
+        result_da = op.process(clean, noise)
+
+        assert isinstance(result_da, DaArray)
+        assert result_da.dtype == np.float64
+        assert result_da.compute().dtype == np.float64
+
     # -- Layer 3: Integration (SNR verification) ---------------------------
 
     def test_add_with_snr_actual_snr_matches_target(self, pure_sine_440hz_dask: tuple[DaArray, int]) -> None:

--- a/tests/processing/test_effect_operations.py
+++ b/tests/processing/test_effect_operations.py
@@ -296,6 +296,14 @@ class TestAddWithSNR:
         assert result_da.dtype == np.float64
         assert result_da.compute().dtype == np.float64
 
+    def test_add_with_snr_rejects_missing_noise_before_dask_compute(self) -> None:
+        """AddWithSNR declares two inputs so process() validates arity early."""
+        clean = da_from_array(np.array([[1.0, -1.0, 0.5, -0.5]], dtype=np.float32), chunks=(1, -1))
+        op = AddWithSNR(_SR, 10.0)
+
+        with pytest.raises(ValueError, match="Expected exactly 2 inputs"):
+            op.process(clean)
+
     # -- Layer 3: Integration (SNR verification) ---------------------------
 
     def test_add_with_snr_actual_snr_matches_target(self, pure_sine_440hz_dask: tuple[DaArray, int]) -> None:

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -1394,13 +1394,23 @@ class BaseFrame(ABC, Generic[T]):
             Extra constructor keyword arguments required by *output_frame_class*
             (e.g. ``{"n_fft": 1024, "window": "hann"}``).
         """
+        if operation_name is None:
+            operation_name = getattr(operation, "name", "unknown_operation")
+        expected_input_count = getattr(operation, "_expected_input_count", 1)
+        if isinstance(expected_input_count, int) and expected_input_count != 1:
+            raise ValueError(
+                "Operation requires multiple runtime inputs\n"
+                f"  Operation: {operation_name}\n"
+                f"  Expected inputs: {expected_input_count}\n"
+                "  Got: apply_operation provides one frame input\n"
+                "Use an operation-specific method that can pass all runtime inputs."
+            )
+
         ensure_dependencies = getattr(operation, "ensure_dependencies", None)
         if ensure_dependencies is not None:
             ensure_dependencies()
         processed_data = operation.process(self._data)
 
-        if operation_name is None:
-            operation_name = getattr(operation, "name", "unknown_operation")
         params = getattr(operation, "params", {})
 
         new_metadata = self._updated_metadata(operation_name, params)

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -528,11 +528,11 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             return self + other
         from wandas.processing import create_operation
 
-        operation = create_operation("add_with_snr", self.sampling_rate, other=other._data, snr=snr)
+        operation = create_operation("add_with_snr", self.sampling_rate, snr=snr)
         ensure_dependencies = getattr(operation, "ensure_dependencies", None)
         if ensure_dependencies is not None:
             ensure_dependencies()
-        result_data = operation.process(self._data)
+        result_data = operation.process(self._data, other._data)
         get_display_name = getattr(operation, "get_display_name", None)
         display_name = get_display_name() if callable(get_display_name) else getattr(operation, "name", "add_with_snr")
         return self._create_new_instance(

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -5,6 +5,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Iterator, Mapping, MutableMapping
 from dataclasses import dataclass
+from functools import wraps
 from typing import Any, ClassVar, Generic, TypeVar, cast
 
 import dask.array as da
@@ -223,6 +224,21 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
 
     _config: dict[str, Any]
 
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """Ensure subclass ``process`` overrides keep the base input contract."""
+        super().__init_subclass__(**kwargs)
+        process = cls.__dict__.get("process")
+        if process is None or getattr(process, "_wandas_validates_process_input_count", False):
+            return
+
+        @wraps(process)
+        def validated_process(self: "AudioOperation[Any, Any]", data: Any, *inputs: Any) -> Any:
+            self._validate_process_input_count(1 + len(inputs))
+            return process(self, data, *inputs)
+
+        setattr(validated_process, "_wandas_validates_process_input_count", True)
+        cls.process = cast(Any, validated_process)
+
     def __init__(self, sampling_rate: float, *, pure: bool = True, **params: Any):
         """
         Initialize AudioOperation.
@@ -334,21 +350,19 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
         # Default is no-op function
         raise NotImplementedError("Subclasses must implement this method.")
 
-    def _validate_input_count(self, input_count: int, *, expected: int) -> None:
-        """Validate operation input arity."""
-        if input_count != expected:
-            noun = "input" if expected == 1 else "inputs"
-            expected_text = "one" if expected == 1 else str(expected)
-            raise ValueError(
-                f"Expected exactly {expected_text} {noun} for {self.__class__.__name__}; "
-                f"got {input_count}. Set _expected_input_count and override _process_inputs "
-                "for multi-input operations."
-            )
-
     def _validate_process_input_count(self, input_count: int) -> None:
         """Validate process input arity using the operation class contract."""
-        if self._expected_input_count is not None:
-            self._validate_input_count(input_count, expected=self._expected_input_count)
+        expected = self._expected_input_count
+        if expected is None or input_count == expected:
+            return
+
+        noun = "input" if expected == 1 else "inputs"
+        expected_text = "one" if expected == 1 else str(expected)
+        raise ValueError(
+            f"Expected exactly {expected_text} {noun} for {self.__class__.__name__}; "
+            f"got {input_count}. Set _expected_input_count and override _process_inputs "
+            "for multi-input operations."
+        )
 
     def _process_inputs(self, *inputs: InputArrayType) -> OutputArrayType:
         """Process one or more concrete input arrays.

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -23,9 +23,9 @@ InputArrayType = TypeVar("InputArrayType", NDArrayReal, NDArrayComplex)
 OutputArrayType = TypeVar("OutputArrayType", NDArrayReal, NDArrayComplex)
 
 
-def _execute_wandas_operation(operation: "AudioOperation[Any, Any]", data: Any) -> Any:
+def _execute_wandas_operation(operation: "AudioOperation[Any, Any]", *inputs: Any) -> Any:
     """Execute a Wandas operation from a Dask task."""
-    return operation._process_array(data)
+    return operation._process_inputs(*inputs)
 
 
 def _mark_wandas_operation(data: Any, operation: "AudioOperation[Any, Any]") -> Any:
@@ -333,9 +333,29 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
         # Default is no-op function
         raise NotImplementedError("Subclasses must implement this method.")
 
-    def _delayed(self, data: Any) -> Any:
+    def _validate_input_count(self, input_count: int, *, expected: int) -> None:
+        """Validate operation input arity."""
+        if input_count != expected:
+            noun = "input" if expected == 1 else "inputs"
+            expected_text = "one" if expected == 1 else str(expected)
+            raise ValueError(
+                f"Expected exactly {expected_text} {noun} for {self.__class__.__name__}; "
+                f"got {input_count}. Override _process_inputs for multi-input operations."
+            )
+
+    def _process_inputs(self, *inputs: InputArrayType) -> OutputArrayType:
+        """Process one or more concrete input arrays.
+
+        The base operation contract remains single-input. Multi-input
+        subclasses override this method and keep ``_process_array`` available
+        for existing single-input implementations.
+        """
+        self._validate_input_count(len(inputs), expected=1)
+        return self._process_array(inputs[0])
+
+    def _delayed(self, *inputs: Any) -> Any:
         """Create a ``dask.delayed`` result for *data* with an explicit operation marker."""
-        return delayed(_execute_wandas_operation, name=self.name, pure=self.pure)(self, data)
+        return delayed(_execute_wandas_operation, name=self.name, pure=self.pure)(self, *inputs)
 
     def _mark_array(self, data: DaArray) -> DaArray:
         """Attach an explicit operation marker to a Dask-native array result."""
@@ -383,13 +403,13 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
         """
         return input_shape
 
-    def process(self, data: DaArray) -> DaArray:
+    def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
         """
         Execute operation and return result
         data shape is (channels, samples)
         """
         logger.debug("Adding delayed operation to computation graph")
-        delayed_result = self._delayed(data)
+        delayed_result = self._delayed(data, *inputs)
         output_shape = self.calculate_output_shape(data.shape)
         return _da_from_delayed(delayed_result, shape=output_shape, dtype=data.dtype)
 

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -403,6 +403,15 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
         """
         return input_shape
 
+    def calculate_output_dtype(self, *input_dtypes: np.dtype[Any]) -> np.dtype[Any]:
+        """
+        Calculate output data dtype after operation.
+
+        The default follows NumPy promotion rules across all inputs. Subclasses
+        that intentionally normalize precision can override this method.
+        """
+        return np.result_type(*input_dtypes)
+
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
         """
         Execute operation and return result
@@ -411,7 +420,9 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
         logger.debug("Adding delayed operation to computation graph")
         delayed_result = self._delayed(data, *inputs)
         output_shape = self.calculate_output_shape(data.shape)
-        return _da_from_delayed(delayed_result, shape=output_shape, dtype=data.dtype)
+        input_dtypes = tuple(input_data.dtype for input_data in (data, *inputs))
+        output_dtype = self.calculate_output_dtype(*input_dtypes)
+        return _da_from_delayed(delayed_result, shape=output_shape, dtype=output_dtype)
 
 
 # Automatically collect operation types and corresponding classes

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -219,6 +219,7 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
 
     # Class variable: operation name
     name: ClassVar[str]
+    _expected_input_count: ClassVar[int | None] = 1
 
     _config: dict[str, Any]
 
@@ -340,8 +341,14 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
             expected_text = "one" if expected == 1 else str(expected)
             raise ValueError(
                 f"Expected exactly {expected_text} {noun} for {self.__class__.__name__}; "
-                f"got {input_count}. Override _process_inputs for multi-input operations."
+                f"got {input_count}. Set _expected_input_count and override _process_inputs "
+                "for multi-input operations."
             )
+
+    def _validate_process_input_count(self, input_count: int) -> None:
+        """Validate process input arity using the operation class contract."""
+        if self._expected_input_count is not None:
+            self._validate_input_count(input_count, expected=self._expected_input_count)
 
     def _process_inputs(self, *inputs: InputArrayType) -> OutputArrayType:
         """Process one or more concrete input arrays.
@@ -350,7 +357,7 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
         subclasses override this method and keep ``_process_array`` available
         for existing single-input implementations.
         """
-        self._validate_input_count(len(inputs), expected=1)
+        self._validate_process_input_count(len(inputs))
         return self._process_array(inputs[0])
 
     def _delayed(self, *inputs: Any) -> Any:
@@ -417,6 +424,7 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
         Execute operation and return result
         data shape is (channels, samples)
         """
+        self._validate_process_input_count(1 + len(inputs))
         logger.debug("Adding delayed operation to computation graph")
         delayed_result = self._delayed(data, *inputs)
         output_shape = self.calculate_output_shape(data.shape)

--- a/wandas/processing/effects.py
+++ b/wandas/processing/effects.py
@@ -223,8 +223,9 @@ class Normalize(AudioOperation[NDArrayReal, NDArrayReal]):
         logger.debug(f"Normalization applied, returning result with shape: {result.shape}")
         return result
 
-    def process(self, data: DaArray) -> DaArray:
+    def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
         """Execute normalization with accurate floating output dtype metadata."""
+        self._validate_input_count(1 + len(inputs), expected=1)
         logger.debug("Adding delayed normalize operation to computation graph")
         delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)
@@ -285,7 +286,7 @@ class AddWithSNR(AudioOperation[NDArrayReal, NDArrayReal]):
     name = "add_with_snr"
     _display = "+SNR"
 
-    def __init__(self, sampling_rate: float, other: DaArray, snr: float = 1.0):
+    def __init__(self, sampling_rate: float, snr: float = 1.0):
         """
         Initialize addition operation considering SNR
 
@@ -293,12 +294,10 @@ class AddWithSNR(AudioOperation[NDArrayReal, NDArrayReal]):
         ----------
         sampling_rate : float
             Sampling rate (Hz)
-        other : DaArray
-            Noise signal to add (channel-frame format)
         snr : float
             Signal-to-noise ratio (dB)
         """
-        super().__init__(sampling_rate, other=other, snr=snr)
+        super().__init__(sampling_rate, snr=snr)
         logger.debug(f"Initialized AddWithSNR operation with SNR: {snr} dB")
 
     @property
@@ -306,10 +305,15 @@ class AddWithSNR(AudioOperation[NDArrayReal, NDArrayReal]):
         """Signal-to-noise ratio captured at operation construction time."""
         return self._config_value("snr")
 
-    def _process_array(self, x: NDArrayReal) -> NDArrayReal:
+    def _process_inputs(self, *inputs: NDArrayReal) -> NDArrayReal:
         """Perform addition processing considering SNR"""
+        if len(inputs) != 2:
+            raise ValueError(
+                f"Expected exactly two inputs for AddWithSNR; got {len(inputs)}. "
+                "Pass clean and noise arrays to process()."
+            )
+        x, other = inputs
         logger.debug(f"Applying SNR-based addition with shape: {x.shape}")
-        other: NDArrayReal = self._config["other"].compute()
 
         # Use multi-channel versions of calculate_rms and calculate_desired_noise_rms
         clean_rms = util.calculate_rms(x)

--- a/wandas/processing/effects.py
+++ b/wandas/processing/effects.py
@@ -225,7 +225,7 @@ class Normalize(AudioOperation[NDArrayReal, NDArrayReal]):
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
         """Execute normalization with accurate floating output dtype metadata."""
-        self._validate_input_count(1 + len(inputs), expected=1)
+        self._validate_process_input_count(1 + len(inputs))
         logger.debug("Adding delayed normalize operation to computation graph")
         delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)
@@ -285,6 +285,7 @@ class AddWithSNR(AudioOperation[NDArrayReal, NDArrayReal]):
 
     name = "add_with_snr"
     _display = "+SNR"
+    _expected_input_count = 2
 
     def __init__(self, sampling_rate: float, snr: float = 1.0):
         """

--- a/wandas/processing/effects.py
+++ b/wandas/processing/effects.py
@@ -305,6 +305,10 @@ class AddWithSNR(AudioOperation[NDArrayReal, NDArrayReal]):
         """Signal-to-noise ratio captured at operation construction time."""
         return self._config_value("snr")
 
+    def calculate_output_dtype(self, *input_dtypes: np.dtype[Any]) -> np.dtype[Any]:
+        """Promote SNR mixing to at least float32 precision."""
+        return np.result_type(*input_dtypes, np.float32)
+
     def _process_inputs(self, *inputs: NDArrayReal) -> NDArrayReal:
         """Perform addition processing considering SNR"""
         if len(inputs) != 2:
@@ -312,7 +316,8 @@ class AddWithSNR(AudioOperation[NDArrayReal, NDArrayReal]):
                 f"Expected exactly two inputs for AddWithSNR; got {len(inputs)}. "
                 "Pass clean and noise arrays to process()."
             )
-        x, other = inputs
+        work_dtype = self.calculate_output_dtype(*(np.asarray(input_data).dtype for input_data in inputs))
+        x, other = (input_data.astype(work_dtype, copy=False) for input_data in inputs)
         logger.debug(f"Applying SNR-based addition with shape: {x.shape}")
 
         # Use multi-channel versions of calculate_rms and calculate_desired_noise_rms

--- a/wandas/processing/effects.py
+++ b/wandas/processing/effects.py
@@ -225,7 +225,6 @@ class Normalize(AudioOperation[NDArrayReal, NDArrayReal]):
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
         """Execute normalization with accurate floating output dtype metadata."""
-        self._validate_process_input_count(1 + len(inputs))
         logger.debug("Adding delayed normalize operation to computation graph")
         delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)

--- a/wandas/processing/psychoacoustic.py
+++ b/wandas/processing/psychoacoustic.py
@@ -130,7 +130,6 @@ class _PsychoacousticOperation(AudioOperation[NDArrayReal, NDArrayReal]):
         return super().process_array(x)
 
     def process(self, data: Any, *inputs: Any) -> Any:
-        self._validate_process_input_count(1 + len(inputs))
         self.ensure_dependencies()
         return super().process(data)
 

--- a/wandas/processing/psychoacoustic.py
+++ b/wandas/processing/psychoacoustic.py
@@ -130,7 +130,7 @@ class _PsychoacousticOperation(AudioOperation[NDArrayReal, NDArrayReal]):
         return super().process_array(x)
 
     def process(self, data: Any, *inputs: Any) -> Any:
-        self._validate_input_count(1 + len(inputs), expected=1)
+        self._validate_process_input_count(1 + len(inputs))
         self.ensure_dependencies()
         return super().process(data)
 

--- a/wandas/processing/psychoacoustic.py
+++ b/wandas/processing/psychoacoustic.py
@@ -129,7 +129,8 @@ class _PsychoacousticOperation(AudioOperation[NDArrayReal, NDArrayReal]):
         self.ensure_dependencies()
         return super().process_array(x)
 
-    def process(self, data: Any) -> Any:
+    def process(self, data: Any, *inputs: Any) -> Any:
+        self._validate_input_count(1 + len(inputs), expected=1)
         self.ensure_dependencies()
         return super().process(data)
 

--- a/wandas/processing/spectral.py
+++ b/wandas/processing/spectral.py
@@ -781,7 +781,7 @@ class _NOctBase(AudioOperation[NDArrayReal, NDArrayReal]):
         return super().process_array(x)
 
     def process(self, data: Any, *inputs: Any) -> Any:
-        self._validate_input_count(1 + len(inputs), expected=1)
+        self._validate_process_input_count(1 + len(inputs))
         self.ensure_dependencies()
         return super().process(data)
 

--- a/wandas/processing/spectral.py
+++ b/wandas/processing/spectral.py
@@ -780,7 +780,8 @@ class _NOctBase(AudioOperation[NDArrayReal, NDArrayReal]):
         self.ensure_dependencies()
         return super().process_array(x)
 
-    def process(self, data: Any) -> Any:
+    def process(self, data: Any, *inputs: Any) -> Any:
+        self._validate_input_count(1 + len(inputs), expected=1)
         self.ensure_dependencies()
         return super().process(data)
 

--- a/wandas/processing/spectral.py
+++ b/wandas/processing/spectral.py
@@ -781,7 +781,6 @@ class _NOctBase(AudioOperation[NDArrayReal, NDArrayReal]):
         return super().process_array(x)
 
     def process(self, data: Any, *inputs: Any) -> Any:
-        self._validate_process_input_count(1 + len(inputs))
         self.ensure_dependencies()
         return super().process(data)
 

--- a/wandas/processing/stats.py
+++ b/wandas/processing/stats.py
@@ -27,7 +27,6 @@ class ABS(AudioOperation[NDArrayReal, NDArrayReal]):
         super().__init__(sampling_rate)
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
-        self._validate_process_input_count(1 + len(inputs))
         return self._mark_array(da.abs(data))
 
 
@@ -61,7 +60,6 @@ class Power(AudioOperation[NDArrayReal, NDArrayReal]):
         return self.exponent
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
-        self._validate_process_input_count(1 + len(inputs))
         return self._mark_array(da.power(data, self.exponent))
 
 
@@ -72,7 +70,6 @@ class Sum(AudioOperation[NDArrayReal, NDArrayReal]):
     _display = "sum"
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
-        self._validate_process_input_count(1 + len(inputs))
         return self._mark_array(data.sum(axis=0, keepdims=True))
 
 
@@ -83,7 +80,6 @@ class Mean(AudioOperation[NDArrayReal, NDArrayReal]):
     _display = "mean"
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
-        self._validate_process_input_count(1 + len(inputs))
         return self._mark_array(data.mean(axis=0, keepdims=True))
 
 
@@ -112,7 +108,6 @@ class ChannelDifference(AudioOperation[NDArrayReal, NDArrayReal]):
         return self._config_value("other_channel")
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
-        self._validate_process_input_count(1 + len(inputs))
         other_channel = self.other_channel
         if not -data.shape[0] <= other_channel < data.shape[0]:
             raise IndexError("Channel index out of range")

--- a/wandas/processing/stats.py
+++ b/wandas/processing/stats.py
@@ -26,7 +26,8 @@ class ABS(AudioOperation[NDArrayReal, NDArrayReal]):
         """
         super().__init__(sampling_rate)
 
-    def process(self, data: DaArray) -> DaArray:
+    def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
+        self._validate_input_count(1 + len(inputs), expected=1)
         return self._mark_array(da.abs(data))
 
 
@@ -59,7 +60,8 @@ class Power(AudioOperation[NDArrayReal, NDArrayReal]):
         """Backward-compatible read-only alias for the captured exponent."""
         return self.exponent
 
-    def process(self, data: DaArray) -> DaArray:
+    def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
+        self._validate_input_count(1 + len(inputs), expected=1)
         return self._mark_array(da.power(data, self.exponent))
 
 
@@ -69,7 +71,8 @@ class Sum(AudioOperation[NDArrayReal, NDArrayReal]):
     name = "sum"
     _display = "sum"
 
-    def process(self, data: DaArray) -> DaArray:
+    def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
+        self._validate_input_count(1 + len(inputs), expected=1)
         return self._mark_array(data.sum(axis=0, keepdims=True))
 
 
@@ -79,7 +82,8 @@ class Mean(AudioOperation[NDArrayReal, NDArrayReal]):
     name = "mean"
     _display = "mean"
 
-    def process(self, data: DaArray) -> DaArray:
+    def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
+        self._validate_input_count(1 + len(inputs), expected=1)
         return self._mark_array(data.mean(axis=0, keepdims=True))
 
 
@@ -107,7 +111,8 @@ class ChannelDifference(AudioOperation[NDArrayReal, NDArrayReal]):
         """Other channel index captured at operation construction time."""
         return self._config_value("other_channel")
 
-    def process(self, data: DaArray) -> DaArray:
+    def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
+        self._validate_input_count(1 + len(inputs), expected=1)
         other_channel = self.other_channel
         if not -data.shape[0] <= other_channel < data.shape[0]:
             raise IndexError("Channel index out of range")

--- a/wandas/processing/stats.py
+++ b/wandas/processing/stats.py
@@ -27,7 +27,7 @@ class ABS(AudioOperation[NDArrayReal, NDArrayReal]):
         super().__init__(sampling_rate)
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
-        self._validate_input_count(1 + len(inputs), expected=1)
+        self._validate_process_input_count(1 + len(inputs))
         return self._mark_array(da.abs(data))
 
 
@@ -61,7 +61,7 @@ class Power(AudioOperation[NDArrayReal, NDArrayReal]):
         return self.exponent
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
-        self._validate_input_count(1 + len(inputs), expected=1)
+        self._validate_process_input_count(1 + len(inputs))
         return self._mark_array(da.power(data, self.exponent))
 
 
@@ -72,7 +72,7 @@ class Sum(AudioOperation[NDArrayReal, NDArrayReal]):
     _display = "sum"
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
-        self._validate_input_count(1 + len(inputs), expected=1)
+        self._validate_process_input_count(1 + len(inputs))
         return self._mark_array(data.sum(axis=0, keepdims=True))
 
 
@@ -83,7 +83,7 @@ class Mean(AudioOperation[NDArrayReal, NDArrayReal]):
     _display = "mean"
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
-        self._validate_input_count(1 + len(inputs), expected=1)
+        self._validate_process_input_count(1 + len(inputs))
         return self._mark_array(data.mean(axis=0, keepdims=True))
 
 
@@ -112,7 +112,7 @@ class ChannelDifference(AudioOperation[NDArrayReal, NDArrayReal]):
         return self._config_value("other_channel")
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
-        self._validate_input_count(1 + len(inputs), expected=1)
+        self._validate_process_input_count(1 + len(inputs))
         other_channel = self.other_channel
         if not -data.shape[0] <= other_channel < data.shape[0]:
             raise IndexError("Channel index out of range")

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -140,7 +140,7 @@ class ReSampling(AudioOperation[NDArrayReal, NDArrayReal]):
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
         """Execute resampling with accurate floating output dtype metadata."""
-        self._validate_input_count(1 + len(inputs), expected=1)
+        self._validate_process_input_count(1 + len(inputs))
         logger.debug("Adding delayed resampling operation to computation graph")
         delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)
@@ -428,7 +428,7 @@ class RmsTrend(AudioOperation[NDArrayReal, NDArrayReal]):
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
         """Execute RMS trend with accurate floating output dtype metadata."""
-        self._validate_input_count(1 + len(inputs), expected=1)
+        self._validate_process_input_count(1 + len(inputs))
         logger.debug("Adding delayed RMS trend operation to computation graph")
         delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)
@@ -579,7 +579,7 @@ class SoundLevel(AudioOperation[NDArrayReal, NDArrayReal]):
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
         """Execute sound level with floating output dtype metadata."""
-        self._validate_input_count(1 + len(inputs), expected=1)
+        self._validate_process_input_count(1 + len(inputs))
         logger.debug("Adding delayed sound level operation to computation graph")
         delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -140,7 +140,6 @@ class ReSampling(AudioOperation[NDArrayReal, NDArrayReal]):
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
         """Execute resampling with accurate floating output dtype metadata."""
-        self._validate_process_input_count(1 + len(inputs))
         logger.debug("Adding delayed resampling operation to computation graph")
         delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)
@@ -428,7 +427,6 @@ class RmsTrend(AudioOperation[NDArrayReal, NDArrayReal]):
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
         """Execute RMS trend with accurate floating output dtype metadata."""
-        self._validate_process_input_count(1 + len(inputs))
         logger.debug("Adding delayed RMS trend operation to computation graph")
         delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)
@@ -579,7 +577,6 @@ class SoundLevel(AudioOperation[NDArrayReal, NDArrayReal]):
 
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
         """Execute sound level with floating output dtype metadata."""
-        self._validate_process_input_count(1 + len(inputs))
         logger.debug("Adding delayed sound level operation to computation graph")
         delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -138,8 +138,9 @@ class ReSampling(AudioOperation[NDArrayReal, NDArrayReal]):
         logger.debug(f"Resampling applied, returning result with shape: {result.shape}")
         return result
 
-    def process(self, data: DaArray) -> DaArray:
+    def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
         """Execute resampling with accurate floating output dtype metadata."""
+        self._validate_input_count(1 + len(inputs), expected=1)
         logger.debug("Adding delayed resampling operation to computation graph")
         delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)
@@ -425,8 +426,9 @@ class RmsTrend(AudioOperation[NDArrayReal, NDArrayReal]):
         logger.debug(f"RMS applied, returning result with shape: {result.shape}")
         return result
 
-    def process(self, data: DaArray) -> DaArray:
+    def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
         """Execute RMS trend with accurate floating output dtype metadata."""
+        self._validate_input_count(1 + len(inputs), expected=1)
         logger.debug("Adding delayed RMS trend operation to computation graph")
         delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)
@@ -575,8 +577,9 @@ class SoundLevel(AudioOperation[NDArrayReal, NDArrayReal]):
         logger.debug(f"Sound level applied, returning result with shape: {result.shape}")
         return np.asarray(result, dtype=output_dtype)
 
-    def process(self, data: DaArray) -> DaArray:
+    def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
         """Execute sound level with floating output dtype metadata."""
+        self._validate_input_count(1 + len(inputs), expected=1)
         logger.debug("Adding delayed sound level operation to computation graph")
         delayed_result = self._delayed(data)
         output_shape = self.calculate_output_shape(data.shape)


### PR DESCRIPTION
## Summary
- Add variadic Dask-input support to `AudioOperation` while keeping single-input operations explicit about arity.
- Convert `AddWithSNR` so noise is passed as a Dask graph input instead of stored in operation config or lineage params.
- Update `ChannelFrame.add(..., snr=...)` tests for clean operation history params and two-parent lineage graphs.

## Impact
- `ChannelFrame.add(noise, snr=...)` keeps the same public behavior, but `operation_history[-1]["params"]` now contains only `{"snr": ...}`.
- Noise inputs participate in Dask graph dependencies directly, avoiding operation-owned Dask array state.

## Validation
- `uv run pytest tests/processing/test_base_operations.py tests/processing/test_effect_operations.py tests/frames/test_channel_processing.py tests/core/test_base_frame_lineage.py tests/processing/test_display_names.py tests/frames/test_channel_frame.py`
- `uv run ruff check wandas tests --config=pyproject.toml -v`
- `uv run ty check wandas tests`