### PR TITLE
[codex] Unify Recipe graph default input names

### DIFF
--- a/docs/src/explanation/pipeline-recipe-extraction-boundaries.md
+++ b/docs/src/explanation/pipeline-recipe-extraction-boundaries.md
@@ -46,7 +46,7 @@ Issue #259 is satisfied by the current replay-intent contract:
 
 The remaining larger graph-model decisions are follow-up work:
 
-- Recipe input-name inference for graph recipes is tracked by #263.
+- Graph recipe input-name inference is intentionally avoided; omitted names use mechanical `input_0`, `input_1`, ... defaults.
 - True DAG identity / shared branch graph recipes are tracked by #264.
 - Automatic graph recipe dispatch from `RecipeSpec.from_frame(...)` is tracked by #265.
 
@@ -229,7 +229,7 @@ Implemented:
 - `GraphRecipeSpec.from_frame(processed, input_names=("signal", "noise"))` for root frame-frame binary / `add_with_snr` graphs with two linear parents
 - `GraphRecipeSpec.from_frame(processed, input_names=("signal", "noise"))` for a single binary merge followed by a replayable linear tail, such as `(signal.normalize() + noise.remove_dc()).stft()`
 - `GraphRecipeSpec.from_frame(processed, input_names=("signal", "noise"))` when one or both binary parents are unprocessed source frames
-- `GraphRecipeSpec.from_frame(processed)` with default structural input names `left` and `right`
+- `GraphRecipeSpec.from_frame(processed)` with default structural input names `input_0` and `input_1`
 - `NodeGraphRecipeSpec.from_frame(processed)` for replayable tree graphs with multiple binary merges
 - `NodeGraphRecipeSpec.from_frame(processed, input_names=("base", "base"))` for duplicated parent paths replayed from the same external input
 - `NodeGraphRecipeSpec.from_frame(processed, input_names=("base", "added"))` for `base.add_channel(added_frame, ...)`
@@ -267,7 +267,7 @@ BinaryOperandStep(operation="+", frame="signal", operand="offset")
 
 `ScalarOperationStep` は既存 frame operator を呼ぶだけで、二項演算の metadata/history/Dask laziness は frame 本体に委譲する。対応 operand は operation graph に値として保存された Python / NumPy real scalar に限定する。NaN は recipe equality が安定しないため拒否する。`2 - frame` のように scalar が左辺にある場合は `reverse=True` を保存し、`frame - 2` と取り違えない。
 
-`GraphRecipeSpec` は名前付き入力ごとに linear `RecipeSpec` を適用し、`BinaryFrameStep` で既存 frame-frame 演算を呼び、その後に optional な linear `tail_recipe` を適用する。`from_frame(..., input_names=...)` は 1 回だけ merge する graph だけを対象にし、入力名は呼び出し側が与える。`input_names` を省略した場合は、Python 変数名や frame label ではなく、構造上の左右を表す `left` / `right` を使う。tail は既存 `RecipeSpec` step で表現するため、merge 後の `normalize()`、`trim()`、`stft()` のような replayable operation / method / typed method は同じ仕組みで扱う。
+`GraphRecipeSpec` は名前付き入力ごとに linear `RecipeSpec` を適用し、`BinaryFrameStep` で既存 frame-frame 演算を呼び、その後に optional な linear `tail_recipe` を適用する。`from_frame(..., input_names=...)` は 1 回だけ merge する graph だけを対象にし、入力名は呼び出し側が与える。`input_names` を省略した場合は、Python 変数名、frame label、channel label、metadata から名前を推定せず、source leaf の順番に基づく `input_0` / `input_1` を使う。二項演算では `input_0` が左 operand、`input_1` が右 operand であり、`input_0 - input_1` のような非可換演算でも順序を保つ。tail は既存 `RecipeSpec` step で表現するため、merge 後の `normalize()`、`trim()`、`stft()` のような replayable operation / method / typed method は同じ仕組みで扱う。
 
 For `add_with_snr`, Recipe stores the two frame inputs and the public `snr` value. If the runtime method internally adjusts the noise length, that helper operation is not extracted as a separate `fix_length` step. Replay calls `frame.add(other, snr=...)`, so the current inputs decide any length alignment.
 
@@ -283,7 +283,7 @@ For `add_with_snr`, Recipe stores the two frame inputs and the public `snr` valu
 
 Not implemented yet:
 
