### PR TITLE
[codex] Clarify legacy lineage history boundaries

### DIFF
--- a/docs/src/explanation/pipeline-recipe-developer-guide.md
+++ b/docs/src/explanation/pipeline-recipe-developer-guide.md
@@ -24,8 +24,10 @@ The important design constraints are:
 
 | Term | Meaning |
 | --- | --- |
+| `previous` | Stable compatibility/debug pointer to the immediate prior frame when available. It is useful for inspection, but it is not the source of truth for history or Recipe extraction. |
 | `lineage` | Runtime tree stored on a frame. It records the operation object and parent lineage nodes used to create the frame. |
-| `operation_history` | Backward-compatible linear list derived from `lineage`. Good for user inspection, but not enough for graph extraction because it loses parent structure. |
+| `operation_history` | Backward-compatible linear list derived from `lineage`. Good for user inspection, but not enough for graph extraction because it loses parent structure. It is not backed by `previous` or `_xr.attrs["operation_history"]`. |
+| `operation_summaries` | Display-oriented operation list derived from runtime `lineage`, or from an inspection-only snapshot after WDF load or `persist()`. |
 | `operation_graph` | JSON-like tree derived from `lineage`. Recipe extraction reads this structure because it preserves operation params, parent edges, source leaves, and selected custom metadata. |
 | `OperationSpec` | A replayable `frame.apply_operation(operation, **params)` call for registered single-input operations. |
 | `RecipeSpec` | A single-input ordered sequence of replayable steps. It can be extracted from one linear parent chain with `RecipeSpec.from_frame(frame)`. |
