### PR TITLE
[codex] Add operation summary snapshot boundaries

### DIFF
--- a/docs/superpowers/specs/2026-07-05-operation-summary-snapshot-boundary-design.md
+++ b/docs/superpowers/specs/2026-07-05-operation-summary-snapshot-boundary-design.md
@@ -1,0 +1,87 @@
+# Operation Summary Snapshot Boundary Design
+
+## Context
+
+PR #252 added `operation_summaries` as a display-only projection derived from runtime frame lineage. That projection is useful while a frame still has live lineage, but `persist()` and WDF save/load are boundary operations where live lineage or Dask operation tasks may no longer be available.
+
+Issue #245 should therefore focus on snapshotting display summaries at these boundaries. It should not become Recipe persistence, live operation serialization, or legacy history cleanup.
+
+## Goal
+
+Preserve display-only operation summaries across `persist()` and WDF round trips without retaining old Dask graphs, live `AudioOperation` objects, or executable Recipe specs.
+
+## Contract
+
+`operation_summaries` remains the public display API. For ordinary live frames, it is derived from runtime lineage. For persisted or loaded frames that no longer have live lineage, it may return a stored summary snapshot.
+
+The snapshot is a JSON-safe list of dictionaries produced from the existing `operation_summaries` projection. It is not an executable representation and cannot reconstruct `frame.operations`, Dask tasks, or `AudioOperation` instances.
+
+`operation_history` remains a compatibility view. This issue should not deprecate it or perform broader cleanup; that belongs to #246.
+
+## Persist Boundary
+
+Before `BaseFrame.persist()` materializes the Dask collection, it snapshots `self.operation_summaries`. The new persisted frame receives the persisted data and the summary snapshot.
+
+The persisted frame must not retain a strong reference to the old graph or live operation objects solely for summary display. If live lineage remains naturally available through existing frame construction, the snapshot must still be the stable source for summaries after persistence.
+
+Expected behavior:
+
+- `persisted.operation_summaries == original.operation_summaries`
+- retrieving summaries does not call `.compute()`
+- summary records are plain JSON-safe values
+- `persist()` itself is not recorded as a semantic operation
+
+## WDF Boundary
+
+WDF save writes only the display summary snapshot, not live operations and not executable Recipe specs.
+
+Use a schema-versioned JSON field at the file root:
+
+```text
+operation_summaries_schema = 1
+operation_summaries_json = "[...]"
+```
+
+WDF load restores that JSON into the frame as a summary snapshot. Loaded frames expose `operation_summaries` from the snapshot, but do not regain executable lineage or operation instances.
+
+The legacy `operation_history` HDF5 group remains a compatibility concern. For this issue, keep its behavior explicit and covered by tests. The recommended default is to ignore legacy groups rather than silently translating unstable old history into the new summary schema.
+
+## Recipe Boundary
+
+Recipe persistence is separate. `RecipeSpec`, `GraphRecipeSpec`, and `NodeGraphRecipeSpec` may later define `recipe_json` or another executable schema in #257.
+
+This issue must not save executable Recipe specs as operation summaries, and it must not infer Recipe specs from loaded summaries.
+
+## Implementation Shape
+
+Add a small internal snapshot helper on frames or a focused utility near frame lineage handling. It should:
+
+- take a defensive deep copy of summary records
+- validate JSON safety with strict JSON encoding
+- avoid references to arrays, frames, callables, Dask collections, and operation objects
+- provide one path used by both `persist()` and WDF save
+
+Frame constructors or `_create_new_instance()` need a private way to carry a summary snapshot. Keep it internal and avoid adding public mutable state that must be synchronized with lineage.
+
+## Tests
+
+Add focused tests for:
+
+- `persist()` preserves `operation_summaries`
+- persisted summaries do not require compute when read
+- persisted summaries do not retain live operation objects
+- WDF save writes schema-versioned `operation_summaries_json`
+- WDF load restores `operation_summaries`
+- WDF load does not restore executable `operations` or live lineage
+- legacy `operation_history` HDF5 groups keep the clarified compatibility behavior
+- built-in, custom non-portable, and multi-input operation summaries round trip as display summaries
+
+Run relevant `uv run pytest` targets for core frame lineage and WDF I/O, then `uv run ruff check` and `uv run ty check`.
+
+## Out Of Scope
+
+- saving live `AudioOperation` objects
+- rebuilding Dask graphs from persisted or loaded summaries
+- Recipe persistence or replay schema
+- broad `operation_history` cleanup
+- public deprecation of `operation_history`

--- a/tests/core/test_base_frame_lineage.py
+++ b/tests/core/test_base_frame_lineage.py
@@ -1,4 +1,5 @@
 import json
+from types import MappingProxyType
 from typing import Any
 from unittest import mock
 
@@ -256,6 +257,103 @@ def test_operation_summaries_are_strict_json_serializable() -> None:
     summaries = _frame().normalize().operation_summaries
 
     json.dumps(summaries, allow_nan=False)
+
+
+def test_persist_preserves_operation_summaries_from_snapshot() -> None:
+    result = _frame().high_pass_filter(100).normalize()
+    expected = result.operation_summaries
+
+    persisted = result.persist()
+
+    assert persisted.operation_summaries == expected
+
+
+def test_persisted_operation_summaries_do_not_compute_on_read() -> None:
+    persisted = _frame().normalize().persist()
+
+    with mock.patch("dask.array.core.Array.compute") as compute:
+        summaries = persisted.operation_summaries
+
+    compute.assert_not_called()
+    assert [summary["operation"] for summary in summaries] == ["normalize"]
+
+
+def test_persist_preserves_custom_operation_summaries_from_snapshot() -> None:
+    def scale(x: NDArrayReal, gain: float) -> NDArrayReal:
+        return x * gain
+
+    result = _frame().apply(scale, gain=2.0)
+    expected = result.operation_summaries
+
+    persisted = result.persist()
+
+    with mock.patch("dask.array.core.Array.compute") as compute:
+        summaries = persisted.operation_summaries
+
+    compute.assert_not_called()
+    assert summaries == expected
+    assert summaries[-1]["operation"] == "custom"
+
+
+def test_persist_preserves_multi_input_operation_summaries_from_snapshot() -> None:
+    result = _frame().normalize() + _frame().remove_dc()
+    expected = result.operation_summaries
+
+    persisted = result.persist()
+
+    with mock.patch("dask.array.core.Array.compute") as compute:
+        summaries = persisted.operation_summaries
+
+    compute.assert_not_called()
+    assert summaries == expected
+    assert [summary["operation"] for summary in summaries] == ["normalize", "remove_dc", "+"]
+
+
+def test_snapshot_backed_getitem_hides_temporary_get_channel_summary() -> None:
+    frame = ChannelFrame(
+        da_from_array(np.array([[1.0, 2.0], [3.0, 4.0]]), chunks=(1, -1)),
+        sampling_rate=16000,
+        channel_metadata=[{"label": "left"}, {"label": "right"}],
+        operation_summaries_snapshot=[{"operation": "loaded", "params": {}}],
+    )
+
+    result = frame[np.array([True, False])]
+
+    assert [summary["operation"] for summary in result.operation_summaries] == ["loaded", "__getitem__"]
+
+
+def test_operation_summaries_snapshot_is_defensive_copy() -> None:
+    snapshot = [{"operation": "loaded", "params": {"gain": 2.0}}]
+    frame = ChannelFrame(
+        da_from_array(np.array([[1.0, 2.0]]), chunks=(1, -1)),
+        sampling_rate=16000,
+        operation_summaries_snapshot=snapshot,
+    )
+
+    snapshot[0]["params"]["gain"] = 3.0
+    returned = frame.operation_summaries
+    returned[0]["params"]["gain"] = 4.0
+
+    assert frame.operation_summaries == [{"operation": "loaded", "params": {"gain": 2.0}}]
+
+
+def test_operation_summaries_snapshot_accepts_non_dict_mapping() -> None:
+    frame = ChannelFrame(
+        da_from_array(np.array([[1.0, 2.0]]), chunks=(1, -1)),
+        sampling_rate=16000,
+        operation_summaries_snapshot=[MappingProxyType({"operation": "loaded", "params": {"gain": 2.0}})],
+    )
+
+    assert frame.operation_summaries == [{"operation": "loaded", "params": {"gain": 2.0}}]
+
+
+def test_operation_summaries_snapshot_requires_strict_json_values() -> None:
+    with pytest.raises(ValueError, match="Operation summaries snapshot must be strict JSON serializable"):
+        ChannelFrame(
+            da_from_array(np.array([[1.0, 2.0]]), chunks=(1, -1)),
+            sampling_rate=16000,
+            operation_summaries_snapshot=[{"operation": "bad", "params": {"value": float("nan")}}],
+        )
 
 
 def test_operation_summaries_include_multi_input_lineage() -> None:

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -1388,6 +1388,47 @@ class TestRoughnessOperations:
             err_msg="Specific roughness values differ from MoSQITo calculation",
         )
 