-- Python 変数名や frame label に基づく入力名推定。現在の runtime lineage は source identity を保存しないため、名前推定は `left` / `right` の構造名に限定する。
+- 名前推定は行わず、Python 変数名、frame label、channel label、metadata は見ない。省略時は source leaf の順番に基づく `input_0` / `input_1` / ... の機械的な名前だけを使う。
 - `RecipeSpec.from_frame(frame_a + frame_b)` が graph recipe を返すこと。`RecipeSpec` は単一入力・直列 recipe のままとし、複数入力 graph は `GraphRecipeSpec.from_frame(...)` で抽出する。
 - 入力名を推定する `RecipeSpec.from_frame(signal.add(noise, snr=6.0))` の自動 graph 抽出
 - true DAG identity を持つ shared branch graph。現在は tree として duplicated parent path を replay する。

--- a/docs/src/how-to/pipeline-recipes.md
+++ b/docs/src/how-to/pipeline-recipes.md
@@ -137,7 +137,7 @@ replayed = graph_recipe.apply(
 )
 ```
 
-`input_names` are explicit because runtime lineage does not know Python variable names.
+`input_names` are explicit because runtime lineage does not know Python variable names, and graph recipes do not infer names from frame labels, channel labels, or metadata. If omitted, graph recipes use source leaf order to assign mechanical names such as `input_0` and `input_1`; for binary frame recipes, `input_0` is the left operand and `input_1` is the right operand.
 
 Use `NodeGraphRecipeSpec` for more general tree-shaped graphs:
 
@@ -318,7 +318,7 @@ These are the user-facing categories to remember:
 | Boundary category | Alternative |
 | --- | --- |
 | Multi-input work through `RecipeSpec.from_frame(...)` | Use `GraphRecipeSpec.from_frame(...)` or `NodeGraphRecipeSpec.from_frame(...)`. |
-| Implicit runtime names or values | Pass explicit `input_names=(...)` and runtime inputs. |
+| Semantic runtime names or values | Pass explicit `input_names=(...)` and runtime inputs; omitted names are source-order mechanical `input_0`, `input_1`, ... labels, not inferred from frame/channel metadata. |
 | Selection/indexing forms that cannot be replayed by intent | Use supported literal selections, or keep the operation outside recipe extraction. |
 | Non-importable custom code | Move the function to an importable module-level function. |
 | Terminal NumPy arrays without lineage | Build a recipe with an explicit `TerminalStep`. |

--- a/docs/superpowers/plans/2026-07-05-recipe-input-name-defaults.md
+++ b/docs/superpowers/plans/2026-07-05-recipe-input-name-defaults.md
@@ -1,0 +1,391 @@
+# Recipe Input Name Defaults Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close #263 by making omitted graph Recipe input names consistently default to `input_0`, `input_1`, ... instead of mixing `left`/`right` with `input_n`.
+
+**Architecture:** Keep name generation local to graph Recipe extraction. `GraphRecipeSpec.from_frame(..., input_names=None)` should use the same mechanical naming style already used by `NodeGraphRecipeSpec.from_frame(...)`; explicit `input_names` remains unchanged and remains the recommended user-facing path.
+
+**Tech Stack:** Python 3.10, Wandas `wandas.pipeline.specs`, pytest, MkDocs, `uv run ruff`, `uv run ty`.
+
+---
+
+## File Structure
+
+- `wandas/pipeline/specs.py`: change the default name resolution in `GraphRecipeSpec.from_frame(...)`.
+- `tests/pipeline/test_recipe.py`: update default-name tests and add one non-commutative order test.
+- `docs/src/explanation/pipeline-recipe-extraction-boundaries.md`: document `input_0` / `input_1` default names and no semantic inference.
+- `docs/src/how-to/pipeline-recipes.md`: update user-facing guidance for omitted and explicit `input_names`.
+- `docs/superpowers/specs/2026-07-05-recipe-input-name-defaults-design.md`: already created design reference.
+
+### Task 1: Pin GraphRecipeSpec Default Input Names
+
+**Files:**
+- Modify: `tests/pipeline/test_recipe.py`
+
+- [ ] **Step 1: Rename and update the existing GraphRecipeSpec default-name test**
+
+Replace the full body of `test_graph_recipe_from_frame_uses_default_structural_input_names` with:
+
+```python
+def test_graph_recipe_from_frame_uses_numbered_default_input_names() -> None:
+    base = _frame()
+    left_source = ChannelFrame.from_numpy(base.data, sampling_rate=base.sampling_rate, label="signal")
+    right_source = ChannelFrame.from_numpy(base.data * 0.25, sampling_rate=base.sampling_rate, label="noise")
+    processed = left_source.remove_dc() + right_source.high_pass_filter(cutoff=500.0)
+
+    graph_recipe = GraphRecipeSpec.from_frame(processed)
+    replayed = graph_recipe.apply({"input_0": left_source, "input_1": right_source})
+
+    assert graph_recipe.input_recipes == (
+        ("input_0", RecipeSpec([OperationSpec("remove_dc")])),
+        ("input_1", RecipeSpec([OperationSpec("highpass_filter", {"cutoff": 500.0, "order": 4})])),
+    )
+    assert graph_recipe.output == BinaryFrameStep("+", "input_0", "input_1")
+    np.testing.assert_allclose(replayed.data, processed.data)
+    assert replayed.operation_history == processed.operation_history
+```
+
+- [ ] **Step 2: Update raw add-with-SNR default-name test**
+
+Replace the full body of `test_graph_recipe_from_frame_uses_default_names_for_raw_add_with_snr` with:
+
+```python
+def test_graph_recipe_from_frame_uses_numbered_default_names_for_raw_add_with_snr() -> None:
+    base = _frame()
+    signal_source = ChannelFrame.from_numpy(base.data, sampling_rate=base.sampling_rate, label="signal")
+    noise_source = ChannelFrame.from_numpy(np.flip(base.data), sampling_rate=base.sampling_rate, label="noise")
+    processed = signal_source.add(noise_source, snr=6.0)
+
+    graph_recipe = GraphRecipeSpec.from_frame(processed)
+    replayed = graph_recipe.apply({"input_0": signal_source, "input_1": noise_source})
+
+    assert graph_recipe.input_recipes == (("input_0", RecipeSpec(())), ("input_1", RecipeSpec(())))
+    assert graph_recipe.output == BinaryFrameStep("add_with_snr", "input_0", "input_1", {"snr": 6.0})
+    np.testing.assert_allclose(replayed.data, processed.data)
+    assert replayed.operation_history == processed.operation_history
+```
+
+- [ ] **Step 3: Update typed-tail default-name test**
+
+Replace the default-name assertions and replay call inside `test_graph_recipe_from_frame_uses_default_names_with_typed_tail` so the function body becomes:
+
+```python
+def test_graph_recipe_from_frame_uses_numbered_default_names_with_typed_tail() -> None:
+    base = _frame()
+    left_source = ChannelFrame.from_numpy(base.data, sampling_rate=base.sampling_rate, label="signal")
+    right_source = ChannelFrame.from_numpy(base.data * 0.25, sampling_rate=base.sampling_rate, label="noise")
+    processed = (left_source + right_source).stft(
+        n_fft=512,
+        hop_length=128,
+        win_length=512,
+        window="hann",
+    )
+
+    graph_recipe = GraphRecipeSpec.from_frame(processed)
+    replayed = graph_recipe.apply({"input_0": left_source, "input_1": right_source})
+
+    assert graph_recipe.input_recipes == (("input_0", RecipeSpec(())), ("input_1", RecipeSpec(())))
+    assert graph_recipe.output == BinaryFrameStep("+", "input_0", "input_1")
+    assert graph_recipe.tail_recipe == RecipeSpec(
+        [TypedMethodStep("stft", {"n_fft": 512, "hop_length": 128, "win_length": 512, "window": "hann"})]
+    )
+    np.testing.assert_allclose(replayed.data, processed.data)
+    assert isinstance(replayed, SpectrogramFrame)
+```
+
+- [ ] **Step 4: Add a non-commutative order test**
+
+Add this test after the default add-with-SNR test:
+
+```python
+def test_graph_recipe_numbered_default_names_preserve_binary_operand_order() -> None:
+    base = _frame()
+    signal_source = ChannelFrame.from_numpy(base.data, sampling_rate=base.sampling_rate, label="signal")
+    noise_source = ChannelFrame.from_numpy(base.data * 0.25, sampling_rate=base.sampling_rate, label="noise")
+    processed = signal_source.remove_dc() - noise_source.normalize()
+
+    graph_recipe = GraphRecipeSpec.from_frame(processed)
+    replayed = graph_recipe.apply({"input_0": signal_source, "input_1": noise_source})
+
+    assert graph_recipe.input_recipes == (
+        ("input_0", RecipeSpec([OperationSpec("remove_dc")])),
+        (
+            "input_1",
+            RecipeSpec(
+                [OperationSpec("normalize", {"axis": -1, "fill": None, "norm": float("inf"), "threshold": None})]
+            ),
+        ),
+    )
+    assert graph_recipe.output == BinaryFrameStep("-", "input_0", "input_1")
+    np.testing.assert_allclose(replayed.data, processed.data)
+    assert replayed.operation_history == processed.operation_history
+```
+
+- [ ] **Step 5: Run focused tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/pipeline/test_recipe.py::test_graph_recipe_from_frame_uses_numbered_default_input_names \
+  tests/pipeline/test_recipe.py::test_graph_recipe_from_frame_uses_numbered_default_names_for_raw_add_with_snr \
+  tests/pipeline/test_recipe.py::test_graph_recipe_numbered_default_names_preserve_binary_operand_order \
+  tests/pipeline/test_recipe.py::test_graph_recipe_from_frame_uses_numbered_default_names_with_typed_tail \
+  -q
+```
+
+Expected: failures showing current default names are still `left` / `right`.
+
+### Task 2: Change GraphRecipeSpec Default Names
+
+**Files:**
+- Modify: `wandas/pipeline/specs.py`
+- Test: `tests/pipeline/test_recipe.py`
+
+- [ ] **Step 1: Implement the default-name change**
+
+In `GraphRecipeSpec.from_frame(...)`, replace:
+
+```python
+resolved_input_names = ("left", "right") if input_names is None and len(inputs) == 2 else input_names
+```
+
+with:
+
+```python
+resolved_input_names = tuple(f"input_{index}" for index in range(len(inputs))) if input_names is None else input_names
+```
+
+- [ ] **Step 2: Run focused tests and verify they pass**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/pipeline/test_recipe.py::test_graph_recipe_from_frame_uses_numbered_default_input_names \
+  tests/pipeline/test_recipe.py::test_graph_recipe_from_frame_uses_numbered_default_names_for_raw_add_with_snr \
+  tests/pipeline/test_recipe.py::test_graph_recipe_numbered_default_names_preserve_binary_operand_order \
+  tests/pipeline/test_recipe.py::test_graph_recipe_from_frame_uses_numbered_default_names_with_typed_tail \
+  -q
+```
+
+Expected: `4 passed`.
+
+- [ ] **Step 3: Run nearby GraphRecipeSpec tests**
+
+Run:
+
+```bash
+uv run pytest tests/pipeline/test_recipe.py -q
+```
+
+Expected: all tests in `tests/pipeline/test_recipe.py` pass.
+
+- [ ] **Step 4: Commit tests and implementation**
+
+Run:
+
+```bash
+git add wandas/pipeline/specs.py tests/pipeline/test_recipe.py
+git commit -m "fix: unify graph recipe default input names"
+```
+
+Expected: one commit containing only implementation and test changes.
+
+### Task 3: Update User And Boundary Docs
+
+**Files:**
+- Modify: `docs/src/explanation/pipeline-recipe-extraction-boundaries.md`
+- Modify: `docs/src/how-to/pipeline-recipes.md`
+
+- [ ] **Step 1: Update extraction-boundaries implemented list**
+
+In `docs/src/explanation/pipeline-recipe-extraction-boundaries.md`, replace:
+
+```markdown
+- `GraphRecipeSpec.from_frame(processed)` with default structural input names `left` and `right`
+```
+
+with:
+
+```markdown
+- `GraphRecipeSpec.from_frame(processed)` with default structural input names `input_0` and `input_1`
+```
+
+- [ ] **Step 2: Update GraphRecipeSpec explanation paragraph**
+
+Replace the sentence:
+
+```markdown
+`input_names` を省略した場合は、Python 変数名や frame label ではなく、構造上の左右を表す `left` / `right` を使う。
+```
+
+with:
+
+```markdown
+`input_names` を省略した場合は、Python 変数名や frame label ではなく、source leaf の順番に基づく `input_0` / `input_1` を使う。二項演算では `input_0` が左 operand、`input_1` が右 operand であり、`input_0 - input_1` のような非可換演算でも順序を保つ。
+```
+
+- [ ] **Step 3: Update not-implemented naming bullet**
+
+Replace:
+
+```markdown
+- Python 変数名や frame label に基づく入力名推定。現在の runtime lineage は source identity を保存しないため、名前推定は `left` / `right` の構造名に限定する。
+```
+
+with:
+
+```markdown
+- Python 変数名や frame label に基づく入力名推定。現在の runtime lineage は source identity を保存しないため、名前推定は行わず、省略時は `input_0` / `input_1` / ... の機械的な名前だけを使う。
+```
+
+- [ ] **Step 4: Add a default-name note to the how-to Graph Recipes section**
+
+In `docs/src/how-to/pipeline-recipes.md`, replace:
+
+```markdown
+`input_names` are explicit because runtime lineage does not know Python variable names.
+```
+
+with:
+
+```markdown
+`input_names` are explicit because runtime lineage does not know Python variable names. If omitted, graph recipes use mechanical names such as `input_0` and `input_1`; for binary frame recipes, `input_0` is the left operand and `input_1` is the right operand.
+```
+
+- [ ] **Step 5: Update unsupported boundary table wording**
+
+In `docs/src/how-to/pipeline-recipes.md`, replace:
+
+```markdown
+| Implicit runtime names or values | Pass explicit `input_names=(...)` and runtime inputs. |
+```
+
+with:
+
+```markdown
+| Semantic runtime names or values | Pass explicit `input_names=(...)` and runtime inputs; omitted names are mechanical `input_0`, `input_1`, ... labels. |
+```
+
+- [ ] **Step 6: Run docs build**
+
+Run:
+
+```bash
+uv run mkdocs build -f docs/mkdocs.yml
+```
+
+Expected: documentation builds successfully.
+
+- [ ] **Step 7: Commit docs**
+
+Run:
+
+```bash
+git add docs/src/explanation/pipeline-recipe-extraction-boundaries.md docs/src/how-to/pipeline-recipes.md
+git commit -m "docs: clarify graph recipe input name defaults"
+```
+
+Expected: one docs commit.
+
+### Task 4: Final Verification And PR
+
+**Files:**
+- No new files expected beyond previous tasks.
+
+- [ ] **Step 1: Run full Recipe tests**
+
+Run:
+
+```bash
+uv run pytest tests/pipeline/test_recipe.py -q
+```
+
+Expected: all tests in `tests/pipeline/test_recipe.py` pass.
+
+- [ ] **Step 2: Run docs build**
+
+Run:
+
+```bash
+uv run mkdocs build -f docs/mkdocs.yml
+```
+
+Expected: documentation builds successfully.
+
+- [ ] **Step 3: Run lint and type checks**
+
+Run:
+
+```bash
+uv run ruff check
+uv run ty check
+```
+
+Expected:
+
+- `uv run ruff check` passes.
+- If full `uv run ty check` still reports unrelated diagnostics in `learning-path/07_frame_centric_recipe_ux.py`, run and record:
+
+```bash
+uv run ty check wandas tests/pipeline/test_recipe.py
+```
+
+Expected for the diff-scope check: `All checks passed!`.
+
+- [ ] **Step 4: Run whitespace check and clean generated artifacts**
+
+Run:
+
+```bash
+git diff --check
+rm -rf .coverage .pytest_cache .ruff_cache coverage.xml docs/site tests/__pycache__ tests/pipeline/__pycache__ wandas/__pycache__ wandas/core/__pycache__ wandas/frames/__pycache__ wandas/frames/mixins/__pycache__ wandas/io/__pycache__ wandas/pipeline/__pycache__ wandas/processing/__pycache__ wandas/utils/__pycache__
+git status --short --branch --ignored
+```
+
+Expected: `git diff --check` has no output, and final status shows no generated artifacts.
+
+- [ ] **Step 5: Push and open PR**
+
+Run:
+
+```bash
+git push -u origin codex/issue-263-input-names
+gh pr create --repo kasahart/wandas \
+  --base develop \
+  --head codex/issue-263-input-names \
+  --title "[codex] Unify Recipe graph default input names" \
+  --body "## Summary
+- Change omitted GraphRecipeSpec input names from left/right to input_0/input_1.
+- Keep explicit input_names behavior unchanged and keep NodeGraphRecipeSpec defaults aligned.
+- Document that Wandas does not infer semantic input names from Python variables or frame labels.
+
+## Issue Relationship
+Closes #263
+Related #264
+Related #265
+Related #257
+Related #258
+
+## Validation
+- \`uv run pytest tests/pipeline/test_recipe.py -q\`
+- \`uv run mkdocs build -f docs/mkdocs.yml\`
+- \`uv run ruff check\`
+- \`uv run ty check\` or documented diff-scope \`uv run ty check wandas tests/pipeline/test_recipe.py\`
+- \`git diff --check\`"
+```
+
+Expected: PR URL is printed.
+
+- [ ] **Step 6: Confirm PR state and SHA alignment**
+
+Run:
+
+```bash
+gh pr view --repo kasahart/wandas --json number,state,isDraft,url,headRefOid,statusCheckRollup,reviewRequests,reviewDecision
+git rev-parse HEAD origin/codex/issue-263-input-names
+```
+
+Expected: PR is open, local/remote/PR head SHAs match, and checks are queued or successful.

