### PR TITLE
Avoid folder rediscovery for dataset subsets

### DIFF
--- a/tests/utils/test_frame_dataset_metadata.py
+++ b/tests/utils/test_frame_dataset_metadata.py
@@ -9,7 +9,7 @@ import soundfile as sf
 
 import wandas as wd
 from wandas.frames.channel import ChannelFrame
-from wandas.utils.frame_dataset import ChannelFrameDataset, _SampledFrameDataset
+from wandas.utils.frame_dataset import ChannelFrameDataset, FrameDataset, _SampledFrameDataset
 
 
 @pytest.fixture
@@ -219,6 +219,42 @@ def test_sample_then_select_preserves_subset_contract_without_loading(metadata_a
     frame = selected[0]
     assert frame is not None
     assert frame.metadata["split"] == "train"
+
+
+def test_select_and_sample_reuse_discovered_frames_without_rediscovery(
+    metadata_audio_folder: Path,
+) -> None:
+    dataset = ChannelFrameDataset.from_folder(
+        str(metadata_audio_folder),
+        recursive=True,
+        file_extensions=[".wav"],
+        metadata_resolver=dcase_resolver,
+    )
+
+    with (
+        patch.object(FrameDataset, "_discover_files", side_effect=AssertionError("rediscovered folder")),
+        patch.object(ChannelFrame, "from_file") as from_file,
+    ):
+        selected = dataset.select(machine="fan")
+        sampled = dataset.sample(n=2, seed=3)
+
+    from_file.assert_not_called()
+    assert [path.name for path in selected._get_file_paths()] == [
+        "section_01_target.wav",
+        "section_00_source.wav",
+    ]
+    assert sampled._get_file_paths() == [
+        dataset._get_file_paths()[0],
+        dataset._get_file_paths()[2],
+    ]
+    assert [lazy_frame.metadata for lazy_frame in selected._lazy_frames] == [
+        dataset._lazy_frames[0].metadata,
+        dataset._lazy_frames[1].metadata,
+    ]
+    assert selected._lazy_frames[0].metadata is not dataset._lazy_frames[0].metadata
+    selected._lazy_frames[0].metadata["machine"] = "changed"
+    assert dataset._lazy_frames[0].metadata["machine"] == "fan"
+    assert all(not lazy_frame.is_loaded for lazy_frame in (*selected._lazy_frames, *sampled._lazy_frames))
 
 
 def test_csv_lookup_resolver(metadata_audio_folder: Path) -> None:

--- a/wandas/utils/frame_dataset.py
+++ b/wandas/utils/frame_dataset.py
@@ -548,23 +548,19 @@ class _SubsetFrameDataset(FrameDataset[F]):
             signal_length=original_dataset.signal_length,
             file_extensions=original_dataset.file_extensions,
             recursive=original_dataset._recursive,
+            source_dataset=original_dataset,
         )
 
         # Store the original dataset
         self._original_dataset = original_dataset
-        self._path_metadata = original_dataset._path_metadata
 
         # Mapping of sampled indices
         self._original_indices = sampled_indices
 
-        # Get file paths from the original dataset and create new LazyFrames
+        # Select from the LazyFrame copies initialized from the source dataset
         original_file_paths = original_dataset._get_file_paths()
         try:
-            selected_frames = [original_dataset._lazy_frames[i] for i in sampled_indices]
-            self._lazy_frames = [
-                LazyFrame(lazy_frame.file_path, metadata=deepcopy(lazy_frame.metadata))
-                for lazy_frame in selected_frames
-            ]
+            self._lazy_frames = [self._lazy_frames[i] for i in sampled_indices]
         except IndexError as e:
             logger.error("Sampled indices are out of range for the original dataset")
             logger.error(f"  Original dataset file count: {len(original_file_paths)}")


### PR DESCRIPTION
## Summary

- initialize subset datasets from the already discovered source dataset instead of globbing the folder again
- select from copied LazyFrames while preserving order, laziness, metadata isolation, and dataset-level state
- add a regression test proving both `select()` and `sample()` avoid discovery and audio loading

## Validation

- `uv run pytest tests/utils/test_frame_dataset_metadata.py tests/utils/test_frame_dataset.py -q` — 156 passed
- `uv run pytest -n auto --cov=wandas --cov-report=term-missing` — 2435 passed, 3 skipped; `wandas/utils/frame_dataset.py` 100%
- `uv run ruff check wandas tests --config=pyproject.toml`
- `uv run ruff format --check wandas tests`
- `uv run ty check wandas tests`
- `git diff --check`

CI note: repository CI is configured for pull requests targeting `main`; this PR targets `develop`, so only Release Drafter runs remotely.

Closes #297