+    def test_roughness_dw_spec_preserves_snapshot_backed_operation_summaries(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class FakeRoughnessSpecOperation:
+            name = "roughness_dw_spec"
+            params = {"overlap": 0.5}
+
+            def process(self, data: DaArray) -> DaArray:
+                return da.ones((data.shape[0], 47, 2), chunks=(1, 47, 2))
+
+            def get_metadata_updates(self) -> dict[str, object]:
+                return {"sampling_rate": 10.0, "bark_axis": np.linspace(0.5, 23.5, 47)}
+
+            def to_params(self) -> dict[str, float]:
+                return {"overlap": 0.5}
+
+        def fake_create_operation(operation_name: str, sampling_rate: float, **params: object) -> object:
+            assert operation_name == "roughness_dw_spec"
+            assert sampling_rate == self.sample_rate
+            assert params == {"overlap": 0.5}
+            return FakeRoughnessSpecOperation()
+
+        monkeypatch.setattr(
+            "wandas.frames.mixins.channel_processing_mixin.create_operation",
+            fake_create_operation,
+        )
+        frame = ChannelFrame(
+            data=_da_from_array(np.ones((1, 16)), chunks=(1, -1)),
+            sampling_rate=self.sample_rate,
+            operation_summaries_snapshot=[{"operation": "loaded", "params": {}}],
+        )
+
+        result = frame.roughness_dw_spec(overlap=0.5)
+
+        assert [summary["operation"] for summary in result.operation_summaries] == [
+            "loaded",
+            "roughness_dw_spec",
+        ]
+        assert [record["operation"] for record in result.operation_history] == ["roughness_dw_spec"]
+
     def test_roughness_dw_spec_plot(self) -> None:
         """Test that roughness_dw_spec plot method works."""
         import matplotlib.pyplot as plt

--- a/tests/frames/test_roughness_frame.py
+++ b/tests/frames/test_roughness_frame.py
@@ -472,6 +472,41 @@ class TestRoughnessFrame:
         assert result.operation_graph is not None
         assert [node["kind"] for node in result.operation_graph["inputs"]] == ["source", "source"]
 
+    def test_binary_op_preserves_snapshot_backed_operation_summaries(self) -> None:
+        frame = RoughnessFrame(
+            data=_DATA_MONO,
+            sampling_rate=_SAMPLING_RATE,
+            bark_axis=_BARK_AXIS,
+            overlap=_OVERLAP,
+            operation_summaries_snapshot=[{"operation": "loaded", "params": {}}],
+        )
+
+        result = frame + 1.0
+
+        assert [summary["operation"] for summary in result.operation_summaries] == ["loaded", "+"]
+        assert [record["operation"] for record in result.operation_history] == ["+"]
+
+    def test_binary_op_merges_snapshot_backed_roughness_frame_input_summaries(self) -> None:
+        left = RoughnessFrame(
+            data=_DATA_MONO,
+            sampling_rate=_SAMPLING_RATE,
+            bark_axis=_BARK_AXIS,
+            overlap=_OVERLAP,
+            lineage=LineageNode(Normalize(_SAMPLING_RATE)),
+        )
+        right = RoughnessFrame(
+            data=_DATA_MONO,
+            sampling_rate=_SAMPLING_RATE,
+            bark_axis=_BARK_AXIS,
+            overlap=_OVERLAP,
+            operation_summaries_snapshot=[{"operation": "loaded", "params": {}}],
+        )
+
+        result = left + right
+
+        assert [summary["operation"] for summary in result.operation_summaries] == ["normalize", "loaded", "+"]
+        assert [record["operation"] for record in result.operation_history] == ["normalize", "+"]
+
     def test_binary_op_sampling_rate_mismatch(self) -> None:
         """Test binary operation raises error on sampling rate mismatch."""
         frame1 = RoughnessFrame(

--- a/tests/io/test_wdf_io.py
+++ b/tests/io/test_wdf_io.py
@@ -235,14 +235,181 @@ def test_wdf_roundtrip_preserves_stable_channel_ids(tmp_path: Path) -> None:
     }
 
 
-def test_wdf_does_not_roundtrip_operation_history(known_signal_frame, tmp_path: Path) -> None:
-    """WDF does not persist operation_history; lineage is runtime-only."""
-    path = tmp_path / "op_history.wdf"
-    known_signal_frame.normalize().low_pass_filter(cutoff=1000, order=4).save(path)
+def test_wdf_roundtrips_operation_summaries_but_not_operation_history(known_signal_frame, tmp_path: Path) -> None:
+    """WDF restores display summaries, not executable runtime history."""
+    path = tmp_path / "op_summaries.wdf"
+    processed = known_signal_frame.normalize().low_pass_filter(cutoff=1000, order=4)
+    expected_summaries = processed.operation_summaries
+
+    processed.save(path)
 
     loaded = ChannelFrame.load(path)
 
+    assert loaded.operation_summaries == expected_summaries
     assert loaded.operation_history == []
+    assert loaded.operations == ()
+
+
+def test_wdf_roundtrips_custom_operation_summaries(tmp_path: Path) -> None:
+    def scale(x: np.ndarray, gain: float) -> np.ndarray:
+        return x * gain
+
+    path = tmp_path / "custom_summaries.wdf"
+    processed = ChannelFrame.from_numpy(np.array([[1.0, -1.0, 0.5]]), 16000).apply(scale, gain=2.0)
+    expected_summaries = processed.operation_summaries
+
+    processed.save(path)
+    loaded = ChannelFrame.load(path)
+
+    assert loaded.operation_summaries == expected_summaries
+    assert loaded.operation_summaries[-1]["operation"] == "custom"
+    assert loaded.operation_history == []
+    assert loaded.operations == ()
+
+
+def test_wdf_roundtrips_multi_input_operation_summaries(tmp_path: Path) -> None:
+    path = tmp_path / "multi_input_summaries.wdf"
+    left = ChannelFrame.from_numpy(np.array([[1.0, -1.0, 0.5]]), 16000).normalize()
+    right = ChannelFrame.from_numpy(np.array([[0.25, 0.5, -0.25]]), 16000).remove_dc()
+    processed = left + right
+    expected_summaries = processed.operation_summaries
+
+    processed.save(path)
+    loaded = ChannelFrame.load(path)
+
+    assert loaded.operation_summaries == expected_summaries
+    assert [summary["operation"] for summary in loaded.operation_summaries] == ["normalize", "remove_dc", "+"]
+    assert loaded.operation_history == []
+    assert loaded.operations == ()
+
+
+def test_wdf_loaded_summary_snapshot_extends_across_followup_operations(tmp_path: Path) -> None:
+    path = tmp_path / "loaded_followup.wdf"
+    loaded = ChannelFrame.from_numpy(np.array([[1.0, -1.0, 0.5]]), 16000).normalize()
+    loaded.save(path)
+
+    result = ChannelFrame.load(path).low_pass_filter(cutoff=1000, order=4)
+
+    assert [summary["operation"] for summary in result.operation_summaries] == ["normalize", "lowpass_filter"]
+    assert [record["operation"] for record in result.operation_history] == ["lowpass_filter"]
+
+
+def test_wdf_loaded_summary_snapshot_extends_across_binary_followup(tmp_path: Path) -> None:
+    left_path = tmp_path / "loaded_left.wdf"
+    right_path = tmp_path / "loaded_right.wdf"
+    left = ChannelFrame.from_numpy(np.array([[1.0, -1.0, 0.5]]), 16000).normalize()
+    right = ChannelFrame.from_numpy(np.array([[0.25, 0.5, -0.25]]), 16000).remove_dc()
+    left.save(left_path)
+    right.save(right_path)
+
+    result = ChannelFrame.load(left_path) + ChannelFrame.load(right_path)
+
+    assert [summary["operation"] for summary in result.operation_summaries] == ["normalize", "remove_dc", "+"]
+    assert [record["operation"] for record in result.operation_history] == ["+"]
+
+
+def test_wdf_loaded_summary_snapshot_extends_after_inplace_channel_update(tmp_path: Path) -> None:
+    source_path = tmp_path / "loaded_inplace_source.wdf"
+    renamed_path = tmp_path / "loaded_inplace_renamed.wdf"
+    processed = ChannelFrame.from_numpy(np.array([[1.0, -1.0, 0.5]]), 16000).normalize()
+    processed.save(source_path)
+
+    loaded = ChannelFrame.load(source_path)
+    loaded.rename_channels({0: "renamed"}, inplace=True)
+    loaded.save(renamed_path)
+    reloaded = ChannelFrame.load(renamed_path)
+
+    assert [summary["operation"] for summary in loaded.operation_summaries] == ["normalize", "rename_channels"]
+    assert [summary["operation"] for summary in reloaded.operation_summaries] == ["normalize", "rename_channels"]
+    assert [record["operation"] for record in loaded.operation_history] == ["rename_channels"]
+
+
+def test_wdf_loaded_summary_snapshot_extends_across_domain_transition(tmp_path: Path) -> None:
+    source_path = tmp_path / "loaded_stft_source.wdf"
+    processed = ChannelFrame.from_numpy(np.linspace(-1.0, 1.0, 16).reshape(1, -1), 16000).normalize()
+    processed.save(source_path)
+
+    result = ChannelFrame.load(source_path).stft(n_fft=8, hop_length=4)
+
+    assert [summary["operation"] for summary in result.operation_summaries] == ["normalize", "stft"]
+    assert [record["operation"] for record in result.operation_history] == ["stft"]
+
+
+def test_add_channel_merges_snapshot_backed_frame_input_summaries(tmp_path: Path) -> None:
+    added_path = tmp_path / "loaded_added_channel.wdf"
+    added = ChannelFrame.from_numpy(np.array([[1.0, -1.0, 0.5]]), 16000).normalize()
+    added.save(added_path)
+    base = ChannelFrame.from_numpy(np.array([[0.25, 0.5, -0.25]]), 16000).remove_dc()
+
+    result = base.add_channel(ChannelFrame.load(added_path))
+
+    assert [summary["operation"] for summary in result.operation_summaries] == ["remove_dc", "normalize", "add_channel"]
+    assert [record["operation"] for record in result.operation_history] == ["remove_dc", "add_channel"]
+
+
+def test_wdf_loaded_summary_snapshot_extends_through_inverse_stft(tmp_path: Path) -> None:
+    source_path = tmp_path / "loaded_istft_source.wdf"
+    processed = ChannelFrame.from_numpy(np.linspace(-1.0, 1.0, 16).reshape(1, -1), 16000).normalize()
+    processed.save(source_path)
+
+    result = ChannelFrame.load(source_path).stft(n_fft=8, hop_length=4).istft()
+
+    assert [summary["operation"] for summary in result.operation_summaries] == ["normalize", "stft", "istft"]
+    assert [record["operation"] for record in result.operation_history] == ["stft", "istft"]
+
+
+def test_wdf_loaded_summary_snapshot_extends_through_stft_frame_extraction(tmp_path: Path) -> None:
+    source_path = tmp_path / "loaded_stft_frame_source.wdf"
+    processed = ChannelFrame.from_numpy(np.linspace(-1.0, 1.0, 16).reshape(1, -1), 16000).normalize()
+    processed.save(source_path)
+
+    result = ChannelFrame.load(source_path).stft(n_fft=8, hop_length=4).get_frame_at(0)
+
+    assert [summary["operation"] for summary in result.operation_summaries] == ["normalize", "stft", "get_frame_at"]
+    assert [record["operation"] for record in result.operation_history] == ["stft", "get_frame_at"]
+
+
+def test_wdf_loaded_summary_snapshot_extends_through_inverse_fft(tmp_path: Path) -> None:
+    source_path = tmp_path / "loaded_ifft_source.wdf"
+    processed = ChannelFrame.from_numpy(np.linspace(-1.0, 1.0, 16).reshape(1, -1), 16000).normalize()
+    processed.save(source_path)
+
+    result = ChannelFrame.load(source_path).fft(n_fft=16).ifft()
+
+    assert [summary["operation"] for summary in result.operation_summaries] == ["normalize", "fft", "ifft"]
+    assert [record["operation"] for record in result.operation_history] == ["fft", "ifft"]
+
+
+def test_add_with_snr_merges_snapshot_backed_frame_input_summaries(tmp_path: Path) -> None:
+    noise_path = tmp_path / "loaded_snr_noise.wdf"
+    noise = ChannelFrame.from_numpy(np.array([[1.0, -1.0, 0.5]]), 16000).normalize()
+    noise.save(noise_path)
+    signal = ChannelFrame.from_numpy(np.array([[0.25, 0.5, -0.25]]), 16000).remove_dc()
+
+    result = signal.add(ChannelFrame.load(noise_path), snr=12.0)
+
+    assert [summary["operation"] for summary in result.operation_summaries] == [
+        "remove_dc",
+        "normalize",
+        "add_with_snr",
+    ]
+    assert [record["operation"] for record in result.operation_history] == ["remove_dc", "add_with_snr"]
+
+
+def test_add_with_snr_excludes_implicit_fix_length_from_snapshot_input_summaries(tmp_path: Path) -> None:
+    noise_path = tmp_path / "loaded_short_snr_noise.wdf"
+    noise = ChannelFrame.from_numpy(np.array([[1.0, -1.0]]), 16000).normalize()
+    noise.save(noise_path)
+    signal = ChannelFrame.from_numpy(np.array([[0.25, 0.5, -0.25, 0.75]]), 16000).remove_dc()
+
+    result = signal.add(ChannelFrame.load(noise_path), snr=12.0)
+
+    assert [summary["operation"] for summary in result.operation_summaries] == [
+        "remove_dc",
+        "normalize",
+        "add_with_snr",
+    ]
+    assert [record["operation"] for record in result.operation_history] == ["remove_dc", "add_with_snr"]
 
 
 def test_save_wdf_dtype_float32_converts_stored_data(tmp_path: Path) -> None:
@@ -369,6 +536,43 @@ def test_save_wdf_does_not_create_operation_history_group(tmp_path: Path) -> Non
         assert "operation_history" not in f
 
 
+def test_save_wdf_writes_operation_summaries_json(tmp_path: Path) -> None:
+    frame = ChannelFrame.from_numpy(np.array([[1.0, -1.0, 0.5]]), 16000).normalize()
+    path = tmp_path / "summaries.wdf"
+
+    wdf_io.save(frame, path)
+
+    with h5py.File(path, "r") as f:
+        assert f.attrs["operation_summaries_schema"] == 1
+        summaries = json.loads(f.attrs["operation_summaries_json"])
+    assert [summary["operation"] for summary in summaries] == ["normalize"]
+
+
+def test_save_wdf_operation_summaries_json_is_strict_json(tmp_path: Path) -> None:
+    frame = ChannelFrame.from_numpy(np.array([[1.0, -1.0, 0.5]]), 16000).normalize()
+    path = tmp_path / "strict_summaries.wdf"
+
+    wdf_io.save(frame, path)
+
+    with h5py.File(path, "r") as f:
+        json.loads(f.attrs["operation_summaries_json"])
+
+
+def test_save_wdf_validates_operation_summaries_before_overwrite(tmp_path: Path) -> None:
+    path = tmp_path / "existing.wdf"
+    original = ChannelFrame.from_numpy(np.array([[1.0, 2.0, 3.0]]), 16000)
+    original.save(path)
+    candidate = ChannelFrame.from_numpy(np.array([[4.0, 5.0, 6.0]]), 16000)
+
+    with patch.object(candidate, "_operation_summaries_for_storage", side_effect=ValueError("bad summaries")):
+        with pytest.raises(ValueError, match="bad summaries"):
+            wdf_io.save(candidate, path, overwrite=True)
+
+    loaded = ChannelFrame.load(path)
+
+    np.testing.assert_array_equal(loaded.compute(), original.compute())
+
+
 def test_load_no_channels(tmp_path: Path) -> None:
     """Test loading a file with no channels raises ValueError."""
     path = tmp_path / "empty_channels.wdf"
@@ -402,9 +606,32 @@ def test_load_json_decode_error(tmp_path: Path) -> None:
         # Invalid JSON string
         op0.attrs["params"] = "{bad_json"
 
-    # Legacy operation_history groups are ignored.
+    # Legacy operation_history groups are ignored and are not translated into
+    # operation_summaries.
     cf = wdf_io.load(path)
     assert cf.operation_history == []
+    assert cf.operation_summaries == []
+
+
+def test_load_wdf_restores_operation_summaries_snapshot(tmp_path: Path) -> None:
+    path = tmp_path / "manual_summaries.wdf"
+    summaries = [{"operation": "loaded", "params": {"gain": 2.0}}]
+
+    with h5py.File(path, "w") as f:
+        f.attrs["version"] = wdf_io.WDF_FORMAT_VERSION
+        f.attrs["sampling_rate"] = 16000.0
+        f.attrs["operation_summaries_schema"] = 1
+        f.attrs["operation_summaries_json"] = json.dumps(summaries)
+        channels = f.create_group("channels")
+        channel = channels.create_group("0")
+        channel.create_dataset("data", data=np.zeros(4, dtype=np.float32))
+        channel.attrs["label"] = "mic"
+        channel.attrs["unit"] = ""
+
+    loaded = wdf_io.load(path)
+
+    assert loaded.operation_summaries == summaries
+    assert loaded.operation_history == []
 
 
 def test_load_file_not_found(tmp_path: Path) -> None:

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -187,6 +187,7 @@ class BaseFrame(ABC, Generic[T]):
         previous: "BaseFrame[Any] | None" = None,
         source_time_offset: float | Sequence[float] | NDArrayReal = 0.0,
         lineage: "LineageNode | None" = None,
+        operation_summaries_snapshot: Sequence[Mapping[str, Any]] | None = None,
     ):
         normalized_data = self._normalize_data(data)
         frame_label = label or "unnamed_frame"