@@ -61,6 +63,10 @@ lineage
   -> operation_graph
        {"operation": "normalize", "inputs": [{"operation": "remove_dc", ...}], ...}
 ```
+
+`previous` is separate from this flow. It may point to the prior frame for debugging or compatibility, but changing or missing `previous` must not change `operation_history`, `operation_summaries`, `operation_graph`, or Recipe extraction.
+
+At WDF and `persist()` boundaries, `operation_summaries` may come from an inspection-only snapshot instead of live runtime lineage. That snapshot is for display continuity only; it does not rebuild `operation_history` or executable Recipe lineage.
 
 Recipe extraction reads `operation_graph`, not `operation_history`:
 

--- a/docs/superpowers/plans/2026-07-06-legacy-lineage-history-cleanup.md
+++ b/docs/superpowers/plans/2026-07-06-legacy-lineage-history-cleanup.md
@@ -1,0 +1,291 @@
+# Legacy Lineage History Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pin the first #246 cleanup slice: `previous` stays a stable debug/compat accessor, while `operation_history` and `operation_summaries` are derived only from runtime lineage or inspection snapshots.
+
+**Architecture:** Add focused contract tests around `BaseFrame` lineage/history boundaries, then update developer-facing docs and docstrings to match. Avoid behavior changes unless a test shows legacy attrs or `previous` are still acting as provenance sources.
+
+**Tech Stack:** Python, pytest, Dask arrays, Wandas `ChannelFrame`, Markdown docs.
+
+---
+
+## File Map
+
+- Modify `tests/core/test_base_frame_lineage.py`
+  - Add focused tests for `previous`, runtime `lineage`, `operation_history`, and `operation_summaries`.
+- Modify `wandas/core/base_frame.py`
+  - Update `previous`, `operation_history`, and `operation_summaries` docstrings only unless tests fail.
+- Modify `docs/src/explanation/pipeline-recipe-developer-guide.md`
+  - Add beginner-friendly core-term entries for `previous` and `operation_summaries`.
+  - Clarify that Recipe extraction reads `operation_graph`, while `previous` is only a debug/compat pointer.
+- Keep `docs/superpowers/specs/2026-07-06-legacy-lineage-history-cleanup-design.md`
+  - This is the approved design source for the PR.
+
+## Task 1: Pin Previous And Lineage Boundaries
+
+**Files:**
+- Modify: `tests/core/test_base_frame_lineage.py`
+
+- [ ] **Step 1: Add tests proving `previous` is not a history source**
+
+Add these tests after `test_operation_history_public_behavior_is_read_only_lineage_view`:
+
+```python
+def test_previous_is_stable_debug_accessor_not_history_source() -> None:
+    previous = _frame().normalize()
+    frame = ChannelFrame(
+        da_from_array(np.array([[1.0, 2.0, 3.0]]), chunks=(1, -1)),
+        sampling_rate=16000,
+        previous=previous,
+    )
+
+    assert frame.previous is previous
+    assert frame.lineage is None
+    assert frame.operation_history == []
+    assert frame.operation_summaries == []
+    assert frame.operation_graph is None
+
+
+def test_operation_history_comes_from_lineage_without_previous() -> None:
+    frame = ChannelFrame(
+        da_from_array(np.array([[1.0, 2.0, 3.0]]), chunks=(1, -1)),
+        sampling_rate=16000,
+        lineage=LineageNode(Normalize(16000)),
+        previous=None,
+    )
+
+    assert frame.previous is None
+    assert [record["operation"] for record in frame.operation_history] == ["normalize"]
+    assert [summary["operation"] for summary in frame.operation_summaries] == ["normalize"]
+    assert frame.operation_graph is not None
+    assert frame.operation_graph["operation"] == "normalize"
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/core/test_base_frame_lineage.py::test_previous_is_stable_debug_accessor_not_history_source \
+  tests/core/test_base_frame_lineage.py::test_operation_history_comes_from_lineage_without_previous \
+  -q
+```
+
+Expected: PASS. These tests should pin current behavior. If they fail, fix only the failing provenance boundary in `wandas/core/base_frame.py`.
+
+- [ ] **Step 3: Commit the boundary tests**
+
+Run:
+
+```bash
+git add tests/core/test_base_frame_lineage.py
+git commit -m "test: pin previous and lineage history boundary"
+```
+
+## Task 2: Pin Legacy Operation History Attr Boundaries
+
+**Files:**
+- Modify: `tests/core/test_base_frame_lineage.py`
+
+- [ ] **Step 1: Add tests proving legacy attrs are not summary sources**
+
+Add these tests near the operation summaries snapshot tests:
+
+```python
+def test_operation_summaries_ignore_legacy_operation_history_attrs() -> None:
+    frame = _frame().normalize()
+    frame._xr.attrs["operation_history"] = [{"operation": "legacy", "params": {"gain": 2.0}}]
+
+    assert [summary["operation"] for summary in frame.operation_summaries] == ["normalize"]
+    assert [record["operation"] for record in frame.operation_history] == ["normalize"]
+
+
+def test_snapshot_operation_summaries_ignore_legacy_operation_history_attrs() -> None:
+    frame = ChannelFrame(
+        da_from_array(np.array([[1.0, 2.0, 3.0]]), chunks=(1, -1)),
+        sampling_rate=16000,
+        operation_summaries_snapshot=[{"operation": "loaded", "params": {"gain": 2.0}}],
+    )
+    frame._xr.attrs["operation_history"] = [{"operation": "legacy", "params": {"gain": 3.0}}]
+
+    assert frame.operation_summaries == [{"operation": "loaded", "params": {"gain": 2.0}}]
+    assert frame.operation_history == []
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/core/test_base_frame_lineage.py::test_operation_summaries_ignore_legacy_operation_history_attrs \
+  tests/core/test_base_frame_lineage.py::test_snapshot_operation_summaries_ignore_legacy_operation_history_attrs \
+  -q
+```
+
+Expected: PASS. If either fails, remove the legacy attr read path from the smallest affected code path.
+
+- [ ] **Step 3: Run the focused lineage test file**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_base_frame_lineage.py -q
+```
+
+Expected: all tests in the file pass.
+
+- [ ] **Step 4: Commit the legacy attr tests**
+
+Run:
+
+```bash
+git add tests/core/test_base_frame_lineage.py
+git commit -m "test: pin operation summary provenance sources"
+```
+
+## Task 3: Update Public Documentation And Docstrings
+
+**Files:**
+- Modify: `wandas/core/base_frame.py`
+- Modify: `docs/src/explanation/pipeline-recipe-developer-guide.md`
+
+- [ ] **Step 1: Update `BaseFrame.previous` and view docstrings**
+
+In `wandas/core/base_frame.py`, replace the current docstrings for `previous`, `operation_history`, and `operation_summaries` with:
+
+```python
+    @property
+    def previous(self) -> "BaseFrame[Any] | None":
+        """Return the immediate prior frame for compatibility/debug inspection.
+
+        This strong reference is not the source of truth for processing
+        history. Runtime lineage drives ``operation_history``,
+        ``operation_summaries``, ``operation_graph``, and Recipe extraction.
+        """
+        return self._previous
+```
+
+```python
+    @property
+    def operation_history(self) -> list[dict[str, Any]]:
+        """Return a flat read-only compatibility view derived from ``lineage``."""
+        return self._lineage_to_history(self.lineage)
+```
+
+```python
+    @property
+    def operation_summaries(self) -> list[dict[str, Any]]:
+        """Return display summaries derived from lineage or a boundary snapshot."""
+        if self._operation_summaries_snapshot is not None:
+            return copy.deepcopy(self._operation_summaries_snapshot)
+        return self._lineage_to_summaries(self.lineage)
+```
+
+- [ ] **Step 2: Update the developer guide term table**
+
+In `docs/src/explanation/pipeline-recipe-developer-guide.md`, replace the first three term rows under `## Core Terms` with:
+
+```markdown
+| `previous` | Stable compatibility/debug pointer to the immediate prior frame when available. It is useful for inspection, but it is not the source of truth for history or Recipe extraction. |
+| `lineage` | Runtime tree stored on a frame. It records the operation object and parent lineage nodes used to create the frame. |
+| `operation_history` | Backward-compatible linear list derived from `lineage`. Good for user inspection, but not enough for graph extraction because it loses parent structure. It is not backed by `previous` or `_xr.attrs["operation_history"]`. |
+| `operation_summaries` | Display-oriented operation list derived from runtime `lineage`, or from an inspection-only snapshot after WDF load or `persist()`. |
+| `operation_graph` | JSON-like tree derived from `lineage`. Recipe extraction reads this structure because it preserves operation params, parent edges, source leaves, and selected custom metadata. |
+```
+
+- [ ] **Step 3: Update the data flow explanation**
+
+In the same file, after the text block showing `lineage -> operation_history -> operation_graph`, add:
+
+```markdown
+`previous` is separate from this flow. It may point to the prior frame for debugging or compatibility, but changing or missing `previous` must not change `operation_history`, `operation_summaries`, `operation_graph`, or Recipe extraction.
+
+At WDF and `persist()` boundaries, `operation_summaries` may come from an inspection-only snapshot instead of live runtime lineage. That snapshot is for display continuity only; it does not rebuild `operation_history` or executable Recipe lineage.
+```
+
+- [ ] **Step 4: Run docs/text-focused checks**
+
+Run:
+
+```bash
+uv run ruff check wandas/core/base_frame.py tests/core/test_base_frame_lineage.py
+uv run ty check wandas/core tests/core/test_base_frame_lineage.py
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 5: Commit docs and docstrings**
+
+Run:
+
+```bash
+git add wandas/core/base_frame.py docs/src/explanation/pipeline-recipe-developer-guide.md
+git commit -m "docs: clarify previous and lineage history roles"
+```
+
+## Task 4: Final Verification And PR Prep
+
+**Files:**
+- Verify all modified files.
+- Update PR body when the PR is created.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+uv run pytest tests/core/test_base_frame_lineage.py tests/core/test_xarray_storage_only.py tests/io/test_wdf_io.py -q
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 2: Run lint and scoped type checks**
+
+Run:
+
+```bash
+uv run ruff check
+uv run ty check wandas/core tests/core/test_base_frame_lineage.py tests/core/test_xarray_storage_only.py tests/io/test_wdf_io.py
+```
+
+Expected: both commands pass. If full `uv run ty check` is also run and reports unrelated existing diagnostics, record the affected files separately.
+
+- [ ] **Step 3: Check generated artifacts**
+
+Run:
+
+```bash
+git status --short --ignored
+```
+
+Expected: only intentional tracked changes. Remove unintended `.coverage`, `coverage.xml`, `.pytest_cache/`, `.ruff_cache/`, and `__pycache__/` artifacts before reporting readiness.
+
+- [ ] **Step 4: Open PR**
+
+Run:
+
+```bash
+git push -u origin codex/issue-246-lineage-history-cleanup
+gh pr create \
+  --base develop \
+  --head codex/issue-246-lineage-history-cleanup \
+  --title "[codex] Clarify legacy lineage history boundaries" \
+  --body "## Summary
+
+- Documents the #246 first-slice contract: previous stays a stable debug/compat accessor, not a provenance source.
+- Adds tests pinning operation_history as lineage-derived and operation_summaries as lineage/snapshot-derived.
+- Clarifies contributor docs around previous, lineage, operation_history, operation_summaries, and operation_graph.
+
+## Validation
+
+- \`uv run pytest tests/core/test_base_frame_lineage.py tests/core/test_xarray_storage_only.py tests/io/test_wdf_io.py -q\`
+- \`uv run ruff check\`
+- \`uv run ty check wandas/core tests/core/test_base_frame_lineage.py tests/core/test_xarray_storage_only.py tests/io/test_wdf_io.py\`
+
+Related #246"
+```
+
+Expected: PR opens against `develop`. Use `Related #246`, not `Closes #246`, because this is the first cleanup slice and does not finish all remaining #246 cleanup.