--- a/docs/superpowers/specs/2026-07-05-recipe-input-name-defaults-design.md
+++ b/docs/superpowers/specs/2026-07-05-recipe-input-name-defaults-design.md
@@ -1,0 +1,116 @@
+# Recipe Input Name Defaults Design
+
+## Goal
+
+Close issue #263 by making graph Recipe input naming easier to explain and safer to replay.
+
+The current implementation has two default naming styles:
+
+- `GraphRecipeSpec.from_frame(processed)` uses `left` and `right`.
+- `NodeGraphRecipeSpec.from_frame(processed)` uses `input_0`, `input_1`, and so on.
+
+This is confusing because `left` and `right` can also mean audio channel labels, while Recipe graph inputs are external runtime inputs. The default names should be mechanical and consistent across graph recipe types.
+
+## Decision
+
+Do not infer semantic input names from Python variable names, frame labels, channel labels, or source metadata in this issue.
+
+Instead, unify omitted `input_names` defaults:
+
+- `GraphRecipeSpec.from_frame(..., input_names=None)` uses `input_0` and `input_1`.
+- `NodeGraphRecipeSpec.from_frame(..., input_names=None)` continues to use `input_0`, `input_1`, ...
+- The order is the operation-graph source order. For a binary expression, `input_0` is the left operand and `input_1` is the right operand.
+- Users who want readable names should pass explicit `input_names=("signal", "noise")`.
+
+## Why Not Infer Names Yet
+
+Runtime lineage does not preserve Python variable names. Frame labels and channel labels are not the same as graph input names:
+
+- a frame can contain multiple channels with labels such as `left` or `right`;
+- multiple different frames can share the same frame label;
+- array operands and raw `add_channel` data do not have frame labels;
+- generated names must be stable enough to serialize and replay later.
+
+Inferring names from unstable or ambiguous metadata would make a Recipe look more user-friendly while weakening the replay contract.
+
+## UX Contract
+
+The default names are intentionally plain:
+
+```python
+recipe = GraphRecipeSpec.from_frame(signal + noise)
+replayed = recipe.apply({"input_0": new_signal, "input_1": new_noise})
+```
+
+Readable names remain explicit:
+
+```python
+recipe = GraphRecipeSpec.from_frame(
+    signal + noise,
+    input_names=("signal", "noise"),
+)
+replayed = recipe.apply({"signal": new_signal, "noise": new_noise})
+```
+
+This keeps the default API usable without pretending Wandas knows semantic names that were never recorded.
+
+## Implementation Scope
+
+Change only the default naming contract:
+
+1. Update `GraphRecipeSpec.from_frame(...)` so omitted `input_names` resolves to `("input_0", "input_1")`.
+2. Keep explicit `input_names` behavior unchanged.
+3. Keep `NodeGraphRecipeSpec.from_frame(...)` default behavior unchanged.
+4. Update tests that currently expect `left` / `right` defaults.
+5. Add or update docs to state that no semantic name inference happens yet.
+
+## Compatibility
+
+This is a behavior change for callers who relied on omitted `GraphRecipeSpec` names and then applied recipes with `{"left": ..., "right": ...}`.
+
+The change is acceptable because:
+
+- `GraphRecipeSpec.from_frame(..., input_names=None)` is recent prototype API;
+- explicit `input_names=("left", "right")` still supports the previous spelling;
+- the new default aligns with existing `NodeGraphRecipeSpec` behavior and avoids channel-name ambiguity.
+
+## Error Handling
+
+No new error type is needed.
+
+Existing validation remains:
+
+- explicit `input_names` must have one name per parent;
+- `GraphRecipeSpec` explicit names must be distinct;
+- `NodeGraphRecipeSpec` external input names must be unique after duplicate source paths are collapsed by order-preserving uniqueness;
+- empty or non-string names continue to fail.
+
+## Testing
+
+Focused tests should prove:
+
+- `GraphRecipeSpec.from_frame(processed)` defaults to `input_0` / `input_1`;
+- binary operand order is preserved for non-commutative operations such as subtraction;
+- frame labels such as `"signal"` and `"noise"` are not inferred as Recipe input names;
+- explicit `input_names=("signal", "noise")` still works;
+- `NodeGraphRecipeSpec.from_frame(processed)` still defaults to `input_0`, `input_1`, ...
+
+## Documentation
+
+Update the how-to and extraction-boundaries docs:
+
+- Replace `left` / `right` default examples with `input_0` / `input_1`.
+- Explain that `input_0` is the left operand and `input_1` is the right operand for binary graph recipes.
+- Recommend explicit `input_names` for user-facing or persisted recipes.
+- State that Python variable-name and frame-label inference is outside the current contract.
+
+## Issue Closure
+
+The PR should use `Closes #263`.
+
+It should not close:
+
+- #264, true DAG identity;
+- #265, automatic graph recipe dispatch from `RecipeSpec.from_frame(...)`;
+- #257, WDF persistence;
+- #258, interoperability/export.