@@ -207,6 +208,11 @@ class BaseFrame(ABC, Generic[T]):
         self.sampling_rate = sampling_rate
         self.metadata = metadata
         self._lineage = lineage
+        self._operation_summaries_snapshot = (
+            self._snapshot_operation_summaries(operation_summaries_snapshot)
+            if operation_summaries_snapshot is not None
+            else None
+        )
         self._set_channel_metadata(normalized_channel_metadata, self._pending_channel_ids)
         self.source_time_offset = source_time_offset
         del self._pending_channel_metadata
@@ -539,8 +545,29 @@ class BaseFrame(ABC, Generic[T]):
 
     @property
     def operation_summaries(self) -> list[dict[str, Any]]:
-        """Return lightweight display summaries derived from ``lineage``."""
+        """Return lightweight display summaries derived from lineage or a boundary snapshot."""
+        if self._operation_summaries_snapshot is not None:
+            return copy.deepcopy(self._operation_summaries_snapshot)
         return self._lineage_to_summaries(self.lineage)
+
+    def _operation_summaries_for_storage(self) -> list[dict[str, Any]]:
+        """Return a defensive strict-JSON-safe snapshot for persistence boundaries."""
+        return self._snapshot_operation_summaries(self.operation_summaries)
+
+    def _operation_summaries_with_lineage_delta(self, lineage: "LineageNode | None") -> list[dict[str, Any]]:
+        """Extend a boundary snapshot with summaries added since this frame."""
+        snapshot = self._snapshot_operation_summaries(self._operation_summaries_snapshot or [])
+        current_lineage_summaries = self._lineage_to_summaries(self.lineage)
+        new_lineage_summaries = self._lineage_to_summaries(lineage)
+        if new_lineage_summaries[: len(current_lineage_summaries)] != current_lineage_summaries:
+            return snapshot
+        return self._snapshot_operation_summaries([*snapshot, *new_lineage_summaries[len(current_lineage_summaries) :]])
+
+    def _operation_summaries_snapshot_kwargs(self, lineage: "LineageNode | None") -> dict[str, Any]:
+        """Return constructor kwargs that propagate a boundary snapshot for ``lineage``."""
+        if self._operation_summaries_snapshot is None:
+            return {}
+        return {"operation_summaries_snapshot": self._operation_summaries_with_lineage_delta(lineage)}
 
     @staticmethod
     def _operation_name(operation: Any) -> str:
