### PR TITLE
Test documented audio format support

### DIFF
--- a/docs/src/api/utils.md
+++ b/docs/src/api/utils.md
@@ -24,8 +24,8 @@ The `FrameDataset` classes enable efficient batch processing of audio files in a
 
 ### Main Classes / 主なクラス
 
-- **`ChannelFrameDataset`**: For time-domain audio data (WAV, MP3, FLAC, CSV files).
-  **`ChannelFrameDataset`**: 時間領域の音声データ用（WAV、MP3、FLAC、CSVファイル）。
+- **`ChannelFrameDataset`**: For time-domain data (WAV, FLAC, OGG, AIFF, SND, and CSV files).
+  **`ChannelFrameDataset`**: 時間領域データ用（WAV、FLAC、OGG、AIFF、SND、CSVファイル）。
 - **`SpectrogramFrameDataset`**: For time-frequency domain data (typically created from STFT).
   **`SpectrogramFrameDataset`**: 時間周波数領域データ用（通常はSTFTから作成）。
 
@@ -39,7 +39,7 @@ from wandas.utils.frame_dataset import ChannelFrameDataset
 dataset = ChannelFrameDataset.from_folder(
     folder_path="path/to/audio/files",
     sampling_rate=16000,  # Optional: resample all files to this rate / オプション: すべてのファイルをこのレートにリサンプリング
-    file_extensions=[".wav", ".mp3"],  # File types to include / 含めるファイルタイプ
+    file_extensions=[".wav", ".flac"],  # File types to include / 含めるファイルタイプ
     recursive=True,  # Search subdirectories / サブディレクトリを検索
     lazy_loading=True  # Load files on demand (recommended) / オンデマンドでファイルを読み込む（推奨）
 )
@@ -145,8 +145,8 @@ for i in range(len(dataset)):
 **sampling_rate** (Optional[int]): Target sampling rate. Files will be resampled if different from this rate.
 ターゲットサンプリングレート。このレートと異なる場合、ファイルはリサンプリングされます。
 
-**file_extensions** (Optional[list[str]]): List of file extensions to include. Default: `[".wav", ".mp3", ".flac", ".csv"]`.
-含めるファイル拡張子のリスト。デフォルト: `[".wav", ".mp3", ".flac", ".csv"]`。
+**file_extensions** (Optional[list[str]]): List of file extensions to include. By default, all registered reader extensions from `wd.supported_formats()` are used: `[".aif", ".aiff", ".csv", ".flac", ".ogg", ".snd", ".wav"]`. Audio format availability follows the libsndfile library bundled or installed with SoundFile. MP3 is not a registered Wandas reader format.
+含めるファイル拡張子のリスト。デフォルトでは、`wd.supported_formats()` が返す登録済み reader 拡張子 `[".aif", ".aiff", ".csv", ".flac", ".ogg", ".snd", ".wav"]` をすべて使用します。音声形式の利用可否は SoundFile に同梱またはインストールされた libsndfile に従います。MP3 は Wandas の登録済み reader 形式ではありません。
 
 **lazy_loading** (bool): If True, files are loaded only when accessed. Default: True.
 Trueの場合、ファイルはアクセス時にのみ読み込まれます。デフォルト: True。

--- a/tests/io/test_file_readers.py
+++ b/tests/io/test_file_readers.py
@@ -5,8 +5,11 @@ import numpy as np
 import pandas as pd
 import pytest
 import soundfile as sf
+from dask.array.core import Array as DaArray
 
+import wandas as wd
 import wandas.io.readers as readers
