### PR TITLE
Pin constructor provenance boundary

### DIFF
--- a/tests/core/test_base_frame_additional.py
+++ b/tests/core/test_base_frame_additional.py
@@ -777,6 +777,8 @@ def test_create_new_instance_rejects_legacy_history_and_validates_channel_ids():
 
     with pytest.raises(TypeError, match="unexpected keyword argument 'operation_history'"):
         f._create_new_instance(data=f._data, operation_history="bad")
+    with pytest.raises(TypeError, match="unexpected keyword argument 'operation_graph'"):
+        f._create_new_instance(data=f._data, operation_graph={"operation": "bad"})
     with pytest.raises(TypeError, match="unexpected keyword argument 'operations'"):
         make_frame(np.arange(6).reshape(2, 3), operations=["bad"])
     with pytest.raises(TypeError, match="Channel ids must be a list"):

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -183,6 +183,15 @@ class TestChannelFrame:
         assert cf.previous is previous
         np.testing.assert_array_equal(cf.source_time_offset, np.array([0.0, 0.0]))
 
+    def test_constructor_rejects_legacy_history_provenance_kwargs(self) -> None:
+        """Legacy history/provenance names are not constructor state sources."""
+        with pytest.raises(TypeError, match="unexpected keyword argument 'operation_history'"):
+            ChannelFrame(self.dask_data, self.sample_rate, operation_history=[])  # ty: ignore[unknown-argument]
+        with pytest.raises(TypeError, match="unexpected keyword argument 'operation_graph'"):
+            ChannelFrame(self.dask_data, self.sample_rate, operation_graph={})  # ty: ignore[unknown-argument]
+        with pytest.raises(TypeError, match="unexpected keyword argument 'operations'"):
+            ChannelFrame(self.dask_data, self.sample_rate, operations=[])  # ty: ignore[unknown-argument]
+
     def test_binary_op_allows_source_time_offset_mismatch_and_inherits_left_offset(self) -> None:
         """Frame-frame binary ops are index-wise and keep the left source timeline."""
         left = ChannelFrame(self.dask_data, self.sample_rate, source_time_offset=2.0)

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -138,12 +138,14 @@ class BaseFrame(ABC, Generic[T]):
     metadata : dict, optional
         Additional metadata for the frame.
     lineage : LineageNode, optional
-        Computation lineage for this frame.
+        Runtime operation lineage for this frame. This is the source of truth
+        for executable replay and the derived ``operation_history`` view.
     channel_metadata : list[ChannelMetadata | dict], optional
         Metadata for each channel in the frame. Can be ChannelMetadata objects
         or dicts that will be converted to ChannelMetadata objects.
     previous : BaseFrame, optional
-        The frame that this frame was derived from.
+        Compatibility/debug pointer to the immediate prior frame. This strong
+        reference is not the source of truth for processing history.
 
     Attributes
     ----------

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -230,9 +230,14 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
                 Must be a positive value.
             label: A label for the frame.
             metadata: Optional metadata dictionary.
-            lineage: Runtime operation lineage for this frame.
+            lineage: Runtime operation lineage for this frame. This is the
+                provenance source for executable replay and derived history
+                views.
             channel_metadata: Metadata for each channel.
-            previous: Reference to the previous frame in the processing chain.
+            previous: Compatibility/debug pointer to the immediate prior frame;
+                not the provenance source of truth.
+            operation_summaries_snapshot: Inspection-only summary snapshot used
+                across persistence boundaries.
 
         Raises:
             ValueError: If data has more than 2 dimensions, or if

--- a/wandas/frames/noct.py
+++ b/wandas/frames/noct.py
@@ -67,7 +67,8 @@ class NOctFrame(BaseFrame[NDArrayReal]):
     channel_metadata : list[ChannelMetadata], optional
         Metadata for each channel in the frame.
     previous : BaseFrame, optional
-        The frame that this frame was derived from.
+        Compatibility/debug pointer to the immediate prior frame; not the
+        provenance source of truth.
 
     Attributes
     ----------

--- a/wandas/frames/roughness.py
+++ b/wandas/frames/roughness.py
@@ -56,7 +56,8 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
     channel_metadata : list[ChannelMetadata], optional
         Metadata for each channel.
     previous : BaseFrame, optional
-        Reference to the previous frame in the processing chain.
+        Compatibility/debug pointer to the immediate prior frame; not the
+        provenance source of truth.
 
     Attributes
     ----------

--- a/wandas/frames/spectral.py
+++ b/wandas/frames/spectral.py
@@ -60,7 +60,8 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
     channel_metadata : list[ChannelMetadata], optional
         Metadata for each channel in the frame.
     previous : BaseFrame, optional
-        The frame that this frame was derived from.
+        Compatibility/debug pointer to the immediate prior frame; not the
+        provenance source of truth.
 
     Attributes
     ----------

--- a/wandas/frames/spectrogram.py
+++ b/wandas/frames/spectrogram.py
@@ -58,7 +58,8 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
     channel_metadata : list[ChannelMetadata], optional
         Metadata for each channel in the frame.
     previous : BaseFrame, optional
-        The frame that this frame was derived from.
+        Compatibility/debug pointer to the immediate prior frame; not the
+        provenance source of truth.
 
     Attributes
     ----------


### PR DESCRIPTION
## Summary
- Clarify constructor docs so `previous` is a compatibility/debug pointer, not provenance truth
- Keep runtime lineage as the source for executable replay and derived history views
- Add tests that legacy `operation_history`, `operation_graph`, and `operations` kwargs are not accepted as constructor provenance state

## Validation
- `uv run pytest tests/frames/test_channel_frame.py tests/core/test_base_frame_additional.py -q`
- `uv run ruff check`
- `uv run ty check wandas/core wandas/frames tests/core/test_base_frame_additional.py tests/frames/test_channel_frame.py`

Related #246