@@ -632,6 +659,26 @@ class BaseFrame(ABC, Generic[T]):
             records.extend(cls._lineage_to_summaries(input_lineage))
         records.append(cls._operation_summary(lineage.operation))
         return records
+
+    @classmethod
+    def _snapshot_operation_summaries(cls, summaries: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+        records = list(summaries)
+        if not all(isinstance(record, Mapping) for record in records):
+            raise ValueError(
+                "Operation summaries snapshot must be a sequence of mappings\n"
+                f"  Got: {type(summaries).__name__}\n"
+                "Use frame.operation_summaries or another JSON-safe summary list."
+            )
+        snapshot = [copy.deepcopy(dict(record)) for record in records]
+        try:
+            json.dumps(snapshot, allow_nan=False)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "Operation summaries snapshot must be strict JSON serializable\n"
+                f"  Got: {snapshot!r}\n"
+                "Use operation_summaries, which converts runtime values to display-safe summaries."
+            ) from exc
+        return snapshot
 
     def _lineage_with_operation(self, operation: Any, *inputs: "LineageNode | None") -> "LineageNode":
         from wandas.processing.base import LineageNode
@@ -982,29 +1029,43 @@ class BaseFrame(ABC, Generic[T]):
                 mask = [bool(value) for value in cast(npt.NDArray[np.bool_], key).tolist()]
                 indices = np.where(cast(npt.NDArray[np.bool_], key))[0]
                 result = self.get_channel(indices)