--- a/tests/pipeline/test_recipe.py
+++ b/tests/pipeline/test_recipe.py
@@ -600,20 +600,20 @@ def test_graph_recipe_from_frame_extracts_root_frame_addition_with_input_names()
     assert replayed.operation_history == processed.operation_history
 
 
-def test_graph_recipe_from_frame_uses_default_structural_input_names() -> None:
+def test_graph_recipe_from_frame_uses_numbered_default_input_names() -> None:
     base = _frame()
     left_source = ChannelFrame.from_numpy(base.data, sampling_rate=base.sampling_rate, label="signal")
     right_source = ChannelFrame.from_numpy(base.data * 0.25, sampling_rate=base.sampling_rate, label="noise")
     processed = left_source.remove_dc() + right_source.high_pass_filter(cutoff=500.0)
 
     graph_recipe = GraphRecipeSpec.from_frame(processed)
-    replayed = graph_recipe.apply({"left": left_source, "right": right_source})
+    replayed = graph_recipe.apply({"input_0": left_source, "input_1": right_source})
 
     assert graph_recipe.input_recipes == (
-        ("left", RecipeSpec([OperationSpec("remove_dc")])),
-        ("right", RecipeSpec([OperationSpec("highpass_filter", {"cutoff": 500.0, "order": 4})])),
+        ("input_0", RecipeSpec([OperationSpec("remove_dc")])),
+        ("input_1", RecipeSpec([OperationSpec("highpass_filter", {"cutoff": 500.0, "order": 4})])),
     )
