### PR TITLE
[codex] Add operation summaries

### DIFF
--- a/docs/superpowers/plans/2026-07-01-operation-summary-portability.md
+++ b/docs/superpowers/plans/2026-07-01-operation-summary-portability.md
@@ -1,0 +1,370 @@
+# Operation Summary Portability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `operation_summaries` strict-JSON safe and mark summaries portable only when parameter values are faithfully represented.
+
+**Architecture:** Keep `AudioOperation.to_summary()` thin. Extend the private summary helpers in `wandas/processing/base.py`: `_summary_value()` produces JSON-safe display descriptors, `_summary_is_portable()` decides whether the original parameter values are faithfully represented.
+
+**Tech Stack:** Python 3.10, NumPy, Dask array, pytest, ruff, ty, uv.
+
+---
+
+## File Structure
+
+- Modify `wandas/processing/base.py`
+  - Add a local stable JSON sort key helper for deterministic set/frozenset summaries.
+  - Update Dask array descriptor generation to normalize `shape` and `chunks` recursively.
+  - Add set/frozenset summary conversion.
+  - Tighten `_summary_is_portable()` so opaque values are non-portable.
+- Modify `tests/processing/test_base_operations.py`
+  - Add `Path` and `dask.array as da` imports.
+  - Add focused tests for Dask unknown shape/chunks, set/frozenset preservation, and opaque object non-portability.
+- No frame method changes.
+- No WDF persistence changes.
+
+---
+
+### Task 1: Add Dask Unknown Shape Regression Test
+
+**Files:**
+- Modify: `tests/processing/test_base_operations.py`
+
+- [ ] **Step 1: Add imports for this test**
+
+At the top of `tests/processing/test_base_operations.py`, add:
+
+```python
+from pathlib import Path
+```
+
+Add the Dask array module import near the existing third-party imports:
+
+```python
+import dask.array as da
+```
+
+Add the delayed helper import near the other Dask imports:
+
+```python
+from dask import delayed
+```
+
+- [ ] **Step 2: Write the failing Dask descriptor test**
+
+Add this method after `test_audio_operation_summary_sanitizes_array_like_params`:
+
+```python
+    def test_audio_operation_summary_sanitizes_dask_shape_and_chunks_for_strict_json(self) -> None:
+        test_op_cls = self._make_test_op_class()
+        weights = da.from_delayed(delayed(lambda: np.array([1.0, 2.0]))(), shape=(np.nan,), dtype=float)
+        op = test_op_cls(16000, weights=weights)
+
+        summary = op.to_summary()
+
+        assert summary["params"]["weights"] == {
+            "type": "dask.array",
+            "shape": [{"type": "float", "value": "nan"}],
+            "dtype": "float64",
+            "chunks": [[{"type": "float", "value": "nan"}]],
+        }
+        assert summary["portable"] is True
+        json.dumps(summary, allow_nan=False)
+```
+
+- [ ] **Step 3: Run the failing test**
+
+Run:
+
+```bash
+uv run pytest tests/processing/test_base_operations.py::TestAudioOperation::test_audio_operation_summary_sanitizes_dask_shape_and_chunks_for_strict_json -q
+```
+
+Expected: FAIL because `shape` or `chunks` still contain raw `nan`.
+
+---
+
+### Task 2: Add Set/Frozenset Regression Test
+
+**Files:**
+- Modify: `tests/processing/test_base_operations.py`
+
+- [ ] **Step 1: Write the failing set/frozenset test**
+
+Add this method after the Dask descriptor test from Task 1:
+
+```python
+    def test_audio_operation_summary_preserves_set_values_deterministically(self) -> None:
+        test_op_cls = self._make_test_op_class()
+        op = test_op_cls(
+            16000,
+            channels={2, 1},
+            bands=frozenset({np.float32(0.5), np.float32(0.25)}),
+        )
+
+        summary = op.to_summary()
+
+        assert summary["params"]["channels"] == [1, 2]
+        assert summary["params"]["bands"] == [0.25, 0.5]
+        assert summary["portable"] is True
+        json.dumps(summary, allow_nan=False)
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+uv run pytest tests/processing/test_base_operations.py::TestAudioOperation::test_audio_operation_summary_preserves_set_values_deterministically -q
+```
+
+Expected: FAIL because sets currently fall back to `{"type": "set"}` or `{"type": "frozenset"}`.
+
+---
+
+### Task 3: Add Opaque Object Portability Test
+
+**Files:**
+- Modify: `tests/processing/test_base_operations.py`
+
+- [ ] **Step 1: Write the failing opaque object test**
+
+Add this method after the set/frozenset test from Task 2:
+
+```python
+    def test_audio_operation_summary_marks_opaque_params_non_portable(self) -> None:
+        test_op_cls = self._make_test_op_class()
+        op = test_op_cls(16000, impulse_response=Path("ir.wav"), resource=object())
+
+        summary = op.to_summary()
+
+        assert summary["params"] == {
+            "impulse_response": {"type": "PosixPath"},
+            "resource": {"type": "object"},
+        }
+        assert summary["portable"] is False
+        json.dumps(summary, allow_nan=False)
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+uv run pytest tests/processing/test_base_operations.py::TestAudioOperation::test_audio_operation_summary_marks_opaque_params_non_portable -q
+```
+
+Expected: FAIL because `_summary_is_portable()` currently returns `True` for opaque non-callable values.
+
+---
+
+### Task 4: Implement JSON-Safe Summary Values
+
+**Files:**
+- Modify: `wandas/processing/base.py`
+
+- [ ] **Step 1: Add JSON import**
+
+Add this import near the existing standard library imports:
+
+```python
+import json
+```
+
+- [ ] **Step 2: Add stable sort helper**
+
+Add this helper immediately before `_summary_value()`:
+
+```python
+def _summary_sort_key(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+```
+
+- [ ] **Step 3: Update `_summary_value()` container and Dask branches**
+
+Replace the mapping/list/array/Dask tail of `_summary_value()` with:
+
+```python
+    if isinstance(value, Mapping):
+        return {str(key): _summary_value(item) for key, item in value.items()}
+    if isinstance(value, tuple | list):
+        return [_summary_value(item) for item in value]
+    if isinstance(value, set | frozenset):
+        return sorted((_summary_value(item) for item in value), key=_summary_sort_key)
+    if isinstance(value, np.ndarray):
+        return {"type": "ndarray", "shape": [_summary_value(item) for item in value.shape], "dtype": str(value.dtype)}
+    if isinstance(value, DaArray):
+        return {
+            "type": "dask.array",
+            "shape": [_summary_value(item) for item in value.shape],
+            "dtype": str(value.dtype),
+            "chunks": [[_summary_value(item) for item in chunk] for chunk in value.chunks],
+        }
+    return {"type": type(value).__name__}
+```
+
+- [ ] **Step 4: Run Task 1 and Task 2 tests**
+
+Run:
+
+```bash
+uv run pytest tests/processing/test_base_operations.py::TestAudioOperation::test_audio_operation_summary_sanitizes_dask_shape_and_chunks_for_strict_json tests/processing/test_base_operations.py::TestAudioOperation::test_audio_operation_summary_preserves_set_values_deterministically -q
+```
+
+Expected: both tests PASS.
+
+---
+
+### Task 5: Implement Strict Portability Boundary
+
+**Files:**
+- Modify: `wandas/processing/base.py`
+
+- [ ] **Step 1: Replace `_summary_is_portable()`**
+
+Replace `_summary_is_portable()` with:
+
+```python
+def _summary_is_portable(value: Any) -> bool:
+    """Return whether a value can be represented as a portable summary."""
+    if callable(value):
+        return False
+    if value is None or isinstance(value, str | bool | np.bool_):
+        return True
+    if isinstance(value, numbers.Number):
+        return True
+    if isinstance(value, np.ndarray | DaArray):
+        return True
+    if isinstance(value, Mapping):
+        return all(_summary_is_portable(item) for item in value.values())
+    if isinstance(value, tuple | list | set | frozenset):
+        return all(_summary_is_portable(item) for item in value)
+    return False
+```
+
+- [ ] **Step 2: Run Task 3 test**
+
+Run:
+
+```bash
+uv run pytest tests/processing/test_base_operations.py::TestAudioOperation::test_audio_operation_summary_marks_opaque_params_non_portable -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run existing callable and scalar summary tests**
+
+Run:
+
+```bash
+uv run pytest tests/processing/test_base_operations.py::TestAudioOperation::test_audio_operation_summary_preserves_nested_callable_params_as_non_portable tests/processing/test_base_operations.py::TestAudioOperation::test_audio_operation_summary_preserves_numpy_and_complex_scalars_for_strict_json -q
+```
+
+Expected: both tests PASS.
+
+---
+
+### Task 6: Run Focused Summary Test Set
+
+**Files:**
+- Test only.
+
+- [ ] **Step 1: Run all AudioOperation summary tests**
+
+Run:
+
+```bash
+uv run pytest tests/processing/test_base_operations.py -q
+```
+
+Expected: all tests in `test_base_operations.py` PASS.
+
+- [ ] **Step 2: Commit implementation**
+
+Run:
+
+```bash
+git add wandas/processing/base.py tests/processing/test_base_operations.py
+git commit -m "Tighten operation summary portability"
+```
+
+Expected: commit hooks PASS.
+
+---
+
+### Task 7: Validate PR Scope and Update PR
+
+**Files:**
+- Modify only PR metadata through `gh`.
+
+- [ ] **Step 1: Run relevant validation**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_base_frame_lineage.py tests/processing/test_base_operations.py tests/processing/test_custom_operation.py tests/frames/test_channel_processing.py
+```
+
+Expected: all tests PASS. The count should increase by 3 from the previous 195 because three tests were added.
+
+Run:
+
+```bash
+uv run ruff check wandas tests --config=pyproject.toml -v
+```
+
+Expected: `All checks passed!`
+
+Run:
+
+```bash
+uv run ty check wandas tests
+```
+
+Expected: `All checks passed!`
+
+- [ ] **Step 2: Push branch**
+
+Run:
+
+```bash
+git push
+```
+
+Expected: `codex/operation-summaries` updates on GitHub.
+
+- [ ] **Step 3: Update PR body validation and summary**
+
+Run:
+
+```bash
+gh pr edit 250 --repo kasahart/wandas --body $'## Summary\n- Add `AudioOperation.to_summary()` and `BinaryOperation.to_summary()` for lightweight portable operation summaries.\n- Mark `CustomOperation` summaries as non-portable and include a callable implementation reference.\n- Add `BaseFrame.operation_summaries` as a read-only projection from existing `LineageNode` provenance without changing `previous` or `operation_history`.\n- Sanitize non-finite numeric summary params so summaries are strict-JSON serializable.\n- Preserve nested callable params as explicit descriptors and mark affected summaries as non-portable.\n- Normalize Dask descriptor shape/chunks, preserve set/frozenset contents deterministically, and mark opaque type-only params non-portable.\n\n## Linked Issues\n- Closes #244\n- Part of #232\n\n## Validation\n- `uv run pytest tests/core/test_base_frame_lineage.py tests/processing/test_base_operations.py tests/processing/test_custom_operation.py tests/frames/test_channel_processing.py` -> 198 passed\n- `uv run ruff check wandas tests --config=pyproject.toml -v` -> All checks passed\n- `uv run ty check wandas tests` -> All checks passed\n- commit hooks: ruff check, ruff format, ty -> Passed\n\n## Notes\n- WDF/persist summary snapshots are intentionally left for a later phase.\n- `previous` retention is unchanged because frames are lazy and this phase focuses on summary contracts.'
+```
+
+Expected: command prints the PR URL.
+
+- [ ] **Step 4: Reply to and resolve the three new review threads**
+
+Use the same thread-aware GraphQL workflow used earlier. Reply with:
+
+```text
+Addressed in `<commit>`: Dask descriptor shape/chunks are now recursively normalized through `_summary_value()`, so unknown dimensions/chunks remain strict-JSON safe while the descriptor stays portable. Added regression coverage with `json.dumps(..., allow_nan=False)`.
+```
+
+```text
+Addressed in `<commit>`: set and frozenset params now preserve their contents as deterministic summary lists. Summaries remain portable when all contained values are portable, and the regression test covers stable values and strict JSON encoding.
+```
+
+```text
+Addressed in `<commit>`: opaque non-callable params still get display-safe type descriptors, but `_summary_is_portable()` now marks them non-portable because the original value is not faithfully represented. Added coverage for `Path` and `object()`.
+```
+
+Then call `resolveReviewThread` for each thread and confirm all new threads have `isResolved: true`.
+
+---
+
+## Self-Review
+
+- Spec coverage: Dask unknown shape/chunks is covered by Task 1 and Task 4. Set/frozenset preservation is covered by Task 2 and Task 4. Opaque non-portability is covered by Task 3 and Task 5. Validation and PR update are covered by Task 7.
+- Incomplete-marker scan: no unfinished markers remain. All code changes and commands are explicit.
+- Type consistency: helper names `_summary_value`, `_summary_is_portable`, and `_summary_sort_key` are consistent across tasks. Test class and file paths match the current codebase.