+                lineage = self._lineage_with_method(
+                    "__getitem__",
+                    {"indexing": "boolean_mask", "mask": tuple(mask)},
+                )
+                creation_kwargs: dict[str, Any] = {}
+                if self._operation_summaries_snapshot is not None:
+                    creation_kwargs["operation_summaries_snapshot"] = self._operation_summaries_with_lineage_delta(
+                        lineage
+                    )
                 return result._create_new_instance(
                     data=result._data,
                     channel_metadata=result.channels.to_list(),
                     channel_ids=result._channel_ids,
                     source_time_offset=result.source_time_offset,
-                    lineage=self._lineage_with_method(
-                        "__getitem__",
-                        {"indexing": "boolean_mask", "mask": tuple(mask)},
-                    ),
+                    lineage=lineage,
+                    **creation_kwargs,
                 )
             if np.issubdtype(key.dtype, np.integer):
                 # Integer array
                 int_list = [int(index) for index in cast(npt.NDArray[np.integer[Any]], key).tolist()]
                 result = self.get_channel(cast(npt.NDArray[np.int_], key))
+                lineage = self._lineage_with_method(
+                    "__getitem__",
+                    {"indexing": "integer_list", "indices": tuple(int_list)},
+                )
+                creation_kwargs = {}
+                if self._operation_summaries_snapshot is not None:
+                    creation_kwargs["operation_summaries_snapshot"] = self._operation_summaries_with_lineage_delta(
+                        lineage
+                    )
                 return result._create_new_instance(
                     data=result._data,
                     channel_metadata=result.channels.to_list(),
                     channel_ids=result._channel_ids,
                     source_time_offset=result.source_time_offset,
-                    lineage=self._lineage_with_method(
-                        "__getitem__",
-                        {"indexing": "integer_list", "indices": tuple(int_list)},
-                    ),
+                    lineage=lineage,
+                    **creation_kwargs,
                 )
             raise TypeError(f"NumPy array must be of integer or boolean type, got {key.dtype}")
 
@@ -1037,15 +1098,22 @@ class BaseFrame(ABC, Generic[T]):
                 # Multiple indices - convert to list[int] for type safety
                 int_list = [int(k) for k in key]
                 result = self.get_channel(int_list)
+                lineage = self._lineage_with_method(
+                    "__getitem__",
+                    {"indexing": "integer_list", "indices": tuple(int_list)},
+                )
+                creation_kwargs = {}
+                if self._operation_summaries_snapshot is not None:
+                    creation_kwargs["operation_summaries_snapshot"] = self._operation_summaries_with_lineage_delta(
+                        lineage
+                    )
                 return result._create_new_instance(
                     data=result._data,
                     channel_metadata=result.channels.to_list(),
                     channel_ids=result._channel_ids,
                     source_time_offset=result.source_time_offset,
-                    lineage=self._lineage_with_method(
-                        "__getitem__",
-                        {"indexing": "integer_list", "indices": tuple(int_list)},
-                    ),
+                    lineage=lineage,
+                    **creation_kwargs,
                 )
 
             raise TypeError(f"List must contain all str or all int, got mixed types: {[type(k).__name__ for k in key]}")
@@ -1256,9 +1324,13 @@ class BaseFrame(ABC, Generic[T]):
         """Plot the data"""
 
     def persist(self: S) -> S:
-        """Persist the data in memory"""
+        """Persist the data in memory."""
+        operation_summaries_snapshot = self._operation_summaries_for_storage()
         persisted_data = self._data.persist()
-        return self._create_new_instance(data=persisted_data)
+        return self._create_new_instance(
+            data=persisted_data,
+            operation_summaries_snapshot=operation_summaries_snapshot,
+        )
 
     def _get_additional_init_kwargs(self) -> dict[str, Any]:
         """Return additional keyword arguments for ``_create_new_instance``.
@@ -1287,6 +1359,9 @@ class BaseFrame(ABC, Generic[T]):
             raise TypeError("Metadata must be a dictionary")
 
         lineage = kwargs.pop("lineage", self.lineage)
+        operation_summaries_snapshot = kwargs.pop("operation_summaries_snapshot", None)
+        if operation_summaries_snapshot is None and self._operation_summaries_snapshot is not None:
+            operation_summaries_snapshot = self._operation_summaries_with_lineage_delta(lineage)
 
         channel_metadata = kwargs.pop("channel_metadata", self.channels.to_list())
         if not isinstance(channel_metadata, list):
@@ -1320,6 +1395,8 @@ class BaseFrame(ABC, Generic[T]):
             "lineage": lineage,
             **kwargs,
         }
+        if operation_summaries_snapshot is not None:
+            init_kwargs["operation_summaries_snapshot"] = operation_summaries_snapshot
 
         return type(self)(**init_kwargs)
 
@@ -1484,6 +1561,17 @@ class BaseFrame(ABC, Generic[T]):
             operand_position="left" if reverse and operand_kind == "operand" else "right",
         )
         lineage = self._lineage_with_operation(binary_operation, *lineage_inputs)
+        operation_summaries_snapshot = None
+        if isinstance(other, type(self)) and (
+            self._operation_summaries_snapshot is not None or other._operation_summaries_snapshot is not None
+        ):
+            operation_summaries_snapshot = self._snapshot_operation_summaries(
+                [
+                    *self.operation_summaries,
+                    *other.operation_summaries,
+                    self._operation_summary(binary_operation),
+                ]
+            )
 
         label = (
             f"({other_str} {symbol} {self.label})"
@@ -1496,6 +1584,7 @@ class BaseFrame(ABC, Generic[T]):
             metadata=metadata,
             lineage=lineage,
             channel_metadata=new_channel_metadata,
+            operation_summaries_snapshot=operation_summaries_snapshot,
         )
 
     @staticmethod
@@ -1750,6 +1839,7 @@ class BaseFrame(ABC, Generic[T]):
                 "previous": self,
                 "lineage": lineage,
             }
+            kw.update(self._operation_summaries_snapshot_kwargs(lineage))
             kw.update(metadata_updates)
             if output_frame_kwargs:
                 kw.update(output_frame_kwargs)

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, BinaryIO, TypeVar, cast
 
@@ -219,6 +219,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         previous: "BaseFrame[Any] | None" = None,
         source_time_offset: float | Sequence[float] | NDArrayReal = 0.0,
         lineage: Any | None = None,
+        operation_summaries_snapshot: Sequence[Mapping[str, Any]] | None = None,
     ) -> None:
         """Initialize a ChannelFrame.
 
@@ -263,6 +264,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             channel_ids=channel_ids,
             source_time_offset=source_time_offset,
             lineage=lineage,
+            operation_summaries_snapshot=operation_summaries_snapshot,
             previous=previous,
         )
 
@@ -294,15 +296,26 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         channel_ids: list[str],
         source_time_offset: float | Sequence[float] | NDArrayReal | None = None,
         lineage: Any | None = None,
+        operation_summaries_snapshot: Sequence[Mapping[str, Any]] | None = None,
     ) -> "ChannelFrame":
         """Apply *new_data* and *new_chmeta* either in-place or as a new frame."""
         offsets = self.source_time_offset if source_time_offset is None else source_time_offset
+        if operation_summaries_snapshot is not None:
+            operation_summaries_snapshot = self._snapshot_operation_summaries(operation_summaries_snapshot)
+        elif self._operation_summaries_snapshot is not None:
+            operation_summaries_snapshot = (
+                self._operation_summaries_with_lineage_delta(lineage)
+                if lineage is not None
+                else self._operation_summaries_for_storage()
+            )
         if inplace:
             self._replace_data(new_data)
             self._set_channel_metadata(new_chmeta, channel_ids)
             self.source_time_offset = cast(Any, offsets)
             if lineage is not None:
                 self._lineage = lineage