-    assert graph_recipe.output == BinaryFrameStep("+", "left", "right")
+    assert graph_recipe.output == BinaryFrameStep("+", "input_0", "input_1")
     np.testing.assert_allclose(replayed.data, processed.data)
     assert replayed.operation_history == processed.operation_history
 
@@ -721,17 +721,40 @@ def test_graph_recipe_add_with_snr_serializes_snr_without_implicit_fix_length_st
     }
 
 
-def test_graph_recipe_from_frame_uses_default_names_for_raw_add_with_snr() -> None:
+def test_graph_recipe_from_frame_uses_numbered_default_names_for_raw_add_with_snr() -> None:
     base = _frame()
     signal_source = ChannelFrame.from_numpy(base.data, sampling_rate=base.sampling_rate, label="signal")
     noise_source = ChannelFrame.from_numpy(np.flip(base.data), sampling_rate=base.sampling_rate, label="noise")
     processed = signal_source.add(noise_source, snr=6.0)
 
     graph_recipe = GraphRecipeSpec.from_frame(processed)
-    replayed = graph_recipe.apply({"left": signal_source, "right": noise_source})
+    replayed = graph_recipe.apply({"input_0": signal_source, "input_1": noise_source})
 
-    assert graph_recipe.input_recipes == (("left", RecipeSpec(())), ("right", RecipeSpec(())))
-    assert graph_recipe.output == BinaryFrameStep("add_with_snr", "left", "right", {"snr": 6.0})
+    assert graph_recipe.input_recipes == (("input_0", RecipeSpec(())), ("input_1", RecipeSpec(())))
+    assert graph_recipe.output == BinaryFrameStep("add_with_snr", "input_0", "input_1", {"snr": 6.0})
+    np.testing.assert_allclose(replayed.data, processed.data)
+    assert replayed.operation_history == processed.operation_history
+
+
+def test_graph_recipe_numbered_default_names_preserve_binary_operand_order() -> None:
+    base = _frame()
+    signal_source = ChannelFrame.from_numpy(base.data, sampling_rate=base.sampling_rate, label="signal")
+    noise_source = ChannelFrame.from_numpy(base.data * 0.25, sampling_rate=base.sampling_rate, label="noise")
+    processed = signal_source.remove_dc() - noise_source.normalize()
+
+    graph_recipe = GraphRecipeSpec.from_frame(processed)
+    replayed = graph_recipe.apply({"input_0": signal_source, "input_1": noise_source})
+
+    assert graph_recipe.input_recipes == (
+        ("input_0", RecipeSpec([OperationSpec("remove_dc")])),
+        (
+            "input_1",
+            RecipeSpec(
+                [OperationSpec("normalize", {"axis": -1, "fill": None, "norm": float("inf"), "threshold": None})]
+            ),
+        ),
+    )
+    assert graph_recipe.output == BinaryFrameStep("-", "input_0", "input_1")
     np.testing.assert_allclose(replayed.data, processed.data)
     assert replayed.operation_history == processed.operation_history
 
