### PR TITLE
Add PR review lifecycle guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Core rules:
 - Treat repeated PR review feedback about the same contract as a design signal, not an endless patch queue; stop and reassess the contract before adding more defensive branches.
 - Restarting a PR from a clean base is an exception, used only when old PR history or review context would obscure a revised contract.
 - After pushing PR updates, verify that local `HEAD`, `origin/<branch>`, and the PR head SHA match before reporting completion.
-- After pushing PR updates, use finite automated-review monitoring: 10 minutes by default, 30 minutes maximum; check unresolved review threads and pending reviews before reporting completion.
+- After pushing PR updates, use finite post-push monitoring: wait for CI/checks and review state to settle (up to 10 minutes by default, 30 minutes maximum); before reporting completion, confirm there are no unresolved review threads and no pending requested reviews.
 - After a PR is merged, check closing issue references and close any completed-but-open source issue with a concise comment.
 
 Area-specific guidance lives in:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,10 @@ Core rules:
 - Avoid duplicated state, silent no-op compatibility shims, and public mutable state that must be synchronized with internal state.
 - When changing behavior, update the relevant tests so they describe the clarified contract.
 - Run relevant `uv run pytest`, `uv run ruff check`, and `uv run ty check` commands before finishing.
+- Treat repeated PR review feedback about the same contract as a design signal, not an endless patch queue; stop and reassess the contract before adding more defensive branches.
+- Restarting a PR from a clean base is an exception, used only when old PR history or review context would obscure a revised contract.
 - After pushing PR updates, verify that local `HEAD`, `origin/<branch>`, and the PR head SHA match before reporting completion.
+- After pushing PR updates, use finite automated-review monitoring: 10 minutes by default, 30 minutes maximum; check unresolved review threads and pending reviews before reporting completion.
 - After a PR is merged, check closing issue references and close any completed-but-open source issue with a concise comment.
 
 Area-specific guidance lives in:


### PR DESCRIPTION
## Summary
- Add concise Codex-facing guardrails to `AGENTS.md` for repeated PR review feedback.
- Clarify that clean-base PR restarts are exceptional, not the default.
- Require finite post-push automated review monitoring before reporting completion.

## Why
Recent PR work showed that repeated review feedback on the same contract should trigger design reassessment instead of indefinite patching. The new guidance keeps the behavior close to the root `AGENTS.md` entry point without adding extra linked instruction files.

## Validation
- Markdown-only change; commit hooks ran and skipped Python checks because no Python files changed.
- Reviewed `AGENTS.md` diff manually.