### PR TITLE
[codex] Clarify Recipe dispatch boundary

### DIFF
--- a/docs/src/explanation/pipeline-recipe-developer-guide.md
+++ b/docs/src/explanation/pipeline-recipe-developer-guide.md
@@ -196,7 +196,7 @@ Common messages:
 
 | Error theme | Meaning | Usual next step |
 | --- | --- | --- |
-| "Graph operation requires graph recipe support" | A linear `RecipeSpec` saw multiple parents. | Use `GraphRecipeSpec.from_frame(...)` or `NodeGraphRecipeSpec.from_frame(...)`. |
+| "RecipeSpec.from_frame(...) cannot extract graph lineage as a linear recipe" | A linear `RecipeSpec` saw graph or multi-input lineage. | Use `GraphRecipeSpec.from_frame(...)` or `NodeGraphRecipeSpec.from_frame(...)`. |
 | "Operation is outside the Stage 1 recipe allowlist" | The operation is registered, but not yet declared replayable. | Confirm replay semantics, then add allowlist/tests/docs. |
 | "Typed operation requires frame method lineage" | A typed transform was called through a generic operation path. | Use the public method, or define a new typed extraction rule. |
 | "Custom operation recipe extraction requires importable..." | The callable or output shape function cannot be imported by module path. | Move the function into an importable module-level function. |

--- a/docs/src/explanation/pipeline-recipe-extraction-boundaries.md
+++ b/docs/src/explanation/pipeline-recipe-extraction-boundaries.md
@@ -48,7 +48,7 @@ The remaining larger graph-model decisions are follow-up work:
 
 - Graph recipe input-name inference is intentionally avoided; omitted names use mechanical `input_0`, `input_1`, ... defaults.
 - True DAG identity / shared branch graph recipes are tracked by #264.
-- Automatic graph recipe dispatch from `RecipeSpec.from_frame(...)` is tracked by #265.
+- Automatic graph recipe dispatch is intentionally deferred. `RecipeSpec.from_frame(...)` remains linear-only; a future higher-level factory may provide explicit union-return dispatch.
 
 WDF Recipe persistence remains tracked by #257. Recipe interoperability and export remain tracked by #258.
 
@@ -284,8 +284,8 @@ For `add_with_snr`, Recipe stores the two frame inputs and the public `snr` valu
 Not implemented yet:
 
 - 名前推定は行わず、Python 変数名、frame label、channel label、metadata は見ない。省略時は source leaf の順番に基づく `input_0` / `input_1` / ... の機械的な名前だけを使う。
-- `RecipeSpec.from_frame(frame_a + frame_b)` が graph recipe を返すこと。`RecipeSpec` は単一入力・直列 recipe のままとし、複数入力 graph は `GraphRecipeSpec.from_frame(...)` で抽出する。
-- 入力名を推定する `RecipeSpec.from_frame(signal.add(noise, snr=6.0))` の自動 graph 抽出
+- `RecipeSpec.from_frame(frame_a + frame_b)` が graph recipe を返すことは現時点では行わない。`RecipeSpec` は単一入力・直列 recipe のままとし、複数入力 graph は `GraphRecipeSpec.from_frame(...)` または `NodeGraphRecipeSpec.from_frame(...)` で明示的に抽出する。
+- 将来の上位 factory による自動 graph 抽出。追加する場合も `RecipeSpec.from_frame(...)` の戻り値型は変えない。
 - true DAG identity を持つ shared branch graph。現在は tree として duplicated parent path を replay する。
 
 これらは直列 Recipe では表現できない。特に `operation_history` だけを見ると `normalize -> lowpass_filter -> add_with_snr` のように直列に見えることがあるが、`operation_graph` では複数 parent や外部 operand が必要である。array operand も shape、chunking、保存形式を Recipe 側で決める必要があるため、scalar operand と同じ扱いにはしない。

--- a/docs/src/how-to/pipeline-recipes.md
+++ b/docs/src/how-to/pipeline-recipes.md
@@ -301,6 +301,8 @@ Wandas Recipe remains the canonical representation. sklearn `Pipeline` is for in
 Most users should start with `RecipeSpec.from_frame(processed)`. Use this table only when the frame
 result crosses the single-input linear boundary or an integration layer requires another API.
 
+`RecipeSpec.from_frame(...)` is intentionally linear-only and does not automatically return `GraphRecipeSpec` or `NodeGraphRecipeSpec`. When a result has graph lineage, choose the graph recipe class explicitly. A future higher-level factory may add automatic dispatch without changing the `RecipeSpec.from_frame(...)` return type.
+
 | Your calculation | Recommended class | Example |
 | --- | --- | --- |
 | One input, linear frame result | `RecipeSpec` | `frame.remove_dc().normalize()` |
@@ -317,7 +319,7 @@ These are the user-facing categories to remember:
 
 | Boundary category | Alternative |
 | --- | --- |
-| Multi-input work through `RecipeSpec.from_frame(...)` | Use `GraphRecipeSpec.from_frame(...)` or `NodeGraphRecipeSpec.from_frame(...)`. |
+| Multi-input work through `RecipeSpec.from_frame(...)` | `RecipeSpec.from_frame(...)` stays linear-only; use `GraphRecipeSpec.from_frame(...)` or `NodeGraphRecipeSpec.from_frame(...)` explicitly. |
 | Semantic runtime names or values | Pass explicit `input_names=(...)` and runtime inputs; omitted names are source-order mechanical `input_0`, `input_1`, ... labels, not inferred from frame/channel metadata. |
 | Selection/indexing forms that cannot be replayed by intent | Use supported literal selections, or keep the operation outside recipe extraction. |
 | Non-importable custom code | Move the function to an importable module-level function. |

--- a/docs/src/tutorial/pipeline-recipe-requirements-check.ipynb
+++ b/docs/src/tutorial/pipeline-recipe-requirements-check.ipynb
@@ -477,7 +477,7 @@
                 "try:\n",
                 "    RecipeSpec.from_frame(bad_graph)\n",
                 "except RecipeExtractionError as exc:\n",
-                "    assert \"Graph operation requires graph recipe support\" in str(exc)\n",
+                "    assert \"RecipeSpec.from_frame(...) cannot extract graph lineage as a linear recipe\" in str(exc)\n",
                 "else:\n",
                 "    raise AssertionError(\"multi-input graph should use a graph recipe class\")\n",
                 "\n",