--- a/docs/superpowers/specs/2026-07-01-operation-summary-portability-design.md
+++ b/docs/superpowers/specs/2026-07-01-operation-summary-portability-design.md
@@ -1,0 +1,104 @@
+# Operation Summary Portability Design
+
+## Context
+
+PR #250 adds `operation_summaries` as a lightweight projection of operation lineage.
+New review feedback found three cases where a summary can claim `portable: True`
+while either losing parameter values or emitting values that strict JSON cannot
+persist:
+
+- Dask arrays with unknown shape or chunks can include `NaN` in descriptor fields.
+- `set` and `frozenset` parameters currently fall back to type-only descriptors.
+- Opaque objects such as `Path("ir.wav")` also fall back to type-only descriptors.
+
+The chosen contract is strict: a summary is portable only when it preserves enough
+parameter information to interpret or persist the operation configuration, not
+merely when the resulting summary can be encoded as JSON.
+
+## Goals
+
+- Keep `operation_summaries` strict-JSON safe with `json.dumps(..., allow_nan=False)`.
+- Preserve values for supported scalar and container parameter types.
+- Mark summaries as non-portable when parameter values are represented only by
+  opaque type descriptors.
+- Keep frame methods thin and keep summary behavior in `wandas/processing`.
+- Avoid sharing `operation_history` internals directly with summary generation,
+  because summaries use lightweight display descriptors rather than full history
+  snapshots.
+
+## Non-Goals
+
+- Do not add WDF persistence for `operation_summaries` in this change.
+- Do not remove or redesign `previous`, `operation_history`, or lineage storage.
+- Do not introduce a new public `json_safe` field in this PR.
+- Do not attempt to serialize arbitrary Python objects by value.
+
+## Design
+
+`_summary_value(value)` remains responsible for producing a lightweight,
+JSON-safe representation:
+
+- Existing scalar handling stays in place, including sentinel objects for
+  non-finite numbers.
+- Dask array descriptors should recursively normalize `shape` and `chunks`
+  entries through `_summary_value()` so unknown dimensions such as `np.nan` do
+  not leak raw non-finite floats.
+- `set` and `frozenset` should be represented as deterministic lists. Each item
+  is converted through `_summary_value()`, then sorted by a stable JSON-based
+  sort key so output is repeatable.
+- `callable` values remain callable descriptors with a qualified name.
+- Opaque values continue to fall back to `{"type": type(value).__name__}` for
+  display, but that fallback is not considered portable.
+
+`_summary_is_portable(value)` remains responsible for deciding whether the
+original parameter value is sufficiently represented:
+
+- Scalars, NumPy arrays, Dask arrays, mappings, lists, tuples, sets, and
+  frozensets are portable when their nested values are portable.
+- Callable values are not portable.
+- Unknown opaque objects are not portable.
+- Type-only descriptors do not make a value portable.
+
+`AudioOperation.to_summary()` should stay thin:
+
+1. Capture `params = self.to_params()` once.
+2. Build `params` with `_summary_value()`.
+3. Set `portable` with `_summary_is_portable()` over the original parameter
+   values.
+
+## Data Flow
+
+```text
+AudioOperation.to_params()
+  -> raw params
+  -> _summary_value() for display / JSON-safe params
+  -> _summary_is_portable() for strict portability
+  -> OperationSummary
+```
+
+This keeps the display projection and portability decision separate while
+ensuring they follow the same supported-type boundary.
+
+## Error Handling
+
+Summary generation should not raise for unsupported parameter objects. Unknown
+objects should produce a type descriptor and mark the summary non-portable. This
+keeps `operation_summaries` usable for inspection even when the operation cannot
+be faithfully persisted.
+
+## Testing
+
+Add focused regression tests in `tests/processing/test_base_operations.py`:
+
+- A Dask array parameter with unknown shape or chunks is strict-JSON safe and
+  keeps `portable: True` when descriptor fields are normalized.
+- `set` and `frozenset` parameters preserve their contents as deterministic
+  lists and remain portable when their items are portable.
+- `Path` or another opaque non-callable object uses a type descriptor and marks
+  the operation summary as non-portable.
+
+Run the existing relevant validation set after implementation:
+
+- `uv run pytest tests/core/test_base_frame_lineage.py tests/processing/test_base_operations.py tests/processing/test_custom_operation.py tests/frames/test_channel_processing.py`
+- `uv run ruff check wandas tests --config=pyproject.toml -v`
+- `uv run ty check wandas tests`