--- a/docs/superpowers/specs/2026-07-06-legacy-lineage-history-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-06-legacy-lineage-history-cleanup-design.md
@@ -1,0 +1,126 @@
+# Legacy Lineage And History Cleanup Design
+
+## Context
+
+Issue #246 is the Phase 5 cleanup for legacy lineage and history behavior. Recent work already moved the main provenance model away from stored `operation_history` state:
+
+- Runtime `lineage` is held on frames and drives executable replay.
+- `operation_graph` is derived from runtime `lineage` and preserves parent structure for Recipe extraction.
+- `operation_history` is a read-only compatibility view derived from runtime `lineage`.
+- `operation_summaries` is a display view derived from runtime `lineage`, unless a WDF or `persist()` boundary supplies an inspection-only summaries snapshot.
+- WDF stores inspection-only operation summaries snapshots, not executable Recipe lineage.
+
+The first #246 PR should not remove or weaken `previous`. It should clarify the remaining contract and add tests where the current behavior is easy to misunderstand.
+
+## Decision
+
+Keep `_previous` and the public `previous` accessor as strong references for now.
+
+`previous` is a stable compatibility/debug accessor. It can help users inspect the frame they just transformed, and some user-facing examples rely on that stable behavior. It is not the source of truth for processing history, Recipe extraction, or WDF summaries.
+
+Do not weak-reference `previous` in this issue. Wandas frame data is Dask-backed, so computation dependencies already live in the Dask graph. Turning `previous` into a weak reference would not make computation meaningfully safer, but it would make a public/debug accessor depend on garbage collection timing. That is poor beginner UX: a frame that was visible a moment ago could unexpectedly become `None`.
+
+If future memory work needs to deprecate, remove, or weak-reference `previous`, that should be a separate issue with an explicit deprecation plan.
+
+## Source Of Truth Contract
+
+Wandas should expose four distinct concepts:
+
+1. `previous`
+   - Strong reference to the immediate prior frame when a frame operation creates a new frame.
+   - Compatibility/debug convenience only.
+   - Not used to build `operation_history`, `operation_summaries`, `operation_graph`, or Recipe specs.
+
+2. `lineage`
+   - Runtime source of truth for operation provenance inside the current process.
+   - Used to derive `operation_history`, `operation_summaries`, and `operation_graph` when no boundary snapshot is present.
+   - Not exported as public xarray attrs or WDF executable state.
+
+3. `operation_history`
+   - Backward-compatible flat list for user inspection.
+   - Read-only derived view from runtime `lineage`.
+   - Not backed by `_xr.attrs["operation_history"]`.
+   - Mutating a returned list must not mutate frame state.
+
+4. `operation_summaries`
+   - Display-oriented summary view.
+   - Derived from runtime `lineage` during normal processing.
+   - Derived from an inspection-only snapshot after WDF load or `persist()`.
+   - Not backed by legacy `operation_history` attrs, legacy WDF `operation_history` groups, or manual append paths.
+
+## First PR Scope
+
+The first #246 PR should be small and contract-focused:
+
+- Keep `_previous` and `previous` as strong references.
+- Update docstrings or docs so `previous` is described as a compatibility/debug accessor, not a history source of truth.
+- Rename or adjust misleading tests such as `previous_property_tracks_lineage` so they no longer imply `previous` powers lineage.
+- Add focused tests proving that `operation_history` does not read from `previous`.
+- Add focused tests proving that legacy `operation_history` attrs do not affect `operation_summaries`.
+- Add or update docs for the beginner-facing distinction between `previous`, `operation_history`, `operation_summaries`, `operation_graph`, and WDF snapshots.
+
+Production code changes should be minimal. If the new tests already pass, the PR can be mostly docs and test contract pinning. If a new test exposes legacy state being treated as authoritative, fix only that path.
+
+## Explicit Non-Goals
+
+The first #246 PR should not:
+
+- weak-reference `_previous`;
+- remove `previous`;
+- deprecate public `operation_history`;
+- implement executable Recipe WDF persistence;
+- change Recipe graph identity or DAG behavior;
+- remove constructor compatibility in a broad sweep;
+- change Dask graph construction or numerical processing behavior.
+
+## Later #246 Cleanup Slices
+
+After the first PR, remaining #246 work can be split into smaller issues or PRs:
+
+1. Constructor compatibility cleanup
+   - Audit positional constructor compatibility around `previous`, `source_time_offset`, `lineage`, and `operation_summaries_snapshot`.
+   - Prefer explicit keyword-only future APIs if a breaking change is approved.
+
+2. Legacy `operation_history` storage cleanup
+   - Remove or tighten any remaining compatibility paths that accept stored `operation_history` as input.
+   - Keep WDF legacy groups ignored unless a migration requirement is explicitly added.
+
+3. Metadata/history duplication cleanup
+   - Ensure metadata remains durable frame state while history remains runtime lineage or inspection snapshot state.
+   - Avoid storing the same processing fact in both metadata and lineage.
+
+4. Public deprecation decisions
+   - If `previous` or `operation_history` should change public behavior, open a separate issue with migration text and deprecation timing.
+
+## Test Strategy
+
+Add tests before production changes:
+
+- `previous` remains stable across a normal operation and is not weakref/GC-dependent.
+- A frame with `previous` but no `lineage` has empty `operation_history` and `operation_graph`.
+- A frame with runtime `lineage` but no `previous` still exposes `operation_history`.
+- Injecting `_xr.attrs["operation_history"]` does not affect `operation_history` or `operation_summaries`.
+- A snapshot-backed frame returns snapshot `operation_summaries` even if legacy `operation_history` attrs are present.
+
+Run focused checks first:
+
+- `uv run pytest tests/core/test_base_frame_lineage.py tests/core/test_xarray_storage_only.py -q`
+- `uv run pytest tests/io/test_wdf_io.py -q`
+
+Before PR readiness, run:
+
+- `uv run pytest tests/core/test_base_frame_lineage.py tests/core/test_xarray_storage_only.py tests/io/test_wdf_io.py -q`
+- `uv run ruff check`
+- `uv run ty check wandas/core tests/core/test_base_frame_lineage.py tests/core/test_xarray_storage_only.py tests/io/test_wdf_io.py`
+
+Full `uv run ty check` may still report pre-existing diagnostics outside this PR. If so, report them separately with the affected files.
+
+## Acceptance
+
+The first #246 PR is complete when:
+
+- `previous` is explicitly documented and tested as a stable debug/compat accessor, not a history source of truth.
+- `operation_history` is explicitly tested as a lineage-derived read-only compatibility view.
+- `operation_summaries` is explicitly tested as lineage-derived or snapshot-derived, never legacy history attr-derived.
+- No new public behavior depends on legacy `operation_history` attrs or manual append paths.
+- Relevant tests, lint, and scoped type checks pass.

