### PR TITLE
Finalize legacy history cleanup contract

### DIFF
--- a/docs/superpowers/specs/2026-07-06-legacy-lineage-history-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-06-legacy-lineage-history-cleanup-design.md
@@ -46,7 +46,9 @@ Wandas should expose four distinct concepts:
    - Display-oriented summary view.
    - Derived from runtime `lineage` during normal processing.
    - Derived from an inspection-only snapshot after WDF load or `persist()`.
-   - Not backed by legacy `operation_history` attrs, legacy WDF `operation_history` groups, or manual append paths.
+   - Not backed by `_xr.attrs["operation_history"]`, WDF `operation_history` groups, or manual append paths.
+   - WDF `operation_history` groups are not a supported load contract; WDF history display uses the
+     `operation_summaries_json` snapshot instead.
 
 ## First PR Scope
 
@@ -56,7 +58,7 @@ The first #246 PR should be small and contract-focused:
 - Update docstrings or docs so `previous` is described as a compatibility/debug accessor, not a history source of truth.
 - Rename or adjust misleading tests such as `previous_property_tracks_lineage` so they no longer imply `previous` powers lineage.
 - Add focused tests proving that `operation_history` does not read from `previous`.
-- Add focused tests proving that legacy `operation_history` attrs do not affect `operation_summaries`.
+- Add focused tests proving that unsupported `operation_history` attrs do not affect `operation_summaries`.
 - Add or update docs for the beginner-facing distinction between `previous`, `operation_history`, `operation_summaries`, `operation_graph`, and WDF snapshots.
 
 Production code changes should be minimal. If the new tests already pass, the PR can be mostly docs and test contract pinning. If a new test exposes legacy state being treated as authoritative, fix only that path.
@@ -83,7 +85,7 @@ After the first PR, remaining #246 work can be split into smaller issues or PRs:
 
 2. Legacy `operation_history` storage cleanup
    - Remove or tighten any remaining compatibility paths that accept stored `operation_history` as input.
-   - Keep WDF legacy groups ignored unless a migration requirement is explicitly added.
+   - Do not add compatibility for WDF `operation_history` groups unless a migration requirement is explicitly added.
 
 3. Metadata/history duplication cleanup
    - Ensure metadata remains durable frame state while history remains runtime lineage or inspection snapshot state.
@@ -99,8 +101,8 @@ Add tests before production changes:
 - `previous` remains stable across a normal operation and is not weakref/GC-dependent.
 - A frame with `previous` but no `lineage` has empty `operation_history` and `operation_graph`.
 - A frame with runtime `lineage` but no `previous` still exposes `operation_history`.
-- Injecting `_xr.attrs["operation_history"]` does not affect `operation_history` or `operation_summaries`.
-- A snapshot-backed frame returns snapshot `operation_summaries` even if legacy `operation_history` attrs are present.
+- Injecting unsupported `_xr.attrs["operation_history"]` does not affect `operation_history` or `operation_summaries`.
+- A snapshot-backed frame returns snapshot `operation_summaries` even if unsupported `operation_history` attrs are present.
 
 Run focused checks first:
 
@@ -121,6 +123,6 @@ The first #246 PR is complete when:
 
 - `previous` is explicitly documented and tested as a stable debug/compat accessor, not a history source of truth.
 - `operation_history` is explicitly tested as a lineage-derived read-only compatibility view.
-- `operation_summaries` is explicitly tested as lineage-derived or snapshot-derived, never legacy history attr-derived.
-- No new public behavior depends on legacy `operation_history` attrs or manual append paths.
+- `operation_summaries` is explicitly tested as lineage-derived or snapshot-derived, never unsupported history attr-derived.
+- No new public behavior depends on unsupported `operation_history` attrs or manual append paths.
 - Relevant tests, lint, and scoped type checks pass.

--- a/tests/core/test_base_frame_additional.py
+++ b/tests/core/test_base_frame_additional.py
@@ -744,7 +744,7 @@ def test_empty_channel_ids_are_defaulted_when_setting_metadata():
     assert f._channel_ids == ["c0", "c1"]
 
 
-def test_label_metadata_and_operation_history_attrs_validation():
+def test_label_metadata_attrs_and_lineage_assignment_validation():
     f = make_frame(np.arange(6).reshape(2, 3))
 
     f.label = None