--- a/tests/core/test_base_frame_lineage.py
+++ b/tests/core/test_base_frame_lineage.py
@@ -230,3 +230,37 @@ def test_operations_property_is_read_only_sequence() -> None:
     assert isinstance(result.operations, tuple)
     with pytest.raises(AttributeError):
         result.operations = ()  # ty: ignore[invalid-assignment]
+
+
+def test_operation_summaries_returns_serial_lineage_summaries() -> None:
+    result = _frame().normalize().low_pass_filter(1000)
+
+    assert [summary["operation"] for summary in result.operation_summaries] == [
+        "normalize",
+        "lowpass_filter",
+    ]
+    assert all(summary["schema_version"] == 1 for summary in result.operation_summaries)
+    assert all(summary["portable"] is True for summary in result.operation_summaries)
+
+
+def test_operation_summaries_does_not_compute_data() -> None:
+    result = _frame().normalize()
+
+    with mock.patch("dask.array.core.Array.compute") as compute:
+        summaries = result.operation_summaries
+
+    compute.assert_not_called()
+    assert summaries[0]["operation"] == "normalize"
+
+
+def test_operation_summaries_include_multi_input_lineage() -> None:
+    signal = _frame().normalize()
+    noise = _frame().low_pass_filter(1000)
+
+    result = signal.add(noise, snr=6.0)
+
+    assert [summary["operation"] for summary in result.operation_summaries] == [
+        "normalize",
+        "lowpass_filter",
+        "add_with_snr",
+    ]

--- a/tests/core/test_base_frame_lineage.py
+++ b/tests/core/test_base_frame_lineage.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 from unittest import mock
 
@@ -251,6 +252,13 @@ def test_operation_summaries_does_not_compute_data() -> None:
 
     compute.assert_not_called()
     assert summaries[0]["operation"] == "normalize"
