### PR TITLE
[codex] Document PR completion guardrails

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -119,6 +119,10 @@ These instructions are for Wandas custom agents. For substantive implementation,
   - Keep review read-only and verify the recorded validation evidence, problems, and changed files directly from the workspace instead of owning task execution.
   - Confirm non-mutating validation evidence such as `Run ruff check`; do not use `Run ruff check --fix` during review.
   - Verify that frame immutability and metadata rules are respected, that new APIs align with existing naming/parameter patterns, and that tests cover the main branches and edge cases discussed in the planner handoff.
+- **Publisher**:
+  - After pushing a PR update, verify that local `HEAD`, `origin/<branch>`, and the PR head all point to the intended commit. Use `git rev-parse HEAD`, `git rev-parse origin/<branch>`, and `gh pr view <pr> --json headRefOid,headRefName,url`.
+  - When responding to PR review feedback, distinguish inline review threads from top-level PR comments. Resolve inline threads only when the feedback has been addressed and the thread still exists; top-level PR comments cannot be resolved, so reply with the commit and validation evidence instead.
+  - After a PR is merged, check `gh pr view <pr> --json closingIssuesReferences,state,mergedAt`. If a referenced issue is complete but still open, close it with a concise comment that links the merge outcome to the issue acceptance criteria.
 
 ## 7. Test Documentation Reference
 

--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,9 @@ venv.bak/
 # Design documents (temporary working files)
 docs/design/working/
 
+# Agent execution plans (temporary working files)
+docs/superpowers/plans/
+
 # ty
 .ty_cache/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ Core rules:
 - Avoid duplicated state, silent no-op compatibility shims, and public mutable state that must be synchronized with internal state.
 - When changing behavior, update the relevant tests so they describe the clarified contract.
 - Run relevant `uv run pytest`, `uv run ruff check`, and `uv run ty check` commands before finishing.
+- After pushing PR updates, verify that local `HEAD`, `origin/<branch>`, and the PR head SHA match before reporting completion.
+- After a PR is merged, check closing issue references and close any completed-but-open source issue with a concise comment.
 
 Area-specific guidance lives in:
 


### PR DESCRIPTION
## Summary
- Document publisher guardrails for verifying pushed PR heads and handling PR review comments.
- Add merge follow-up guidance for closing completed source issues.
- Ignore temporary agent execution plans under docs/superpowers/plans/.

## Validation
- git diff --check
- git check-ignore docs/superpowers/plans/example.md

Docs/ignore-only change; pytest, ruff, and ty were not run.