### PR TITLE
Clarify cross-agent harness source of truth

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,10 @@
 <!-- A clear and concise description of what this PR does and why.
      このPRが何をするものか、なぜ必要かを明確・簡潔に説明してください。 -->
 
-<!-- Closes #<issue-number> / 関連Issue: #<issue-number> -->
+<!-- Closes #<issue-number> only when this PR fully satisfies the issue.
+     Use Related: #<issue-number> for parent, partial, or follow-up work.
+     このPRでIssueを完全に満たす場合のみ Closes #<issue-number> を使ってください。
+     親Issue、部分対応、残件がある場合は Related: #<issue-number> を使ってください。 -->
 
 <!-- Please confirm your source branch follows the allowed working-branch patterns: `feat/*`, `fix/*`, `refactor/*`, `chore/*`, or `release/vx.x.x` (`main` is reserved as the release-ready base branch).
      ソースブランチが許可された作業ブランチ命名パターン（`feat/*`、`fix/*`、`refactor/*`、`chore/*`、`release/vx.x.x`）に従っていることを確認してください（`main` はリリース可能なベースブランチとして予約されています）。 -->
@@ -32,6 +35,17 @@
 
 -
 -
+
+---
+
+## PR Readiness / PR準備状況
+
+<!-- Confirm the PR metadata and follow-up tracking are current. / PRメタデータと残件追跡が最新であることを確認してください。 -->
+
+- [ ] PR title and description describe the full current scope, not only the latest review fix / PRタイトルと説明が、直近の修正だけでなく現在の全体スコープを表している
+- [ ] Linked issues use `Closes` only when fully satisfied; otherwise they are marked `Related` / 完了したIssueのみ `Closes` とし、それ以外は `Related` としている
+- [ ] Follow-up issue created or linked for meaningful deferred work / 意味のある残件について Follow-up issue を作成またはリンクした
+- [ ] No generated or ignored work files are left behind / 生成物やignoredな作業ファイルを残していない
 
 ---
 

--- a/.github/agents/wandas-publisher.agent.md
+++ b/.github/agents/wandas-publisher.agent.md
@@ -13,11 +13,13 @@ handoffs:
     send: true
 ---
 # Publishing Protocol
+- This file is a Copilot-specific adapter for the publisher role, not the repository-canonical checklist. Use `AGENTS.md` as the cross-agent source of truth and [pr-lifecycle-harness.instructions.md](../instructions/pr-lifecycle-harness.instructions.md) for detailed PR lifecycle guidance.
 - Ensure the reviewer has approved the changes and that any required quality checks are recorded as passed or explicitly justified.
 - Once `wandas-publisher` is active, perform publishing directly and hand off forward only after publishing is complete; do not re-delegate publishing to `wandas-publisher` again.
 - Keep this role limited to branch, stage, commit, push, and pull request create or update work.
 - Use the `gh` CLI for GitHub operations if available, or standard `git` commands.
 - Treat reviewer approval and the recorded quality-check results as the gate for publishing; do not expand scope into running implementation or review tasks from this agent.
+- Before reporting a PR ready to merge, follow the canonical checklist in `AGENTS.md` and the PR completion, issue triage, workspace hygiene, and finite monitoring gates in [pr-lifecycle-harness.instructions.md](../instructions/pr-lifecycle-harness.instructions.md).
 - After publishing is complete, hand off to the planner for follow-up work if additional tasks remain.
 
 ## Workflow
@@ -39,7 +41,9 @@ handoffs:
    - Body: Include the implementation summary and reviewer notes.
    - Reviewers: Assign if specified.
    - **Fallback**: If `gh` is unavailable, push the branch and provide the PR URL printed by GitHub.
-5. **Agent Retrospective**:
+5. **PR Completion Checks**:
+   - Run the `AGENTS.md` PR lifecycle checklist and consult [pr-lifecycle-harness.instructions.md](../instructions/pr-lifecycle-harness.instructions.md) for detailed gates.
+6. **Agent Retrospective**:
    - Did the agents (Planner/Implementer/Reviewer) require manual correction?
    - If yes, create a new issue or task to update the `.github/agents/` or `instructions/` files.
    - Refer to [agent-maintenance.instructions.md](../instructions/agent-maintenance.instructions.md) for policies on updating agents.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,8 @@
 # Copilot Instructions for the Wandas Repository
 