+
+
+def test_operation_summaries_are_strict_json_serializable_with_default_normalize() -> None:
+    summaries = _frame().normalize().operation_summaries
+
+    assert summaries[0]["params"]["norm"] == {"type": "float", "value": "inf"}
+    json.dumps(summaries, allow_nan=False)
 
 
 def test_operation_summaries_include_multi_input_lineage() -> None:

--- a/tests/processing/test_base_operations.py
+++ b/tests/processing/test_base_operations.py
@@ -1,4 +1,5 @@
 import abc
+import json
 from collections import Counter, defaultdict, namedtuple
 from typing import Any
 from unittest import mock
@@ -24,6 +25,7 @@ from wandas.processing.base import (
     register_lazy_operation,
     register_operation,
 )
+from wandas.processing.effects import Normalize
 from wandas.processing.filters import HighPassFilter
 from wandas.processing.spectral import STFT
 from wandas.utils.dask_helpers import da_from_array
@@ -249,6 +251,12 @@ class TestAudioOperation:
             "shape": [2],
             "dtype": "float64",
         }
+
+    def test_audio_operation_summary_sanitizes_non_finite_numbers_for_strict_json(self) -> None:
+        summary = Normalize(16000).to_summary()
+
+        assert summary["params"]["norm"] == {"type": "float", "value": "inf"}
+        json.dumps(summary, allow_nan=False)
 
     def test_process_rejects_1d_direct_input(self) -> None:
         """process() requires Frame-internal ch-first Dask arrays."""

--- a/tests/processing/test_base_operations.py
+++ b/tests/processing/test_base_operations.py
@@ -1,6 +1,7 @@
 import abc
 import json
 from collections import Counter, defaultdict, namedtuple
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 from unittest import mock
@@ -161,6 +162,25 @@ def test_binary_operation_to_summary_returns_portable_summary() -> None:
     }
 
 
+@pytest.mark.parametrize(
+    ("operand", "expected_operand"),
+    [
+        (np.float32(0.5), {"type": "float32", "shape": []}),
+        (np.array([0.5, 1.5]), {"type": "ndarray", "shape": [2], "dtype": "float64"}),
+    ],
+)
+def test_binary_operation_to_summary_marks_descriptor_only_operands_non_portable(
+    operand: Any, expected_operand: dict[str, Any]
+) -> None:
+    operation = BinaryOperation(symbol="+", operand_kind="scalar", operand=operand)
+
+    summary = operation.to_summary()
+
+    assert summary["params"]["operand"] == expected_operand
+    assert summary["portable"] is False
+    json.dumps(summary, allow_nan=False)
+
+
 class TestAudioOperation:
     """Test AudioOperation base class."""
 
@@ -307,6 +327,26 @@ class TestAudioOperation:
         summary = op.to_summary()
 
         assert summary["params"]["config"] == {"1": "log"}
+        assert summary["portable"] is False
+        json.dumps(summary, allow_nan=False)
+
+    def test_audio_operation_summary_marks_unsupported_numeric_params_non_portable(self) -> None:
+        test_op_cls = self._make_test_op_class()
+        op = test_op_cls(16000, amount=Decimal("1.25"))
+
+        summary = op.to_summary()
+
+        assert summary["params"]["amount"] == {"type": "Decimal"}
+        assert summary["portable"] is False
+        json.dumps(summary, allow_nan=False)
+
+    def test_audio_operation_summary_handles_timedelta_params_as_non_portable(self) -> None:
+        test_op_cls = self._make_test_op_class()
+        op = test_op_cls(16000, window=np.timedelta64(1, "s"))
+
+        summary = op.to_summary()
+
+        assert summary["params"]["window"] == {"type": "timedelta64"}
         assert summary["portable"] is False
         json.dumps(summary, allow_nan=False)
 

--- a/tests/processing/test_base_operations.py
+++ b/tests/processing/test_base_operations.py
@@ -1,12 +1,15 @@
 import abc
 import json
 from collections import Counter, defaultdict, namedtuple
+from pathlib import Path
 from typing import Any
 from unittest import mock
 
 import cloudpickle
+import dask.array as da
 import numpy as np
 import pytest
+from dask import delayed
 from dask.array.core import Array as DaArray
 from dask.base import tokenize
 
@@ -251,6 +254,51 @@ class TestAudioOperation:
             "shape": [2],
             "dtype": "float64",
         }
+
+    def test_audio_operation_summary_sanitizes_dask_shape_and_chunks_for_strict_json(self) -> None:
+        test_op_cls = self._make_test_op_class()
+        weights = da.from_delayed(delayed(lambda: np.array([1.0, 2.0]))(), shape=(np.nan,), dtype=float)
+        op = test_op_cls(16000, weights=weights)
+
+        summary = op.to_summary()
+
+        assert summary["params"]["weights"] == {
+            "type": "dask.array",
+            "shape": [{"type": "float", "value": "nan"}],
+            "dtype": "float64",
+            "chunks": [[{"type": "float", "value": "nan"}]],
+        }
+        assert summary["portable"] is True
+        json.dumps(summary, allow_nan=False)
+
+    def test_audio_operation_summary_preserves_set_values_deterministically(self) -> None:
+        test_op_cls = self._make_test_op_class()
+        op = test_op_cls(
+            16000,
+            channels={2, 1},
+            bands=frozenset({np.float32(0.5), np.float32(0.25)}),
+        )
+
+        summary = op.to_summary()
+
+        assert summary["params"]["channels"] == [1, 2]
+        assert summary["params"]["bands"] == [0.25, 0.5]
+        assert summary["portable"] is True
+        json.dumps(summary, allow_nan=False)
+
+    def test_audio_operation_summary_marks_opaque_params_non_portable(self) -> None:
+        test_op_cls = self._make_test_op_class()
+        impulse_response = Path("ir.wav")
+        op = test_op_cls(16000, impulse_response=impulse_response, resource=object())
+
+        summary = op.to_summary()
+
+        assert summary["params"] == {
+            "impulse_response": {"type": type(impulse_response).__name__},
+            "resource": {"type": "object"},
+        }
+        assert summary["portable"] is False
+        json.dumps(summary, allow_nan=False)
 
     def test_audio_operation_summary_sanitizes_non_finite_numbers_for_strict_json(self) -> None:
         summary = Normalize(16000).to_summary()

--- a/tests/processing/test_base_operations.py
+++ b/tests/processing/test_base_operations.py
@@ -163,6 +163,16 @@ def test_binary_operation_to_summary_returns_portable_summary() -> None:
     }
 
 
