### PR TITLE
test: prototype shared processing operation runners

### DIFF
--- a/tests/processing/test_effect_operations.py
+++ b/tests/processing/test_effect_operations.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from dask.array.core import Array as DaArray
 
+from tests.processing_helpers import run_operation_eager
 from wandas.processing.base import create_operation, get_operation
 from wandas.processing.effects import (
     AddWithSNR,
@@ -18,20 +19,6 @@ from wandas.utils import util
 from wandas.utils.dask_helpers import da_from_array
 
 _SR: int = 16000
-
-
-def _as_dask(data: Any) -> DaArray:
-    if isinstance(data, DaArray):
-        return data
-    array = np.asarray(data)
-    if array.ndim == 1:
-        array = array.reshape(1, -1)
-    chunks = (1, *(-1,) * (array.ndim - 1))
-    return da_from_array(array, chunks=chunks)
-
-
-def _compute_process(operation: Any, data: Any, *inputs: Any) -> Any:
-    return operation.process(_as_dask(data), *(_as_dask(input_data) for input_data in inputs)).compute()
 
 
 class TestHpssHarmonic:
@@ -149,7 +136,7 @@ class TestHpssHarmonic:
         dask_input, sr = mixed_harmonic_percussive_dask
         hpss = HpssHarmonic(sr)
         raw = dask_input.compute()
-        result = _compute_process(hpss, dask_input)
+        result = run_operation_eager(hpss, dask_input)
 
         n_fft = 2048
         orig_spec = np.abs(np.fft.rfft(raw[0], n_fft))
@@ -215,7 +202,7 @@ class TestHpssPercussive:
         dask_input, sr = mixed_harmonic_percussive_dask
         hpss = HpssPercussive(sr)
         raw = dask_input.compute()
-        result = _compute_process(hpss, dask_input)
+        result = run_operation_eager(hpss, dask_input)
 
         n_fft = 2048
         orig_spec = np.abs(np.fft.rfft(raw[0], n_fft))
@@ -334,7 +321,7 @@ class TestAddWithSNR:
         op = AddWithSNR(sr, target_snr)
 
         clean = dask_input.compute()
-        result = _compute_process(op, dask_input, noise)
+        result = run_operation_eager(op, dask_input, noise)
 
         clean_power = util.calculate_rms(clean) ** 2
         noise_component = result - clean
@@ -370,7 +357,7 @@ class TestRemoveDC:
         dask_signal = da_from_array(signal, chunks=(1, -1))
         remove_dc = RemoveDC(_SR)
 
-        result = _compute_process(remove_dc, dask_signal)
+        result = run_operation_eager(remove_dc, dask_signal)
 
         expected = signal - signal.mean(axis=-1, keepdims=True)
         np.testing.assert_allclose(result, expected)
@@ -466,7 +453,7 @@ class TestNormalize:
         dask_sig = da_from_array(sig, chunks=(1, -1))
         normalize = Normalize(_SR, norm=None)
 
-        result = _compute_process(normalize, dask_sig)
+        result = run_operation_eager(normalize, dask_sig)
 
         np.testing.assert_array_equal(result, sig)
 
@@ -512,7 +499,7 @@ class TestNormalize:
         dask_sig = da_from_array(sig, chunks=(1, -1))
         normalize = Normalize(_SR, norm=np.inf, axis=-1)
 
-        result = _compute_process(normalize, dask_sig)
+        result = run_operation_eager(normalize, dask_sig)
 
         expected = sig / np.max(np.abs(sig), axis=-1, keepdims=True)
         np.testing.assert_allclose(result, expected)
@@ -522,7 +509,7 @@ class TestNormalize:
         dask_sig = da_from_array(sig, chunks=(1, -1))
         normalize = Normalize(_SR, norm=-np.inf, axis=-1)
 
-        result = _compute_process(normalize, dask_sig)
+        result = run_operation_eager(normalize, dask_sig)
 
         expected = sig / np.min(np.abs(sig), axis=-1, keepdims=True)
         np.testing.assert_allclose(result, expected)
@@ -677,7 +664,7 @@ class TestNormalize:
         dask_small = da_from_array(small, chunks=(1, -1))
 
         normalize = Normalize(_SR, norm=np.inf, axis=-1)
-        result = _compute_process(normalize, dask_small)
+        result = run_operation_eager(normalize, dask_small)
 
         assert np.max(np.abs(result)) < 1.0
         np.testing.assert_array_equal(result, small)
@@ -704,7 +691,7 @@ class TestNormalize:
         dask_small = da_from_array(small, chunks=(1, -1))
         normalize = Normalize(_SR, norm=np.inf, axis=-1, threshold=1e-10, fill=False)
 
-        result = _compute_process(normalize, dask_small)
+        result = run_operation_eager(normalize, dask_small)
 
         np.testing.assert_array_equal(result, np.zeros_like(small))
 
@@ -714,7 +701,7 @@ class TestNormalize:
         dask_zero = da_from_array(zero, chunks=(1, -1))
         normalize = Normalize(_SR, norm=2, axis=-1, fill=True)
 
-        result = _compute_process(normalize, dask_zero)
+        result = run_operation_eager(normalize, dask_zero)
 
         np.testing.assert_allclose(np.sqrt(np.sum(result**2, axis=-1)), 1.0)
 
@@ -768,13 +755,13 @@ class TestFade:
         fade = Fade(1000, fade_ms=5)
 
         with pytest.raises(ValueError, match="Fade length too long"):
-            _compute_process(fade, np.ones((1, 10)))
+            run_operation_eager(fade, np.ones((1, 10)))
 
     def test_fade_1d_input_is_reshaped_to_channel_axis(self) -> None:
         fade = Fade(1000, fade_ms=1)
         signal = np.ones(10)
 
-        result = _compute_process(fade, signal)
+        result = run_operation_eager(fade, signal)
 
         assert result.shape == (1, 10)
         assert result[0, 0] == 0.0
@@ -784,7 +771,7 @@ class TestFade:
         fade = Fade(1000, fade_ms=0)
         signal = np.array([1.0, 2.0, 3.0])
 
-        result = _compute_process(fade, signal)
+        result = run_operation_eager(fade, signal)
 
         np.testing.assert_array_equal(result, signal.reshape(1, -1))
 

--- a/tests/processing/test_operation_lazy_metadata_contract.py
+++ b/tests/processing/test_operation_lazy_metadata_contract.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import numpy as np
 import pytest
-from dask.array.core import Array as DaArray
 
 import wandas.processing.custom  # noqa: F401
 import wandas.processing.effects as effects_module
@@ -15,6 +14,7 @@ import wandas.processing.psychoacoustic as psychoacoustic_module
 import wandas.processing.spectral as spectral_module
 import wandas.processing.stats  # noqa: F401
 import wandas.processing.temporal  # noqa: F401
+from tests.processing_helpers import run_operation_lazy
 from wandas.processing.base import _OPERATION_REGISTRY, AudioOperation
 from wandas.processing.cepstral import (
     Cepstrum,
@@ -47,7 +47,6 @@ from wandas.processing.spectral import (
 )
 from wandas.processing.stats import ABS, ChannelDifference, Mean, Power, Sum
 from wandas.processing.temporal import FixLength, ReSampling, RmsTrend, SoundLevel, Trim
-from wandas.utils.dask_helpers import da_from_array
 
 SR = 16000
 
@@ -58,10 +57,6 @@ class OperationCase:
     operation_factory: Callable[[], AudioOperation[Any, Any]]
     data: np.ndarray
     extra_inputs: tuple[np.ndarray, ...] = ()
-
-
-def _as_dask(data: np.ndarray) -> DaArray:
-    return da_from_array(data, chunks=(1, *(-1,) * (data.ndim - 1)))
 
 
 def _wave(samples: int, *, channels: int = 2, dtype: np.dtype[Any] | type[Any] = np.float64) -> np.ndarray:
@@ -300,7 +295,7 @@ def test_operation_lazy_metadata_matches_computed_result(case: OperationCase, mo
     _patch_optional_backends(monkeypatch)
     operation = case.operation_factory()
 
-    result_da = operation.process(_as_dask(case.data), *(_as_dask(input_data) for input_data in case.extra_inputs))
+    result_da = run_operation_lazy(operation, case.data, *case.extra_inputs)
     result = result_da.compute()
 
     assert result_da.shape == result.shape
@@ -340,7 +335,7 @@ def test_operation_lazy_metadata_contract_mocks_optional_backends(
     case = next(case for case in OPERATION_CASES if case.name == case_name)
     operation = case.operation_factory()
 
-    result_da = operation.process(_as_dask(case.data), *(_as_dask(input_data) for input_data in case.extra_inputs))
+    result_da = run_operation_lazy(operation, case.data, *case.extra_inputs)
     result = result_da.compute()
 
     assert result_da.shape == result.shape

--- a/tests/processing/test_psychoacoustic_operations.py
+++ b/tests/processing/test_psychoacoustic_operations.py
@@ -5,7 +5,6 @@ Tolerance convention:
   - rtol=1e-10: near-exact match (MoSQITo wrapper, float64 precision guard)
 """
 
-from typing import Any
 from unittest.mock import patch
 
 import numpy as np
@@ -17,6 +16,7 @@ from mosqito.sq_metrics import sharpness_din_st as sharpness_din_st_mosqito
 from mosqito.sq_metrics import sharpness_din_tv as sharpness_din_tv_mosqito
 
 import wandas.processing.psychoacoustic as psychoacoustic_module
+from tests.processing_helpers import run_operation_eager
 from wandas.frames.channel import ChannelFrame
 from wandas.frames.roughness import RoughnessFrame
 from wandas.processing.base import _OPERATION_REGISTRY, create_operation, get_operation
@@ -34,20 +34,6 @@ from wandas.utils.dask_helpers import da_from_array
 from wandas.utils.types import NDArrayReal
 
 _SR: int = 48000
-
-
-def _as_dask(data: Any) -> DaArray:
-    if isinstance(data, DaArray):
-        return data
-    array = np.asarray(data)
-    if array.ndim == 1:
-        array = array.reshape(1, -1)
-    chunks = (1, *(-1,) * (array.ndim - 1))
-    return da_from_array(array, chunks=chunks)
-
-
-def _compute_process(operation: Any, data: Any, *inputs: Any) -> Any:
-    return operation.process(_as_dask(data), *(_as_dask(input_data) for input_data in inputs)).compute()
 
 
 def _psychoacoustic_class(name: str) -> type:
@@ -258,7 +244,7 @@ class TestLoudnessZwtv:
         """Test loudness calculation output shape for mono signal."""
         signal_mono, _, _, _ = _loudness_signal()
         op = LoudnessZwtv(_SR, field_type="free")
-        result = _compute_process(op, signal_mono)
+        result = run_operation_eager(op, signal_mono)
 
         # Result should be 2D (channels, time_samples)
         assert result.ndim == 2
@@ -270,7 +256,7 @@ class TestLoudnessZwtv:
         """Test loudness calculation output shape for stereo signal."""
         _, signal_stereo, _, _ = _loudness_signal()
         loudness_op = LoudnessZwtv(_SR, field_type="free")
-        result = _compute_process(loudness_op, signal_stereo)
+        result = run_operation_eager(loudness_op, signal_stereo)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         n_ch1_direct, _, _, _ = loudness_zwtv(signal_stereo[0], _SR, field_type="free")
@@ -283,7 +269,7 @@ class TestLoudnessZwtv:
         """Test that loudness values match MoSQITo output."""
         signal_mono, _, _, _ = _loudness_signal()
         op = LoudnessZwtv(_SR, field_type="free")
-        result = _compute_process(op, signal_mono)
+        result = run_operation_eager(op, signal_mono)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         n_direct, _, _, _ = loudness_zwtv(signal_mono[0], _SR, field_type="free")
@@ -300,7 +286,7 @@ class TestLoudnessZwtv:
         """
         signal_mono, _, _, _ = _loudness_signal()
         op = LoudnessZwtv(_SR, field_type="free")
-        our_result = _compute_process(op, signal_mono)
+        our_result = run_operation_eager(op, signal_mono)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         n_direct, _, _, _ = loudness_zwtv(signal_mono[0], _SR, field_type="free")
@@ -314,11 +300,11 @@ class TestLoudnessZwtv:
         """Test that free field and diffuse field give different results."""
         signal_mono, _, _, _ = _loudness_signal()
         loudness_free = LoudnessZwtv(_SR, field_type="free")
-        result_free = _compute_process(loudness_free, signal_mono)
+        result_free = run_operation_eager(loudness_free, signal_mono)
 
         # Calculate with diffuse field
         loudness_diffuse = LoudnessZwtv(_SR, field_type="diffuse")
-        result_diffuse = _compute_process(loudness_diffuse, signal_mono)
+        result_diffuse = run_operation_eager(loudness_diffuse, signal_mono)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         n_free_direct, _, _, _ = loudness_zwtv(signal_mono[0], _SR, field_type="free")
@@ -342,8 +328,8 @@ class TestLoudnessZwtv:
         signal_high = np.array([0.2 * np.sin(2 * np.pi * freq * t)])
 
         # Calculate loudness using wandas
-        loudness_low = _compute_process(op, signal_low)
-        loudness_high = _compute_process(op, signal_high)
+        loudness_low = run_operation_eager(op, signal_low)
+        loudness_high = run_operation_eager(op, signal_high)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         n_low_direct, _, _, _ = loudness_zwtv(signal_low[0], _SR, field_type="free")
@@ -359,7 +345,7 @@ class TestLoudnessZwtv:
         # Create silent signal
         silence = np.zeros((1, int(_SR * duration)))
 
-        result = _compute_process(op, silence)
+        result = run_operation_eager(op, silence)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         n_direct, _, _, _ = loudness_zwtv(silence[0], _SR, field_type="free")
@@ -374,7 +360,7 @@ class TestLoudnessZwtv:
         rng = np.random.default_rng(42)
         noise = rng.normal(0, 0.02, (1, int(_SR * duration)))
 
-        result = _compute_process(op, noise)
+        result = run_operation_eager(op, noise)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         n_direct, _, _, _ = loudness_zwtv(noise[0], _SR, field_type="free")
@@ -404,7 +390,7 @@ class TestLoudnessZwtv:
 
         stereo_signal = np.vstack([signal_ch1, signal_ch2])
 
-        result = _compute_process(op, stereo_signal)
+        result = run_operation_eager(op, stereo_signal)
 
         # Compare each channel with MoSQITo direct calculation
         n_ch1_direct, _, _, _ = loudness_zwtv(signal_ch1, _SR, field_type="free")
@@ -433,7 +419,7 @@ class TestLoudnessZwtv:
         t = np.linspace(0, duration, int(_SR * duration))
         signal_1d = 0.05 * np.sin(2 * np.pi * 1000 * t)
 
-        result = _compute_process(op, signal_1d)
+        result = run_operation_eager(op, signal_1d)
 
         # Should be reshaped to 2D with 1 channel
         assert result.ndim == 2
@@ -443,8 +429,8 @@ class TestLoudnessZwtv:
         """Test that repeated calls with same input produce same output."""
         signal_mono, _, _, _ = _loudness_signal()
         op = LoudnessZwtv(_SR, field_type="free")
-        result1 = _compute_process(op, signal_mono)
-        result2 = _compute_process(op, signal_mono)
+        result1 = run_operation_eager(op, signal_mono)
+        result2 = run_operation_eager(op, signal_mono)
 
         # Results should be identical
         np.testing.assert_array_equal(result1, result2)
@@ -453,7 +439,7 @@ class TestLoudnessZwtv:
         """Test that time resolution matches MoSQITo output."""
         signal_mono, _, _, _ = _loudness_signal()
         op = LoudnessZwtv(_SR, field_type="free")
-        result = _compute_process(op, signal_mono)
+        result = run_operation_eager(op, signal_mono)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         n_direct, _, _, _ = loudness_zwtv(signal_mono[0], _SR, field_type="free")
@@ -593,7 +579,7 @@ class TestLoudnessZwst:
         """Test steady-state loudness calculation output shape for mono signal."""
         signal_mono, _, _, _ = _loudness_signal()
         op = LoudnessZwst(_SR, field_type="free")
-        result = _compute_process(op, signal_mono)
+        result = run_operation_eager(op, signal_mono)
 
         # Result should be 2D (channels, 1)
         assert result.ndim == 2
@@ -604,7 +590,7 @@ class TestLoudnessZwst:
         """Test steady-state loudness calculation output shape for stereo signal."""
         _, signal_stereo, _, _ = _loudness_signal()
         loudness_op = LoudnessZwst(_SR, field_type="free")
-        result = _compute_process(loudness_op, signal_stereo)
+        result = run_operation_eager(loudness_op, signal_stereo)
 
         # Result should be 2D (channels, 1)
         assert result.ndim == 2
@@ -630,7 +616,7 @@ class TestLoudnessZwst:
         """Test that loudness values match MoSQITo output."""
         signal_mono, _, _, _ = _loudness_signal()
         op = LoudnessZwst(_SR, field_type="free")
-        result = _compute_process(op, signal_mono)
+        result = run_operation_eager(op, signal_mono)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         n_direct, _, _ = loudness_zwst(signal_mono[0], _SR, field_type="free")
@@ -652,7 +638,7 @@ class TestLoudnessZwst:
         """
         signal_mono, _, _, _ = _loudness_signal()
         op = LoudnessZwst(_SR, field_type="free")
-        our_result = _compute_process(op, signal_mono)
+        our_result = run_operation_eager(op, signal_mono)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         n_direct, _, _ = loudness_zwst(signal_mono[0], _SR, field_type="free")
@@ -667,11 +653,11 @@ class TestLoudnessZwst:
         """Test that free field and diffuse field give different results."""
         signal_mono, _, _, _ = _loudness_signal()
         loudness_free = LoudnessZwst(_SR, field_type="free")
-        result_free = _compute_process(loudness_free, signal_mono)
+        result_free = run_operation_eager(loudness_free, signal_mono)
 
         # Calculate with diffuse field
         loudness_diffuse = LoudnessZwst(_SR, field_type="diffuse")
-        result_diffuse = _compute_process(loudness_diffuse, signal_mono)
+        result_diffuse = run_operation_eager(loudness_diffuse, signal_mono)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         n_free_direct, _, _ = loudness_zwst(signal_mono[0], _SR, field_type="free")
@@ -703,8 +689,8 @@ class TestLoudnessZwst:
         signal_high = np.array([0.2 * np.sin(2 * np.pi * freq * t)])
 
         # Calculate loudness using wandas
-        loudness_low = _compute_process(op, signal_low)
-        loudness_high = _compute_process(op, signal_high)
+        loudness_low = run_operation_eager(op, signal_low)
+        loudness_high = run_operation_eager(op, signal_high)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         n_low_direct, _, _ = loudness_zwst(signal_low[0], _SR, field_type="free")
@@ -731,7 +717,7 @@ class TestLoudnessZwst:
         # Create silent signal
         silence = np.zeros((1, int(_SR * duration)))
 
-        result = _compute_process(op, silence)
+        result = run_operation_eager(op, silence)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         n_direct, _, _ = loudness_zwst(silence[0], _SR, field_type="free")
@@ -750,7 +736,7 @@ class TestLoudnessZwst:
         rng = np.random.default_rng(42)
         noise = rng.normal(0, 0.02, (1, int(_SR * duration)))
 
-        result = _compute_process(op, noise)
+        result = run_operation_eager(op, noise)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         n_direct, _, _ = loudness_zwst(noise[0], _SR, field_type="free")
@@ -788,7 +774,7 @@ class TestLoudnessZwst:
 
         stereo_signal = np.vstack([signal_ch1, signal_ch2])
 
-        result = _compute_process(op, stereo_signal)
+        result = run_operation_eager(op, stereo_signal)
 
         # Compare each channel with MoSQITo direct calculation
         n_ch1_direct, _, _ = loudness_zwst(signal_ch1, _SR, field_type="free")
@@ -829,7 +815,7 @@ class TestLoudnessZwst:
         t = np.linspace(0, duration, int(_SR * duration))
         signal_1d = 0.05 * np.sin(2 * np.pi * 1000 * t)
 
-        result = _compute_process(op, signal_1d)
+        result = run_operation_eager(op, signal_1d)
 
         # Should be reshaped to 2D with 1 channel
         assert result.ndim == 2
@@ -840,8 +826,8 @@ class TestLoudnessZwst:
         """Test that repeated calls with same input produce same output."""
         signal_mono, _, _, _ = _loudness_signal()
         op = LoudnessZwst(_SR, field_type="free")
-        result1 = _compute_process(op, signal_mono)
-        result2 = _compute_process(op, signal_mono)
+        result1 = run_operation_eager(op, signal_mono)
+        result2 = run_operation_eager(op, signal_mono)
 
         # Results should be identical
         np.testing.assert_array_equal(result1, result2)
@@ -985,7 +971,7 @@ class TestRoughnessDw:
         """Test roughness calculation output shape for mono signal."""
         signal_mono, _, _, _ = _roughness_signal()
         op = RoughnessDw(_SR, overlap=0.5)
-        result = _compute_process(op, signal_mono)
+        result = run_operation_eager(op, signal_mono)
 
         # Result should be 2D (channels, time_samples)
         assert result.ndim == 2
@@ -998,7 +984,7 @@ class TestRoughnessDw:
         """Test roughness calculation output shape for stereo signal."""
         _, signal_stereo, _, _ = _roughness_signal()
         op = RoughnessDw(_SR, overlap=0.5)
-        result = _compute_process(op, signal_stereo)
+        result = run_operation_eager(op, signal_stereo)
 
         # Result should be 2D (channels, time_samples)
         assert result.ndim == 2
@@ -1010,7 +996,7 @@ class TestRoughnessDw:
         signal_mono, _, _, _ = _roughness_signal()
         op = RoughnessDw(_SR, overlap=0.5)
         overlap = 0.5
-        our_result = _compute_process(op, signal_mono)
+        our_result = run_operation_eager(op, signal_mono)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         r_direct, _, _, _ = roughness_dw_mosqito(signal_mono[0], _SR, overlap=overlap)
@@ -1026,7 +1012,7 @@ class TestRoughnessDw:
         _, signal_stereo, _, _ = _roughness_signal()
         op = RoughnessDw(_SR, overlap=0.5)
         overlap = 0.5
-        result = _compute_process(op, signal_stereo)
+        result = run_operation_eager(op, signal_stereo)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         r_ch1_direct, _, _, _ = roughness_dw_mosqito(signal_stereo[0], _SR, overlap=overlap)
@@ -1041,8 +1027,8 @@ class TestRoughnessDw:
         roughness_overlap0 = RoughnessDw(_SR, overlap=0.0)
         roughness_overlap05 = RoughnessDw(_SR, overlap=0.5)
 
-        result_overlap0 = _compute_process(roughness_overlap0, signal_mono)
-        result_overlap05 = _compute_process(roughness_overlap05, signal_mono)
+        result_overlap0 = run_operation_eager(roughness_overlap0, signal_mono)
+        result_overlap05 = run_operation_eager(roughness_overlap05, signal_mono)
 
         # Higher overlap should give more time points
         # (overlap=0.5 has 100ms hop, overlap=0.0 has 200ms hop)
@@ -1054,7 +1040,7 @@ class TestRoughnessDw:
         signal_mono, _, _, _ = _roughness_signal()
         op = RoughnessDw(_SR, overlap=0.5)
         overlap = 0.5
-        result = _compute_process(op, signal_mono)
+        result = run_operation_eager(op, signal_mono)
 
         # Roughness values should be non-negative
         assert np.all(result >= 0)
@@ -1075,7 +1061,7 @@ class TestRoughnessDw:
         overlap = 0.5
         silence = np.zeros((1, int(_SR * duration)))
 
-        result = _compute_process(op, silence)
+        result = run_operation_eager(op, silence)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         r_direct, _, _, _ = roughness_dw_mosqito(silence[0], _SR, overlap=overlap)
@@ -1103,7 +1089,7 @@ class TestRoughnessDw:
         _, signal_stereo, _, _ = _roughness_signal()
         op = RoughnessDw(_SR, overlap=0.5)
         overlap = 0.5
-        result = _compute_process(op, signal_stereo)
+        result = run_operation_eager(op, signal_stereo)
 
         # Compare each channel with MoSQITo direct calculation
         r_ch1_direct, _, _, _ = roughness_dw_mosqito(signal_stereo[0], _SR, overlap=overlap)
@@ -1120,7 +1106,7 @@ class TestRoughnessDw:
         t = np.linspace(0, duration, int(_SR * duration))
         signal_1d = 0.1 * np.sin(2 * np.pi * 1000 * t)
 
-        result = _compute_process(op, signal_1d)
+        result = run_operation_eager(op, signal_1d)
 
         # Should be reshaped to 2D with 1 channel
         assert result.ndim == 2
@@ -1130,8 +1116,8 @@ class TestRoughnessDw:
         """Test that repeated calls with same input produce same output."""
         signal_mono, _, _, _ = _roughness_signal()
         op = RoughnessDw(_SR, overlap=0.5)
-        result1 = _compute_process(op, signal_mono)
-        result2 = _compute_process(op, signal_mono)
+        result1 = run_operation_eager(op, signal_mono)
+        result2 = run_operation_eager(op, signal_mono)
 
         # Results should be identical
         np.testing.assert_array_equal(result1, result2)
@@ -1325,7 +1311,7 @@ class TestRoughnessDwSpec:
         """Test roughness_spec calculation output shape for mono signal."""
         signal_mono, _, _, _ = _roughness_spec_signal()
         op = RoughnessDwSpec(_SR, overlap=0.5)
-        result = _compute_process(op, signal_mono)
+        result = run_operation_eager(op, signal_mono)
 
         # Result should be 2D (n_bark_bands, time_samples) for mono
         assert result.ndim == 2
@@ -1336,7 +1322,7 @@ class TestRoughnessDwSpec:
         """Test roughness_spec calculation output shape for stereo signal."""
         _, signal_stereo, _, _ = _roughness_spec_signal()
         op = RoughnessDwSpec(_SR, overlap=0.5)
-        result = _compute_process(op, signal_stereo)
+        result = run_operation_eager(op, signal_stereo)
 
         # Result should be 3D (n_channels, n_bark_bands, time_samples) for stereo
         assert result.ndim == 3
@@ -1349,7 +1335,7 @@ class TestRoughnessDwSpec:
         signal_mono, _, _, _ = _roughness_spec_signal()
         op = RoughnessDwSpec(_SR, overlap=0.5)
         overlap = 0.5
-        our_result = _compute_process(op, signal_mono)
+        our_result = run_operation_eager(op, signal_mono)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         _, r_spec_direct, _, _ = roughness_dw_mosqito(signal_mono[0], _SR, overlap=overlap)
@@ -1365,7 +1351,7 @@ class TestRoughnessDwSpec:
         _, signal_stereo, _, _ = _roughness_spec_signal()
         op = RoughnessDwSpec(_SR, overlap=0.5)
         overlap = 0.5
-        result = _compute_process(op, signal_stereo)
+        result = run_operation_eager(op, signal_stereo)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         _, r_spec_ch1_direct, _, _ = roughness_dw_mosqito(signal_stereo[0], _SR, overlap=overlap)
@@ -1407,7 +1393,7 @@ class TestRoughnessDwSpec:
         op = RoughnessDwSpec(_SR, overlap=0.5)
         overlap = 0.5
         # Calculate specific roughness
-        r_spec = _compute_process(op, signal_mono)
+        r_spec = run_operation_eager(op, signal_mono)
 
         # Calculate total roughness directly
         r_total, _, _, _ = roughness_dw_mosqito(signal_mono[0], _SR, overlap=overlap)
@@ -1449,7 +1435,7 @@ class TestRoughnessDwSpec:
         overlap = 0.5
         silence = np.zeros((1, int(_SR * duration)))
 
-        result = _compute_process(op, silence)
+        result = run_operation_eager(op, silence)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         _, r_spec_direct, _, _ = roughness_dw_mosqito(silence[0], _SR, overlap=overlap)
@@ -1480,7 +1466,7 @@ class TestRoughnessDwSpec:
         t = np.linspace(0, duration, int(_SR * duration))
         signal_1d = 0.1 * np.sin(2 * np.pi * 1000 * t)
 
-        result = _compute_process(op, signal_1d)
+        result = run_operation_eager(op, signal_1d)
 
         # Should be reshaped to 2D with shape (n_bark_bands, n_time)
         assert result.ndim == 2
@@ -1490,8 +1476,8 @@ class TestRoughnessDwSpec:
         """Test that repeated calls with same input produce same output."""
         signal_mono, _, _, _ = _roughness_spec_signal()
         op = RoughnessDwSpec(_SR, overlap=0.5)
-        result1 = _compute_process(op, signal_mono)
-        result2 = _compute_process(op, signal_mono)
+        result1 = run_operation_eager(op, signal_mono)
+        result2 = run_operation_eager(op, signal_mono)
 
         # Results should be identical
         np.testing.assert_array_equal(result1, result2)
@@ -1670,7 +1656,7 @@ class TestSharpnessDin:
         """Test sharpness calculation output shape for mono signal."""
         signal_mono, _, _, _ = _sharpness_signal()
         op = SharpnessDin(_SR)
-        result = _compute_process(op, signal_mono)
+        result = run_operation_eager(op, signal_mono)
 
         # Result should be 2D (channels, time_samples)
         assert result.ndim == 2
@@ -1680,7 +1666,7 @@ class TestSharpnessDin:
         """Test sharpness calculation output shape for stereo signal."""
         _, signal_stereo, _, _ = _sharpness_signal()
         op = SharpnessDin(_SR)
-        result = _compute_process(op, signal_stereo)
+        result = run_operation_eager(op, signal_stereo)
 
         # Result should be 2D (channels, time_samples)
         assert result.ndim == 2
@@ -1691,7 +1677,7 @@ class TestSharpnessDin:
         """Test that values match MoSQITo direct calculation."""
         signal_mono, _, _, _ = _sharpness_signal()
         op = SharpnessDin(_SR)
-        our_result = _compute_process(op, signal_mono)
+        our_result = run_operation_eager(op, signal_mono)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         s_direct, _ = sharpness_din_tv_mosqito(signal_mono[0], _SR)
@@ -1706,7 +1692,7 @@ class TestSharpnessDin:
         """Test stereo signal matches MoSQITo for each channel."""
         _, signal_stereo, _, _ = _sharpness_signal()
         op = SharpnessDin(_SR)
-        result = _compute_process(op, signal_stereo)
+        result = run_operation_eager(op, signal_stereo)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         s_ch1_direct, _ = sharpness_din_tv_mosqito(signal_stereo[0], _SR)
@@ -1719,7 +1705,7 @@ class TestSharpnessDin:
         """Test that sharpness values are in reasonable range."""
         signal_mono, _, _, _ = _sharpness_signal()
         op = SharpnessDin(_SR)
-        result = _compute_process(op, signal_mono)
+        result = run_operation_eager(op, signal_mono)
 
         # Sharpness values should be non-negative
         assert np.all(result >= 0)
@@ -1739,7 +1725,7 @@ class TestSharpnessDin:
         duration = 0.1
         silence = np.zeros((1, int(_SR * duration)))
 
-        result = _compute_process(op, silence)
+        result = run_operation_eager(op, silence)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         s_direct, _ = sharpness_din_tv_mosqito(silence[0], _SR)
@@ -1765,7 +1751,7 @@ class TestSharpnessDin:
         """Test that each channel is processed independently."""
         _, signal_stereo, _, _ = _sharpness_signal()
         op = SharpnessDin(_SR)
-        result = _compute_process(op, signal_stereo)
+        result = run_operation_eager(op, signal_stereo)
 
         # Compare each channel with MoSQITo direct calculation
         s_ch1_direct, _ = sharpness_din_tv_mosqito(signal_stereo[0], _SR)
@@ -1782,7 +1768,7 @@ class TestSharpnessDin:
         t = np.linspace(0, duration, int(_SR * duration))
         signal_1d = 0.05 * np.sin(2 * np.pi * 4000 * t)
 
-        result = _compute_process(op, signal_1d)
+        result = run_operation_eager(op, signal_1d)
 
         # Should be reshaped to 2D with 1 channel
         assert result.ndim == 2
@@ -1792,8 +1778,8 @@ class TestSharpnessDin:
         """Test that repeated calls with same input produce same output."""
         signal_mono, _, _, _ = _sharpness_signal()
         op = SharpnessDin(_SR)
-        result1 = _compute_process(op, signal_mono)
-        result2 = _compute_process(op, signal_mono)
+        result1 = run_operation_eager(op, signal_mono)
+        result2 = run_operation_eager(op, signal_mono)
 
         # Results should be identical
         np.testing.assert_array_equal(result1, result2)
@@ -1991,7 +1977,7 @@ class TestSharpnessDinSt:
         """Test steady-state sharpness calculation output shape for mono signal."""
         signal_mono, _, _, _ = _sharpness_signal()
         op = SharpnessDinSt(_SR)
-        result = _compute_process(op, signal_mono)
+        result = run_operation_eager(op, signal_mono)
 
         # Result should be 2D (channels, 1)
         assert result.ndim == 2
@@ -2002,7 +1988,7 @@ class TestSharpnessDinSt:
         """Test steady-state sharpness calculation output shape for stereo signal."""
         _, signal_stereo, _, _ = _sharpness_signal()
         op = SharpnessDinSt(_SR)
-        result = _compute_process(op, signal_stereo)
+        result = run_operation_eager(op, signal_stereo)
 
         # Result should be 2D (channels, 1)
         assert result.ndim == 2
@@ -2013,7 +1999,7 @@ class TestSharpnessDinSt:
         """Test that values match MoSQITo direct calculation."""
         signal_mono, _, _, _ = _sharpness_signal()
         op = SharpnessDinSt(_SR)
-        our_result = _compute_process(op, signal_mono)
+        our_result = run_operation_eager(op, signal_mono)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         s_direct = sharpness_din_st_mosqito(signal_mono[0], _SR)
@@ -2030,7 +2016,7 @@ class TestSharpnessDinSt:
         """Test stereo signal matches MoSQITo for each channel."""
         _, signal_stereo, _, _ = _sharpness_signal()
         op = SharpnessDinSt(_SR)
-        result = _compute_process(op, signal_stereo)
+        result = run_operation_eager(op, signal_stereo)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         s_ch1_direct = sharpness_din_st_mosqito(signal_stereo[0], _SR)
@@ -2051,7 +2037,7 @@ class TestSharpnessDinSt:
         """Test that sharpness values are in reasonable range."""
         signal_mono, _, _, _ = _sharpness_signal()
         op = SharpnessDinSt(_SR)
-        result = _compute_process(op, signal_mono)
+        result = run_operation_eager(op, signal_mono)
 
         # Sharpness values should be non-negative
         assert np.all(result >= 0)
@@ -2075,7 +2061,7 @@ class TestSharpnessDinSt:
         duration = 0.1
         silence = np.zeros((1, int(_SR * duration)))
 
-        result = _compute_process(op, silence)
+        result = run_operation_eager(op, silence)
 
         # MoSQITo wrapper — exact match expected (same algorithm)
         s_direct = sharpness_din_st_mosqito(silence[0], _SR)
@@ -2113,7 +2099,7 @@ class TestSharpnessDinSt:
         """Test that each channel is processed independently."""
         _, signal_stereo, _, _ = _sharpness_signal()
         op = SharpnessDinSt(_SR)
-        result = _compute_process(op, signal_stereo)
+        result = run_operation_eager(op, signal_stereo)
 
         # Compare each channel with MoSQITo direct calculation
         s_ch1_direct = sharpness_din_st_mosqito(signal_stereo[0], _SR)
@@ -2154,7 +2140,7 @@ class TestSharpnessDinSt:
         t = np.linspace(0, duration, int(_SR * duration))
         signal_1d = 0.05 * np.sin(2 * np.pi * 4000 * t)
 
-        result = _compute_process(op, signal_1d)
+        result = run_operation_eager(op, signal_1d)
 
         # Should be reshaped to 2D with 1 channel
         assert result.ndim == 2
@@ -2165,8 +2151,8 @@ class TestSharpnessDinSt:
         """Test that repeated calls with same input produce same output."""
         signal_mono, _, _, _ = _sharpness_signal()
         op = SharpnessDinSt(_SR)
-        result1 = _compute_process(op, signal_mono)
-        result2 = _compute_process(op, signal_mono)
+        result1 = run_operation_eager(op, signal_mono)
+        result2 = run_operation_eager(op, signal_mono)
 
         # Results should be identical
         np.testing.assert_array_equal(result1, result2)

--- a/tests/processing/test_spectral_operations.py
+++ b/tests/processing/test_spectral_operations.py
@@ -1,4 +1,3 @@
-from typing import Any
 from unittest import mock
 
 import numpy as np
@@ -11,6 +10,7 @@ from scipy.signal import ShortTimeFFT as ScipySTFT
 from scipy.signal import get_window
 
 import wandas.processing.spectral as spectral_module
+from tests.processing_helpers import run_operation_eager, run_operation_lazy
 from wandas.processing.base import create_operation, get_operation
 from wandas.processing.spectral import (
     CSD,
@@ -28,24 +28,6 @@ from wandas.utils.dask_helpers import da_from_array
 from wandas.utils.types import NDArrayComplex, NDArrayReal
 
 _SR: int = 16000
-
-
-def _as_dask(data: Any) -> DaArray:
-    if isinstance(data, DaArray):
-        return data
-    array = np.asarray(data)
-    if array.ndim == 1:
-        array = array.reshape(1, -1)
-    chunks = (1, *(-1,) * (array.ndim - 1))
-    return da_from_array(array, chunks=chunks)
-
-
-def _lazy_process(operation: Any, data: Any, *inputs: Any) -> DaArray:
-    return operation.process(_as_dask(data), *(_as_dask(input_data) for input_data in inputs))
-
-
-def _compute_process(operation: Any, data: Any, *inputs: Any) -> Any:
-    return _lazy_process(operation, data, *inputs).compute()
 
 
 class TestGetDisplayNames:
@@ -164,7 +146,7 @@ class TestFFTOperation:
         """FFT truncates signal longer than n_fft."""
         long_signal = np.random.default_rng(42).standard_normal(2048)
         fft_op = FFT(_SR, n_fft=1024)
-        result = _compute_process(fft_op, np.array([long_signal]))
+        result = run_operation_eager(fft_op, np.array([long_signal]))
         assert result.shape == (1, 1024 // 2 + 1)
 
     # -- Layer 3: Theoretical / numpy reference ----------------------------
@@ -178,7 +160,7 @@ class TestFFTOperation:
         sig = np.array([4.0 * np.sin(2 * np.pi * self._FREQ * t)])
         fft = FFT(_SR, n_fft=self._N_FFT, window=self._WINDOW)
 
-        result = _compute_process(fft, sig)
+        result = run_operation_eager(fft, sig)
         freq_bins = np.fft.rfftfreq(self._N_FFT, 1.0 / _SR)
         target_idx = np.argmin(np.abs(freq_bins - self._FREQ))
         magnitude = np.abs(result[0])
@@ -204,7 +186,7 @@ class TestFFTOperation:
         cos_wave = amp * np.cos(2 * np.pi * self._FREQ * t)
 
         fft_inst = FFT(_SR, n_fft=None, window=self._WINDOW)
-        fft_result = _compute_process(fft_inst, np.array([cos_wave]))
+        fft_result = run_operation_eager(fft_inst, np.array([cos_wave]))
 
         win = get_window(self._WINDOW, len(cos_wave))
         scaled_cos = cos_wave * win
@@ -240,8 +222,8 @@ class TestFFTOperation:
         t = np.linspace(0, 1, _SR, endpoint=False)
         sig = np.array([4.0 * np.sin(2 * np.pi * self._FREQ * t)])
 
-        rect_result = _compute_process(FFT(_SR, n_fft=None, window="boxcar"), sig)
-        hann_result = _compute_process(FFT(_SR, n_fft=None, window="hann"), sig)
+        rect_result = run_operation_eager(FFT(_SR, n_fft=None, window="boxcar"), sig)
+        hann_result = run_operation_eager(FFT(_SR, n_fft=None, window="hann"), sig)
 
         assert not np.allclose(rect_result, hann_result)
         # Both should detect the same peak amplitude (~4.0)
@@ -318,7 +300,7 @@ class TestIFFTOperation:
         spectrum = np.zeros((1, self._N_FFT // 2 + 1), dtype=complex)
         spectrum[0, 32] = 1.0
         ifft = IFFT(_SR, n_fft=self._N_FFT, window=self._WINDOW)
-        result = _compute_process(ifft, spectrum)
+        result = run_operation_eager(ifft, spectrum)
         assert result.shape == (1, self._N_FFT)
 
     def test_ifft_shape_stereo(self) -> None:
@@ -327,7 +309,7 @@ class TestIFFTOperation:
         spectrum[0, 32] = 1.0
         spectrum[1, 16] = 1.0
         ifft = IFFT(_SR, n_fft=self._N_FFT, window=self._WINDOW)
-        result = _compute_process(ifft, spectrum)
+        result = run_operation_eager(ifft, spectrum)
         assert result.shape == (2, self._N_FFT)
 
     def test_ifft_odd_size_restores_last_positive_frequency_scaling(self) -> None:
@@ -345,7 +327,7 @@ class TestIFFTOperation:
         spectrum = np.zeros(513, dtype=complex)
         spectrum[50] = 1.0
         ifft = IFFT(_SR, n_fft=None)
-        result = _compute_process(ifft, np.array([spectrum]))
+        result = run_operation_eager(ifft, np.array([spectrum]))
         assert result.shape == (1, 1024)
 
     def test_ifft_1d_input_reshaped(self) -> None:
@@ -376,7 +358,7 @@ class TestIFFTOperation:
         spectrum[target_idx] = 1.0
 
         ifft = IFFT(_SR, n_fft=self._N_FFT, window=self._WINDOW)
-        result = _compute_process(ifft, np.array([spectrum]))
+        result = run_operation_eager(ifft, np.array([spectrum]))
 
         assert np.isrealobj(result)
 
@@ -401,8 +383,8 @@ class TestIFFTOperation:
         fft = FFT(_SR, n_fft=self._N_FFT, window=self._WINDOW)
         ifft = IFFT(_SR, n_fft=self._N_FFT, window=self._WINDOW)
 
-        spectrum = _lazy_process(fft, original)
-        recovered = _compute_process(ifft, spectrum)
+        spectrum = run_operation_lazy(fft, original)
+        recovered = run_operation_eager(ifft, spectrum)
 
         # Verify frequency is preserved (not amplitude, due to analysis scaling)
         fft_of_recovered = np.fft.rfft(recovered[0])
@@ -582,7 +564,7 @@ class TestSTFTOperation:
 
         sig, _ = self._make_mono()
         stft = self._stft()
-        result = _compute_process(stft, sig)
+        result = run_operation_eager(stft, sig)
 
         assert result.ndim == 3
         sft = ScipySTFT(
@@ -600,7 +582,7 @@ class TestSTFTOperation:
 
         sig, _ = self._make_stereo()
         stft = self._stft()
-        result = _compute_process(stft, sig)
+        result = run_operation_eager(stft, sig)
 
         assert result.ndim == 3
         sft = ScipySTFT(
@@ -616,15 +598,15 @@ class TestSTFTOperation:
     def test_stft_1d_input_reshaped(self) -> None:
         """1D input produces 3D output with 1 channel."""
         sig_1d = np.sin(2 * np.pi * 440 * np.linspace(0, 1, _SR, endpoint=False))
-        result = _compute_process(self._stft(), sig_1d)
+        result = run_operation_eager(self._stft(), sig_1d)
         assert result.ndim == 3
         assert result.shape[0] == 1
 
     def test_istft_shape_matches_original(self) -> None:
         """ISTFT output shape close to original signal length."""
         sig, _ = self._make_mono()
-        stft_data = _lazy_process(self._stft(), sig)
-        result = _compute_process(self._istft(), stft_data)
+        stft_data = run_operation_lazy(self._stft(), sig)
+        result = run_operation_eager(self._istft(), stft_data)
 
         assert result.ndim == 2
         assert result.shape[0] == 1
@@ -633,17 +615,17 @@ class TestSTFTOperation:
     def test_istft_process_rejects_2d_direct_lazy_input(self) -> None:
         """ISTFT.process requires channel-first spectrograms."""
         sig, _ = self._make_mono()
-        stft_data = _compute_process(self._stft(), sig)
+        stft_data = run_operation_eager(self._stft(), sig)
         stft_2d = stft_data[0]  # (freqs, frames)
 
         with pytest.raises(ValueError, match=r"AudioOperation.process requires channel-first data"):
-            _compute_process(self._istft(), stft_2d)
+            run_operation_eager(self._istft(), stft_2d)
 
     def test_istft_with_length_trims_output(self) -> None:
         """ISTFT with length parameter trims to exact output length."""
         sig, _ = self._make_mono()
-        stft_data = _lazy_process(self._stft(), sig)
-        result = _compute_process(self._istft(length=8000), stft_data)
+        stft_data = run_operation_lazy(self._stft(), sig)
+        result = run_operation_eager(self._istft(length=8000), stft_data)
         assert result.shape[1] == 8000
 
     # -- Layer 3: Numerical verification -----------------------------------
@@ -679,7 +661,7 @@ class TestSTFTOperation:
         n_fft = 15
         hop_length = 3
         signal = np.arange(60, dtype=float)[None, :]
-        result = _compute_process(
+        result = run_operation_eager(
             STFT(
                 _SR,
                 n_fft=n_fft,
@@ -710,7 +692,7 @@ class TestSTFTOperation:
         amp = 2.0
         t = np.linspace(0, 1, _SR, endpoint=False)
         cos_wave = amp * np.cos(2 * np.pi * 500 * t)
-        result_da = _lazy_process(self._stft(), cos_wave)
+        result_da = run_operation_lazy(self._stft(), cos_wave)
         assert isinstance(result_da, DaArray)  # Pillar 1: Dask graph preserved
         result = result_da.compute()
 
@@ -726,8 +708,8 @@ class TestSTFTOperation:
         Boundary: 16 samples trimmed from each end for edge effects.
         """
         sig, _ = self._make_mono()
-        stft_data = _lazy_process(self._stft(), sig)
-        istft_data = _compute_process(self._istft(), stft_data)
+        stft_data = run_operation_lazy(self._stft(), sig)
+        istft_data = run_operation_eager(self._istft(), stft_data)
 
         orig_length = sig.shape[1]
         reconstructed = istft_data[:, :orig_length]
@@ -860,10 +842,10 @@ class TestNOctSynthesisOperation:
         input_copy = sig.copy()
 
         fft = FFT(self._NOCT_SR, n_fft=None, window="hann")
-        spectrum = _compute_process(fft, dask_sig)
+        spectrum = run_operation_eager(fft, dask_sig)
         spec_copy = spectrum.copy()
 
-        result = _compute_process(self._op(), spectrum)
+        result = run_operation_eager(self._op(), spectrum)
 
         np.testing.assert_array_equal(sig, input_copy)
         np.testing.assert_array_equal(spectrum, spec_copy)
@@ -904,7 +886,7 @@ class TestNOctSynthesisOperation:
         fft = FFT(self._NOCT_SR, n_fft=None, window="hann")
         rng = np.random.default_rng(99)
         test_signal = rng.standard_normal(52)
-        spectrum = _compute_process(fft, np.array([test_signal]))
+        spectrum = run_operation_eager(fft, np.array([test_signal]))
         assert spectrum.shape[-1] % 2 == 1
         result_da = self._op().process(da_from_array(spectrum, chunks=(1, -1)))
         assert isinstance(result_da, DaArray)  # Pillar 1: Dask graph preserved
@@ -920,8 +902,8 @@ class TestNOctSynthesisOperation:
         dask_sig = da_from_array(sig, chunks=(1, 1000))
 
         fft = FFT(self._NOCT_SR, n_fft=None, window="hann")
-        spectrum = _compute_process(fft, dask_sig)
-        result_da = _lazy_process(self._op(), spectrum)
+        spectrum = run_operation_eager(fft, dask_sig)
+        result_da = run_operation_lazy(self._op(), spectrum)
         assert isinstance(result_da, DaArray)  # Pillar 1: Dask graph preserved
         result = result_da.compute()
 
@@ -953,8 +935,8 @@ class TestNOctSynthesisOperation:
         dask_sig = da_from_array(sig, chunks=(2, 1000))
 
         fft = FFT(self._NOCT_SR, n_fft=None, window="hann")
-        spectrum = _compute_process(fft, dask_sig)
-        result_da = _lazy_process(self._op(), spectrum)
+        spectrum = run_operation_eager(fft, dask_sig)
+        result_da = run_operation_lazy(self._op(), spectrum)
         assert isinstance(result_da, DaArray)  # Pillar 1: Dask graph preserved
         result = result_da.compute()
 
@@ -1148,13 +1130,13 @@ class TestWelchOperation:
 
     def test_shape_mono(self) -> None:
         sig, _ = self._make_mono()
-        result = _compute_process(self._op(), sig)
+        result = run_operation_eager(self._op(), sig)
         expected_bins = self._N_FFT // 2 + 1
         assert result.shape == (1, expected_bins)
 
     def test_shape_stereo(self) -> None:
         sig, _ = self._make_stereo()
-        result = _compute_process(self._op(), sig)
+        result = run_operation_eager(self._op(), sig)
         expected_bins = self._N_FFT // 2 + 1
         assert result.shape == (2, expected_bins)
 
@@ -1166,7 +1148,7 @@ class TestWelchOperation:
         Tolerance: rtol=0.05 — frequency bin resolution.
         """
         sig, _ = self._make_mono(freq=1000.0)
-        result = _compute_process(self._op(), sig)
+        result = run_operation_eager(self._op(), sig)
         freq_bins = np.fft.rfftfreq(self._N_FFT, 1.0 / _SR)
         detected_freq = freq_bins[np.argmax(result[0])]
         np.testing.assert_allclose(detected_freq, 1000.0, rtol=0.05)
@@ -1177,7 +1159,7 @@ class TestWelchOperation:
         Tolerance: rtol=0.05 — frequency bin resolution.
         """
         sig, _ = self._make_stereo()
-        result = _compute_process(self._op(), sig)
+        result = run_operation_eager(self._op(), sig)
         freq_bins = np.fft.rfftfreq(self._N_FFT, 1.0 / _SR)
         detected_freq = freq_bins[np.argmax(result[1])]
         np.testing.assert_allclose(detected_freq, 2000.0, rtol=0.05)
@@ -1189,7 +1171,7 @@ class TestWelchOperation:
         """
 
         sig, _ = self._make_stereo()
-        result = _compute_process(self._op(), sig)
+        result = run_operation_eager(self._op(), sig)
 
         _, expected = ss.welch(
             x=sig,
@@ -1218,7 +1200,7 @@ class TestWelchOperation:
         amp = 5.0
         t = np.linspace(0, 1, _SR, endpoint=False)
         sine = amp * np.sin(2 * np.pi * 1000 * t)
-        result = _compute_process(self._op(), np.array([sine]))
+        result = run_operation_eager(self._op(), np.array([sine]))
 
         freq_bins = np.fft.rfftfreq(self._N_FFT, 1.0 / _SR)
         peak_idx = np.argmax(result[0])
@@ -1329,14 +1311,14 @@ class TestCoherenceOperation:
 
     def test_shape_stereo(self) -> None:
         sig, _ = self._make_stereo()
-        result = _compute_process(self._op(), sig)
+        result = run_operation_eager(self._op(), sig)
         n_ch = sig.shape[0]
         n_freqs = self._N_FFT // 2 + 1
         assert result.shape == (n_ch * n_ch, n_freqs)
 
     def test_shape_multi_channel(self) -> None:
         sig, _ = self._make_multi()
-        result = _compute_process(self._op(), sig)
+        result = run_operation_eager(self._op(), sig)
         n_ch = sig.shape[0]
         n_freqs = self._N_FFT // 2 + 1
         assert result.shape == (n_ch * n_ch, n_freqs)
@@ -1350,7 +1332,7 @@ class TestCoherenceOperation:
         """
 
         sig, _ = self._make_stereo()
-        result = _compute_process(self._op(), sig)
+        result = run_operation_eager(self._op(), sig)
 
         assert np.all(result >= 0)
         assert np.all(result <= 1.000001)
@@ -1484,14 +1466,14 @@ class TestCSDOperation:
 
     def test_shape_stereo(self) -> None:
         sig, _ = self._make_stereo()
-        result = _compute_process(self._op(), sig)
+        result = run_operation_eager(self._op(), sig)
         n_ch = sig.shape[0]
         n_freqs = self._N_FFT // 2 + 1
         assert result.shape == (n_ch * n_ch, n_freqs)
 
     def test_shape_multi_channel(self) -> None:
         sig, _ = self._make_multi()
-        result = _compute_process(self._op(), sig)
+        result = run_operation_eager(self._op(), sig)
         n_ch = sig.shape[0]
         n_freqs = self._N_FFT // 2 + 1
         assert result.shape == (n_ch * n_ch, n_freqs)
@@ -1505,7 +1487,7 @@ class TestCSDOperation:
         """
 
         sig, _ = self._make_stereo()
-        result = _compute_process(self._op(), sig)
+        result = run_operation_eager(self._op(), sig)
 
         _, csd_expected = ss.csd(
             x=sig[:, np.newaxis, :],
@@ -1525,7 +1507,7 @@ class TestCSDOperation:
     def test_auto_spectrum_peaks_at_signal_frequency(self) -> None:
         """Auto-CSD peaks at the respective signal frequencies."""
         sig, _ = self._make_stereo()
-        result = _compute_process(self._op(), sig)
+        result = run_operation_eager(self._op(), sig)
         freq_bins = np.fft.rfftfreq(self._N_FFT, 1.0 / _SR)
 
         idx_1000 = np.argmin(np.abs(freq_bins - 1000))
@@ -1641,14 +1623,14 @@ class TestTransferFunctionOperation:
 
     def test_shape_stereo(self) -> None:
         sig, _ = self._make_stereo()
-        result = _compute_process(self._op(), sig)
+        result = run_operation_eager(self._op(), sig)
         n_ch = sig.shape[0]
         n_freqs = self._N_FFT // 2 + 1
         assert result.shape == (n_ch * n_ch, n_freqs)
 
     def test_shape_multi_channel(self) -> None:
         sig, _ = self._make_multi()
-        result = _compute_process(self._op(), sig)
+        result = run_operation_eager(self._op(), sig)
         n_ch = sig.shape[0]
         n_freqs = self._N_FFT // 2 + 1
         assert result.shape == (n_ch * n_ch, n_freqs)
@@ -1661,7 +1643,7 @@ class TestTransferFunctionOperation:
         Tolerance: rtol=0.2 — noise in simulated system.
         """
         sig, _ = self._make_stereo()
-        result = _compute_process(self._op(), sig)
+        result = run_operation_eager(self._op(), sig)
         freq_bins = np.fft.rfftfreq(self._N_FFT, 1.0 / _SR)
         idx_1000 = np.argmin(np.abs(freq_bins - 1000))
 
@@ -1685,7 +1667,7 @@ class TestTransferFunctionOperation:
         """
 
         sig, _ = self._make_stereo()
-        result = _compute_process(self._op(), sig)
+        result = run_operation_eager(self._op(), sig)
 
         _, p_yx = ss.csd(
             x=sig[:, np.newaxis, :],

--- a/tests/processing_helpers.py
+++ b/tests/processing_helpers.py
@@ -1,0 +1,52 @@
+"""Shared Dask execution adapters for processing-layer tests."""
+
+from typing import Any, Protocol
+
+import numpy as np
+from dask.array.core import Array as DaArray
+
+from wandas.utils.dask_helpers import da_from_array
+
+
+class ProcessingOperation(Protocol):
+    """Structural contract required by the processing test runners."""
+
+    def process(self, data: DaArray, *inputs: DaArray) -> DaArray:
+        """Build a lazy processing graph for channel-first inputs."""
+        ...
+
+
+def as_operation_dask(data: Any) -> DaArray:
+    """Return operation input as channel-wise Dask data.
+
+    Existing Dask arrays retain their caller-selected chunks. Concrete 1D
+    arrays receive the channel axis required by ``AudioOperation.process``.
+    """
+    if isinstance(data, DaArray):
+        return data
+    array = np.asarray(data)
+    if array.ndim == 1:
+        array = array.reshape(1, -1)
+    chunks = (1, *(-1,) * (array.ndim - 1))
+    return da_from_array(array, chunks=chunks)
+
+
+def run_operation_lazy(
+    operation: ProcessingOperation,
+    data: Any,
+    *inputs: Any,
+) -> DaArray:
+    """Build an operation graph from concrete or existing Dask inputs."""
+    return operation.process(
+        as_operation_dask(data),
+        *(as_operation_dask(input_data) for input_data in inputs),
+    )
+
+
+def run_operation_eager(
+    operation: ProcessingOperation,
+    data: Any,
+    *inputs: Any,
+) -> Any:
+    """Compute an operation result after applying the shared input contract."""
+    return run_operation_lazy(operation, data, *inputs).compute()


### PR DESCRIPTION
## Summary

- add a test-only `tests.processing_helpers` module for channel-wise Dask conversion and lazy/eager `AudioOperation` execution
- replace eight duplicated local helper definitions across effect, spectral, psychoacoustic, and lazy-metadata contract tests
- use explicit `run_operation_lazy` / `run_operation_eager` names while leaving test cases, parameters, expected values, and assertions unchanged

## Why this prototype

Several processing suites independently maintained the same NumPy-to-Dask conversion and operation-execution adapter. The copies already differed slightly: spectral tests exposed both lazy and eager paths, two suites exposed only eager execution, and the metadata contract had a fourth conversion helper.

This draft tests whether one small structural contract makes the execution boundary easier to recognize and prevents future chunking or channel-axis drift. It deliberately does not migrate purpose-specific `da_from_array` calls or standard-signal fixtures.

## Measured scope

- 8 local helper definitions replaced by 3 shared functions and 1 structural Protocol
- 124 eager-operation call sites and 9 lazy-operation call sites use the shared contract
- 5 test files changed; production code unchanged
- 189 insertions / 187 deletions; the near-neutral line count retains descriptive names, typing, and docstrings

## Validation

- four affected processing suites — 389 passed, 2 warnings
- `uv run pytest -q --disable-warnings` — 2317 passed, 3 skipped, 41 warnings
- `uv run ruff check wandas tests scripts` — passed
- `uv run ruff format --check wandas tests` — passed
- `uv run ty check wandas tests` — passed
- MkDocs not run because this prototype changes test code only

## Review focus

- whether `tests/processing_helpers.py` is the right ownership boundary
- whether the runner names make lazy versus computed execution clearer
- whether this pattern should remain limited to repeated operation adapters or be extended later