-These instructions are for Wandas custom agents. For substantive implementation, validation, and review work, the default workflow is `wandas-planner` -> `wandas-implementer` -> `wandas-reviewer`; use `wandas-publisher` only after review for PR publication handoff. GitHub Release drafting and tag-driven release publication stay in GitHub Actions.
+These instructions are the GitHub Copilot adapter for the Wandas repository. `AGENTS.md` is the cross-agent source of truth; keep Copilot-only role and loading details here, and keep detailed PR lifecycle guidance in `.github/instructions/pr-lifecycle-harness.instructions.md`.
+
+For substantive implementation, validation, and review work, the default workflow is `wandas-planner` -> `wandas-implementer` -> `wandas-reviewer`; use `wandas-publisher` only after review for PR publication handoff. GitHub Release drafting and tag-driven release publication stay in GitHub Actions.
 
 ## 1. Big Picture & Architecture
 - **Purpose**: Wandas provides pandas‑like data structures and operations for waveform/signal analysis (see `README.md`).
@@ -120,7 +122,7 @@ These instructions are for Wandas custom agents. For substantive implementation,
   - Confirm non-mutating validation evidence such as `Run ruff check`; do not use `Run ruff check --fix` during review.
   - Verify that frame immutability and metadata rules are respected, that new APIs align with existing naming/parameter patterns, and that tests cover the main branches and edge cases discussed in the planner handoff.
 - **Publisher**:
-  - After pushing a PR update, verify that local `HEAD`, `origin/<branch>`, and the PR head all point to the intended commit. Use `git rev-parse HEAD`, `git rev-parse origin/<branch>`, and `gh pr view <pr> --json headRefOid,headRefName,url`.
+  - Use the canonical checklist in `AGENTS.md` and the detailed PR lifecycle harness in [pr-lifecycle-harness.instructions.md](instructions/pr-lifecycle-harness.instructions.md) before reporting that a PR is ready to merge.
   - When responding to PR review feedback, distinguish inline review threads from top-level PR comments. Resolve inline threads only when the feedback has been addressed and the thread still exists; top-level PR comments cannot be resolved, so reply with the commit and validation evidence instead.
   - After a PR is merged, check `gh pr view <pr> --json closingIssuesReferences,state,mergedAt`. If a referenced issue is complete but still open, close it with a concise comment that links the merge outcome to the issue acceptance criteria.
 

--- a/.github/instructions/agent-maintenance.instructions.md
+++ b/.github/instructions/agent-maintenance.instructions.md
@@ -30,6 +30,7 @@ Only the `.instructions.md` files in this directory are live agent guidance. Arc
 | `processing-api.instructions.md` | `wandas/processing/**` | Processing layer |
 | `io-contracts.instructions.md` | `wandas/io/**` | I/O contracts |
 | `agent-maintenance.instructions.md` | `.github/agents/**` | This file |
+| `pr-lifecycle-harness.instructions.md` | (none) | PR completion, issue triage, finite monitoring, and workspace cleanup gates |
 | `test-grand-policy.instructions.md` | `tests/**` | Test quality: 4 pillars + pyramid |
 | `test-frames-policy.instructions.md` | `tests/frames/**` | Frame test patterns |
 | `test-processing-policy.instructions.md` | `tests/processing/**` | Processing test patterns |