+def test_binary_operation_to_summary_marks_unlabeled_frame_operand_non_portable() -> None:
+    operation = BinaryOperation(symbol="+", operand_kind="frame", operand=None)
+
+    summary = operation.to_summary()
+
+    assert summary["params"] == {"symbol": "+", "operand_kind": "frame"}
+    assert summary["portable"] is False
+    json.dumps(summary, allow_nan=False)
+
+
 @pytest.mark.parametrize(
     ("operand", "expected_operand"),
     [
@@ -372,6 +382,22 @@ class TestAudioOperation:
             "shape": [2],
             "dtype": "float64",
         }
+        assert summary["portable"] is False
+        json.dumps(summary, allow_nan=False)
+
+    def test_audio_operation_summary_marks_container_subclasses_non_portable(self) -> None:
+        Config = namedtuple("Config", ["gain"])
+        test_op_cls = self._make_test_op_class()
+        op = test_op_cls(
+            16000,
+            config=defaultdict(lambda: 2.0, {"gain": 3.0}),
+            preset=Config(gain=2.0),
+        )
+
+        summary = op.to_summary()
+
+        assert summary["params"]["config"] == {"gain": 3.0}
+        assert summary["params"]["preset"] == [2.0]
         assert summary["portable"] is False
         json.dumps(summary, allow_nan=False)
 

--- a/tests/processing/test_base_operations.py
+++ b/tests/processing/test_base_operations.py
@@ -141,6 +141,21 @@ def test_binary_operation_params_delegate_to_params() -> None:
     }
 
 
+def test_binary_operation_to_summary_returns_portable_summary() -> None:
+    operation = BinaryOperation(symbol="+", operand_kind="scalar", operand=2.0)
+
+    assert operation.to_summary() == {
+        "schema_version": 1,
+        "operation": "+",
+        "params": {
+            "symbol": "+",
+            "operand_kind": "scalar",
+            "operand": {"type": "float", "value": 2.0},
+        },
+        "portable": True,
+    }
+
+
 class TestAudioOperation:
     """Test AudioOperation base class."""
 
@@ -202,6 +217,38 @@ class TestAudioOperation:
         op = SimpleOp(16000)
 
         assert not hasattr(op, "process_array")
+
+    def test_audio_operation_to_summary_returns_portable_summary(self) -> None:
+        test_op_cls = self._make_test_op_class()
+        op = test_op_cls(16000, gain=2.0, enabled=True)
+
+        assert op.to_summary() == {
+            "schema_version": 1,
+            "operation": "test_op",
+            "params": {"gain": 2.0, "enabled": True},
+            "portable": True,
+        }
+
+    def test_audio_operation_to_summary_returns_defensive_params(self) -> None:
+        test_op_cls = self._make_test_op_class()
+        op = test_op_cls(16000, config={"gain": 2.0})
+
+        summary = op.to_summary()
+        summary["params"]["config"]["gain"] = 99.0
+
+        assert op.to_params()["config"] == {"gain": 2.0}
+
+    def test_audio_operation_summary_sanitizes_array_like_params(self) -> None:
+        test_op_cls = self._make_test_op_class()
+        op = test_op_cls(16000, weights=np.array([1.0, 2.0]))
+
+        summary = op.to_summary()
+
+        assert summary["params"]["weights"] == {
+            "type": "ndarray",
+            "shape": [2],
+            "dtype": "float64",
+        }
 
     def test_process_rejects_1d_direct_input(self) -> None:
         """process() requires Frame-internal ch-first Dask arrays."""

--- a/tests/processing/test_base_operations.py
+++ b/tests/processing/test_base_operations.py
@@ -2,6 +2,7 @@ import abc
 import json
 from collections import Counter, defaultdict, namedtuple
 from decimal import Decimal
+from fractions import Fraction
 from pathlib import Path
 from typing import Any
 from unittest import mock
@@ -347,6 +348,46 @@ class TestAudioOperation:
         summary = op.to_summary()
 
         assert summary["params"]["window"] == {"type": "timedelta64"}
+        assert summary["portable"] is False
+        json.dumps(summary, allow_nan=False)
+
+    def test_audio_operation_summary_marks_lossy_rational_params_non_portable(self) -> None:
+        test_op_cls = self._make_test_op_class()
+        op = test_op_cls(16000, ratio=Fraction(1, 3))
+
+        summary = op.to_summary()
+
+        assert summary["params"]["ratio"] == {"type": "Fraction"}
+        assert summary["portable"] is False
+        json.dumps(summary, allow_nan=False)
+
+    def test_audio_operation_summary_marks_ndarray_params_non_portable(self) -> None:
+        test_op_cls = self._make_test_op_class()
+        op = test_op_cls(16000, weights=np.array([0.1, 0.9]))
+
+        summary = op.to_summary()
+
+        assert summary["params"]["weights"] == {
+            "type": "ndarray",
+            "shape": [2],
+            "dtype": "float64",
+        }
+        assert summary["portable"] is False
+        json.dumps(summary, allow_nan=False)
+
+    def test_audio_operation_summary_normalizes_top_level_param_keys_for_strict_json(self) -> None:
+        class NonStringParamKeyOperation(AudioOperation[NDArrayReal, NDArrayReal]):
+            name = "non_string_param_key_op"
+
+            def to_params(self) -> dict[Any, Any]:
+                return {1: "linear", "1": "log"}
+
+            def _process(self, x: NDArrayReal) -> NDArrayReal:
+                return x
+
+        summary = NonStringParamKeyOperation(16000).to_summary()
+
+        assert summary["params"] == {"1": "log"}
         assert summary["portable"] is False
         json.dumps(summary, allow_nan=False)
 

--- a/tests/processing/test_base_operations.py
+++ b/tests/processing/test_base_operations.py
@@ -258,6 +258,47 @@ class TestAudioOperation:
         assert summary["params"]["norm"] == {"type": "float", "value": "inf"}
         json.dumps(summary, allow_nan=False)
 