--- a/docs/superpowers/plans/2026-07-05-recipe-dispatch-contract.md
+++ b/docs/superpowers/plans/2026-07-05-recipe-dispatch-contract.md
@@ -1,0 +1,460 @@
+# Recipe Dispatch Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close #265 by keeping `RecipeSpec.from_frame(...)` linear-only while making graph-boundary failures actionable and documenting the future automatic-dispatch path.
+
+**Architecture:** `RecipeSpec.from_frame(...)` continues to call `_steps_from_graph(...)` and returns only `RecipeSpec`. Graph-boundary failures in `wandas/pipeline/extraction.py` will share one helper that points users to `GraphRecipeSpec.from_frame(...)` and `NodeGraphRecipeSpec.from_frame(...)`; explicit graph extractors remain unchanged. Docs will state that automatic dispatch is intentionally deferred and should be revisited through a future higher-level factory rather than by widening `RecipeSpec.from_frame(...)`.
+
+**Tech Stack:** Python 3.10, Wandas recipe pipeline classes, pytest, ruff, ty, MkDocs.
+
+---
+
+## File Structure
+
+- Modify `wandas/pipeline/extraction.py`
+  - Add a small private helper for `RecipeSpec.from_frame(...)` graph-boundary errors.
+  - Reuse it where linear extraction sees multi-input graph lineage or external graph operands.
+- Modify `tests/pipeline/test_recipe.py`
+  - Add focused tests that lock the linear-only return type and actionable graph guidance.
+  - Update existing graph-boundary message assertions from the older terse wording.
+- Modify `docs/src/how-to/pipeline-recipes.md`
+  - Add beginner-facing text that `RecipeSpec.from_frame(...)` does not automatically return graph recipe types.
+  - Keep explicit graph entry points as the recommended path.
+- Modify `docs/src/explanation/pipeline-recipe-extraction-boundaries.md`
+  - Replace the #265 follow-up wording with the chosen decision.
+  - Keep future automatic dispatch as a possible higher-level factory, not a `RecipeSpec.from_frame(...)` behavior change.
+
+No new public class, wrapper type, serialization schema, or recipe dispatch factory is added.
+
+---
+
+### Task 1: Pin The Linear-Only Dispatch Contract With Failing Tests
+
+**Files:**
+- Modify: `tests/pipeline/test_recipe.py`
+
+- [ ] **Step 1: Add tests for the explicit graph extractor guidance**
+
+Add these tests near the existing `test_recipe_from_frame_reports_graph_recipe_boundary_for_multi_input_operation` block:
+
+```python
+def test_recipe_from_frame_reports_explicit_graph_extractors_for_binary_merge() -> None:
+    frame = _frame()
+    noise = _frame().remove_dc()
+    processed = frame.normalize() + noise
+
+    with pytest.raises(RecipeExtractionError) as exc_info:
+        RecipeSpec.from_frame(processed)
+
+    message = str(exc_info.value)
+    assert "RecipeSpec.from_frame(...) cannot extract graph lineage as a linear recipe" in message
+    assert "RecipeSpec.from_frame(...) only supports single-input linear recipes" in message
+    assert "GraphRecipeSpec.from_frame(...)" in message
+    assert "NodeGraphRecipeSpec.from_frame(...)" in message
+    assert isinstance(GraphRecipeSpec.from_frame(processed), GraphRecipeSpec)
+
+
+def test_recipe_from_frame_reports_node_graph_extractor_for_external_operand() -> None:
+    frame = _frame()
+    processed = frame + np.ones(frame.shape)
+
+    with pytest.raises(RecipeExtractionError) as exc_info:
+        RecipeSpec.from_frame(processed)
+
+    message = str(exc_info.value)
+    assert "RecipeSpec.from_frame(...) cannot extract graph lineage as a linear recipe" in message
+    assert "NodeGraphRecipeSpec.from_frame(...)" in message
+    assert "external operands" in message
+    assert isinstance(
+        NodeGraphRecipeSpec.from_frame(processed, input_names=("signal", "offset")),
+        NodeGraphRecipeSpec,
+    )
+```
+
+- [ ] **Step 2: Strengthen the existing linear success test**
+
+Replace the body of `test_recipe_from_frame_empty_history_returns_empty_recipe` with:
+
+```python
+def test_recipe_from_frame_empty_history_returns_linear_recipe() -> None:
+    recipe = RecipeSpec.from_frame(_frame())
+
+    assert isinstance(recipe, RecipeSpec)
+    assert recipe.steps == ()
+```
+
+- [ ] **Step 3: Update existing message fragments that should now point to graph extractors**
+
+In `test_recipe_from_frame_reports_current_boundary_for_non_replayable_operations`, change the `"binary frame operation"` expected message to:
+
+```python
+"RecipeSpec.from_frame(...) cannot extract graph lineage as a linear recipe"
+```
+
+In the `"array operand operation"` case, change the expected message to:
+
+```python
+"NodeGraphRecipeSpec.from_frame(...)"
+```
+
+In `test_recipe_from_frame_reports_graph_recipe_boundary_for_multi_input_operation`, change the assertion to:
+
+```python
+with pytest.raises(RecipeExtractionError, match=r"GraphRecipeSpec\.from_frame"):
+    RecipeSpec.from_frame(processed)
+```
+
+In `test_recipe_from_frame_rejects_add_channel_boundary`, change the assertion to:
+
+```python
+with pytest.raises(RecipeExtractionError, match=r"NodeGraphRecipeSpec\.from_frame"):
+    RecipeSpec.from_frame(processed)
+```
+
+- [ ] **Step 4: Run focused tests to verify red**
+
+Run:
+
+```bash
+uv run pytest tests/pipeline/test_recipe.py \
+  -k "explicit_graph_extractors or node_graph_extractor or current_boundary_for_non_replayable_operations or graph_recipe_boundary_for_multi_input_operation or add_channel_boundary or empty_history_returns_linear_recipe" \
+  -q
+```
+
+Expected: FAIL because current errors still use older wording such as `Graph operation requires graph recipe support` or `Scalar operation requires a numeric scalar operand`.
+
+- [ ] **Step 5: Commit the red tests**
+
+```bash
+git add tests/pipeline/test_recipe.py
+git commit -m "test: pin recipe dispatch boundary guidance"
+```
+
+---
+
+### Task 2: Centralize RecipeSpec Graph-Boundary Errors
+
+**Files:**
+- Modify: `wandas/pipeline/extraction.py`
+- Test: `tests/pipeline/test_recipe.py`
+
+- [ ] **Step 1: Add a private graph-boundary error helper**
+
+In `wandas/pipeline/extraction.py`, after the imports and before `_validate_replayable_operation(...)`, add:
+
+```python
+def _recipe_spec_graph_boundary_error(
+    operation: str,
+    *,
+    parent_count: int | None = None,
+    runtime_inputs: int | None = None,
+    detail: str | None = None,
+) -> RecipeExtractionError:
+    lines = [
+        "RecipeSpec.from_frame(...) cannot extract graph lineage as a linear recipe",
+        f"  Operation: {operation}",
+    ]
+    if parent_count is not None:
+        lines.append(f"  Parent count: {parent_count}")
+    if runtime_inputs is not None:
+        lines.append(f"  Runtime inputs: {runtime_inputs}")
+    if detail is not None:
+        lines.append(f"  Detail: {detail}")
+    lines.extend(
+        [
+            "  RecipeSpec.from_frame(...) only supports single-input linear recipes.",
+            "  Use GraphRecipeSpec.from_frame(...) for one binary frame merge.",
+            "  Use NodeGraphRecipeSpec.from_frame(...) for tree-shaped graph recipes, external operands, or add_channel inputs.",
+        ]
+    )
+    return RecipeExtractionError("\n".join(lines))
+```
+
+- [ ] **Step 2: Replace the multi-input operation validation error**
+
+In `_validate_replayable_operation(...)`, replace the `expected_input_count != 1` raise block with:
+
+```python
+        raise _recipe_spec_graph_boundary_error(operation, runtime_inputs=expected_input_count)
+```
+
+- [ ] **Step 3: Replace the scalar external operand boundary error**
+
+In `_scalar_operand_from_params(...)`, replace the `params.get("operand_kind") != "operand"` raise block with:
+
+```python
+        raise _recipe_spec_graph_boundary_error(
+            operation,
+            detail="ScalarOperationStep only handles numeric scalar operands; external operands need graph inputs.",
+        )
+```
+
+- [ ] **Step 4: Replace multidimensional parent graph boundary wording**
+
+In `_multidimensional_steps_from_graph(...)`, replace the `len(parent_inputs) > 1` raise block with:
+
+```python
+        raise _recipe_spec_graph_boundary_error(
+            str(parent["operation"]),
+            parent_count=len(parent_inputs),
+            detail="Multidimensional indexing requires one replayable parent chain.",
+        )
+```
+
+- [ ] **Step 5: Replace the add_channel linear extraction boundary**
+
+In `_steps_from_graph(...)`, replace the `operation == "add_channel"` raise block with:
+
+```python
+        raise _recipe_spec_graph_boundary_error(
+            operation,
+            detail="add_channel needs a graph recipe or external data/input reference.",
+        )
+```
+
+- [ ] **Step 6: Replace the general multi-parent linear extraction boundary**
+
+In `_steps_from_graph(...)`, replace the `len(inputs) > 1` raise block with:
+
+```python
+        raise _recipe_spec_graph_boundary_error(operation, parent_count=len(inputs))
+```
+
+- [ ] **Step 7: Run focused tests to verify green**
+
+Run:
+
+```bash
+uv run pytest tests/pipeline/test_recipe.py \
+  -k "explicit_graph_extractors or node_graph_extractor or current_boundary_for_non_replayable_operations or graph_recipe_boundary_for_multi_input_operation or add_channel_boundary or empty_history_returns_linear_recipe" \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run the full recipe tests**
+
+Run:
+
+```bash
+uv run pytest tests/pipeline/test_recipe.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit implementation and tests**
+
+```bash
+git add wandas/pipeline/extraction.py tests/pipeline/test_recipe.py
+git commit -m "fix: clarify recipe graph dispatch boundary"
+```
+
+---
+
+### Task 3: Document The Explicit Dispatch Decision
+
+**Files:**
+- Modify: `docs/src/how-to/pipeline-recipes.md`
+- Modify: `docs/src/explanation/pipeline-recipe-extraction-boundaries.md`
+- Test: docs build
+
+- [ ] **Step 1: Update the how-to class selection guidance**
+
+In `docs/src/how-to/pipeline-recipes.md`, after this paragraph:
+
+```markdown
+Most users should start with `RecipeSpec.from_frame(processed)`. Use this table only when the frame
+result crosses the single-input linear boundary or an integration layer requires another API.
+```
+
+add:
+
+```markdown
+`RecipeSpec.from_frame(...)` is intentionally linear-only and does not automatically return `GraphRecipeSpec` or `NodeGraphRecipeSpec`. When a result has graph lineage, choose the graph recipe class explicitly. A future higher-level factory may add automatic dispatch without changing the `RecipeSpec.from_frame(...)` return type.
+```
+
+- [ ] **Step 2: Update the how-to unsupported boundary row**
+
+In the unsupported boundary table, replace:
+
+```markdown
+| Multi-input work through `RecipeSpec.from_frame(...)` | Use `GraphRecipeSpec.from_frame(...)` or `NodeGraphRecipeSpec.from_frame(...)`. |
+```
+
+with:
+
+```markdown
+| Multi-input work through `RecipeSpec.from_frame(...)` | `RecipeSpec.from_frame(...)` stays linear-only; use `GraphRecipeSpec.from_frame(...)` or `NodeGraphRecipeSpec.from_frame(...)` explicitly. |
+```
+
+- [ ] **Step 3: Update the extraction-boundary follow-up list**
+
+In `docs/src/explanation/pipeline-recipe-extraction-boundaries.md`, replace:
+
+```markdown
+- Automatic graph recipe dispatch from `RecipeSpec.from_frame(...)` is tracked by #265.
+```
+
+with:
+
+```markdown
+- Automatic graph recipe dispatch is intentionally deferred. `RecipeSpec.from_frame(...)` remains linear-only; a future higher-level factory may provide explicit union-return dispatch.
+```
+
+- [ ] **Step 4: Update the not-implemented graph bullet**
+
+In the same explanation doc, replace:
+
+```markdown
+- `RecipeSpec.from_frame(frame_a + frame_b)` が graph recipe を返すこと。`RecipeSpec` は単一入力・直列 recipe のままとし、複数入力 graph は `GraphRecipeSpec.from_frame(...)` で抽出する。
+```
+
+with:
+
+```markdown
+- `RecipeSpec.from_frame(frame_a + frame_b)` が graph recipe を返すことは現時点では行わない。`RecipeSpec` は単一入力・直列 recipe のままとし、複数入力 graph は `GraphRecipeSpec.from_frame(...)` または `NodeGraphRecipeSpec.from_frame(...)` で明示的に抽出する。
+```
+
+Replace:
+
+```markdown
+- 入力名を推定する `RecipeSpec.from_frame(signal.add(noise, snr=6.0))` の自動 graph 抽出
+```
+
+with:
+
+```markdown
+- 将来の上位 factory による自動 graph 抽出。追加する場合も `RecipeSpec.from_frame(...)` の戻り値型は変えない。
+```
+
+- [ ] **Step 5: Build docs**
+
+Run:
+
+```bash
+uv run mkdocs build -f docs/mkdocs.yml --strict --site-dir /tmp/wandas-docs-issue-265
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Clean generated artifacts**
+
+Run:
+
+```bash
+rm -rf .coverage .pytest_cache .ruff_cache coverage.xml docs/site tests/__pycache__ tests/pipeline/__pycache__ wandas/__pycache__ wandas/core/__pycache__ wandas/frames/__pycache__ wandas/frames/mixins/__pycache__ wandas/io/__pycache__ wandas/pipeline/__pycache__ wandas/processing/__pycache__ wandas/utils/__pycache__
+```
+
+Expected: `git status --short --ignored=matching` shows no generated artifacts.
+
+- [ ] **Step 7: Commit docs**
+
+```bash
+git add docs/src/how-to/pipeline-recipes.md docs/src/explanation/pipeline-recipe-extraction-boundaries.md
+git commit -m "docs: clarify recipe dispatch contract"
+```
+
+---
+
+### Task 4: Final Verification And PR
+
+**Files:**
+- Verify all changed files.
+- Update PR title/body after push.
+
+- [ ] **Step 1: Run focused recipe tests**
+
+```bash
+uv run pytest tests/pipeline/test_recipe.py \
+  -k "explicit_graph_extractors or node_graph_extractor or current_boundary_for_non_replayable_operations or graph_recipe_boundary_for_multi_input_operation or add_channel_boundary or empty_history_returns_linear_recipe" \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full recipe tests**
+
+```bash
+uv run pytest tests/pipeline/test_recipe.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run docs build**
+
+```bash
+uv run mkdocs build -f docs/mkdocs.yml --strict --site-dir /tmp/wandas-docs-issue-265
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run lint**
+
+```bash
+uv run ruff check wandas tests --config=pyproject.toml
+```
+
+Expected: `All checks passed!`
+
+- [ ] **Step 5: Run type checks**
+
+```bash
+uv run ty check wandas tests
+```
+
+Expected: `All checks passed!`
+
+- [ ] **Step 6: Clean generated artifacts**
+
+```bash
+rm -rf .coverage .pytest_cache .ruff_cache coverage.xml docs/site tests/__pycache__ tests/pipeline/__pycache__ wandas/__pycache__ wandas/core/__pycache__ wandas/frames/__pycache__ wandas/frames/mixins/__pycache__ wandas/io/__pycache__ wandas/pipeline/__pycache__ wandas/processing/__pycache__ wandas/utils/__pycache__
+git status --short --ignored=matching
+```
+
+Expected: no output from `git status --short --ignored=matching`.
+
+- [ ] **Step 7: Push and create PR**
+
+```bash
+git push -u origin codex/issue-265-recipe-dispatch
+gh pr create \
+  --repo kasahart/wandas \
+  --base develop \
+  --head codex/issue-265-recipe-dispatch \
+  --title "[codex] Clarify Recipe dispatch boundary" \
+  --body "## Summary
+- Keep RecipeSpec.from_frame(...) linear-only and improve graph-boundary guidance.
+- Document that automatic graph dispatch is deferred to a future higher-level factory.
+- Add tests for explicit GraphRecipeSpec / NodeGraphRecipeSpec guidance.
+
+## Validation
+- uv run pytest tests/pipeline/test_recipe.py -q
+- uv run mkdocs build -f docs/mkdocs.yml --strict --site-dir /tmp/wandas-docs-issue-265
+- uv run ruff check wandas tests --config=pyproject.toml
+- uv run ty check wandas tests
+
+Closes #265
+Related #264
+Related #257
+Related #258"
+```
+
+- [ ] **Step 8: Confirm PR readiness**
+
+Run:
+
+```bash
+git rev-parse HEAD
+git rev-parse origin/codex/issue-265-recipe-dispatch
+gh pr view --repo kasahart/wandas --json number,url,headRefOid,baseRefName,title,body,reviewDecision,reviewRequests,mergeable,statusCheckRollup
+PR_NUMBER=$(gh pr view --repo kasahart/wandas --json number --jq .number)
+gh api graphql -f owner=kasahart -f name=wandas -F number="$PR_NUMBER" -f query='query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { reviewThreads(first:100) { nodes { isResolved isOutdated comments(first:5) { nodes { path line body } } } } } } }'
+```
+
+Expected:
+
+- local `HEAD`, `origin/codex/issue-265-recipe-dispatch`, and PR `headRefOid` match;
+- PR body includes `Closes #265`;
+- no unresolved review threads;
+- GitHub checks are passing or still pending within the monitoring timebox.