@@ -762,10 +762,6 @@ def test_label_metadata_and_operation_history_attrs_validation():
     with pytest.raises(TypeError, match="Metadata must be a dictionary"):
         f.metadata = cast(Any, "bad")
 
-    f._xr.attrs["operation_history"] = None
-    assert f.operation_history == []
-    f._xr.attrs["operation_history"] = "bad"
-    assert f.operation_history == []
     with pytest.raises(AttributeError):
         setattr(f, "operation_history", cast(Any, "bad"))
     with pytest.raises(AttributeError):

--- a/tests/core/test_base_frame_lineage.py
+++ b/tests/core/test_base_frame_lineage.py
@@ -339,21 +339,21 @@ def test_persist_preserves_multi_input_operation_summaries_from_snapshot() -> No
     assert [summary["operation"] for summary in summaries] == ["normalize", "remove_dc", "+"]
 
 
-def test_operation_summaries_ignore_legacy_operation_history_attrs() -> None:
+def test_operation_views_do_not_read_xarray_operation_history_attrs() -> None:
     frame = _frame().normalize()
-    frame._xr.attrs["operation_history"] = [{"operation": "legacy", "params": {"gain": 2.0}}]
+    frame._xr.attrs["operation_history"] = [{"operation": "attrs", "params": {"gain": 2.0}}]
 
     assert [summary["operation"] for summary in frame.operation_summaries] == ["normalize"]
     assert [record["operation"] for record in frame.operation_history] == ["normalize"]
 
 
-def test_snapshot_operation_summaries_ignore_legacy_operation_history_attrs() -> None:
+def test_snapshot_operation_summaries_do_not_read_xarray_operation_history_attrs() -> None:
     frame = ChannelFrame(
         da_from_array(np.array([[1.0, 2.0, 3.0]]), chunks=(1, -1)),
         sampling_rate=16000,
         operation_summaries_snapshot=[{"operation": "loaded", "params": {"gain": 2.0}}],
     )
-    frame._xr.attrs["operation_history"] = [{"operation": "legacy", "params": {"gain": 3.0}}]
+    frame._xr.attrs["operation_history"] = [{"operation": "attrs", "params": {"gain": 3.0}}]
 
     assert frame.operation_summaries == [{"operation": "loaded", "params": {"gain": 2.0}}]
     assert frame.operation_history == []

--- a/tests/core/test_xarray_storage_only.py
+++ b/tests/core/test_xarray_storage_only.py
@@ -610,7 +610,6 @@ def test_frame_state_properties_are_backed_by_xarray_attrs() -> None:
     frame._xr.attrs["sampling_rate"] = 8.0
     frame._xr.attrs["label"] = "from-attrs"
     frame._xr.attrs["metadata"] = {"owner": "mutated"}
-    frame._xr.attrs["operation_history"] = [{"operation": "mutated", "params": {"x": 1}}]
 
     assert frame.sampling_rate == 8.0
     assert frame.label == "from-attrs"

--- a/tests/io/test_wdf_io.py
+++ b/tests/io/test_wdf_io.py
@@ -582,7 +582,7 @@ def test_load_wdf_modified_version_still_loads(tmp_path: Path) -> None:
 
 
 def test_save_wdf_does_not_create_operation_history_group(tmp_path: Path) -> None:
-    """WDF save omits legacy operation_history groups."""
+    """WDF save stores summary snapshots, not operation_history groups."""
     rng = np.random.default_rng(7)
     sr = 16000
     data = rng.standard_normal((1, sr))


### PR DESCRIPTION
## Summary
- Separate durable xarray attrs validation from runtime `operation_history` provenance tests
- Rename history attrs tests so unsupported attrs are not presented as a supported legacy contract
- Update the #246 design note to keep WDF `operation_history` groups unsupported and point WDF display history at `operation_summaries_json` snapshots

## Validation
- `uv run pytest tests/core/test_base_frame_additional.py tests/core/test_base_frame_lineage.py tests/core/test_xarray_storage_only.py tests/io/test_wdf_io.py -q`
- `uv run ruff check`
- `uv run ty check wandas/core wandas/io tests/core/test_base_frame_additional.py tests/core/test_base_frame_lineage.py tests/core/test_xarray_storage_only.py tests/io/test_wdf_io.py`

Closes #246