+    def test_audio_operation_summary_preserves_nested_callable_params_as_non_portable(self) -> None:
+        def transform(value: float) -> float:
+            return value * 2.0
+
+        test_op_cls = self._make_test_op_class()
+        op = test_op_cls(16000, config={"transform": transform}, steps=[transform])
+
+        summary = op.to_summary()
+
+        expected_name = (
+            "TestAudioOperation."
+            "test_audio_operation_summary_preserves_nested_callable_params_as_non_portable."
+            "<locals>.transform"
+        )
+        assert summary["params"]["config"]["transform"] == {
+            "type": "callable",
+            "name": expected_name,
+        }
+        assert summary["params"]["steps"] == [
+            {
+                "type": "callable",
+                "name": expected_name,
+            }
+        ]
+        assert summary["portable"] is False
+        json.dumps(summary, allow_nan=False)
+
+    def test_audio_operation_summary_preserves_numpy_and_complex_scalars_for_strict_json(self) -> None:
+        test_op_cls = self._make_test_op_class()
+        op = test_op_cls(16000, gain=np.float32(0.5), count=np.int64(4), phase=1 + 2j)
+
+        summary = op.to_summary()
+
+        assert summary["params"] == {
+            "gain": 0.5,
+            "count": 4,
+            "phase": {"type": "complex", "real": 1.0, "imag": 2.0},
+        }
+        assert summary["portable"] is True
+        json.dumps(summary, allow_nan=False)
+
     def test_process_rejects_1d_direct_input(self) -> None:
         """process() requires Frame-internal ch-first Dask arrays."""
         test_op_cls = self._make_test_op_class()

--- a/tests/processing/test_base_operations.py
+++ b/tests/processing/test_base_operations.py
@@ -300,6 +300,16 @@ class TestAudioOperation:
         assert summary["portable"] is False
         json.dumps(summary, allow_nan=False)
 
+    def test_audio_operation_summary_marks_non_string_mapping_keys_non_portable(self) -> None:
+        test_op_cls = self._make_test_op_class()
+        op = test_op_cls(16000, config={1: "linear", "1": "log"})
+
+        summary = op.to_summary()
+
+        assert summary["params"]["config"] == {"1": "log"}
+        assert summary["portable"] is False
+        json.dumps(summary, allow_nan=False)
+
     def test_audio_operation_summary_sanitizes_non_finite_numbers_for_strict_json(self) -> None:
         summary = Normalize(16000).to_summary()
 

--- a/tests/processing/test_custom_operation.py
+++ b/tests/processing/test_custom_operation.py
@@ -146,6 +146,21 @@ class TestCustomOperation:
         assert op.params == {"gain": 2.0}
         assert "dask_pure" not in op.to_params()
 
+    def test_custom_operation_summary_marks_callable_non_portable(self) -> None:
+        def scale(x: np.ndarray, gain: float) -> np.ndarray:
+            return x * gain
+
+        operation = CustomOperation(16000, scale, gain=2.0)
+
+        summary = operation.to_summary()
+
+        assert summary["operation"] == "custom"
+        assert summary["params"] == {"gain": 2.0}
+        assert summary["portable"] is False
+        assert ":" in summary["implementation"]
+        assert summary["implementation"].endswith(".scale")
+        assert summary["implementation"] is not scale
+
     def test_custom_operation_does_not_expose_pure_constructor_option(self) -> None:
         def my_func(x: np.ndarray, pure: bool) -> np.ndarray:
             return x + (1.0 if pure else 2.0)

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -572,6 +572,32 @@ class BaseFrame(ABC, Generic[T]):
             ],
         }
 
+    @classmethod
+    def _lineage_to_summaries(cls, lineage: "LineageNode | None") -> list[dict[str, Any]]:
+        if lineage is None:
+            return []
+        records: list[dict[str, Any]] = []
+        for input_lineage in lineage.inputs:
+            records.extend(cls._lineage_to_summaries(input_lineage))
+        operation = lineage.operation
+        if hasattr(operation, "to_summary"):
+            records.append(cast(dict[str, Any], operation.to_summary()))
+        else:
+            records.append(
+                {
+                    "schema_version": 1,
+                    "operation": cls._operation_name(operation),
+                    "params": cls._operation_params(operation),
+                    "portable": False,
+                }
+            )
+        return records
+
+    @property
+    def operation_summaries(self) -> list[dict[str, Any]]:
+        """Return lightweight operation summaries for display and persistence."""
+        return self._lineage_to_summaries(self.lineage)
+
     def _lineage_with_operation(self, operation: Any, *inputs: "LineageNode | None") -> "LineageNode":
         from wandas.processing.base import LineageNode
 

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -2,6 +2,7 @@ import copy
 import importlib
 import inspect
 import logging
+import numbers
 from collections import defaultdict
 from collections.abc import Callable, Iterator, Mapping, MutableMapping
 from dataclasses import dataclass
@@ -102,8 +103,27 @@ def _operand_descriptor(value: Any) -> dict[str, Any]:
 
 def _summary_value(value: Any) -> Any:
     """Return a lightweight, display-safe representation of a summary value."""
-    if value is None or isinstance(value, bool | int | float | str):
+    if value is None or isinstance(value, str):
         return value
+    if isinstance(value, bool | np.bool_):
+        return bool(value)
+    if isinstance(value, numbers.Integral):
+        return int(value)
+    if isinstance(value, numbers.Real):
+        numeric = float(value)
+        if np.isfinite(numeric):
+            return numeric
+        if np.isnan(numeric):
+            return {"type": "float", "value": "nan"}
+        if numeric > 0:
+            return {"type": "float", "value": "inf"}
+        return {"type": "float", "value": "-inf"}
+    if isinstance(value, numbers.Complex):
+        return {
+            "type": "complex",
+            "real": _summary_value(value.real),
+            "imag": _summary_value(value.imag),
+        }
     if isinstance(value, Mapping):
         return {str(key): _summary_value(item) for key, item in value.items() if not callable(item)}
     if isinstance(value, tuple | list):

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -1,6 +1,7 @@
 import copy
 import importlib
 import inspect
+import json
 import logging
 import numbers
 from collections import defaultdict
@@ -101,6 +102,10 @@ def _operand_descriptor(value: Any) -> dict[str, Any]:
     return {"type": type(value).__name__}
 
 