--- a/.github/instructions/pr-lifecycle-harness.instructions.md
+++ b/.github/instructions/pr-lifecycle-harness.instructions.md
@@ -1,0 +1,63 @@
+---
+description: "PR lifecycle harness: completion gates for publishing, review follow-up, issue triage, and workspace cleanup"
+---
+# PR Lifecycle Harness
+
+AGENTS.md contains the cross-agent canonical PR lifecycle checklist. Use this file as supplemental detail for agents and tools that need the full publishing, issue triage, monitoring, and cleanup procedure.
+
+Use this guidance when creating, updating, or preparing to merge a pull request. The goal is to make the repository-local agent workflow more autonomous without hiding state from the user.
+
+## PR Completion Gate
+
+Before reporting that a PR is ready to merge, verify and report:
+
+- The PR targets the intended base branch.
+- The PR title and description describe the full current scope, not only the latest review fix.
+- The PR body lists validation evidence and any skipped checks with reasons.
+- local `HEAD`, `origin/<branch>`, and the PR head SHA all match.
+- Required checks are passing or explicitly identified as blocked.
+- There are no unresolved actionable review threads.
+- There are no pending requested reviews.
+
+If the PR body has drifted during review, update it before final reporting.
+
+## Issue Triage Gate
+
+Before merge, inspect all linked or mentioned issues:
+
+- Use `Closes` only for issues whose acceptance criteria are fully satisfied by the PR.
+- Use `Related` for broader parent, phase, or design issues that must remain open.
+- Create a follow-up issue when the PR intentionally leaves meaningful work behind.
+- Link the follow-up issue from the PR body.
+
+After merge, check closing issue references. If a completed source issue remains open, close it with a concise comment that links the merge result to the issue acceptance criteria.
+
+## Workspace Hygiene Gate
+
+Before final reporting or publishing:
+
+- Run `git status --short --branch`.
+- Run `git status --short --ignored` when tests, docs builds, notebooks, coverage, or local app tools were executed.
+- Remove generated local artifacts such as `.coverage`, `coverage.xml`, `.pytest_cache/`, `.ruff_cache/`, `docs/site/`, `__pycache__/`, and tool-specific scratch files when they are not intended repository changes.
+- Do not remove user-created untracked files or files outside the task scope.
+
+If cleanup requires deleting ambiguous files, stop and ask instead of guessing.
+
+## Finite Monitoring Gate
+
+After pushing PR updates, monitor for a bounded period:
+
+- Check CI/checks and review state once immediately after push.
+- Recheck after a short settling period when review automation is expected.
+- Stop after the agreed maximum wait. Default: 10 minutes. Maximum: 30 minutes unless the user explicitly asks for longer.
+
+Report whether new reviews arrived, which comments were handled, and what remains open.
+
+## Review Feedback Gate
+
+When review feedback repeats around the same behavior, treat it as a contract or design signal:
+
+- Pause before adding more defensive branches.
+- Identify the underlying invariant that should make the bug impossible.
+- Prefer constructor validation, explicit state boundaries, or shared helpers over scattered point fixes.
+- Record deferred non-blocking concerns in a follow-up issue instead of expanding the PR late.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,27 +2,51 @@
 
 ## Repository Guidance
 
-Follow `.github/copilot-instructions.md` for the full Wandas repository conventions. This file is the short Codex-facing entry point loaded from the repository root.
+This file is the cross-agent source of truth for Wandas repository work. Other harness files may adapt these rules for a specific tool, but they should not replace this checklist.
 
 Core rules:
 
 - Use `uv` for Python commands.
-- For substantive code changes, use a dedicated Git worktree under `.worktrees/` when available and appropriate; follow `.github/copilot-instructions.md` for dirty-checkout and tool-availability rules.
+- For substantive code changes, use a dedicated Git worktree under `.worktrees/` when available and appropriate; inspect `git status --short` first and do not move, stage, revert, or overwrite unrelated user changes. If the current checkout has changes related to the task, continue there or ask before creating a fresh worktree. If the relationship is unclear, ask before editing.
 - Preserve frame immutability, metadata/history, and Dask laziness.
 - Keep frame methods thin; numerical logic belongs in `wandas/processing`.
 - Prefer small, explicit contracts over compatibility layers for undocumented or ambiguous behavior.
 - Avoid duplicated state, silent no-op compatibility shims, and public mutable state that must be synchronized with internal state.
 - When changing behavior, update the relevant tests so they describe the clarified contract.
 - Run relevant `uv run pytest`, `uv run ruff check`, and `uv run ty check` commands before finishing.