+            if operation_summaries_snapshot is not None:
+                self._operation_summaries_snapshot = operation_summaries_snapshot
             return self
         return ChannelFrame(
             data=new_data,
@@ -313,6 +326,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             channel_ids=channel_ids,
             source_time_offset=offsets,
             lineage=self.lineage if lineage is None else lineage,
+            operation_summaries_snapshot=operation_summaries_snapshot,
             previous=self,
         )
 
@@ -541,6 +555,8 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             raise TypeError(f"Addition target with SNR must be a ChannelFrame or NumPy array: {type(other)}")
 
         lineage_other = other._lineage_or_source()
+        other_operation_summaries = other.operation_summaries
+        other_has_operation_summaries_snapshot = other._operation_summaries_snapshot is not None
 
         # If SNR is specified, adjust the length of the other signal
         if other.duration != self.duration:
@@ -565,11 +581,22 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         result_data = operation.process(self._data, other._data)
         get_display_name = getattr(operation, "get_display_name", None)
         display_name = get_display_name() if callable(get_display_name) else getattr(operation, "name", "add_with_snr")
+        lineage = self._lineage_with_operation(operation, self._lineage_or_source(), lineage_other)
+        operation_summaries_snapshot = None
+        if self._operation_summaries_snapshot is not None or other_has_operation_summaries_snapshot:
+            operation_summaries_snapshot = self._snapshot_operation_summaries(
+                [
+                    *self.operation_summaries,
+                    *other_operation_summaries,
+                    self._operation_summary(operation),
+                ]
+            )
         return self._create_new_instance(
             data=result_data,
             metadata=self._updated_metadata("add_with_snr", operation.params),
-            lineage=self._lineage_with_operation(operation, self._lineage_or_source(), lineage_other),
+            lineage=lineage,
             channel_metadata=self._relabel_channels("add_with_snr", display_name),
+            operation_summaries_snapshot=operation_summaries_snapshot,
         )
 
     def plot(
@@ -1379,13 +1406,24 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
                 new_id = self._next_channel_id(new_ids)
                 new_ids.append(new_id)
             new_offsets = np.concatenate([self.source_time_offset, data.source_time_offset])
+            lineage = self._lineage_with_add_channel(lineage_params, data.lineage)
+            operation_summaries_snapshot = None
+            if self._operation_summaries_snapshot is not None or data._operation_summaries_snapshot is not None:
+                operation_summaries_snapshot = self._snapshot_operation_summaries(
+                    [
+                        *self.operation_summaries,
+                        *data.operation_summaries,
+                        self._operation_summary(lineage.operation),
+                    ]
+                )
             return self._finalize_channel_update(
                 new_data,
                 new_chmeta,
                 inplace,
                 new_ids,
                 new_offsets,
-                lineage=self._lineage_with_add_channel(lineage_params, data.lineage),
+                lineage=lineage,
+                operation_summaries_snapshot=operation_summaries_snapshot,
             )
         if isinstance(data, np.ndarray):
             lineage_params["input_kind"] = "ndarray"

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -971,6 +971,7 @@ class ChannelProcessingMixin:
 
         # Create RoughnessFrame. operation.get_metadata_updates() should provide
         # sampling_rate and bark_axis
+        lineage = cast(Any, self)._lineage_with_method(operation_name, operation.to_params())
         roughness_frame = RoughnessFrame(
             data=r_spec_dask,
             sampling_rate=metadata_updates.get("sampling_rate", self.sampling_rate),
@@ -981,8 +982,9 @@ class ChannelProcessingMixin:
             channel_metadata=cast(Any, self).channels.to_list(),
             channel_ids=cast(Any, self)._channel_ids,
             source_time_offset=cast(Any, self).source_time_offset,
-            lineage=cast(Any, self)._lineage_with_method(operation_name, operation.to_params()),
+            lineage=lineage,
             previous=cast("BaseFrame[NDArrayReal]", self),
+            **cast(Any, self)._operation_summaries_snapshot_kwargs(lineage),
         )
 
         logger.debug(

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -58,6 +58,10 @@ def _build_cross_channel_source_time_offsets(source_time_offset: Any) -> Any:
     return np.asarray(result, dtype=float)
 
 
+def _operation_summaries_snapshot_kwargs(frame: TransformFrameProtocol, lineage: Any) -> dict[str, Any]:
+    return cast(Any, frame)._operation_summaries_snapshot_kwargs(lineage)
+
+
 class ChannelTransformMixin:
     """Mixin providing methods related to frequency transformations.
 
@@ -110,6 +114,7 @@ class ChannelTransformMixin:
                 f"Operation '{operation_name}' must provide a positive integer n_fft "
                 f"to create a SpectralFrame, but got {n_fft}."
             )
+        lineage = cast(Any, self)._lineage_with_method(operation_name, operation.to_params())
         return SpectralFrame(
             data=result_data,
             sampling_rate=self.sampling_rate,
@@ -119,8 +124,9 @@ class ChannelTransformMixin:
             metadata=self.metadata,
             channel_metadata=channel_metadata,
             source_time_offset=_build_cross_channel_source_time_offsets(cast(Any, self).source_time_offset),
-            lineage=cast(Any, self)._lineage_with_method(operation_name, operation.to_params()),
+            lineage=lineage,
             previous=self._as_base_frame,
+            **_operation_summaries_snapshot_kwargs(self, lineage),
         )
 
     def fft(self: TransformFrameProtocol, n_fft: int | None = None, window: str = "hann") -> "SpectralFrame":
@@ -150,6 +156,7 @@ class ChannelTransformMixin:
 
         logger.debug(f"Created new SpectralFrame with operation {operation_name} added to graph")
 
+        lineage = cast(Any, self)._lineage_with_method(operation_name, operation.to_params())
         return SpectralFrame(
             data=spectrum_data,
             sampling_rate=self.sampling_rate,
@@ -160,8 +167,9 @@ class ChannelTransformMixin:
             channel_metadata=cast(Any, self).channels.to_list(),
             channel_ids=cast(Any, self)._channel_ids,
             source_time_offset=cast(Any, self).source_time_offset,
-            lineage=cast(Any, self)._lineage_with_method(operation_name, operation.to_params()),
+            lineage=lineage,
             previous=self._as_base_frame,
+            **_operation_summaries_snapshot_kwargs(self, lineage),
         )
 
     def welch(
@@ -206,6 +214,7 @@ class ChannelTransformMixin:
 
         logger.debug(f"Created new SpectralFrame with operation {operation_name} added to graph")
 
+        lineage = cast(Any, self)._lineage_with_method(operation_name, operation.to_params())
         return SpectralFrame(
             data=spectrum_data,
             sampling_rate=self.sampling_rate,
@@ -216,8 +225,9 @@ class ChannelTransformMixin:
             channel_metadata=cast(Any, self).channels.to_list(),
             channel_ids=cast(Any, self)._channel_ids,
             source_time_offset=cast(Any, self).source_time_offset,
-            lineage=cast(Any, self)._lineage_with_method(operation_name, operation.to_params()),
+            lineage=lineage,
             previous=self._as_base_frame,
+            **_operation_summaries_snapshot_kwargs(self, lineage),
         )
 
     def noct_spectrum(
@@ -256,6 +266,7 @@ class ChannelTransformMixin:
 
         logger.debug(f"Created new SpectralFrame with operation {operation_name} added to graph")
 
+        lineage = cast(Any, self)._lineage_with_method(operation_name, operation.to_params())
         return NOctFrame(
             data=spectrum_data,
             sampling_rate=self.sampling_rate,
@@ -269,8 +280,9 @@ class ChannelTransformMixin:
             channel_metadata=cast(Any, self).channels.to_list(),
             channel_ids=cast(Any, self)._channel_ids,
             source_time_offset=cast(Any, self).source_time_offset,
-            lineage=cast(Any, self)._lineage_with_method(operation_name, operation.to_params()),
+            lineage=lineage,
             previous=self._as_base_frame,
+            **_operation_summaries_snapshot_kwargs(self, lineage),
         )
 
     def stft(
@@ -319,6 +331,7 @@ class ChannelTransformMixin:
         logger.debug(f"Created new SpectrogramFrame with operation {operation_name} added to graph")
 
         # Create new instance
+        lineage = cast(Any, self)._lineage_with_method(operation_name, operation.to_params())
         return SpectrogramFrame(
             data=spectrogram_data,
             sampling_rate=self.sampling_rate,
@@ -331,8 +344,9 @@ class ChannelTransformMixin:
             channel_metadata=cast(Any, self).channels.to_list(),
             channel_ids=cast(Any, self)._channel_ids,
             source_time_offset=cast(Any, self).source_time_offset,
-            lineage=cast(Any, self)._lineage_with_method(operation_name, operation.to_params()),
+            lineage=lineage,
             previous=self._as_base_frame,
+            **_operation_summaries_snapshot_kwargs(self, lineage),
         )
 
     def coherence(

--- a/wandas/frames/noct.py
+++ b/wandas/frames/noct.py
@@ -1,6 +1,6 @@
 # spectral_frame.py
 import logging
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import numpy as np
@@ -138,6 +138,7 @@ class NOctFrame(BaseFrame[NDArrayReal]):
         previous: "BaseFrame[Any] | None" = None,
         source_time_offset: float | Sequence[float] | NDArrayReal = 0.0,
         lineage: Any | None = None,
+        operation_summaries_snapshot: Sequence[Mapping[str, Any]] | None = None,
     ) -> None:
         """
         Initialize a NOctFrame instance.
@@ -162,6 +163,7 @@ class NOctFrame(BaseFrame[NDArrayReal]):
             channel_ids=channel_ids,
             source_time_offset=source_time_offset,
             lineage=lineage,
+            operation_summaries_snapshot=operation_summaries_snapshot,
             previous=previous,
         )
 

--- a/wandas/frames/roughness.py
+++ b/wandas/frames/roughness.py
@@ -1,7 +1,7 @@
 """Roughness analysis frame for detailed psychoacoustic analysis."""
 
 import logging
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -122,6 +122,7 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
         previous: "BaseFrame[Any] | None" = None,
         source_time_offset: float | Sequence[float] | NDArrayReal = 0.0,
         lineage: Any | None = None,
+        operation_summaries_snapshot: Sequence[Mapping[str, Any]] | None = None,
     ) -> None:
         """Initialize a RoughnessFrame."""
         # Validate dimensions