--- a/tests/core/test_base_frame_lineage.py
+++ b/tests/core/test_base_frame_lineage.py
@@ -226,6 +226,36 @@ def test_operation_history_public_behavior_is_read_only_lineage_view() -> None:
     assert "operation_history" not in result._xr.attrs
 
 
+def test_previous_is_stable_debug_accessor_not_history_source() -> None:
+    previous = _frame().normalize()
+    frame = ChannelFrame(
+        da_from_array(np.array([[1.0, 2.0, 3.0]]), chunks=(1, -1)),
+        sampling_rate=16000,
+        previous=previous,
+    )
+
+    assert frame.previous is previous
+    assert frame.lineage is None
+    assert frame.operation_history == []
+    assert frame.operation_summaries == []
+    assert frame.operation_graph is None
+
+
+def test_operation_history_comes_from_lineage_without_previous() -> None:
+    frame = ChannelFrame(
+        da_from_array(np.array([[1.0, 2.0, 3.0]]), chunks=(1, -1)),
+        sampling_rate=16000,
+        lineage=LineageNode(Normalize(16000)),
+        previous=None,
+    )
+
+    assert frame.previous is None
+    assert [record["operation"] for record in frame.operation_history] == ["normalize"]
+    assert [summary["operation"] for summary in frame.operation_summaries] == ["normalize"]
+    assert frame.operation_graph is not None
+    assert frame.operation_graph["operation"] == "normalize"
+
+
 def test_operation_summaries_returns_display_lineage_summaries() -> None:
     result = _frame().high_pass_filter(100).normalize()
 