--- a/docs/superpowers/specs/2026-07-05-recipe-dispatch-contract-design.md
+++ b/docs/superpowers/specs/2026-07-05-recipe-dispatch-contract-design.md
@@ -1,0 +1,129 @@
+# Recipe Dispatch Contract Design
+
+## Goal
+
+Close issue #265 by making the `RecipeSpec.from_frame(...)` graph boundary explicit for users and stable for type checkers.
+
+Wandas now has three Recipe extractors:
+
+- `RecipeSpec.from_frame(...)` for single-input linear recipes.
+- `GraphRecipeSpec.from_frame(...)` for two frame inputs with one binary merge and an optional linear tail.
+- `NodeGraphRecipeSpec.from_frame(...)` for tree-shaped graph recipes with multiple external inputs or external operands.
+
+The open question is whether `RecipeSpec.from_frame(...)` should automatically return or delegate to the graph recipe types when it sees multi-input lineage.
+
+## Decision
+
+Do not add automatic graph dispatch to `RecipeSpec.from_frame(...)` in this issue.
+
+Keep the current explicit API:
+
+- `RecipeSpec.from_frame(...)` returns only `RecipeSpec`.
+- Graph extraction uses `GraphRecipeSpec.from_frame(...)` or `NodeGraphRecipeSpec.from_frame(...)`.
+- Multi-input lineage passed to `RecipeSpec.from_frame(...)` fails with `RecipeExtractionError`.
+- The error message should explain that graph lineage needs a graph recipe extractor and should name the likely alternatives.
+
+This keeps the public return type stable today while leaving room for a future higher-level factory.
+
+## Why Not Dispatch Now
+
+Automatic dispatch would make the first example feel easier:
+
+```python
+recipe = RecipeSpec.from_frame(signal + noise)
+```
+
+But it would also make the return type harder to reason about:
+
+```python
+RecipeSpec | GraphRecipeSpec | NodeGraphRecipeSpec
+```
+
+Those types have different `apply(...)` signatures:
+
+- `RecipeSpec.apply(frame)`
+- `GraphRecipeSpec.apply({"input_0": frame_a, "input_1": frame_b})`
+- `NodeGraphRecipeSpec.apply({...})`
+
+Returning graph recipes from `RecipeSpec.from_frame(...)` would make simple-looking code fail later when callers pass a single frame to `apply(...)`. It also makes static typing and beginner documentation harder because the same entry point no longer has one shape.
+
+## Future Improvement Path
+
+Automatic graph extraction remains a valid future UX improvement, but it should not change `RecipeSpec.from_frame(...)` directly.
+
+If Wandas adds a convenience entry point later, prefer a new higher-level factory with an explicit union return type, for example:
+
+```python
+Recipe.from_frame(...)
+# or
+AnyRecipeSpec.from_frame(...)
+```
+
+That future API can document a discriminated recipe family and guide users to the correct `apply(...)` shape. It can also preserve `RecipeSpec.from_frame(...)` as the predictable linear extractor.
+
+## UX Contract
+
+When users call `RecipeSpec.from_frame(...)` on graph lineage, the failure should be actionable:
+
+- state that the frame has graph or multi-input lineage;
+- state that `RecipeSpec.from_frame(...)` only supports single-input linear recipes;
+- suggest `GraphRecipeSpec.from_frame(...)` for one binary frame merge;
+- suggest `NodeGraphRecipeSpec.from_frame(...)` for multiple merges, external operands, or `add_channel` graph inputs.
+
+Example message shape:
+
+```text
+RecipeSpec.from_frame(...) cannot extract graph lineage as a linear recipe
+  Use GraphRecipeSpec.from_frame(...) for one binary frame merge.
+  Use NodeGraphRecipeSpec.from_frame(...) for tree-shaped graph recipes.
+```
+
+The exact text can follow the existing multiline `RecipeExtractionError` style.
+
+## Implementation Scope
+
+The implementation should stay small:
+
+1. Keep `RecipeSpec.from_frame(...)` returning only `RecipeSpec`.
+2. Improve graph-boundary error messages where current text is too terse or does not identify the right graph extractor.
+3. Add or adjust tests that assert the type contract and actionable error text.
+4. Update docs to state that automatic dispatch is intentionally deferred and graph recipes use explicit entry points.
+
+No new recipe class, wrapper type, serialization format, or dispatch factory is added in this issue.
+
+## Compatibility
+
+This is primarily a clarification. Existing successful linear recipes keep working. Existing explicit graph recipes keep working.
+
+The only intended behavior change is clearer error text for callers who pass graph lineage to `RecipeSpec.from_frame(...)`.
+
+## Testing
+
+Tests should cover:
+
+- `RecipeSpec.from_frame(linear_frame)` still returns `RecipeSpec`.
+- `RecipeSpec.from_frame(frame_a + frame_b)` raises `RecipeExtractionError` with graph extractor guidance.
+- At least one graph case that needs `NodeGraphRecipeSpec.from_frame(...)` raises with node-graph guidance.
+- `GraphRecipeSpec.from_frame(...)` and `NodeGraphRecipeSpec.from_frame(...)` remain supported for the same lineage examples.
+
+The tests should assert stable message fragments, not the entire formatted error string.
+
+## Documentation
+
+Update the recipe how-to and extraction-boundary docs:
+
+- explain that `RecipeSpec.from_frame(...)` is intentionally linear-only;
+- keep the table that routes graph cases to `GraphRecipeSpec` or `NodeGraphRecipeSpec`;
+- add a short future note that a higher-level automatic factory can be considered later, without changing the `RecipeSpec.from_frame(...)` return type.
+
+## Issue Closure
+
+The PR should use `Closes #265`.
+
+It should not close:
+
+- #264, true DAG identity;
+- #257, WDF persistence;
+- #258, interoperability/export;
+- #227, source-time policy;
+- #246, legacy lineage/history cleanup.