@@ -156,6 +157,7 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
             channel_ids=channel_ids,
             source_time_offset=source_time_offset,
             lineage=lineage,
+            operation_summaries_snapshot=operation_summaries_snapshot,
             previous=previous,
         )
 
@@ -314,8 +316,10 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
         logger.debug(f"Setting up {symbol} operation (lazy)")
 
         metadata = self.metadata.copy()
+        other_frame: RoughnessFrame | None = None
         # Check if other is a RoughnessFrame
         if isinstance(other, RoughnessFrame):
+            other_frame = other
             if self.sampling_rate != other.sampling_rate:
                 raise ValueError(f"Sampling rates do not match: {self.sampling_rate} vs {other.sampling_rate}")
 
@@ -343,6 +347,20 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
             operand_kind=operand_kind,
             operand=None if operand_kind == "frame" else other,
         )
+        lineage = self._lineage_with_operation(binary_operation, *lineage_inputs)
+        operation_summaries_snapshot = None
+        if other_frame is not None and (
+            self._operation_summaries_snapshot is not None or other_frame._operation_summaries_snapshot is not None
+        ):
+            operation_summaries_snapshot = self._snapshot_operation_summaries(
+                [
+                    *self.operation_summaries,
+                    *other_frame.operation_summaries,
+                    self._operation_summary(binary_operation),
+                ]
+            )
+        elif self._operation_summaries_snapshot is not None:
+            operation_summaries_snapshot = self._operation_summaries_with_lineage_delta(lineage)
 
         # Create new instance
         return RoughnessFrame(
@@ -355,7 +373,8 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
             channel_metadata=self.channels.to_list(),
             channel_ids=self._channel_ids,
             source_time_offset=self.source_time_offset,
-            lineage=self._lineage_with_operation(binary_operation, *lineage_inputs),
+            lineage=lineage,
+            operation_summaries_snapshot=operation_summaries_snapshot,
             previous=self,
         )
 

--- a/wandas/frames/spectral.py
+++ b/wandas/frames/spectral.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
@@ -121,6 +121,7 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         previous: BaseFrame[Any] | None = None,
         source_time_offset: float | Sequence[float] | NDArrayReal = 0.0,
         lineage: Any | None = None,
+        operation_summaries_snapshot: Sequence[Mapping[str, Any]] | None = None,
     ) -> None:
         if data.ndim == 1:
             data = data.reshape(1, -1)
@@ -137,6 +138,7 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             channel_ids=channel_ids,
             source_time_offset=source_time_offset,
             lineage=lineage,
+            operation_summaries_snapshot=operation_summaries_snapshot,
             previous=previous,
         )
 
@@ -292,6 +294,7 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         logger.debug(f"Created new SpectralFrame with operation {operation_name} added to graph")
 
         # Create new instance
+        lineage = self._lineage_with_method(operation_name, operation.to_params())
         return ChannelFrame(
             data=time_series,
             sampling_rate=self.sampling_rate,
@@ -300,7 +303,8 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             channel_metadata=self.channels.to_list(),
             channel_ids=self._channel_ids,
             source_time_offset=self.source_time_offset,
-            lineage=self._lineage_with_method(operation_name, operation.to_params()),
+            lineage=lineage,
+            **self._operation_summaries_snapshot_kwargs(lineage),
         )
 
     def _get_additional_init_kwargs(self) -> dict[str, Any]:
@@ -378,6 +382,7 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
 
         logger.debug(f"Created new SpectralFrame with operation {operation_name} added to graph")
 
+        lineage = self._lineage_with_method(operation_name, operation.to_params())
         return NOctFrame(
             data=spectrum_data,
             sampling_rate=self.sampling_rate,
@@ -391,8 +396,9 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             channel_metadata=self.channels.to_list(),
             channel_ids=self._channel_ids,
             source_time_offset=self.source_time_offset,
-            lineage=self._lineage_with_method(operation_name, operation.to_params()),
+            lineage=lineage,
             previous=self,
+            **self._operation_summaries_snapshot_kwargs(lineage),
         )
 
     def plot_matrix(

--- a/wandas/frames/spectrogram.py
+++ b/wandas/frames/spectrogram.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, cast
 
 import dask.array as da
@@ -119,6 +119,7 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         channel_ids: list[str] | None = None,
         previous: "BaseFrame[Any] | None" = None,
         source_time_offset: float | Sequence[float] | NDArrayReal = 0.0,
+        operation_summaries_snapshot: Sequence[Mapping[str, Any]] | None = None,
     ) -> None:
         if data.ndim == 2:
             data = da.expand_dims(data, axis=0)
@@ -151,6 +152,7 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             channel_ids=channel_ids,
             source_time_offset=source_time_offset,
             lineage=lineage,