+def _summary_sort_key(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
 def _summary_value(value: Any) -> Any:
     """Return a lightweight, display-safe representation of a summary value."""
     if callable(value):
@@ -130,14 +135,16 @@ def _summary_value(value: Any) -> Any:
         return {str(key): _summary_value(item) for key, item in value.items()}
     if isinstance(value, tuple | list):
         return [_summary_value(item) for item in value]
+    if isinstance(value, set | frozenset):
+        return sorted((_summary_value(item) for item in value), key=_summary_sort_key)
     if isinstance(value, np.ndarray):
-        return {"type": "ndarray", "shape": list(value.shape), "dtype": str(value.dtype)}
+        return {"type": "ndarray", "shape": [_summary_value(item) for item in value.shape], "dtype": str(value.dtype)}
     if isinstance(value, DaArray):
         return {
             "type": "dask.array",
-            "shape": list(value.shape),
+            "shape": [_summary_value(item) for item in value.shape],
             "dtype": str(value.dtype),
-            "chunks": [list(chunk) for chunk in value.chunks],
+            "chunks": [[_summary_value(item) for item in chunk] for chunk in value.chunks],
         }
     return {"type": type(value).__name__}
 
@@ -146,11 +153,17 @@ def _summary_is_portable(value: Any) -> bool:
     """Return whether a value can be represented as a portable summary."""
     if callable(value):
         return False
+    if value is None or isinstance(value, str | bool | np.bool_):
+        return True
+    if isinstance(value, numbers.Number):
+        return True
+    if isinstance(value, np.ndarray | DaArray):
+        return True
     if isinstance(value, Mapping):
         return all(_summary_is_portable(item) for item in value.values())
     if isinstance(value, tuple | list | set | frozenset):
         return all(_summary_is_portable(item) for item in value)
-    return True
+    return False
 
 
 @dataclass(frozen=True)

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -22,6 +22,8 @@ _da_from_delayed = da.from_delayed
 # Define TypeVars for input and output array types
 InputArrayType = TypeVar("InputArrayType", NDArrayReal, NDArrayComplex)
 OutputArrayType = TypeVar("OutputArrayType", NDArrayReal, NDArrayComplex)
+OperationSummary = dict[str, Any]
+SUMMARY_SCHEMA_VERSION = 1
 
 
 def _execute_wandas_operation(operation: "AudioOperation[Any, Any]", *inputs: Any) -> Any:
@@ -98,6 +100,28 @@ def _operand_descriptor(value: Any) -> dict[str, Any]:
     return {"type": type(value).__name__}
 
 
+def _summary_value(value: Any) -> Any:
+    """Return a lightweight, display-safe representation of a summary value."""
+    if value is None or isinstance(value, bool | int | float | str):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): _summary_value(item) for key, item in value.items() if not callable(item)}
+    if isinstance(value, tuple | list):
+        return [_summary_value(item) for item in value if not callable(item)]
+    if isinstance(value, np.ndarray):
+        return {"type": "ndarray", "shape": list(value.shape), "dtype": str(value.dtype)}
+    if isinstance(value, DaArray):
+        return {
+            "type": "dask.array",
+            "shape": list(value.shape),
+            "dtype": str(value.dtype),
+            "chunks": [list(chunk) for chunk in value.chunks],
+        }
+    if callable(value):
+        return {"type": "callable", "name": getattr(value, "__qualname__", type(value).__name__)}
+    return {"type": type(value).__name__}
+
+
 @dataclass(frozen=True)
 class BinaryOperation:
     """Lightweight operation record for frame binary computations."""
@@ -121,6 +145,15 @@ class BinaryOperation:
         elif self.operand_kind != "frame":
             params["operand"] = _operand_descriptor(self.operand)
         return params
+
+    def to_summary(self) -> OperationSummary:
+        """Return a lightweight display/persistence summary for this operation."""
+        return {
+            "schema_version": SUMMARY_SCHEMA_VERSION,
+            "operation": self.symbol,
+            "params": {key: _summary_value(value) for key, value in self.to_params().items()},
+            "portable": True,
+        }
 
 
 def _snapshot_config_value(value: Any) -> Any:
@@ -309,6 +342,15 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
     def to_params(self) -> Mapping[str, Any]:
         """Return operation parameters used for lineage and display."""
         return self._config_snapshot()
+
+    def to_summary(self) -> OperationSummary:
+        """Return a lightweight display/persistence summary for this operation."""
+        return {
+            "schema_version": SUMMARY_SCHEMA_VERSION,
+            "operation": self.name,
+            "params": {key: _summary_value(value) for key, value in self.to_params().items()},
+            "portable": True,
+        }
 
     def _config_snapshot(self) -> dict[str, Any]:
         """Return a defensive copy of base-managed constructor config."""

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -103,6 +103,8 @@ def _operand_descriptor(value: Any) -> dict[str, Any]:
 
 def _summary_value(value: Any) -> Any:
     """Return a lightweight, display-safe representation of a summary value."""
+    if callable(value):
+        return {"type": "callable", "name": getattr(value, "__qualname__", type(value).__name__)}
     if value is None or isinstance(value, str):
         return value
     if isinstance(value, bool | np.bool_):
@@ -125,9 +127,9 @@ def _summary_value(value: Any) -> Any:
             "imag": _summary_value(value.imag),
         }
     if isinstance(value, Mapping):
-        return {str(key): _summary_value(item) for key, item in value.items() if not callable(item)}
+        return {str(key): _summary_value(item) for key, item in value.items()}
     if isinstance(value, tuple | list):
-        return [_summary_value(item) for item in value if not callable(item)]
+        return [_summary_value(item) for item in value]
     if isinstance(value, np.ndarray):
         return {"type": "ndarray", "shape": list(value.shape), "dtype": str(value.dtype)}
     if isinstance(value, DaArray):
@@ -137,9 +139,18 @@ def _summary_value(value: Any) -> Any:
             "dtype": str(value.dtype),
             "chunks": [list(chunk) for chunk in value.chunks],
         }
-    if callable(value):
-        return {"type": "callable", "name": getattr(value, "__qualname__", type(value).__name__)}
     return {"type": type(value).__name__}
+
+
+def _summary_is_portable(value: Any) -> bool:
+    """Return whether a value can be represented as a portable summary."""
+    if callable(value):
+        return False
+    if isinstance(value, Mapping):
+        return all(_summary_is_portable(item) for item in value.values())
+    if isinstance(value, tuple | list | set | frozenset):
+        return all(_summary_is_portable(item) for item in value)
+    return True
 
 
 @dataclass(frozen=True)
@@ -365,11 +376,12 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
 
     def to_summary(self) -> OperationSummary:
         """Return a lightweight display/persistence summary for this operation."""
+        params = self.to_params()
         return {
             "schema_version": SUMMARY_SCHEMA_VERSION,
             "operation": self.name,
-            "params": {key: _summary_value(value) for key, value in self.to_params().items()},
-            "portable": True,
+            "params": {key: _summary_value(value) for key, value in params.items()},
+            "portable": all(_summary_is_portable(value) for value in params.values()),
         }
 
     def _config_snapshot(self) -> dict[str, Any]:

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -160,7 +160,7 @@ def _summary_is_portable(value: Any) -> bool:
     if isinstance(value, np.ndarray | DaArray):
         return True
     if isinstance(value, Mapping):