+from wandas.frames.channel import ChannelFrame
 from wandas.io.readers import (
     CSVFileReader,
     SoundFileReader,
@@ -18,6 +21,69 @@ from wandas.io.readers import (
     supported_formats,
 )
 from wandas.utils.types import NDArrayReal
+
+SUPPORTED_AUDIO_CASES = [
+    pytest.param(".wav", "WAV", "PCM_16", id="wav"),
+    pytest.param(".flac", "FLAC", "PCM_16", id="flac"),
+    pytest.param(".ogg", "OGG", "VORBIS", id="ogg-vorbis"),
+    pytest.param(".aiff", "AIFF", "PCM_16", id="aiff"),
+    pytest.param(".aif", "AIFF", "PCM_16", id="aif"),
+    pytest.param(".snd", "AU", "PCM_16", id="snd-au"),
+]
+
+
+@pytest.mark.parametrize(("extension", "file_format", "subtype"), SUPPORTED_AUDIO_CASES)
+def test_read_supported_audio_format_matches_soundfile_reference(
+    tmp_path: Path,
+    extension: str,
+    file_format: str,
+    subtype: str,
+) -> None:
+    """Every advertised audio extension is readable through the public API."""
+    sample_rate = 16_000
+    n_samples = 800
+    time = np.arange(n_samples, dtype=np.float32) / sample_rate
+    source = np.column_stack(
+        [
+            0.5 * np.sin(2 * np.pi * 440 * time),
+            0.25 * np.sin(2 * np.pi * 880 * time),
+        ]
+    ).astype(np.float32)
+    path = tmp_path / f"known_signal{extension}"
+    # Explicit containers keep aliases such as .aif and .snd independent of
+    # libsndfile's extension inference.
+    sf.write(path, source, sample_rate, format=file_format, subtype=subtype)
+    expected, expected_sample_rate = sf.read(path, dtype="float32", always_2d=True)
+
+    frame = wd.read(path, normalize=True)
+
+    assert isinstance(frame, ChannelFrame)
+    assert frame.sampling_rate == expected_sample_rate
+    assert frame.n_channels == 2
+    assert frame._data.shape == (2, n_samples)
+    assert isinstance(frame._data, DaArray)
+    # Wrapper equivalence: Wandas and the authoritative SoundFile read must agree.
+    np.testing.assert_allclose(frame.data, expected.T)
+
+
+@pytest.mark.parametrize(("extension", "file_format", "subtype"), SUPPORTED_AUDIO_CASES)
+def test_read_supported_audio_format_accepts_uppercase_extension(
+    tmp_path: Path,
+    extension: str,
+    file_format: str,
+    subtype: str,
+) -> None:
+    """Reader dispatch normalizes uppercase advertised extensions."""
+    sample_rate = 8_000
+    source = np.zeros((80, 1), dtype=np.float32)
+    path = tmp_path / f"silence{extension.upper()}"
+    sf.write(path, source, sample_rate, format=file_format, subtype=subtype)
+
+    frame = wd.read(path, normalize=True)
+
+    assert frame.sampling_rate == sample_rate
+    assert frame.n_channels == 1
+    np.testing.assert_array_equal(frame.data, np.zeros(80, dtype=np.float32))
 
 
 class TestSoundFileReader:


### PR DESCRIPTION
## Summary

- generate deterministic test audio for every registered audio extension: WAV, FLAC, OGG/Vorbis, AIFF (`.aiff` and `.aif`), and SND/AU
- verify public `wd.read()` dispatch, Dask laziness, sampling rate, channel/sample shape, and SoundFile-equivalent samples
- verify uppercase extension dispatch for every advertised audio extension
- align the dataset API documentation with `wd.supported_formats()` and explicitly document that MP3 is not registered

## Why

The documentation advertised these formats, but the test suite only asserted the registry list and primarily exercised real WAV and CSV inputs. The dataset API page also incorrectly listed MP3 as a default format.

## Validation

- `uv run pytest tests/io/test_file_readers.py -q` — 42 passed
- `uv run pytest tests/test_init.py tests/utils/test_frame_dataset.py tests/docs/test_readme_examples.py -q` — 173 passed, 2 warnings
- `uv run pytest -q` — 2393 passed, 3 skipped, 41 warnings
- `uv run ruff check wandas tests --config=pyproject.toml`
- `uv run ty check wandas tests`
- `uv run mkdocs build -f docs/mkdocs.yml`

Closes #286