--- a/tests/pipeline/test_recipe.py
+++ b/tests/pipeline/test_recipe.py
@@ -3661,8 +3661,11 @@ def test_recipe_from_frame_extracts_spectrogram_to_channel_frame_as_istft() -> N
     assert replayed.sampling_rate == processed.sampling_rate
 
 
-def test_recipe_from_frame_empty_history_returns_empty_recipe() -> None:
-    assert RecipeSpec.from_frame(_frame()).steps == ()
+def test_recipe_from_frame_empty_history_returns_linear_recipe() -> None:
+    recipe = RecipeSpec.from_frame(_frame())
+
+    assert isinstance(recipe, RecipeSpec)
+    assert recipe.steps == ()
 
 
 @pytest.mark.parametrize(
@@ -3671,12 +3674,12 @@ def test_recipe_from_frame_empty_history_returns_empty_recipe() -> None:
         (
             "binary frame operation",
             lambda frame: frame + _frame().normalize(),
-            "Graph operation requires graph recipe support",
+            "RecipeSpec.from_frame(...) cannot extract graph lineage as a linear recipe",
         ),
         (
             "array operand operation",
             lambda frame: frame + np.ones(frame.shape),
-            "Scalar operation requires a numeric scalar operand",
+            "NodeGraphRecipeSpec.from_frame(...)",
         ),
         (
             "custom apply operation",
@@ -3705,7 +3708,7 @@ def test_recipe_from_frame_reports_current_boundary_for_non_replayable_operation
     frame = _frame()
     processed = build_frame(frame)
 
-    with pytest.raises(RecipeExtractionError, match=message):
+    with pytest.raises(RecipeExtractionError, match=re.escape(message)):
         RecipeSpec.from_frame(processed)
 
 
@@ -3726,8 +3729,41 @@ def test_recipe_from_frame_reports_graph_recipe_boundary_for_multi_input_operati
     noise = _frame().low_pass_filter(cutoff=1000.0)
     processed = frame.normalize().add(noise, snr=6.0)
 
-    with pytest.raises(RecipeExtractionError, match="Graph operation requires graph recipe support"):
+    with pytest.raises(RecipeExtractionError, match=r"GraphRecipeSpec\.from_frame"):
         RecipeSpec.from_frame(processed)
+
+
+def test_recipe_from_frame_reports_explicit_graph_extractors_for_binary_merge() -> None:
+    frame = _frame()
+    noise = _frame().remove_dc()
+    processed = frame.normalize() + noise
+
+    with pytest.raises(RecipeExtractionError) as exc_info:
+        RecipeSpec.from_frame(processed)
+
+    message = str(exc_info.value)
+    assert "RecipeSpec.from_frame(...) cannot extract graph lineage as a linear recipe" in message
+    assert "RecipeSpec.from_frame(...) only supports single-input linear recipes" in message
+    assert "GraphRecipeSpec.from_frame(...)" in message
+    assert "NodeGraphRecipeSpec.from_frame(...)" in message
+    assert isinstance(GraphRecipeSpec.from_frame(processed), GraphRecipeSpec)
+
+
+def test_recipe_from_frame_reports_node_graph_extractor_for_external_operand() -> None:
+    frame = _frame()
+    processed = frame + np.ones(frame.shape)
+
+    with pytest.raises(RecipeExtractionError) as exc_info:
+        RecipeSpec.from_frame(processed)
+
+    message = str(exc_info.value)
+    assert "RecipeSpec.from_frame(...) cannot extract graph lineage as a linear recipe" in message
+    assert "NodeGraphRecipeSpec.from_frame(...)" in message
+    assert "external operands" in message
+    assert isinstance(
+        NodeGraphRecipeSpec.from_frame(processed, input_names=("signal", "offset")),
+        NodeGraphRecipeSpec,
+    )
 
 
 @pytest.mark.parametrize(
@@ -3744,5 +3780,5 @@ def test_recipe_from_frame_rejects_add_channel_boundary(
     processed = build_added(frame)
 
     assert processed.operation_history[-1]["operation"] == "add_channel"
-    with pytest.raises(RecipeExtractionError, match="add_channel recipe extraction requires external input support"):
+    with pytest.raises(RecipeExtractionError, match=r"NodeGraphRecipeSpec\.from_frame"):
         RecipeSpec.from_frame(processed)

--- a/tests/pipeline/test_recipe.py
+++ b/tests/pipeline/test_recipe.py
@@ -620,6 +620,20 @@ def test_graph_recipe_from_frame_extracts_root_frame_addition_with_input_names()
     assert replayed.operation_history == processed.operation_history
 
 
+def test_graph_recipe_from_frame_does_not_self_recommend_for_external_operand_parent() -> None:
+    frame = _frame()
+    other = _frame().remove_dc()
+    processed = (frame + np.ones(frame.shape)) + other
+
+    with pytest.raises(RecipeExtractionError) as exc_info:
+        GraphRecipeSpec.from_frame(processed, input_names=("left", "right"))
+
+    message = str(exc_info.value)
+    assert "RecipeSpec.from_frame(...) cannot extract graph lineage as a linear recipe" not in message
+    assert "Use GraphRecipeSpec.from_frame(...)" not in message
+    assert "NodeGraphRecipeSpec.from_frame(...)" in message
+
+
 def test_graph_recipe_from_frame_uses_numbered_default_input_names() -> None:
     base = _frame()
     left_source = ChannelFrame.from_numpy(base.data, sampling_rate=base.sampling_rate, label="signal")
@@ -2014,7 +2028,7 @@ def test_rename_mapping_extraction_rejects_invalid_serialized_items(
 @pytest.mark.parametrize(
     ("operation", "params", "message"),
     [
-        ("+", {"operand_kind": "frame"}, "can only replay a single numeric operand"),
+        ("+", {"operand_kind": "frame"}, "explicit node graph recipe"),
         ("+", {"operand_kind": "operand", "operand": {"type": "bool", "value": True}}, "numeric scalar operand"),
         ("+", {"operand_kind": "operand", "operand": {"type": "str", "value": "x"}}, "numeric scalar operand"),
         ("+", {"symbol": "-", "operand_kind": "operand", "operand": 1.0}, "inconsistent operator metadata"),
@@ -2139,7 +2153,7 @@ def test_channel_key_extraction_accepts_public_get_channel_selectors(
                 },
                 "inputs": [{"operation": "get_channel", "params": {"query": "left"}, "inputs": [{}, {}]}],
             },
-            "Current RecipeSpec can only replay one linear parent chain",
+            "explicit node graph recipe",
         ),
     ],
 )
@@ -2197,7 +2211,7 @@ def test_validate_replayable_operation_rejects_multi_input_operation(
 
     monkeypatch.setitem(_OPERATION_REGISTRY, MultiInputOperation.name, MultiInputOperation)
 
-    with pytest.raises(RecipeExtractionError, match="requires graph recipe support"):
+    with pytest.raises(RecipeExtractionError, match=r"NodeGraphRecipeSpec\.from_frame"):
         _validate_replayable_operation(MultiInputOperation.name)
 
 

--- a/wandas/pipeline/extraction.py
+++ b/wandas/pipeline/extraction.py
@@ -29,7 +29,82 @@ from wandas.pipeline.steps import (
 )
 
 
-def _validate_replayable_operation(operation: str) -> None:
+def _recipe_spec_graph_boundary_error(
+    operation: str,
+    *,
+    parent_count: int | None = None,
+    runtime_inputs: int | None = None,
+    detail: str | None = None,
+) -> RecipeExtractionError:
+    lines = [
+        "RecipeSpec.from_frame(...) cannot extract graph lineage as a linear recipe",
+        f"  Operation: {operation}",
+    ]
+    if parent_count is not None:
+        lines.append(f"  Parent count: {parent_count}")
+    if runtime_inputs is not None:
+        lines.append(f"  Runtime inputs: {runtime_inputs}")
+    if detail is not None:
+        lines.append(f"  Detail: {detail}")
+    lines.extend(
+        [
+            "  RecipeSpec.from_frame(...) only supports single-input linear recipes.",
+            "  Use GraphRecipeSpec.from_frame(...) for one binary frame merge.",
+            "  Use NodeGraphRecipeSpec.from_frame(...) for tree-shaped graph recipes, external operands, "
+            "or add_channel inputs.",
+        ]
+    )
+    return RecipeExtractionError("\n".join(lines))
+
+
+def _graph_extractor_boundary_error(
+    operation: str,
+    *,
+    parent_count: int | None = None,
+    runtime_inputs: int | None = None,
+    detail: str | None = None,
+) -> RecipeExtractionError:
+    lines = [
+        "Graph extraction requires an explicit node graph recipe for this lineage",
+        f"  Operation: {operation}",
+    ]
+    if parent_count is not None:
+        lines.append(f"  Parent count: {parent_count}")
+    if runtime_inputs is not None:
+        lines.append(f"  Runtime inputs: {runtime_inputs}")
+    if detail is not None:
+        lines.append(f"  Detail: {detail}")
+    lines.append(
+        "  Use NodeGraphRecipeSpec.from_frame(...) for tree-shaped graph recipes, external operands, "
+        "or add_channel inputs."
+    )
+    return RecipeExtractionError("\n".join(lines))
+
+
+def _graph_boundary_error(
+    operation: str,
+    *,
+    recipe_spec_context: bool,
+    parent_count: int | None = None,
+    runtime_inputs: int | None = None,
+    detail: str | None = None,
+) -> RecipeExtractionError:
+    if recipe_spec_context:
+        return _recipe_spec_graph_boundary_error(
+            operation,
+            parent_count=parent_count,
+            runtime_inputs=runtime_inputs,
+            detail=detail,
+        )
+    return _graph_extractor_boundary_error(
+        operation,
+        parent_count=parent_count,
+        runtime_inputs=runtime_inputs,
+        detail=detail,
+    )
+
+
+def _validate_replayable_operation(operation: str, *, recipe_spec_context: bool = False) -> None:
     try:
         from wandas.processing import get_operation
 
@@ -44,11 +119,10 @@ def _validate_replayable_operation(operation: str) -> None:
 
     expected_input_count = getattr(operation_class, "_expected_input_count", 1)
     if isinstance(expected_input_count, int) and expected_input_count != 1:
-        raise RecipeExtractionError(
-            "Graph operation requires graph recipe support\n"
-            f"  Operation: {operation}\n"
-            f"  Runtime inputs: {expected_input_count}\n"
-            "  Current RecipeSpec can only replay single-input linear operations."
+        raise _graph_boundary_error(
+            operation,
+            recipe_spec_context=recipe_spec_context,
+            runtime_inputs=expected_input_count,
         )
     if operation not in _REPLAYABLE_APPLY_OPERATIONS:
         raise RecipeExtractionError(
@@ -180,17 +254,28 @@ def _typed_method_step_from_graph(operation: str, params: Mapping[str, Any], kin
     return TypedMethodStep(method, _method_params(params, param_names))
 
 
-def _scalar_operand_from_params(operation: str, params: Mapping[str, Any]) -> int | float:
+def _scalar_operand_from_params(
+    operation: str,
+    params: Mapping[str, Any],
+    *,
+    recipe_spec_context: bool = False,
+) -> int | float:
     if params.get("operand_kind") != "operand":
-        raise RecipeExtractionError(
-            "Graph operation requires graph recipe support\n"
-            f"  Operation: {operation}\n"
-            "  ScalarOperationStep can only replay a single numeric operand stored in the operation graph."
+        raise _graph_boundary_error(
+            operation,
+            recipe_spec_context=recipe_spec_context,
+            detail="ScalarOperationStep only handles numeric scalar operands; external operands need graph inputs.",
         )
 
     operand = params.get("operand")
     if isinstance(operand, int | float) and not isinstance(operand, bool):
         return operand
+    if isinstance(operand, Mapping) and operand.get("type") in {"ndarray", "dask.array"}:
+        raise _graph_boundary_error(
+            operation,
+            recipe_spec_context=recipe_spec_context,
+            detail="ScalarOperationStep only handles numeric scalar operands; external operands need graph inputs.",
+        )
     if not isinstance(operand, Mapping) or set(operand) != {"type", "value"}:
         raise RecipeExtractionError(
             f"Scalar operation requires a numeric scalar operand\n  Operation: {operation}\n  Operand: {operand!r}"
@@ -215,7 +300,12 @@ def _scalar_operand_from_params(operation: str, params: Mapping[str, Any]) -> in
     )
 
 
-def _scalar_step_from_graph(operation: str, params: Mapping[str, Any]) -> ScalarOperationStep:
+def _scalar_step_from_graph(
+    operation: str,
+    params: Mapping[str, Any],
+    *,
+    recipe_spec_context: bool = False,
+) -> ScalarOperationStep:
     symbol = params.get("symbol", operation)
     if symbol != operation:
         raise RecipeExtractionError(
@@ -231,7 +321,7 @@ def _scalar_step_from_graph(operation: str, params: Mapping[str, Any]) -> Scalar
     try:
         return ScalarOperationStep(
             operation,
-            _scalar_operand_from_params(operation, params),
+            _scalar_operand_from_params(operation, params, recipe_spec_context=recipe_spec_context),
             reverse=operand_position == "left",
         )
     except TypeError as exc:
@@ -396,17 +486,23 @@ def _getitem_step_from_graph(params: Mapping[str, Any]) -> IndexingStep:
 def _multidimensional_steps_from_graph(
     params: Mapping[str, Any],
     parent: Mapping[str, Any],
+    *,
+    recipe_spec_context: bool = False,
 ) -> tuple[RecipeStep, ...]:
     axis_slices = _axis_slices_from_params(params)
     parent_inputs = tuple(parent.get("inputs", ()))
     if len(parent_inputs) > 1:
-        raise RecipeExtractionError(
-            "Graph operation requires graph recipe support\n"
-            f"  Operation: {parent['operation']}\n"
-            f"  Parent count: {len(parent_inputs)}\n"
-            "  Current RecipeSpec can only replay one linear parent chain."
+        raise _graph_boundary_error(
+            str(parent["operation"]),
+            recipe_spec_context=recipe_spec_context,
+            parent_count=len(parent_inputs),
+            detail="Multidimensional indexing requires one replayable parent chain.",
         )
-    grandparent_steps = _steps_from_graph(cast(Mapping[str, Any], parent_inputs[0])) if parent_inputs else ()
+    grandparent_steps = (
+        _steps_from_graph(cast(Mapping[str, Any], parent_inputs[0]), recipe_spec_context=recipe_spec_context)
+        if parent_inputs
+        else ()
+    )
     return (*grandparent_steps, IndexingStep((_channel_key_from_parent_graph(parent), *axis_slices)))
 
 
@@ -415,6 +511,8 @@ def _step_from_graph(
     params: Mapping[str, Any],
     kind: str | None,
     custom_metadata: Mapping[str, Any] | None = None,
+    *,
+    recipe_spec_context: bool = False,
 ) -> RecipeStep:
     if operation == "__getitem__":
         return _getitem_step_from_graph(params)
@@ -427,30 +525,29 @@ def _step_from_graph(
     if operation in _REPLAYABLE_TYPED_METHOD_OPERATIONS:
         return _typed_method_step_from_graph(operation, params, kind)
     if operation in _REPLAYABLE_SCALAR_OPERATIONS:
-        return _scalar_step_from_graph(operation, params)
-    _validate_replayable_operation(operation)
+        return _scalar_step_from_graph(operation, params, recipe_spec_context=recipe_spec_context)
+    _validate_replayable_operation(operation, recipe_spec_context=recipe_spec_context)
     return OperationSpec(operation, params)
 
 
-def _steps_from_graph(graph: Mapping[str, Any]) -> tuple[RecipeStep, ...]:
+def _steps_from_graph(
+    graph: Mapping[str, Any],
+    *,
+    recipe_spec_context: bool = False,
+) -> tuple[RecipeStep, ...]:
     operation = str(graph["operation"])
     kind = cast(str | None, graph.get("kind"))
     if kind == "source":
         return ()
     inputs = tuple(graph.get("inputs", ()))
     if operation == "add_channel":
-        raise RecipeExtractionError(
-            "add_channel recipe extraction requires external input support\n"
-            "  Current RecipeSpec can only replay one existing input frame. "
-            "Adding channels needs a graph recipe or external data/input reference."
+        raise _graph_boundary_error(
+            operation,
+            recipe_spec_context=recipe_spec_context,
+            detail="add_channel needs a graph recipe or external data/input reference.",
         )
     if len(inputs) > 1:
-        raise RecipeExtractionError(
-            "Graph operation requires graph recipe support\n"
-            f"  Operation: {operation}\n"
-            f"  Parent count: {len(inputs)}\n"
-            "  Current RecipeSpec can only replay one linear parent chain."
-        )
+        raise _graph_boundary_error(operation, recipe_spec_context=recipe_spec_context, parent_count=len(inputs))
 
     params = cast(Mapping[str, Any], _restore_history_value(graph.get("params", {})))
     if operation == "__getitem__" and params.get("indexing") == "multidimensional_slice":
@@ -459,15 +556,26 @@ def _steps_from_graph(graph: Mapping[str, Any]) -> tuple[RecipeStep, ...]:
                 "Multidimensional indexing recipe extraction requires one channel-selection parent\n"
                 f"  Parent count: {len(inputs)}"
             )
-        return _multidimensional_steps_from_graph(params, cast(Mapping[str, Any], inputs[0]))
-    parent_steps = _steps_from_graph(cast(Mapping[str, Any], inputs[0])) if inputs else ()
+        return _multidimensional_steps_from_graph(
+            params,
+            cast(Mapping[str, Any], inputs[0]),
+            recipe_spec_context=recipe_spec_context,
+        )
+    parent_steps = (
+        _steps_from_graph(cast(Mapping[str, Any], inputs[0]), recipe_spec_context=recipe_spec_context) if inputs else ()
+    )
     step = _step_from_graph(
         operation,
         params,
         kind,
         cast(Mapping[str, Any] | None, graph.get("custom")),
+        recipe_spec_context=recipe_spec_context,
     )
     return (*parent_steps, step)
+
+
+def _recipe_spec_steps_from_graph(graph: Mapping[str, Any]) -> tuple[RecipeStep, ...]:
+    return _steps_from_graph(graph, recipe_spec_context=True)
 
 
 def _binary_frame_step_from_graph(operation: str, params: Mapping[str, Any], left: str, right: str) -> BinaryFrameStep:

--- a/wandas/pipeline/specs.py
+++ b/wandas/pipeline/specs.py
@@ -14,6 +14,7 @@ from wandas.pipeline.extraction import (
     _channel_key_from_parent_graph,
     _is_external_add_channel_data_graph,
     _is_external_operand_graph,
+    _recipe_spec_steps_from_graph,
     _split_graph_at_binary_merge,
     _step_from_graph,
     _steps_from_graph,
@@ -60,7 +61,7 @@ class RecipeSpec:
         graph = frame.operation_graph
         if graph is None:
             return cls(())
-        return cls(_steps_from_graph(cast(Mapping[str, Any], graph)))
+        return cls(_recipe_spec_steps_from_graph(cast(Mapping[str, Any], graph)))
 
     def apply(self, frame: Any) -> Any:
         result: Any = frame


### PR DESCRIPTION
## Summary
- Keep `RecipeSpec.from_frame(...)` linear-only and improve graph-boundary guidance.
- Preserve explicit `GraphRecipeSpec.from_frame(...)` / `NodeGraphRecipeSpec.from_frame(...)` entry points without self-recommending `GraphRecipeSpec` from graph extraction errors.
- Document that automatic graph dispatch is deferred to a future higher-level factory.

## Validation
- `uv run pytest tests/pipeline/test_recipe.py -k "explicit_graph_extractors or node_graph_extractor or current_boundary_for_non_replayable_operations or graph_recipe_boundary_for_multi_input_operation or add_channel_boundary or empty_history_returns_linear_recipe or self_recommend" -q` (11 passed)
- `uv run pytest tests/pipeline/test_recipe.py -q` (369 passed)
- `uv run mkdocs build -f docs/mkdocs.yml --strict --site-dir /tmp/wandas-docs-issue-265`
- `uv run ruff check wandas tests --config=pyproject.toml`
- `uv run ty check wandas tests`

Closes #265
Related #264
Related #257
Related #258