-- Treat repeated PR review feedback about the same contract as a design signal, not an endless patch queue; stop and reassess the contract before adding more defensive branches.
 - Restarting a PR from a clean base is an exception, used only when old PR history or review context would obscure a revised contract.
-- After pushing PR updates, verify that local `HEAD`, `origin/<branch>`, and the PR head SHA match before reporting completion.
-- After pushing PR updates, use finite post-push monitoring: wait for CI/checks and review state to settle (up to 10 minutes by default, 30 minutes maximum); before reporting completion, confirm there are no unresolved review threads and no pending requested reviews.
 - After a PR is merged, check closing issue references and close any completed-but-open source issue with a concise comment.
+
+## PR Lifecycle Checklist
+
+Use this direct checklist before reporting PR completion or readiness to merge. `.github/instructions/pr-lifecycle-harness.instructions.md` contains supplemental detail.
+
+- PR title/body full-scope check: ensure the title and body describe the full current PR scope, not only the latest review fix.
+- Validation evidence: list relevant `uv run pytest`, `uv run ruff check`, `uv run ty check`, docs builds, skipped checks, and reasons.
+- Issue triage with `Closes` vs `Related`: use `Closes` only when the PR fully satisfies the issue acceptance criteria; use `Related` for broader or still-open work.
+- Follow-up issue creation: create and link a follow-up issue for meaningful deferred work instead of burying it in review comments.
+- Generated/ignored artifact cleanup: check ignored files after tests or docs builds and remove unintended `.coverage`, `coverage.xml`, `.pytest_cache/`, `.ruff_cache/`, `docs/site/`, `__pycache__/`, and tool scratch files.
+- SHA alignment: after pushing, verify local `HEAD`, `origin/<branch>`, and the PR head SHA all point to the intended commit.
+- Finite post-push monitoring: wait for CI/checks and review state to settle, up to 10 minutes by default and 30 minutes maximum unless the user asks for longer; before reporting completion, confirm there are no unresolved review threads and no pending requested reviews.
+- Repeated review feedback is a design signal: stop and reassess the contract before adding more defensive branches for the same behavior.
+
+## Instruction Source Matrix
+
+- Codex: loads `AGENTS.md`; treat this file as the repository-canonical cross-agent checklist.
+- GitHub Copilot: loads `.github/copilot-instructions.md` plus applicable `.github/instructions/*.instructions.md` files.
+- Copilot custom agents: load `.github/agents/*.agent.md` only when that agent is selected; those files are role adapters.
+- Skills: runtime procedures from the active agent environment; they are not repository source of truth.
 
 Area-specific guidance lives in:
 
 - `.github/instructions/processing-api.instructions.md`
+- `.github/instructions/io-contracts.instructions.md`
 - `.github/instructions/frames-design.instructions.md`
 - `.github/instructions/testing-workflow.instructions.md`
 - `.github/instructions/test-grand-policy.instructions.md`
+- `.github/instructions/test-frames-policy.instructions.md`
+- `.github/instructions/test-processing-policy.instructions.md`
+- `.github/instructions/test-io-policy.instructions.md`
+- `.github/instructions/test-visualization-policy.instructions.md`
+- `.github/instructions/pr-lifecycle-harness.instructions.md`
+- `.github/instructions/agent-maintenance.instructions.md`