@@ -818,7 +841,7 @@ def test_graph_recipe_from_frame_extracts_single_merge_with_typed_tail() -> None
     assert isinstance(replayed, SpectrogramFrame)
 
 
-def test_graph_recipe_from_frame_uses_default_names_with_typed_tail() -> None:
+def test_graph_recipe_from_frame_uses_numbered_default_names_with_typed_tail() -> None:
     base = _frame()
     left_source = ChannelFrame.from_numpy(base.data, sampling_rate=base.sampling_rate, label="signal")
     right_source = ChannelFrame.from_numpy(base.data * 0.25, sampling_rate=base.sampling_rate, label="noise")
@@ -830,10 +853,10 @@ def test_graph_recipe_from_frame_uses_default_names_with_typed_tail() -> None:
     )
 
     graph_recipe = GraphRecipeSpec.from_frame(processed)
-    replayed = graph_recipe.apply({"left": left_source, "right": right_source})
+    replayed = graph_recipe.apply({"input_0": left_source, "input_1": right_source})
 
-    assert graph_recipe.input_recipes == (("left", RecipeSpec(())), ("right", RecipeSpec(())))
-    assert graph_recipe.output == BinaryFrameStep("+", "left", "right")
+    assert graph_recipe.input_recipes == (("input_0", RecipeSpec(())), ("input_1", RecipeSpec(())))
+    assert graph_recipe.output == BinaryFrameStep("+", "input_0", "input_1")
     assert graph_recipe.tail_recipe == RecipeSpec(
         [TypedMethodStep("stft", {"n_fft": 512, "hop_length": 128, "win_length": 512, "window": "hann"})]
     )

