### PR TITLE
Append shared channel unit to overlay waveform ylabel and add tests

### DIFF
--- a/tests/visualization/test_plotting.py
+++ b/tests/visualization/test_plotting.py
@@ -86,8 +86,8 @@ class TestPlotting:
         self.mock_channel_frame.labels = ["ch1", "ch2"]
         self.mock_channel_frame.label = "Test Channel"
         self.mock_channel_frame.channels = [
-            mock.MagicMock(label="ch1"),
-            mock.MagicMock(label="ch2"),
+            mock.MagicMock(label="ch1", unit=""),
+            mock.MagicMock(label="ch2", unit=""),
         ]
 
         # Single-channel mock channel frame
@@ -98,7 +98,7 @@ class TestPlotting:
         self.mock_single_channel_frame.labels = ["ch1"]
         self.mock_single_channel_frame.label = "Test Single Channel"
         self.mock_single_channel_frame.channels = [
-            mock.MagicMock(label="ch1"),
+            mock.MagicMock(label="ch1", unit=""),
         ]
 
         # Spectral frame mock -- deterministic data
@@ -316,6 +316,52 @@ class TestPlotting:
         assert isinstance(result, Iterator)
         axes_list = list(result)
         assert len(axes_list) == self.mock_channel_frame.n_channels
+
+    def test_overlay_waveform_uses_shared_channel_unit(self) -> None:
+        """Overlay waveform plots include a shared non-empty channel unit."""
+        strategy = WaveformPlotStrategy()
+        self.mock_channel_frame.channels = [
+            mock.MagicMock(label="ch1", unit="Pa"),
+            mock.MagicMock(label="ch2", unit="Pa"),
+        ]
+
+        result = strategy.plot(self.mock_channel_frame, overlay=True)
+
+        assert isinstance(result, Axes)
+        assert result.get_ylabel() == "Amplitude [Pa]"
+
+    def test_overlay_waveform_omits_mixed_or_missing_channel_units(self) -> None:
+        """Overlay waveform plots only show units when every channel shares one unit."""
+        strategy = WaveformPlotStrategy()
+
+        self.mock_channel_frame.channels = [
+            mock.MagicMock(label="ch1", unit="Pa"),
+            mock.MagicMock(label="ch2", unit="V"),
+        ]
+        mixed_result = strategy.plot(self.mock_channel_frame, overlay=True)
+        assert isinstance(mixed_result, Axes)
+        assert mixed_result.get_ylabel() == "Amplitude"
+
+        self.mock_channel_frame.channels = [
+            mock.MagicMock(label="ch1", unit="Pa"),
+            mock.MagicMock(label="ch2", unit=""),
+        ]
+        missing_result = strategy.plot(self.mock_channel_frame, overlay=True)
+        assert isinstance(missing_result, Axes)
+        assert missing_result.get_ylabel() == "Amplitude"
+
+    def test_overlay_waveform_explicit_ylabel_overrides_shared_unit(self) -> None:
+        """Explicit overlay waveform y-labels are not rewritten with channel units."""
+        strategy = WaveformPlotStrategy()
+        self.mock_channel_frame.channels = [
+            mock.MagicMock(label="ch1", unit="Pa"),
+            mock.MagicMock(label="ch2", unit="Pa"),
+        ]
+
+        result = strategy.plot(self.mock_channel_frame, overlay=True, ylabel="Custom")
+
+        assert isinstance(result, Axes)
+        assert result.get_ylabel() == "Custom"
 
     def test_single_channel_waveform_plot_strategy(self) -> None:
         """Test single-channel WaveformPlotStrategy."""

--- a/wandas/visualization/plotting.py
+++ b/wandas/visualization/plotting.py
@@ -298,6 +298,7 @@ class WaveformPlotStrategy(PlotStrategy["ChannelFrame"]):
         kwargs = kwargs or {}
         axes_cls = _matplotlib_axes_type("waveform plot")
         line2d_cls = _matplotlib_line2d_type("waveform plot")
+        explicit_ylabel = "ylabel" in kwargs
         ylabel = kwargs.pop("ylabel", "Amplitude")
         xlabel = kwargs.pop("xlabel", "Time [s]")
         alpha = kwargs.pop("alpha", 1)
@@ -309,6 +310,11 @@ class WaveformPlotStrategy(PlotStrategy["ChannelFrame"]):
         def _waveform_ylabel(ylabel: str, ch_meta: Any) -> str:
             unit_suffix = f" [{ch_meta.unit}]" if ch_meta.unit else ""
             return f"{ylabel}{unit_suffix}"
+
+        if (overlay or ax is not None) and not explicit_ylabel:
+            channel_units = [ch_meta.unit for ch_meta in bf.channels]
+            if channel_units and all(unit and unit == channel_units[0] for unit in channel_units):
+                ylabel = f"{ylabel} [{channel_units[0]}]"
 
         return _plot_line_layout(
             self,


### PR DESCRIPTION
### Motivation

- Make waveform overlay plots display a unit suffix when every channel in the plotted frame shares the same non-empty unit, while avoiding unit suffixes for mixed or missing units and not overriding an explicit `ylabel`.
- Prevent test failures caused by tests referencing a missing `unit` attribute on mocked channel metadata by ensuring mocks include a `unit` field.

### Description

- Updated `WaveformPlotStrategy.plot` to detect whether a `ylabel` was provided via `explicit_ylabel = "ylabel" in kwargs` and, when plotting in overlay mode or with an explicit `ax` and no explicit `ylabel`, append a unit suffix ` [unit]` if all `bf.channels` share the same non-empty `unit`.
- Preserved per-channel y-label generation through the existing `per_channel_ylabel_fn` while ensuring overlay label logic is applied only when appropriate.
- Added three tests in `tests/visualization/test_plotting.py`: `test_overlay_waveform_uses_shared_channel_unit`, `test_overlay_waveform_omits_mixed_or_missing_channel_units`, and `test_overlay_waveform_explicit_ylabel_overrides_shared_unit` to validate the new behavior.
- Updated test setup to include a `unit` attribute on mocked channel metadata (using `unit=""` by default) to reflect real channel metadata and avoid attribute errors.

### Testing

- Ran `pytest tests/visualization/test_plotting.py` which exercised the waveform plotting strategy and the new unit-related tests, and the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fab5ff558832db9e8f437c0f057b3)