### PR TITLE
feat: add reference-signal calibration workflow

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -174,7 +174,7 @@ clean.describe(fmin=20, fmax=fmax, vmin=-80, vmax=-20, image_save="recording_ove
 spectrum.plot(xlim=(20, fmax))
 ```
 
-物理量を扱う解析では、データの校正を保ってください。`normalize()` は振幅を変えるため、SPL、sound level、ラウドネス、粗さ、シャープネスなどを計算するときは、正しく Pa に換算された元データから解析します。心理音響指標には `wandas[psychoacoustic]`、WDF の保存・読み込みには `wandas[io]` が必要です。
+物理量を扱う解析では、データの校正を保ってください。既知の基準信号から`calibration_signal.derive_calibration(...)`で再利用可能な校正値を作り、`recording.calibrate(calibration)`で測定信号へ適用できます。`normalize()`は振幅を変えるため、SPL、sound level、ラウドネス、粗さ、シャープネスなどは校正済みデータから計算します。94 dB SPLと一般センサーの例は[信号校正ガイド](https://kasahart.github.io/wandas/how-to/calibrate-signals/)を参照してください。心理音響指標には`wandas[psychoacoustic]`、WDFの保存・読み込みには`wandas[io]`が必要です。
 
 複数ファイルでは、`wd.from_folder("recordings/", recursive=True)` から始められます。dataset に対して `.resample(16_000).trim(0, 5).normalize().stft(n_fft=512)` のように前処理をまとめて適用できます。ML へ渡すときは `frame.to_tensor(framework="torch")` または `frame.to_tensor(framework="tensorflow")` を使います（`wandas[ml]` が必要で、変換時に遅延データが実体化されます）。
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ clean.describe(fmin=20, fmax=fmax, vmin=-80, vmax=-20, image_save="recording_ove
 spectrum.plot(xlim=(20, fmax))
 ```
 
-Preserve calibration when analyzing physical quantities. Because `normalize()` changes amplitude, calculate SPL, sound level, loudness, roughness, sharpness, and similar metrics from the original data after correctly converting it to Pa. Psychoacoustic metrics require `wandas[psychoacoustic]`, while WDF save and load require `wandas[io]`.
+Preserve calibration when analyzing physical quantities. Derive a reusable value from a known reference with `calibration_signal.derive_calibration(...)`, then convert the measurement with `recording.calibrate(calibration)`. Because `normalize()` changes amplitude, calculate SPL, sound level, loudness, roughness, sharpness, and similar metrics from calibrated data. See the [signal calibration guide](https://kasahart.github.io/wandas/how-to/calibrate-signals/) for 94 dB SPL and generic sensor examples. Psychoacoustic metrics require `wandas[psychoacoustic]`, while WDF save and load require `wandas[io]`.
 
 For multiple files, start with `wd.from_folder("recordings/", recursive=True)`. Apply preprocessing to the dataset with a chain such as `.resample(16_000).trim(0, 5).normalize().stft(n_fft=512)`. To pass a frame to ML code, use `frame.to_tensor(framework="torch")` or `frame.to_tensor(framework="tensorflow")` (`wandas[ml]` is required, and conversion materializes the lazy data).
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - Overview: tutorial/index.md
       - Reuse Processing with RecipePlan: tutorial/pipeline-recipes.md
   - How-to Guides:
+      - Signal Calibration: how-to/calibrate-signals.md
       - Cepstral Analysis: how-to/cepstral-analysis.md
       - Pipeline Recipes: how-to/pipeline-recipes.md
   - API Reference:

--- a/docs/src/api/frames.md
+++ b/docs/src/api/frames.md
@@ -8,6 +8,13 @@ The `wandas.frames` module provides various data frame classes for manipulating 
 ChannelFrame is the basic frame for handling time-domain waveform data.
 ChannelFrameは時間領域の波形データを扱うための基本的なフレームです。
 
+Use `derive_calibration()` and `calibrate()` to convert raw recordings into physical
+units from a known reference signal. The [signal calibration guide](../how-to/calibrate-signals.md)
+covers sound-pressure and generic sensor examples.
+
+既知の基準信号からraw収録を物理単位へ変換するには`derive_calibration()`と`calibrate()`を
+使います。音圧と一般センサーの例は[信号校正ガイド](../how-to/calibrate-signals.md)を参照してください。
+
 ::: wandas.frames.channel.ChannelFrame
 
 ### `get_channel(..., validate_query_keys: bool = True)` parameter

--- a/docs/src/api/index.md
+++ b/docs/src/api/index.md
@@ -49,6 +49,7 @@ The processing module provides various processing functions for audio data, incl
 処理モジュールは、フィルタ、エフェクト、分析など、オーディオデータに対する様々な処理機能を提供します。
 
 - Filters / フィルター - Digital filters for signal processing / 信号処理用デジタルフィルター
+- Calibration / 校正 - Derive and apply physical calibration from known reference signals / 既知の基準信号から物理校正値を導出・適用
 - Effects / エフェクト - Audio effects processing / オーディオエフェクト処理
 - Spectral / スペクトル - Spectral analysis functions / スペクトル解析機能
 - Temporal / 時間領域 - Time-domain processing / 時間領域処理

--- a/docs/src/api/processing.md
+++ b/docs/src/api/processing.md
@@ -10,6 +10,19 @@ Provides basic processing operations.
 
 ::: wandas.processing.base
 
+## Calibration / 校正
+
+Derive auditable physical calibration values from a known reference signal and
+apply their channel-wise factors without materializing the target signal. Start with
+the [signal calibration guide](../how-to/calibrate-signals.md) for the complete
+sound-pressure and generic sensor workflows.
+
+既知の基準信号から監査可能な物理校正値を導出し、対象信号を実体化せずチャンネルごとの倍率を
+適用します。音圧および一般センサーの手順は
+[信号校正ガイド](../how-to/calibrate-signals.md)を参照してください。
+
+::: wandas.processing.calibration
+
 ## Effects / エフェクト
 
 Provides audio effect processing.

--- a/docs/src/how-to/calibrate-signals.md
+++ b/docs/src/how-to/calibrate-signals.md
@@ -1,0 +1,150 @@
+# Calibrate Signals from a Known Reference / 既知の基準信号から校正する
+
+Use a recorded calibration signal to convert raw samples, volts, or counts into a
+physical quantity such as sound pressure in Pa. Wandas separates the workflow into
+two explicit steps:
+
+1. `calibration_signal.derive_calibration(...)` computes an immutable calibration.
+2. `measurement.calibrate(calibration)` applies its factors to another frame lazily.
+
+収録した校正信号を使い、raw sample、電圧、countなどをPaの音圧をはじめとする物理量へ
+変換できます。Wandasでは処理を次の2段階に分けます。
+
+1. `calibration_signal.derive_calibration(...)`で不変な校正値を計算する。
+2. `measurement.calibrate(calibration)`で別のframeへ倍率を遅延適用する。
+
+## Calibrate sound pressure / 音圧を校正する
+
+For an acoustic calibrator whose nominal level is 94 dB SPL, record a steady section
+through the same microphone, preamplifier, input range, and digital gain used for the
+measurement. Then derive and apply the calibration:
+
+公称94 dB SPLの音響校正器では、測定時と同じマイク、プリアンプ、入力レンジ、デジタルゲインを
+通した定常区間を収録し、その信号から校正値を作って適用します。
+
+```python
+import wandas as wd
+
+calibration_tone = wd.read("calibrator-94db.wav").remove_dc()
+measurement = wd.read("measurement.wav")
+
+calibration = calibration_tone.derive_calibration(
+    target_level=94.0,
+    unit="Pa",
+)
+pressure = measurement.calibrate(calibration)
+
+print(calibration.measured_rms)  # RMS recorded from each calibration channel
+print(calibration.target_rms)    # physical RMS represented by the calibrator
+print(calibration.factors)       # Pa per input sample, one value per channel
+
+level = pressure.sound_level(
+    freq_weighting="A",
+    time_weighting="Fast",
+    dB=True,
+)
+```
+
+For `unit="Pa"`, the omitted `ref` defaults to 20 µPa. Wandas converts the known
+amplitude level to physical RMS using
+
+```text
+target_rms = ref * 10 ** (target_level / 20)
+factor     = target_rms / measured_rms
+```
+
+The exact 94 dB target is approximately 1.0024 Pa RMS; 1 Pa corresponds to about
+93.98 dB re 20 µPa. Pass the calibrator's stated level rather than rounding the
+physical target yourself.
+
+`unit="Pa"`で`ref`を省略すると20 µPaが使われます。既知の振幅レベルから上式で物理RMSを
+求め、校正信号で測ったRMSとの比を倍率にします。厳密な94 dBは約1.0024 Pa RMSで、
+1 Paは20 µPa基準で約93.98 dBです。物理値を丸めず、校正器に記載されたレベルを指定します。
+
+## Use a known RMS for other quantities / 他の物理量を既知RMSで校正する
+
+When the reference source states a physical RMS directly, use `target_rms`. For
+example, a vibration reference representing 10 m/s² RMS can calibrate raw sensor
+samples as follows:
+
+基準源が物理RMSを直接示す場合は`target_rms`を使います。たとえば10 m/s² RMSの振動基準は
+次のようにraw sensor sampleへ対応付けられます。
+
+```python
+reference_vibration = wd.read("reference-vibration.csv")
+raw_vibration = wd.read("measurement.csv")
+
+calibration = reference_vibration.derive_calibration(
+    target_rms=10.0,
+    unit="m/s^2",
+)
+acceleration = raw_vibration.calibrate(calibration)
+```
+
+For units other than Pa, the default level reference is 1.0. Supply `ref=` explicitly
+when the domain uses another reference.
+
+Pa以外の単位ではlevel基準値の既定値は1.0です。別の基準値を使う領域では`ref=`を明示します。
+
+## Align calibration channels / 校正チャンネルを対応させる
+
+- A one-channel calibration broadcasts its factor to every measurement channel.
+- A multi-channel calibration must have exactly the same number of channels as the
+  measurement; factors are matched by channel position.
+- A scalar `target_rms` or `target_level` broadcasts across the calibration channels.
+  A sequence must contain one target per calibration channel.
+
+- 1チャンネルの校正値は、測定信号の全チャンネルへ同じ倍率を適用します。
+- 複数チャンネルの校正値は測定信号とチャンネル数が一致する必要があり、位置順に対応します。
+- scalarの`target_rms`または`target_level`は校正信号の全チャンネルへ展開します。sequenceでは
+  校正チャンネルごとに1値を指定します。
+
+Use separate per-channel calibration recordings when sensors have different
+sensitivities. Reorder or select channels explicitly before deriving and applying
+calibration if the acquisition layouts differ.
+
+センサー感度が異なる場合はチャンネルごとの校正信号を使います。校正収録と測定収録で
+チャンネル配置が異なる場合は、校正値の導出・適用前に明示的に並べ替えまたは選択します。
+
+## Understand computation, metadata, and history / 計算・メタデータ・履歴を理解する
+
+`derive_calibration()` is an explicit eager reduction: it computes one RMS scalar per
+calibration channel. The returned `Calibration` is frozen and keeps `measured_rms`,
+`target_rms`, `unit`, and `ref`; `factors` are derived from those authoritative values.
+Derivation does not modify the calibration frame or add frame lineage.
+
+`derive_calibration()`は明示的なeager縮約で、校正チャンネルごとにRMS scalarを計算します。
+返される`Calibration`は不変で、`measured_rms`、`target_rms`、`unit`、`ref`を保持し、
+`factors`はそれらの正本から導出されます。導出は校正frameを変更せず、frame lineageも追加しません。
+
+`calibrate()` does not compute the measurement samples. It returns a new Dask-backed
+`ChannelFrame`, preserves frame metadata, channel extras, sampling rate, channel IDs,
+and `source_time_offset`, and atomically replaces each channel's `unit` and `ref`.
+The operation history records the calibration's measured and target RMS values, and
+the operation can be extracted and replayed through `RecipePlan`.
+
+`calibrate()`は測定sampleを計算せず、新しいDask-backed `ChannelFrame`を返します。frame
+metadata、channel extra、sampling rate、channel ID、`source_time_offset`を維持し、各channelの
+`unit`と`ref`を一度に更新します。操作履歴には校正の測定RMSと目標RMSが残り、`RecipePlan`で
+抽出・再実行できます。
+
+A replayed Recipe applies the captured calibration values; it does not reread or
+recompute the original calibration recording. Derive a new calibration whenever the
+sensor or acquisition gain changes.
+
+Recipeの再実行では記録済みの校正値を適用し、元の校正収録を再読込・再計算しません。センサーや
+収録ゲインが変わった場合は、新しい校正値を導出してください。
+
+## Avoid invalidating physical amplitude / 物理振幅を失わない
+
+Choose a steady calibration interval and remove a known DC offset if necessary before
+deriving calibration. Do not call `normalize()` on the calibration signal or on a
+measurement used for SPL or other absolute physical metrics: normalization changes
+the amplitude that calibration is meant to preserve. Trimming is safe; filters must
+be included only when the same transfer function is intentionally part of both the
+calibration and measurement paths.
+
+校正値の導出には定常区間を選び、必要なら既知のDC offsetを先に除去します。SPLなど絶対物理量を
+求める校正信号・測定信号には`normalize()`を使わないでください。正規化は校正で保持すべき振幅を
+変えます。trimは利用できますが、filterは同じ伝達関数を校正経路と測定経路の両方へ意図的に
+含める場合だけ使います。

--- a/tests/frames/test_frame_calibration.py
+++ b/tests/frames/test_frame_calibration.py
@@ -1,0 +1,170 @@
+from unittest.mock import patch
+
+import dask.array as da
+import numpy as np
+import pytest
+from dask.array.core import Array as DaArray
+
+from wandas.core.metadata import ChannelMetadata
+from wandas.frames.channel import ChannelFrame
+from wandas.processing import Calibration
+
+
+def _frame(data: np.ndarray, *, label: str = "measurement") -> ChannelFrame:
+    channel_count = data.shape[0]
+    channel_metadata = [
+        ChannelMetadata(
+            label=("left", "right")[index] if channel_count == 2 else f"ch{index}",
+            unit="V",
+            ref=1.0,
+            extra={"sensor": f"mic-{index}"},
+        )
+        for index in range(channel_count)
+    ]
+    return ChannelFrame(
+        data=da.from_array(data, chunks=(1, -1)),
+        sampling_rate=48_000,
+        label=label,
+        metadata={"recording": "anechoic-room"},
+        channel_metadata=channel_metadata,
+        source_time_offset=np.arange(channel_count, dtype=float) * 0.25,
+    )
+
+
+def test_derive_calibration_known_rms_returns_auditable_factors() -> None:
+    calibration_signal = _frame(
+        np.array(
+            [
+                [0.5, -0.5, 0.5, -0.5],
+                [0.25, -0.25, 0.25, -0.25],
+            ]
+        ),
+        label="calibrator",
+    )
+
+    calibration = calibration_signal.derive_calibration(
+        target_rms=(1.0, 2.0),
+        unit="Pa",
+    )
+
+    assert isinstance(calibration, Calibration)
+    assert calibration.measured_rms == (0.5, 0.25)
+    assert calibration.target_rms == (1.0, 2.0)
+    assert calibration.factors == (2.0, 8.0)
+    assert calibration.ref == pytest.approx(20e-6)
+    assert calibration_signal.operation_history == []
+
+
+def test_derive_calibration_sound_pressure_level_uses_channel_reference() -> None:
+    calibration_signal = _frame(np.full((1, 16), 0.5), label="94 dB calibrator")
+
+    calibration = calibration_signal.derive_calibration(
+        target_level=94.0,
+        unit="Pa",
+    )
+
+    expected_rms = 20e-6 * 10 ** (94.0 / 20.0)
+    np.testing.assert_allclose(calibration.target_rms, (expected_rms,), rtol=1e-12, atol=0.0)
+    np.testing.assert_allclose(calibration.factors, (expected_rms / 0.5,), rtol=1e-12, atol=0.0)
+
+
+def test_sound_pressure_calibration_recovers_known_spl_end_to_end() -> None:
+    sampling_rate = 48_000
+    time = np.arange(sampling_rate, dtype=float) / sampling_rate
+    raw_tone = 0.5 * np.sqrt(2.0) * np.sin(2.0 * np.pi * 1_000.0 * time)
+    calibration_signal = _frame(raw_tone.reshape(1, -1), label="94 dB calibrator")
+
+    calibration = calibration_signal.derive_calibration(target_level=94.0, unit="Pa")
+    pressure = calibration_signal.calibrate(calibration)
+    recovered_level = 20.0 * np.log10(pressure.rms / pressure.channels[0].ref)
+    meter_level = pressure.sound_level(freq_weighting="Z", time_weighting="Fast", dB=True).compute()
+
+    # Integer-cycle sine RMS and the amplitude-level formula are analytical.
+    np.testing.assert_allclose(recovered_level, [94.0], rtol=0.0, atol=1e-12)
+    # One second is eight Fast time constants; allow the remaining exponential settling error.
+    np.testing.assert_allclose(meter_level[0, -1000:].mean(), 94.0, rtol=0.0, atol=2e-3)
+    assert pressure.channels[0].unit == "Pa"
+
+
+def test_calibrate_is_lazy_immutable_and_updates_physical_metadata_atomically() -> None:
+    calibration = Calibration.from_rms(
+        (0.5, 0.25),
+        target_rms=(1.0, 2.0),
+        unit="Pa",
+    )
+    signal = _frame(np.array([[1.0, -1.0], [1.0, -1.0]]))
+    original_data = signal.compute().copy()
+    original_metadata = signal.metadata.copy()
+    original_channels = signal.channels.to_list()
+    original_offsets = signal.source_time_offset.copy()
+    original_lineage = signal.lineage
+
+    with patch.object(DaArray, "compute", autospec=True, side_effect=AssertionError("unexpected compute")):
+        calibrated = signal.calibrate(calibration)
+
+    assert calibrated is not signal
+    assert isinstance(calibrated, ChannelFrame)
+    assert isinstance(calibrated._data, DaArray)
+    assert calibrated.sampling_rate == signal.sampling_rate
+    assert calibrated.metadata == original_metadata
+    assert calibrated.metadata is not signal.metadata
+    np.testing.assert_array_equal(calibrated.source_time_offset, original_offsets)
+    assert calibrated.labels == ["cal(left)", "cal(right)"]
+    assert [channel.unit for channel in calibrated.channels] == ["Pa", "Pa"]
+    assert [channel.ref for channel in calibrated.channels] == pytest.approx([20e-6, 20e-6])
+    assert [channel.extra for channel in calibrated.channels] == [
+        {"sensor": "mic-0"},
+        {"sensor": "mic-1"},
+    ]
+    np.testing.assert_allclose(calibrated.compute(), [[2.0, -2.0], [8.0, -8.0]], rtol=0.0, atol=0.0)
+
+    np.testing.assert_array_equal(signal.compute(), original_data)
+    assert signal.metadata == original_metadata
+    assert signal.channels.to_list() == original_channels
+    np.testing.assert_array_equal(signal.source_time_offset, original_offsets)
+    assert signal.lineage is original_lineage
+    assert len(calibrated.operation_history) == len(signal.operation_history) + 1
+    assert calibrated.operation_history[-1] == {
+        "operation": "wandas.audio.calibrate",
+        "version": 1,
+        "params": {
+            "measured_rms": [0.5, 0.25],
+            "ref": 20e-6,
+            "target_rms": [1.0, 2.0],
+            "unit": "Pa",
+        },
+    }
+
+
+def test_calibrate_single_channel_calibration_broadcasts_and_chains() -> None:
+    calibration = Calibration.from_rms((0.5,), target_rms=1.0, unit="Pa")
+    signal = _frame(np.array([[1.0, -1.0], [2.0, -2.0]]))
+
+    result = signal.calibrate(calibration).remove_dc()
+
+    assert isinstance(result, ChannelFrame)
+    assert isinstance(result._data, DaArray)
+    np.testing.assert_allclose(result.compute(), [[2.0, -2.0], [4.0, -4.0]], rtol=0.0, atol=0.0)
+    assert [entry["operation"] for entry in result.operation_history] == [
+        "wandas.audio.calibrate",
+        "wandas.audio.remove_dc",
+    ]
+
+
+def test_calibrate_channel_mismatch_raises_error_before_graph_creation() -> None:
+    calibration = Calibration.from_rms(
+        (0.5, 0.25, 0.125),
+        target_rms=1.0,
+        unit="Pa",
+    )
+    signal = _frame(np.ones((2, 8)))
+
+    with pytest.raises(ValueError, match="Calibration channel mismatch"):
+        signal.calibrate(calibration)
+
+
+def test_calibrate_non_calibration_value_raises_error() -> None:
+    signal = _frame(np.ones((1, 8)))
+
+    with pytest.raises(TypeError, match="calibration must be a Calibration"):
+        signal.calibrate(2.0)  # ty: ignore[invalid-argument-type]

--- a/tests/pipeline/test_calibration_recipe.py
+++ b/tests/pipeline/test_calibration_recipe.py
@@ -1,0 +1,61 @@
+import json
+from unittest.mock import patch
+
+import dask.array as da
+import numpy as np
+from dask.array.core import Array as DaArray
+
+from wandas.core.metadata import ChannelMetadata
+from wandas.frames.channel import ChannelFrame
+from wandas.pipeline import RecipePlan
+from wandas.processing import Calibration
+
+
+def _source(data: np.ndarray, *, offset: float) -> ChannelFrame:
+    return ChannelFrame(
+        data=da.from_array(data, chunks=(1, -1)),
+        sampling_rate=48_000,
+        label="measurement",
+        metadata={"session": "calibration-recipe"},
+        channel_metadata=[
+            ChannelMetadata(label="left", unit="V", ref=1.0, extra={"serial": "A"}),
+            ChannelMetadata(label="right", unit="V", ref=1.0, extra={"serial": "B"}),
+        ],
+        source_time_offset=(offset, offset + 0.25),
+    )
+
+
+def test_calibrate_recipe_extracts_serializes_loads_and_applies_without_compute() -> None:
+    calibration = Calibration.from_rms(
+        (0.5, 0.25),
+        target_rms=(1.0, 2.0),
+        unit="Pa",
+    )
+    source = _source(np.array([[1.0, -1.0], [1.0, -1.0]]), offset=0.5)
+    replay_source = _source(np.array([[2.0, -2.0], [0.5, -0.5]]), offset=1.5)
+
+    with patch.object(DaArray, "compute", autospec=True, side_effect=AssertionError("unexpected compute")):
+        calibrated = source.calibrate(calibration)
+        plan = RecipePlan.from_frame(calibrated, input_names=("signal",))
+        payload = plan.to_dict()
+        loaded = RecipePlan.from_dict(payload)
+        replayed = loaded.apply({"signal": replay_source})
+
+    assert loaded.to_dict() == payload
+    json.dumps(payload, allow_nan=False)
+    assert [node.operation for node in loaded.nodes] == ["wandas.audio.calibrate"]
+    assert isinstance(replayed, ChannelFrame)
+    assert isinstance(replayed._data, DaArray)
+    np.testing.assert_allclose(replayed.compute(), [[4.0, -4.0], [4.0, -4.0]], rtol=0.0, atol=0.0)
+    np.testing.assert_array_equal(replayed.source_time_offset, replay_source.source_time_offset)
+    assert replayed.metadata == replay_source.metadata
+    assert replayed.labels == ["cal(left)", "cal(right)"]
+    assert [channel.unit for channel in replayed.channels] == ["Pa", "Pa"]
+    assert [channel.ref for channel in replayed.channels] == [20e-6, 20e-6]
+    assert [channel.extra for channel in replayed.channels] == [{"serial": "A"}, {"serial": "B"}]
+    assert replayed.operation_history[-1]["params"] == {
+        "measured_rms": [0.5, 0.25],
+        "ref": 20e-6,
+        "target_rms": [1.0, 2.0],
+        "unit": "Pa",
+    }

--- a/tests/processing/test_calibration.py
+++ b/tests/processing/test_calibration.py
@@ -1,0 +1,201 @@
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from dask.array.core import Array as DaArray
+
+from wandas.processing import ApplyCalibration, Calibration, create_operation
+from wandas.utils.dask_helpers import da_from_array
+
+
+def test_calibration_from_rms_computes_per_channel_factors() -> None:
+    calibration = Calibration.from_rms(
+        (0.5, 0.25),
+        target_rms=(1.0, 2.0),
+        unit="Pa",
+    )
+
+    assert calibration.measured_rms == (0.5, 0.25)
+    assert calibration.target_rms == (1.0, 2.0)
+    assert calibration.factors == (2.0, 8.0)
+    assert calibration.unit == "Pa"
+    assert calibration.ref == pytest.approx(20e-6)
+
+
+def test_calibration_from_rms_converts_sound_pressure_level_to_rms() -> None:
+    calibration = Calibration.from_rms(
+        (0.5,),
+        target_level=94.0,
+        unit="Pa",
+    )
+
+    expected_rms = 20e-6 * 10 ** (94.0 / 20.0)
+    np.testing.assert_allclose(calibration.target_rms, (expected_rms,), rtol=1e-12, atol=0.0)
+    np.testing.assert_allclose(calibration.factors, (expected_rms / 0.5,), rtol=1e-12, atol=0.0)
+    np.testing.assert_allclose(calibration.target_levels, (94.0,), rtol=1e-12, atol=1e-12)
+
+
+def test_calibration_from_rms_broadcasts_scalar_target() -> None:
+    calibration = Calibration.from_rms(
+        (0.25, 0.5),
+        target_rms=1.0,
+        unit="m/s^2",
+    )
+
+    assert calibration.target_rms == (1.0, 1.0)
+    assert calibration.factors == (4.0, 2.0)
+    assert calibration.ref == 1.0
+
+
+@pytest.mark.parametrize(
+    ("target_rms", "target_level"),
+    [
+        (None, None),
+        (1.0, 94.0),
+    ],
+)
+def test_calibration_from_rms_invalid_target_contract_raises_error(
+    target_rms: float | None,
+    target_level: float | None,
+) -> None:
+    with pytest.raises(ValueError, match="Exactly one calibration target is required"):
+        Calibration.from_rms(
+            (0.5,),
+            target_rms=target_rms,
+            target_level=target_level,
+            unit="Pa",
+        )
+
+
+@pytest.mark.parametrize("measured_rms", [(0.0,), (-1.0,), (float("nan"),), (float("inf"),)])
+def test_calibration_from_rms_invalid_measurement_raises_error(measured_rms: tuple[float]) -> None:
+    with pytest.raises(ValueError, match="Invalid measured calibration RMS"):
+        Calibration.from_rms(measured_rms, target_rms=1.0, unit="Pa")
+
+
+@pytest.mark.parametrize(
+    "measured_rms",
+    [
+        "not-numeric",
+        object(),
+        [True],
+        ["1.0"],
+        [[1.0], [2.0, 3.0]],
+    ],
+)
+def test_calibration_from_rms_non_numeric_measurement_raises_error(measured_rms: object) -> None:
+    with pytest.raises(TypeError, match="Invalid measured calibration RMS"):
+        Calibration.from_rms(measured_rms, target_rms=1.0, unit="Pa")  # ty: ignore[invalid-argument-type]
+
+
+def test_calibration_from_rms_channel_mismatch_raises_error() -> None:
+    with pytest.raises(ValueError, match="Calibration target length mismatch"):
+        Calibration.from_rms((0.5, 0.25), target_rms=(1.0, 2.0, 3.0), unit="Pa")
+
+
+def test_calibration_from_rms_non_finite_target_level_raises_error() -> None:
+    with pytest.raises(ValueError, match="Invalid calibration target level"):
+        Calibration.from_rms((0.5,), target_level=float("nan"), unit="Pa")
+
+
+@pytest.mark.parametrize(
+    ("unit", "ref", "error"),
+    [
+        ("", None, "Invalid calibration unit"),
+        ("Pa", 0.0, "Invalid calibration reference"),
+        ("Pa", float("nan"), "Invalid calibration reference"),
+    ],
+)
+def test_calibration_from_rms_invalid_domain_metadata_raises_error(
+    unit: str,
+    ref: float | None,
+    error: str,
+) -> None:
+    with pytest.raises(ValueError, match=error):
+        Calibration.from_rms((0.5,), target_rms=1.0, unit=unit, ref=ref)
+
+
+def test_calibration_from_rms_non_numeric_reference_raises_error() -> None:
+    with pytest.raises(TypeError, match="Invalid calibration reference"):
+        Calibration.from_rms((0.5,), target_rms=1.0, unit="Pa", ref="20e-6")  # ty: ignore[invalid-argument-type]
+
+
+def test_calibration_rejects_non_positive_requested_channel_count() -> None:
+    calibration = Calibration.from_rms((0.5,), target_rms=1.0, unit="Pa")
+
+    with pytest.raises(ValueError, match="Calibration channel count must be positive"):
+        calibration.factors_for_channels(0)
+
+
+def test_calibration_recipe_params_reject_missing_fields() -> None:
+    with pytest.raises(ValueError, match="Invalid calibration Recipe parameters"):
+        Calibration._from_recipe_params({"unit": "Pa"})
+
+
+def test_calibration_recipe_params_reject_invalid_values() -> None:
+    with pytest.raises(ValueError, match="Invalid calibration Recipe parameters"):
+        Calibration._from_recipe_params(
+            {
+                "measured_rms": None,
+                "target_rms": (1.0,),
+                "unit": "Pa",
+                "ref": 20e-6,
+            }
+        )
+
+
+def test_apply_calibration_process_is_lazy_and_matches_analytical_gain() -> None:
+    source = np.array([[1.0, -2.0], [3.0, -4.0]], dtype=np.float32)
+    lazy_source = da_from_array(source, chunks=(1, -1))
+    operation = ApplyCalibration(48_000, factors=(2.0, 0.5))
+
+    with patch.object(DaArray, "compute", autospec=True, side_effect=AssertionError("unexpected compute")):
+        result = operation.process(lazy_source)
+
+    assert isinstance(result, DaArray)
+    assert result.shape == source.shape
+    assert result.dtype == np.dtype(np.float64)
+    np.testing.assert_allclose(
+        result.compute(),
+        np.array([[2.0, -4.0], [1.5, -2.0]]),
+        rtol=0.0,
+        atol=0.0,
+    )
+    np.testing.assert_array_equal(source, np.array([[1.0, -2.0], [3.0, -4.0]], dtype=np.float32))
+
+
+def test_apply_calibration_single_factor_broadcasts_to_channels() -> None:
+    operation = ApplyCalibration(48_000, factors=(4.0,))
+    data = np.array([[0.25, -0.25], [0.5, -0.5]])
+
+    np.testing.assert_allclose(operation._process(data), data * 4.0, rtol=0.0, atol=0.0)
+
+
+def test_apply_calibration_channel_mismatch_raises_error() -> None:
+    operation = ApplyCalibration(48_000, factors=(1.0, 2.0, 3.0))
+
+    with pytest.raises(ValueError, match="Calibration channel mismatch"):
+        operation._process(np.ones((2, 8)))
+
+
+@pytest.mark.parametrize("factors", [(), (0.0,), (-1.0,), (float("nan"),), (float("inf"),)])
+def test_apply_calibration_invalid_factors_raise_error(factors: tuple[float, ...]) -> None:
+    with pytest.raises(ValueError, match="Invalid calibration factors"):
+        ApplyCalibration(48_000, factors=factors)
+
+
+def test_apply_calibration_snapshots_caller_owned_factors() -> None:
+    factors = [2.0, 4.0]
+    operation = ApplyCalibration(48_000, factors=factors)
+
+    factors[0] = 99.0
+
+    assert operation.factors == (2.0, 4.0)
+    assert operation.params == {"factors": (2.0, 4.0)}
+
+
+def test_apply_calibration_is_registered_with_display_name() -> None:
+    operation = create_operation("apply_calibration", 48_000, factors=(2.0,))
+
+    assert isinstance(operation, ApplyCalibration)
+    assert operation.get_display_name() == "cal"

--- a/tests/processing/test_calibration.py
+++ b/tests/processing/test_calibration.py
@@ -35,6 +35,19 @@ def test_calibration_from_rms_converts_sound_pressure_level_to_rms() -> None:
     np.testing.assert_allclose(calibration.target_levels, (94.0,), rtol=1e-12, atol=1e-12)
 
 
+def test_calibration_from_rms_normalizes_unit_before_default_reference_resolution() -> None:
+    calibration = Calibration.from_rms(
+        (0.5,),
+        target_level=94.0,
+        unit=" Pa ",
+    )
+
+    expected_rms = 20e-6 * 10 ** (94.0 / 20.0)
+    assert calibration.unit == "Pa"
+    assert calibration.ref == pytest.approx(20e-6)
+    np.testing.assert_allclose(calibration.target_rms, (expected_rms,), rtol=1e-12, atol=0.0)
+
+
 def test_calibration_from_rms_broadcasts_scalar_target() -> None:
     calibration = Calibration.from_rms(
         (0.25, 0.5),

--- a/tests/processing/test_operation_lazy_metadata_contract.py
+++ b/tests/processing/test_operation_lazy_metadata_contract.py
@@ -16,6 +16,7 @@ import wandas.processing.stats  # noqa: F401
 import wandas.processing.temporal  # noqa: F401
 from tests.processing_helpers import run_operation_lazy
 from wandas.processing.base import _OPERATION_REGISTRY, AudioOperation
+from wandas.processing.calibration import ApplyCalibration
 from wandas.processing.cepstral import (
     Cepstrum,
     Lifter,
@@ -231,6 +232,7 @@ def _operation_cases() -> list[OperationCase]:
         OperationCase("hpss_harmonic", lambda: HpssHarmonic(SR), stereo_long),
         OperationCase("hpss_percussive", lambda: HpssPercussive(SR), stereo_long),
         OperationCase("normalize", lambda: Normalize(SR, norm=2, axis=-1), real),
+        OperationCase("apply_calibration", lambda: ApplyCalibration(SR, factors=(2.0, 0.5)), real),
         OperationCase("remove_dc", lambda: RemoveDC(SR), real.astype(np.int16)),
         OperationCase("add_with_snr", lambda: AddWithSNR(SR, snr=10), real.astype(np.int16), (real,)),
         OperationCase("fade", lambda: Fade(SR, fade_ms=0), real),

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -1,14 +1,15 @@
 """Module providing mixins related to signal processing."""
 
 import logging
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, SupportsFloat, SupportsIndex, TypeAlias, TypeVar, cast, overload
 
 from wandas.core.metadata import ChannelMetadata
 from wandas.frames.roughness import RoughnessFrame
 from wandas.pipeline.decorators import OperationCapture, recipe_operation
-from wandas.processing import create_operation
+from wandas.processing import Calibration, create_operation
 from wandas.processing.semantic import InputBinding, LineageNode
+from wandas.utils.types import NDArrayReal
 
 from .protocols import ProcessingFrameProtocol, T_Processing
 
@@ -20,7 +21,6 @@ HpssMargin: TypeAlias = HpssFloatLike | tuple[HpssFloatLike, HpssFloatLike] | li
 
 if TYPE_CHECKING:
     from wandas.core.base_frame import BaseFrame
-    from wandas.utils.types import NDArrayReal
 logger = logging.getLogger(__name__)
 
 _RUNTIME_APPLY_ARGUMENTS = {
@@ -30,6 +30,37 @@ _RUNTIME_APPLY_ARGUMENTS = {
     "output_frame_kwargs",
     "dask_pure",
 }
+
+_CALIBRATE_BINDINGS = (InputBinding("frame", "frame"),)
+
+
+def _capture_calibration(args: tuple[Any, ...], params: Mapping[str, Any]) -> OperationCapture:
+    """Capture an immutable calibration as portable primitive parameters."""
+    if not args or not isinstance(getattr(args[0], "lineage", None), LineageNode):
+        raise TypeError("calibrate requires a Frame receiver")
+    calibration = params.get("calibration")
+    if not isinstance(calibration, Calibration):
+        raise TypeError(
+            "calibration must be a Calibration\n"
+            f"  Got: {type(calibration).__name__}\n"
+            "  Expected: Calibration returned by derive_calibration()\n"
+            "Derive calibration from a known reference signal before applying it."
+        )
+    return OperationCapture(
+        _CALIBRATE_BINDINGS,
+        (args[0].lineage,),
+        calibration._recipe_params(),
+    )
+
+
+def _validate_calibration_recipe(params: Mapping[str, Any]) -> None:
+    """Validate decoded calibration intent during complete Recipe validation."""
+    Calibration._from_recipe_params(params)
+
+
+def _calibration_recipe(inputs: tuple[Any, ...], params: Mapping[str, Any]) -> Any:
+    """Replay calibration through the same public Frame method."""
+    return inputs[0].calibrate(Calibration._from_recipe_params(params))
 
 
 def _capture_runtime_apply(args: tuple[Any, ...], params: Mapping[str, Any]) -> OperationCapture:
@@ -93,8 +124,6 @@ class ChannelProcessingMixin:
         Shared post-processing logic for steady-state metrics that return one
         scalar per channel (e.g. ``loudness_zwst``, ``sharpness_din_st``).
         """
-        from wandas.utils.types import NDArrayReal
-
         ensure_dependencies = getattr(operation, "ensure_dependencies", None)
         if ensure_dependencies is not None:
             ensure_dependencies()
@@ -107,6 +136,119 @@ class ChannelProcessingMixin:
         if values.ndim == 0:
             values = values.reshape(1)
         return values
+
+    def derive_calibration(
+        self: ProcessingFrameProtocol,
+        *,
+        target_rms: float | Sequence[float] | NDArrayReal | None = None,
+        target_level: float | Sequence[float] | NDArrayReal | None = None,
+        unit: str,
+        ref: float | None = None,
+    ) -> Calibration:
+        """Derive reusable calibration from this known reference signal.
+
+        Exactly one of ``target_rms`` or ``target_level`` identifies the known
+        physical value represented by the calibration signal. For example, a
+        94 dB SPL acoustic calibrator can be represented with
+        ``target_level=94.0, unit="Pa"``; the default Pa reference is 20 µPa.
+
+        This method computes one RMS value per calibration channel immediately,
+        because deriving reusable scalar factors is a reduction boundary. It does
+        not mutate this frame or add a lineage entry. Call :meth:`calibrate` to
+        apply the returned value lazily to another signal.
+
+        Args:
+            target_rms: Known physical RMS. A scalar broadcasts to all channels.
+            target_level: Known amplitude level in dB relative to ``ref``. A scalar
+                broadcasts to all channels.
+            unit: Physical unit produced by calibration, such as ``"Pa"``.
+            ref: Positive level reference. When omitted, ``"Pa"`` uses ``20e-6``
+                and other units use ``1.0``.
+
+        Returns:
+            Immutable :class:`~wandas.processing.calibration.Calibration` with
+            measured RMS, target RMS, and derived per-channel factors.
+
+        Raises:
+            ValueError: If the signal is silent/non-finite, target selection is
+                ambiguous, channel counts differ, or physical metadata is invalid.
+            TypeError: If numeric inputs have unsupported types.
+
+        Examples:
+            >>> calibration_tone = wd.read("calibrator.wav")
+            >>> calibration = calibration_tone.derive_calibration(
+            ...     target_level=94.0,
+            ...     unit="Pa",
+            ... )
+            >>> pressure = wd.read("measurement.wav").calibrate(calibration)
+        """
+        measured_rms = cast(Any, self).rms
+        return Calibration.from_rms(
+            measured_rms,
+            target_rms=target_rms,
+            target_level=target_level,
+            unit=unit,
+            ref=ref,
+        )
+
+    @recipe_operation(
+        "wandas.audio.calibrate",
+        bindings=_CALIBRATE_BINDINGS,
+        capture=_capture_calibration,
+        handler=_calibration_recipe,
+        validate_params=_validate_calibration_recipe,
+    )
+    def calibrate(self: T_Processing, calibration: Calibration) -> T_Processing:
+        """Apply a previously derived physical calibration lazily.
+
+        Calibration factors are applied by channel. A one-channel calibration
+        broadcasts to every signal channel; otherwise channel counts must match.
+        The result is a new Dask-backed frame whose channel units and references
+        are replaced atomically with the calibration domain metadata. User/frame
+        metadata, channel extras, sampling rate, and source-time offsets are
+        preserved. Runtime lineage records the measured and target RMS values.
+
+        Args:
+            calibration: Value returned by :meth:`derive_calibration` or created
+                with :meth:`wandas.processing.Calibration.from_rms`.
+
+        Returns:
+            New frame with calibrated samples and physical channel metadata.
+
+        Raises:
+            TypeError: If ``calibration`` is not a :class:`Calibration`.
+            ValueError: If a multi-channel calibration does not align with the
+                signal channels.
+        """
+        if not isinstance(calibration, Calibration):
+            raise TypeError(
+                "calibration must be a Calibration\n"
+                f"  Got: {type(calibration).__name__}\n"
+                "  Expected: Calibration returned by derive_calibration()\n"
+                "Derive calibration from a known reference signal before applying it."
+            )
+        calibration.factors_for_channels(self.n_channels)
+        operation = create_operation(
+            "apply_calibration",
+            self.sampling_rate,
+            factors=calibration.factors,
+        )
+        processed_data = operation.process(self._data)
+        new_channel_metadata = cast(Any, self)._relabel_channels(
+            "apply_calibration",
+            operation.get_display_name(),
+        )
+        for channel in new_channel_metadata:
+            channel.unit = calibration.unit
+            channel.ref = calibration.ref
+        result = self._create_new_instance(
+            data=processed_data,
+            metadata=self._updated_metadata("apply_calibration", operation.params),
+            channel_metadata=new_channel_metadata,
+            channel_ids=cast(Any, self)._channel_ids,
+            lineage=cast(Any, self)._required_semantic_lineage(),
+        )
+        return cast(T_Processing, result)
 
     # Overload 1: no domain transition — return type matches caller's frame type.
     @overload

--- a/wandas/processing/__init__.py
+++ b/wandas/processing/__init__.py
@@ -15,6 +15,7 @@ from wandas.processing.base import (
     register_lazy_operation,
     register_operation,
 )
+from wandas.processing.calibration import ApplyCalibration, Calibration
 from wandas.processing.effects import (
     AddWithSNR,
     HpssHarmonic,
@@ -88,6 +89,9 @@ __all__ = [  # noqa: RUF022  # intentionally grouped by category
     "get_operation",
     "register_lazy_operation",
     "register_operation",
+    # Calibration
+    "ApplyCalibration",
+    "Calibration",
     # Cepstral
     "Cepstrum",
     "Lifter",

--- a/wandas/processing/calibration.py
+++ b/wandas/processing/calibration.py
@@ -108,7 +108,8 @@ def _domain_reference(unit: str, ref: float | None) -> float:
             "  Expected: a non-empty physical unit string\n"
             "Use 'Pa' for sound pressure or another unit matching the target RMS values."
         )
-    resolved = unit_to_ref(unit) if ref is None else ref
+    normalized_unit = unit.strip()
+    resolved = unit_to_ref(normalized_unit) if ref is None else ref
     if isinstance(resolved, bool) or not isinstance(resolved, numbers.Real):
         raise TypeError(
             "Invalid calibration reference\n"

--- a/wandas/processing/calibration.py
+++ b/wandas/processing/calibration.py
@@ -1,0 +1,321 @@
+"""Calibration values and numerical gain application."""
+
+from __future__ import annotations
+
+import numbers
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, TypeAlias, cast
+
+import numpy as np
+
+from wandas.processing.base import AudioOperation, register_operation
+from wandas.utils.types import NDArrayReal
+from wandas.utils.util import unit_to_ref
+
+CalibrationInput: TypeAlias = float | Sequence[float] | NDArrayReal
+
+
+def _numeric_values(value: Any, *, error_heading: str) -> tuple[float, ...]:
+    """Return one-dimensional finite numeric values with a stable error contract."""
+    if isinstance(value, str | bytes | bool):
+        raise TypeError(
+            f"{error_heading}\n"
+            f"  Got: {type(value).__name__} ({value!r})\n"
+            "  Expected: a number or one-dimensional numeric sequence\n"
+            "Pass one value for broadcast or one value per channel."
+        )
+    try:
+        array = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            f"{error_heading}\n"
+            f"  Got: {type(value).__name__} ({value!r})\n"
+            "  Expected: a number or one-dimensional numeric sequence\n"
+            "Pass one value for broadcast or one value per channel."
+        ) from exc
+    if array.dtype.kind not in {"f", "i", "u"}:
+        raise TypeError(
+            f"{error_heading}\n"
+            f"  Got: {array.dtype} values\n"
+            "  Expected: real numeric values\n"
+            "Replace booleans, strings, complex values, or objects with real numbers."
+        )
+    array = array.astype(np.float64, copy=False)
+    if array.ndim == 0:
+        array = array.reshape(1)
+    if array.ndim != 1 or array.size == 0:
+        raise ValueError(
+            f"{error_heading}\n"
+            f"  Got shape: {array.shape}\n"
+            "  Expected: one or more values in a one-dimensional sequence\n"
+            "Pass one value for broadcast or one value per channel."
+        )
+    return tuple(float(item) for item in array)
+
+
+def _positive_values(value: Any, *, error_heading: str) -> tuple[float, ...]:
+    """Return finite values greater than zero."""
+    values = _numeric_values(value, error_heading=error_heading)
+    if not all(np.isfinite(item) and item > 0.0 for item in values):
+        raise ValueError(
+            f"{error_heading}\n"
+            f"  Got: {values}\n"
+            "  Expected: finite values greater than zero\n"
+            "Use a non-silent calibration measurement and a positive physical target."
+        )
+    return values
+
+
+def _finite_values(value: Any, *, error_heading: str) -> tuple[float, ...]:
+    """Return finite values, including zero and negative levels."""
+    values = _numeric_values(value, error_heading=error_heading)
+    if not all(np.isfinite(item) for item in values):
+        raise ValueError(
+            f"{error_heading}\n"
+            f"  Got: {values}\n"
+            "  Expected: finite numeric values\n"
+            "Replace NaN or infinite level values before deriving calibration."
+        )
+    return values
+
+
+def _broadcast_values(
+    values: tuple[float, ...],
+    channel_count: int,
+    *,
+    error_heading: str,
+) -> tuple[float, ...]:
+    """Broadcast one value or require an exact channel count."""
+    if len(values) == 1:
+        return values * channel_count
+    if len(values) != channel_count:
+        raise ValueError(
+            f"{error_heading}\n"
+            f"  Got: {len(values)} target values for {channel_count} measured channels\n"
+            "  Expected: one target value or one value per measured channel\n"
+            "Pass a scalar to broadcast or align the target sequence with the calibration channels."
+        )
+    return values
+
+
+def _domain_reference(unit: str, ref: float | None) -> float:
+    """Validate physical unit metadata and resolve its reference value."""
+    if not isinstance(unit, str) or not unit.strip():
+        raise ValueError(
+            "Invalid calibration unit\n"
+            f"  Got: {unit!r}\n"
+            "  Expected: a non-empty physical unit string\n"
+            "Use 'Pa' for sound pressure or another unit matching the target RMS values."
+        )
+    resolved = unit_to_ref(unit) if ref is None else ref
+    if isinstance(resolved, bool) or not isinstance(resolved, numbers.Real):
+        raise TypeError(
+            "Invalid calibration reference\n"
+            f"  Got: {type(resolved).__name__} ({resolved!r})\n"
+            "  Expected: a finite positive number\n"
+            "Use 20e-6 for sound pressure levels in Pa."
+        )
+    result = float(resolved)
+    if not np.isfinite(result) or result <= 0.0:
+        raise ValueError(
+            "Invalid calibration reference\n"
+            f"  Got: {result}\n"
+            "  Expected: a finite value greater than zero\n"
+            "Use 20e-6 for sound pressure levels in Pa."
+        )
+    return result
+
+
+@dataclass(frozen=True, slots=True)
+class Calibration:
+    """Immutable, auditable mapping from measured RMS to physical RMS.
+
+    A calibration stores the RMS measured from one or more calibration-signal
+    channels and the known physical RMS those channels represent. The gain is
+    derived as ``target_rms / measured_rms`` and is therefore never duplicated
+    as mutable state.
+
+    Parameters
+    ----------
+    measured_rms : tuple of float
+        Positive RMS values measured from the calibration signal.
+    target_rms : tuple of float
+        Positive physical RMS values represented by the calibration signal.
+    unit : str
+        Physical output unit, for example ``"Pa"``.
+    ref : float
+        Positive reference value used for level conversions. Sound pressure in
+        Pa conventionally uses ``20e-6``.
+    """
+
+    measured_rms: tuple[float, ...]
+    target_rms: tuple[float, ...]
+    unit: str
+    ref: float
+
+    def __post_init__(self) -> None:
+        """Normalize immutable fields and enforce the calibration invariant."""
+        measured = _positive_values(self.measured_rms, error_heading="Invalid measured calibration RMS")
+        target = _positive_values(self.target_rms, error_heading="Invalid calibration target RMS")
+        target = _broadcast_values(
+            target,
+            len(measured),
+            error_heading="Calibration target length mismatch",
+        )
+        reference = _domain_reference(self.unit, self.ref)
+        object.__setattr__(self, "measured_rms", measured)
+        object.__setattr__(self, "target_rms", target)
+        object.__setattr__(self, "unit", self.unit.strip())
+        object.__setattr__(self, "ref", reference)
+
+    @classmethod
+    def from_rms(
+        cls,
+        measured_rms: CalibrationInput,
+        *,
+        target_rms: CalibrationInput | None = None,
+        target_level: CalibrationInput | None = None,
+        unit: str,
+        ref: float | None = None,
+    ) -> Calibration:
+        """Derive calibration from measured RMS and one known physical target.
+
+        Exactly one of ``target_rms`` or ``target_level`` is required.
+        ``target_level`` uses the amplitude-level relationship
+        ``target_rms = ref * 10 ** (target_level / 20)``. Scalars broadcast to
+        all measured channels; sequences must have one value per channel.
+        """
+        if (target_rms is None) == (target_level is None):
+            raise ValueError(
+                "Exactly one calibration target is required\n"
+                f"  Got target_rms={target_rms!r}, target_level={target_level!r}\n"
+                "  Expected: one of target_rms or target_level\n"
+                "Use target_level=94.0 for a 94 dB acoustic calibrator or pass its known RMS value."
+            )
+
+        measured = _positive_values(measured_rms, error_heading="Invalid measured calibration RMS")
+        reference = _domain_reference(unit, ref)
+        if target_rms is not None:
+            target = _positive_values(target_rms, error_heading="Invalid calibration target RMS")
+        else:
+            levels = _finite_values(target_level, error_heading="Invalid calibration target level")
+            with np.errstate(over="ignore", invalid="ignore"):
+                target_array = reference * np.power(10.0, np.asarray(levels, dtype=np.float64) / 20.0)
+            target = _positive_values(target_array, error_heading="Invalid calibration target level")
+        target = _broadcast_values(
+            target,
+            len(measured),
+            error_heading="Calibration target length mismatch",
+        )
+        return cls(measured, target, unit, reference)
+
+    @property
+    def factors(self) -> tuple[float, ...]:
+        """Return per-channel physical-unit multipliers."""
+        return tuple(target / measured for measured, target in zip(self.measured_rms, self.target_rms, strict=True))
+
+    @property
+    def target_levels(self) -> tuple[float, ...]:
+        """Return target amplitude levels in dB relative to :attr:`ref`."""
+        return tuple(20.0 * float(np.log10(target / self.ref)) for target in self.target_rms)
+
+    def factors_for_channels(self, channel_count: int) -> tuple[float, ...]:
+        """Return factors aligned to ``channel_count``, broadcasting mono calibration."""
+        if channel_count <= 0:
+            raise ValueError("Calibration channel count must be positive")
+        if len(self.factors) == 1:
+            return self.factors * channel_count
+        if len(self.factors) != channel_count:
+            raise ValueError(
+                "Calibration channel mismatch\n"
+                f"  Got: {len(self.factors)} calibration channels for {channel_count} signal channels\n"
+                "  Expected: one calibration channel or one per signal channel\n"
+                "Use a mono calibration for broadcast or derive aligned per-channel factors."
+            )
+        return self.factors
+
+    def _recipe_params(self) -> dict[str, Any]:
+        """Return canonical public intent used by semantic Recipe capture."""
+        return {
+            "measured_rms": self.measured_rms,
+            "target_rms": self.target_rms,
+            "unit": self.unit,
+            "ref": self.ref,
+        }
+
+    @classmethod
+    def _from_recipe_params(cls, params: Mapping[str, Any]) -> Calibration:
+        """Decode and validate calibration parameters at the Recipe boundary."""
+        expected = {"measured_rms", "target_rms", "unit", "ref"}
+        if set(params) != expected:
+            raise ValueError(
+                "Invalid calibration Recipe parameters\n"
+                f"  Got keys: {sorted(params)}\n"
+                f"  Expected keys: {sorted(expected)}\n"
+                "Recreate the Recipe from a current calibrate() call."
+            )
+        try:
+            return cls(
+                measured_rms=cast(tuple[float, ...], tuple(params["measured_rms"])),
+                target_rms=cast(tuple[float, ...], tuple(params["target_rms"])),
+                unit=cast(str, params["unit"]),
+                ref=cast(float, params["ref"]),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(
+                "Invalid calibration Recipe parameters\n"
+                f"  Got: {dict(params)!r}\n"
+                "  Expected: valid measured RMS, target RMS, unit, and reference values\n"
+                "Recreate the Recipe from a current calibrate() call."
+            ) from exc
+
+
+class ApplyCalibration(AudioOperation[NDArrayReal, NDArrayReal]):
+    """Multiply each channel by a positive physical calibration factor."""
+
+    name = "apply_calibration"
+    _display = "cal"
+
+    def __init__(self, sampling_rate: float, factors: CalibrationInput) -> None:
+        normalized = _positive_values(factors, error_heading="Invalid calibration factors")
+        super().__init__(sampling_rate, factors=normalized)
+
+    @property
+    def factors(self) -> tuple[float, ...]:
+        """Calibration factors captured at operation construction time."""
+        return cast(tuple[float, ...], self._config_value("factors"))
+
+    def validate_params(self) -> None:
+        _positive_values(self._config_value("factors"), error_heading="Invalid calibration factors")
+
+    def calculate_output_dtype(
+        self,
+        input_dtype: np.dtype[Any],
+        *input_dtypes: np.dtype[Any],
+    ) -> np.dtype[Any]:
+        """Calibration always promotes the signal to float64."""
+        del input_dtypes
+        return np.result_type(input_dtype, np.float64)
+
+    def _process(self, data: NDArrayReal) -> NDArrayReal:
+        """Apply scalar or channel-wise factors to an eager array block."""
+        channel_count = 1 if data.ndim == 1 else int(data.shape[0])
+        factors = self.factors
+        if len(factors) not in {1, channel_count}:
+            raise ValueError(
+                "Calibration channel mismatch\n"
+                f"  Got: {len(factors)} calibration factors for {channel_count} signal channels\n"
+                "  Expected: one factor or one factor per signal channel\n"
+                "Use a scalar factor for broadcast or align factors with the channel axis."
+            )
+        scale_shape = (len(factors),) + (1,) * (data.ndim - 1)
+        scale = np.asarray(factors, dtype=np.float64).reshape(scale_shape)
+        result: NDArrayReal = np.asarray(data * scale)
+        return result
+
+
+register_operation(ApplyCalibration)
+
+
+__all__ = ["ApplyCalibration", "Calibration", "CalibrationInput"]


### PR DESCRIPTION
## Summary

- add an immutable `Calibration` model and registered `ApplyCalibration` processing operation
- expose `ChannelFrame.derive_calibration()` for reference-signal measurement and lazy `ChannelFrame.calibrate()` application
- preserve frame metadata, channel extras, source timing, Dask laziness, and Recipe provenance/replay
- document sound-pressure and vibration calibration workflows in English and Japanese entry points

## Motivation

Wandas could carry physical-unit metadata, but converting raw samples or volts from a known calibration signal required manual scaling and metadata mutation. This change makes that workflow explicit, reproducible, channel-aware, and serializable.

## Behavior and contract

- derive from a positive finite RMS target or a dB level; `Pa` defaults to the 20 µPa reference
- normalize surrounding unit whitespace before resolving the unit's default reference
- broadcast a mono calibration across channels, while multi-channel factors require exact channel alignment
- keep calibration derivation as an eager scalar reduction and calibration application Dask-lazy
- return a new immutable frame with calibrated unit/reference/label metadata and `wandas.audio.calibrate` lineage
- reject booleans, strings, complex values, non-finite values, and non-positive values

## Validation

- `uv run pytest -n auto --cov=wandas --cov-report=term-missing -q` — 2236 passed, 3 skipped; total coverage 99%, calibration module 100%
- `uv run pytest tests/processing/test_calibration.py tests/frames/test_frame_calibration.py tests/pipeline/test_calibration_recipe.py tests/processing/test_operation_lazy_metadata_contract.py --cov=wandas --cov-report=term-missing -q` — 95 passed
- `uv run ruff check wandas tests --config=pyproject.toml` — passed
- `uv run ruff format --check wandas tests` — passed
- `uv run ty check wandas tests` — passed
- `uv run mkdocs build --strict -f docs/mkdocs.yml` — passed

## Review follow-up

- addressed the Codex and Copilot findings about resolving `" Pa "` as `ref=1.0` by normalizing the unit before default-reference lookup
- added a regression test covering normalized unit storage, the 20 µPa default, and the derived 94 dB target RMS

## Issue triage

No matching source issue was found, so this PR intentionally has no `Closes` or `Related` reference.