-        return all(_summary_is_portable(item) for item in value.values())
+        return all(isinstance(key, str) and _summary_is_portable(item) for key, item in value.items())
     if isinstance(value, tuple | list | set | frozenset):
         return all(_summary_is_portable(item) for item in value)
     return False

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -167,9 +167,9 @@ def _summary_is_portable(value: Any) -> bool:
         return True
     if isinstance(value, np.ndarray):
         return False
-    if isinstance(value, Mapping):
+    if type(value) is dict:
         return all(isinstance(key, str) and _summary_is_portable(item) for key, item in value.items())
-    if isinstance(value, tuple | list | set | frozenset):
+    if type(value) in (tuple, list, set, frozenset):
         return all(_summary_is_portable(item) for item in value)
     return False
 
@@ -210,7 +210,8 @@ class BinaryOperation:
             "schema_version": SUMMARY_SCHEMA_VERSION,
             "operation": self.symbol,
             "params": {key: _summary_value(value) for key, value in params.items()},
-            "portable": self.operand_kind == "frame" or _operand_descriptor_is_portable(self.operand),
+            "portable": (self.operand_kind == "frame" and self.operand is not None)
+            or (self.operand_kind != "frame" and _operand_descriptor_is_portable(self.operand)),
         }
 
 

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -118,6 +118,8 @@ def _summary_value(value: Any) -> Any:
         return bool(value)
     if isinstance(value, numbers.Integral):
         return int(value)
+    if isinstance(value, numbers.Rational):
+        return {"type": type(value).__name__}
     if isinstance(value, numbers.Real):
         numeric = float(value)
         if np.isfinite(numeric):
@@ -159,10 +161,12 @@ def _summary_is_portable(value: Any) -> bool:
         return True
     if isinstance(value, np.timedelta64 | np.datetime64):
         return False
-    if isinstance(value, numbers.Integral | numbers.Real | numbers.Complex):
+    if isinstance(value, int | float | complex | np.integer | np.floating | np.complexfloating):
         return True
-    if isinstance(value, np.ndarray | DaArray):
+    if isinstance(value, DaArray):
         return True
+    if isinstance(value, np.ndarray):
+        return False
     if isinstance(value, Mapping):
         return all(isinstance(key, str) and _summary_is_portable(item) for key, item in value.items())
     if isinstance(value, tuple | list | set | frozenset):
@@ -403,8 +407,8 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
         return {
             "schema_version": SUMMARY_SCHEMA_VERSION,
             "operation": self.name,
-            "params": {key: _summary_value(value) for key, value in params.items()},
-            "portable": all(_summary_is_portable(value) for value in params.values()),
+            "params": {str(key): _summary_value(value) for key, value in params.items()},
+            "portable": all(isinstance(key, str) and _summary_is_portable(value) for key, value in params.items()),
         }
 
     def _config_snapshot(self) -> dict[str, Any]:

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -112,6 +112,8 @@ def _summary_value(value: Any) -> Any:
         return {"type": "callable", "name": getattr(value, "__qualname__", type(value).__name__)}
     if value is None or isinstance(value, str):
         return value
+    if isinstance(value, np.timedelta64 | np.datetime64):
+        return {"type": type(value).__name__}
     if isinstance(value, bool | np.bool_):
         return bool(value)
     if isinstance(value, numbers.Integral):
@@ -155,7 +157,9 @@ def _summary_is_portable(value: Any) -> bool:
         return False
     if value is None or isinstance(value, str | bool | np.bool_):
         return True
-    if isinstance(value, numbers.Number):
+    if isinstance(value, np.timedelta64 | np.datetime64):
+        return False
+    if isinstance(value, numbers.Integral | numbers.Real | numbers.Complex):
         return True
     if isinstance(value, np.ndarray | DaArray):
         return True
@@ -164,6 +168,11 @@ def _summary_is_portable(value: Any) -> bool:
     if isinstance(value, tuple | list | set | frozenset):
         return all(_summary_is_portable(item) for item in value)
     return False
+
+
+def _operand_descriptor_is_portable(value: Any) -> bool:
+    """Return whether ``_operand_descriptor`` preserves the operand value."""
+    return value is None or isinstance(value, bool | int | float | complex | str)
 
 
 @dataclass(frozen=True)
@@ -192,11 +201,12 @@ class BinaryOperation:
 
     def to_summary(self) -> OperationSummary:
         """Return a lightweight display/persistence summary for this operation."""
+        params = self.to_params()
         return {
             "schema_version": SUMMARY_SCHEMA_VERSION,
             "operation": self.symbol,
-            "params": {key: _summary_value(value) for key, value in self.to_params().items()},
-            "portable": True,
+            "params": {key: _summary_value(value) for key, value in params.items()},
+            "portable": self.operand_kind == "frame" or _operand_descriptor_is_portable(self.operand),
         }
 
 

--- a/wandas/processing/custom.py
+++ b/wandas/processing/custom.py
@@ -9,6 +9,14 @@ from wandas.processing.base import (
 )
 
 
+def _callable_reference(func: Callable[..., Any]) -> str:
+    module = getattr(func, "__module__", None)
+    qualname = getattr(func, "__qualname__", None)
+    if module and qualname:
+        return f"{module}:{qualname}"
+    return getattr(func, "__name__", type(func).__name__)
+
+
 class CustomOperation(AudioOperation[InputArrayType, OutputArrayType]):
     """Custom operation defined by a user function."""
 
@@ -76,6 +84,13 @@ class CustomOperation(AudioOperation[InputArrayType, OutputArrayType]):
         if isinstance(name, str):
             return name
         return "custom"
+
+    def to_summary(self) -> dict[str, Any]:
+        """Return a non-portable summary for this custom callable."""
+        summary = super().to_summary()
+        summary["portable"] = False
+        summary["implementation"] = _callable_reference(self.func)
+        return summary
 
 
 register_operation(CustomOperation)


### PR DESCRIPTION
## Status
Closed in favor of a replacement PR.

## Reason
This branch treated `operation_summaries` / `to_summary()` as if they were a portable persistence contract. Review feedback showed that this makes the feature larger than the immediate need and creates ongoing edge-case churn.

The replacement work restarts from `develop` and limits summaries to display-only, strict-JSON-safe operation history inspection. Save/restore is intentionally out of scope and should be handled by a separate `to_spec()` / `from_spec()` design if needed later.