+            operation_summaries_snapshot=operation_summaries_snapshot,
             previous=previous,
         )
 
@@ -408,6 +410,7 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
 
         frame_data = self._data[..., time_idx]
 
+        lineage = self._lineage_with_method("get_frame_at", {"time_idx": time_idx})
         return SpectralFrame(
             data=frame_data,
             sampling_rate=self.sampling_rate,
@@ -418,7 +421,8 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             channel_metadata=self.channels.to_list(),
             channel_ids=self._channel_ids,
             source_time_offset=self.source_time_offset + float(self.times[time_idx]),
-            lineage=self._lineage_with_method("get_frame_at", {"time_idx": time_idx}),
+            lineage=lineage,
+            **self._operation_summaries_snapshot_kwargs(lineage),
         )
 
     def to_channel_frame(self) -> "ChannelFrame":
@@ -458,6 +462,7 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         logger.debug(f"Created new ChannelFrame with operation {operation_name} added to graph")
 
         # Create new instance
+        lineage = self._lineage_with_method(operation_name, operation.to_params())
         return ChannelFrame(
             data=time_series,
             sampling_rate=self.sampling_rate,
@@ -466,7 +471,8 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             channel_metadata=self.channels.to_list(),
             channel_ids=self._channel_ids,
             source_time_offset=self.source_time_offset,
-            lineage=self._lineage_with_method(operation_name, operation.to_params()),
+            lineage=lineage,
+            **self._operation_summaries_snapshot_kwargs(lineage),
         )
 
     def istft(self) -> "ChannelFrame":

--- a/wandas/io/wdf_io.py
+++ b/wandas/io/wdf_io.py
@@ -27,6 +27,9 @@ logger = logging.getLogger(__name__)
 
 # Constants for version management
 WDF_FORMAT_VERSION = "0.1"
+OPERATION_SUMMARIES_SCHEMA_VERSION = 1
+OPERATION_SUMMARIES_SCHEMA_ATTR = "operation_summaries_schema"
+OPERATION_SUMMARIES_JSON_ATTR = "operation_summaries_json"
 
 
 def _decode_hdf5_str(value: object) -> str:
@@ -40,6 +43,25 @@ def _decode_hdf5_str(value: object) -> str:
         except (UnicodeDecodeError, AttributeError):
             return str(value)
     return str(value)
+
+
+def _load_operation_summaries_snapshot(h5_file: Any) -> list[dict[str, Any]] | None:
+    if OPERATION_SUMMARIES_JSON_ATTR not in h5_file.attrs:
+        return None
+    schema = int(h5_file.attrs.get(OPERATION_SUMMARIES_SCHEMA_ATTR, 0))
+    if schema != OPERATION_SUMMARIES_SCHEMA_VERSION:
+        raise ValueError(
+            "Unsupported WDF operation summaries schema\n"
+            f"  Got: {schema}\n"
+            f"  Supported: {OPERATION_SUMMARIES_SCHEMA_VERSION}\n"
+            "Use a compatible Wandas version or resave the file."
+        )
+    parsed = json.loads(_decode_hdf5_str(h5_file.attrs[OPERATION_SUMMARIES_JSON_ATTR]))
+    if not isinstance(parsed, list) or not all(isinstance(record, dict) for record in parsed):
+        raise ValueError(
+            f"Invalid WDF operation summaries JSON\n  Expected: JSON array of objects\n  Got: {type(parsed).__name__}"
+        )
+    return parsed
 
 
 def save(
@@ -80,6 +102,8 @@ def save(
 
     h5py = require_h5py("WDF save")
 
+    operation_summaries = frame._operation_summaries_for_storage()
+
     # Compute data arrays (this triggers actual computation)
     logger.info("Computing data arrays for saving...")
     computed_data = frame.compute()
@@ -97,6 +121,8 @@ def save(
         f.attrs["label"] = frame.label or ""
         f.attrs["frame_type"] = type(frame).__name__
         f.attrs["channel_ids_json"] = json.dumps(frame._channel_ids)
+        f.attrs[OPERATION_SUMMARIES_SCHEMA_ATTR] = OPERATION_SUMMARIES_SCHEMA_VERSION
+        f.attrs[OPERATION_SUMMARIES_JSON_ATTR] = json.dumps(operation_summaries, allow_nan=False)
 
         # Create channels group
         channels_grp = f.create_group("channels")
@@ -220,6 +246,8 @@ def load(path: str | Path, *, format: str = "hdf5", timeout: float = 10.0) -> "C
             if source_file is not None:
                 frame_metadata.setdefault("_source_file", _decode_hdf5_str(source_file))
 
+        operation_summaries_snapshot = _load_operation_summaries_snapshot(f)
+
         # Load channel data and metadata
         all_channel_data = []
         channel_metadata_list = []
@@ -288,6 +316,7 @@ def load(path: str | Path, *, format: str = "hdf5", timeout: float = 10.0) -> "C
             channel_metadata=channel_metadata_list,
             channel_ids=channel_ids,
             source_time_offset=source_time_offset,
+            operation_summaries_snapshot=operation_summaries_snapshot,
         )
 
         logger.debug(f"ChannelFrame loaded from {path}: {len(cf)} channels, {cf.n_samples} samples")


### PR DESCRIPTION
## Summary
- Add display-only operation summary snapshots for `persist()` boundaries.
- Save and load WDF operation summaries as schema-versioned JSON root attributes.
- Preserve the existing boundary that WDF load restores summaries only, not executable lineage, `operations`, or legacy `operation_history`.
- Document the #245 snapshot boundary design.

## Design Notes
- `operation_summaries` remains display-only and JSON-safe.
- Recipe persistence remains out of scope and tracked separately by #257.
- Legacy WDF `operation_history` groups remain ignored rather than translated.
- Snapshot-backed frames carry display summaries forward across follow-up operations without restoring executable lineage.

## Review Follow-up
- Added persist-boundary coverage for custom operation summaries and multi-input summaries.
- Added WDF round-trip coverage for custom operation summaries and multi-input summaries.
- Moved operation summary validation before opening/truncating WDF output.
- Preserved loaded display summaries across unary, binary, channel-update, add-channel, SNR-add, domain-transition, inverse-transform, STFT-frame extraction, roughness-spec, and RoughnessFrame binary follow-up operations.
- Kept snapshot-backed `__getitem__` display summaries from leaking internal temporary `get_channel` selections.
- Kept implicit SNR `fix_length()` resizing out of display summaries while preserving the public `add_with_snr` lineage.
- Refreshed snapshot-backed display summaries when in-place channel updates mutate lineage.

## Validation
- `uv run pytest tests/frames/test_roughness_frame.py::TestRoughnessFrame::test_binary_op_preserves_snapshot_backed_operation_summaries tests/frames/test_roughness_frame.py::TestRoughnessFrame::test_binary_op_merges_snapshot_backed_roughness_frame_input_summaries -q` -> 2 passed
- `uv run pytest tests/core/test_base_frame_lineage.py tests/io/test_wdf_io.py tests/core/test_base_frame.py tests/core/test_base_frame_additional.py tests/frames/test_channel_label_updates.py tests/frames/test_channel_frame.py tests/frames/test_channel_additional.py tests/core/test_xarray_storage_only.py tests/frames/test_channel_transform.py tests/frames/test_channel_processing.py tests/frames/test_spectral_frame.py tests/frames/test_spectrogram_frame.py tests/frames/test_roughness_frame.py -q` -> 734 passed, 7 existing warnings
- `uv run ruff check wandas tests --config=pyproject.toml` -> All checks passed
- `uv run ty check wandas tests` -> All checks passed

Closes #245