### PR TITLE
Fix overlay channel labels

### DIFF
--- a/tests/visualization/test_plotting.py
+++ b/tests/visualization/test_plotting.py
@@ -1,5 +1,5 @@
 import types
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from pathlib import Path
 from typing import Any
 from unittest import mock
@@ -49,7 +49,14 @@ class TestPlotStrategy(PlotStrategy[Any]):
 
     name = "test_strategy"
 
-    def channel_plot(self, x: Any, y: Any, ax: "Axes", label: str | None = None, alpha: float = 1.0) -> None:
+    def channel_plot(
+        self,
+        x: Any,
+        y: Any,
+        ax: "Axes",
+        label: str | Sequence[str] | None = None,
+        alpha: float = 1.0,
+    ) -> None:
         pass
 
     def plot(

--- a/tests/visualization/test_plotting_param.py
+++ b/tests/visualization/test_plotting_param.py
@@ -59,6 +59,26 @@ def test_plot_parametrize(strategy, kwargs, label):
 
 
 @pytest.mark.parametrize("strategy_cls", [WaveformPlotStrategy, FrequencyPlotStrategy, NOctPlotStrategy])
+def test_overlay_uses_frame_channel_labels_by_default(strategy_cls):
+    """Overlay mode labels each line from its corresponding channel metadata."""
+    frame = DummyFrame()
+
+    ax = strategy_cls().plot(frame, overlay=True)
+
+    assert [line.get_label() for line in ax.get_lines()] == ["ch1", "ch2"]
+
+
+@pytest.mark.parametrize("strategy_cls", [WaveformPlotStrategy, FrequencyPlotStrategy, NOctPlotStrategy])
+def test_overlay_label_sequence_overrides_frame_channel_labels(strategy_cls):
+    """An explicit overlay label sequence remains the caller override."""
+    frame = DummyFrame()
+
+    ax = strategy_cls().plot(frame, overlay=True, label=["left", "right"])
+
+    assert [line.get_label() for line in ax.get_lines()] == ["left", "right"]
+
+
+@pytest.mark.parametrize("strategy_cls", [WaveformPlotStrategy, FrequencyPlotStrategy, NOctPlotStrategy])
 def test_non_overlay_label_sequence_uses_per_channel_labels(strategy_cls):
     """Non-overlay mode applies per-channel labels from a sequence."""
     frame = DummyFrame()

--- a/wandas/visualization/plotting.py
+++ b/wandas/visualization/plotting.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 TFrame = TypeVar("TFrame", bound="BaseFrame[Any]")
+PlotLabel = str | Sequence[str] | None
 
 
 def _spectrogram_axis_values(frame: Any, data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
@@ -57,7 +58,7 @@ class PlotStrategy(abc.ABC, Generic[TFrame]):
         x: Any,
         y: Any,
         ax: Axes,
-        label: str | None = None,
+        label: PlotLabel = None,
         alpha: float = 1.0,
     ) -> None:
         """Implementation of channel plotting"""
@@ -224,7 +225,7 @@ def _plot_line_layout(
             x_data,
             data_2d.T,
             ax,
-            label=label if label is not None else (bf.labels[0] if isinstance(bf.labels, list) else bf.labels),
+            label=label if label is not None else bf.labels,
             alpha=alpha,
             **plot_kwargs,
         )
@@ -271,7 +272,7 @@ class WaveformPlotStrategy(PlotStrategy["ChannelFrame"]):
         x: Any,
         y: Any,
         ax: Axes,
-        label: str | None = None,
+        label: PlotLabel = None,
         alpha: float = 1.0,
         **kwargs: Any,
     ) -> None:
@@ -345,7 +346,7 @@ class FrequencyPlotStrategy(PlotStrategy["SpectralFrame"]):
         x: Any,
         y: Any,
         ax: Axes,
-        label: str | None = None,
+        label: PlotLabel = None,
         alpha: float = 1.0,
         **kwargs: Any,
     ) -> None:
@@ -418,7 +419,7 @@ class NOctPlotStrategy(PlotStrategy["NOctFrame"]):
         x: Any,
         y: Any,
         ax: Axes,
-        label: str | None = None,
+        label: PlotLabel = None,
         alpha: float = 1.0,
         **kwargs: Any,
     ) -> None:
@@ -489,7 +490,7 @@ class SpectrogramPlotStrategy(PlotStrategy["SpectrogramFrame"]):
         x: Any,
         y: Any,
         ax: Axes,
-        label: str | None = None,
+        label: PlotLabel = None,
         alpha: float = 1.0,
         **kwargs: Any,
     ) -> None:
@@ -605,7 +606,7 @@ class DescribePlotStrategy(PlotStrategy["ChannelFrame"]):
         x: Any,
         y: Any,
         ax: Axes,
-        label: str | None = None,
+        label: PlotLabel = None,
         alpha: float = 1.0,
         **kwargs: Any,
     ) -> None:
@@ -709,7 +710,7 @@ class MatrixPlotStrategy(PlotStrategy["SpectralFrame"]):
         x: Any,
         y: Any,
         ax: Axes,
-        label: str | None = None,
+        label: PlotLabel = None,
         alpha: float = 1.0,
         **kwargs: Any,
     ) -> None:


### PR DESCRIPTION
## Summary

- use every frame channel label by default for overlay line plots
- preserve explicit scalar and sequence label overrides
- cover waveform, frequency, and N-octave strategies with regression tests

## Root cause

The shared overlay layout selected `bf.labels[0]` when frame labels were stored as a list. Matplotlib therefore received one scalar label for every line in a multi-channel plot.

## Impact

Multi-channel overlay legends now match the plotted channel order without requiring callers to repeat metadata through `label=frame.labels`.

## Validation

- `uv run pytest tests/visualization/test_plotting_param.py tests/visualization/test_plotting.py -q` (69 passed)
- `uv run ruff check wandas/visualization/plotting.py tests/visualization/test_plotting.py tests/visualization/test_plotting_param.py`
- `uv run ty check wandas/visualization/plotting.py tests/visualization/test_plotting.py tests/visualization/test_plotting_param.py`
- Full `uv run ty check` remains blocked by 8 pre-existing diagnostics in `learning-path/07_frame_centric_recipe_ux.py`.

Closes #284
Related #281