--- a/wandas/pipeline/specs.py
+++ b/wandas/pipeline/specs.py
@@ -151,7 +151,9 @@ class GraphRecipeSpec:
 
         merge_graph, tail_steps = _split_graph_at_binary_merge(cast(Mapping[str, Any], graph))
         inputs = tuple(merge_graph.get("inputs", ()))
-        resolved_input_names = ("left", "right") if input_names is None and len(inputs) == 2 else input_names
+        resolved_input_names = (
+            tuple(f"input_{index}" for index in range(len(inputs))) if input_names is None else input_names
+        )
         if len(inputs) != 2 or resolved_input_names is None or len(resolved_input_names) != 2:
             raise RecipeExtractionError(
                 "GraphRecipeSpec extraction requires one input name per parent\n"


### PR DESCRIPTION
## Summary
- Change `GraphRecipeSpec.from_frame(..., input_names=None)` to use source-order mechanical defaults: `input_0`, `input_1`, ...
- Document that graph recipe names are not inferred from Python variables, frame labels, channel labels, or metadata.
- Add regression coverage for default naming, raw `add_with_snr`, typed-tail replay, and binary operand order.

## Validation
- `uv run pytest tests/pipeline/test_recipe.py -q` (228 passed)
- `uv run mkdocs build -f docs/mkdocs.yml --strict --site-dir /tmp/wandas-docs-final`
- `uv run ruff check wandas tests --config=pyproject.toml`
- `uv run ty check wandas tests`

Closes #263
Related #264
Related #265
Related #257
Related #258