--- a/tests/docs/test_github_agent_guidance.py
+++ b/tests/docs/test_github_agent_guidance.py
@@ -6,6 +6,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 GITHUB_DIR = REPO_ROOT / ".github"
 
 
+def _read_repo(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
 def _read(relative_path: str) -> str:
     return (GITHUB_DIR / relative_path).read_text(encoding="utf-8")
 
@@ -54,6 +58,60 @@ def test_agent_docs_keep_planner_first_workflow() -> None:
     assert (
         "**Who**: Use the full `wandas-planner` -> `wandas-implementer` -> `wandas-reviewer` flow" in maintenance_text
     )
+
+
+def test_pr_lifecycle_harness_guidance_is_linked() -> None:
+    """Publisher-facing docs should require PR completion and cleanup gates."""
+    agents_text = _read_repo("AGENTS.md")
+    copilot_text = _read("copilot-instructions.md")
+    publisher_text = _read("agents/wandas-publisher.agent.md")
+    maintenance_text = _read("instructions/agent-maintenance.instructions.md")
+    lifecycle_text = _read("instructions/pr-lifecycle-harness.instructions.md")
+    agents_text_lower = agents_text.lower()
+
+    assert "cross-agent source of truth" in agents_text
+    assert "If the current checkout has changes related to the task" in agents_text
+    assert "If the relationship is unclear, ask before editing." in agents_text
+    assert "PR title/body full-scope check" in agents_text
+    assert "validation evidence" in agents_text_lower
+    assert "Closes" in agents_text
+    assert "Related" in agents_text
+    assert "follow-up issue" in agents_text_lower
+    assert "generated/ignored artifact cleanup" in agents_text_lower
+    assert "local `HEAD`, `origin/<branch>`, and the PR head SHA" in agents_text
+    assert "finite post-push monitoring" in agents_text_lower
+    assert "no unresolved review threads" in agents_text_lower
+    assert "no pending requested reviews" in agents_text_lower
+    assert "repeated review feedback" in agents_text_lower
+    assert "Codex" in agents_text
+    assert ".github/agents/*.agent.md" in agents_text
+    assert "runtime procedures" in agents_text
+    for instruction_path in sorted((GITHUB_DIR / "instructions").glob("*.instructions.md")):
+        assert f"`.github/instructions/{instruction_path.name}`" in agents_text
+    assert "PR lifecycle harness" in copilot_text
+    assert "pr-lifecycle-harness.instructions.md" in publisher_text
+    assert "Copilot-specific adapter" in publisher_text
+    assert "not the repository-canonical checklist" in publisher_text
+    assert "pr-lifecycle-harness.instructions.md" in maintenance_text
+    assert "## PR Completion Gate" in lifecycle_text
+    assert "AGENTS.md contains the cross-agent canonical PR lifecycle checklist" in lifecycle_text
+    assert "local `HEAD`, `origin/<branch>`, and the PR head SHA" in lifecycle_text
+    assert "There are no unresolved actionable review threads." in lifecycle_text
+    assert "There are no pending requested reviews." in lifecycle_text
+    assert "## Issue Triage Gate" in lifecycle_text
+    assert "## Workspace Hygiene Gate" in lifecycle_text
+    assert "## Finite Monitoring Gate" in lifecycle_text
+
+
+def test_pr_template_prompts_for_followup_and_hygiene() -> None:
+    """PR authors should record follow-up issues and generated-file cleanup."""
+    template_text = (GITHUB_DIR / "PULL_REQUEST_TEMPLATE.md").read_text(encoding="utf-8")
+
+    assert "Follow-up issue" in template_text
+    assert "No generated or ignored work files are left behind" in template_text
+    assert "PR title and description describe the full current scope" in template_text
+    assert "Closes #<issue-number> only when this PR fully satisfies the issue" in template_text
+    assert "Related: #<issue-number> for parent, partial, or follow-up work" in template_text
 
 
 def test_all_agent_frontmatter_is_valid_yaml() -> None:


### PR DESCRIPTION
## Summary

- Make `AGENTS.md` the cross-agent source of truth for Wandas repository work.
- Add a direct PR lifecycle checklist for completion, issue triage, follow-up issues, generated artifact cleanup, SHA alignment, finite monitoring, and repeated review feedback.
- Reframe GitHub Copilot files as adapters instead of canonical instructions, while keeping detailed PR lifecycle guidance available under `.github/instructions/`.
- Update the PR template and docs tests so the harness expectations are visible and regression-checked.

## Why

The previous harness was heavily shaped around GitHub Copilot custom agents. That is still useful when those agents are selected, but it is not the effective instruction surface for Codex-driven work. This change makes the repository-level contract explicit in `AGENTS.md` and keeps Copilot-specific files as adapters.

## Validation

- `uv run pytest tests/docs -q`
- `uv run ruff check tests/docs --config=pyproject.toml -v`
- `uv run ty check tests/docs`
- `git diff --check`

## Notes

- No Python runtime behavior changes.
- No package or docs build changes.