--- a/tests/core/test_base_frame_lineage.py
+++ b/tests/core/test_base_frame_lineage.py
@@ -339,6 +339,26 @@ def test_persist_preserves_multi_input_operation_summaries_from_snapshot() -> No
     assert [summary["operation"] for summary in summaries] == ["normalize", "remove_dc", "+"]
 
 
+def test_operation_summaries_ignore_legacy_operation_history_attrs() -> None:
+    frame = _frame().normalize()
+    frame._xr.attrs["operation_history"] = [{"operation": "legacy", "params": {"gain": 2.0}}]
+
+    assert [summary["operation"] for summary in frame.operation_summaries] == ["normalize"]
+    assert [record["operation"] for record in frame.operation_history] == ["normalize"]
+
+
+def test_snapshot_operation_summaries_ignore_legacy_operation_history_attrs() -> None:
+    frame = ChannelFrame(
+        da_from_array(np.array([[1.0, 2.0, 3.0]]), chunks=(1, -1)),
+        sampling_rate=16000,
+        operation_summaries_snapshot=[{"operation": "loaded", "params": {"gain": 2.0}}],
+    )
+    frame._xr.attrs["operation_history"] = [{"operation": "legacy", "params": {"gain": 3.0}}]
+
+    assert frame.operation_summaries == [{"operation": "loaded", "params": {"gain": 2.0}}]
+    assert frame.operation_history == []
+
+
 def test_snapshot_backed_getitem_hides_temporary_get_channel_summary() -> None:
     frame = ChannelFrame(
         da_from_array(np.array([[1.0, 2.0], [3.0, 4.0]]), chunks=(1, -1)),

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -477,8 +477,11 @@ class BaseFrame(ABC, Generic[T]):
 
     @property
     def previous(self) -> "BaseFrame[Any] | None":
-        """
-        Returns the previous frame.
+        """Return the immediate prior frame for compatibility/debug inspection.
+
+        This strong reference is not the source of truth for processing
+        history. Runtime lineage drives ``operation_history``,
+        ``operation_summaries``, ``operation_graph``, and Recipe extraction.
         """
         return self._previous
 
@@ -545,7 +548,7 @@ class BaseFrame(ABC, Generic[T]):
 
     @property
     def operation_summaries(self) -> list[dict[str, Any]]:
-        """Return lightweight display summaries derived from lineage or a boundary snapshot."""
+        """Return display summaries derived from lineage or a boundary snapshot."""
         if self._operation_summaries_snapshot is not None:
             return copy.deepcopy(self._operation_summaries_snapshot)
         return self._lineage_to_summaries(self.lineage)


### PR DESCRIPTION
## Summary

- Documents the #246 first-slice contract: previous stays a stable debug/compat accessor, not a provenance source.
- Adds tests pinning operation_history as lineage-derived and operation_summaries as lineage/snapshot-derived.
- Clarifies contributor docs around previous, lineage, operation_history, operation_summaries, and operation_graph.

## Validation

- `uv run pytest tests/core/test_base_frame_lineage.py tests/core/test_xarray_storage_only.py tests/io/test_wdf_io.py -q` PASS, 128 passed
- `uv run ruff check` PASS
- `uv run ty check wandas/core tests/core/test_base_frame_lineage.py tests/core/test_xarray_storage_only.py tests/io/test_wdf_io.py` PASS

Related #246