### PR TITLE
refactor: separate describe presentation and define Analyzer boundary

### DIFF
--- a/docs/design/2026-07-16-wandas-analyzer-responsibility-boundary.md
+++ b/docs/design/2026-07-16-wandas-analyzer-responsibility-boundary.md
@@ -1,0 +1,57 @@
+# Wandas / Analyzer responsibility boundary
+
+- Status: Accepted
+- Date: 2026-07-16
+- Applies from: Wandas 0.6
+
+## Context
+
+Wandas is a context-preserving signal-analysis library. Its notebook plots and
+`describe()` view are part of the product: they let a user inspect a Frame before and
+after analysis without discarding sampling rate, units, channel metadata, or lineage.
+The separate Analyzer product is an interactive review application. Without a written
+boundary, GUI session state and evidence-report features could gradually enter Frame
+APIs and couple the library to one review interface.
+
+## Decision
+
+Wandas owns:
+
+- immutable xarray/Dask-backed signal Frames;
+- sampling rate, channels, units, references, metadata, and semantic lineage;
+- lazy processing, typed analysis results, Recipe plans, and I/O;
+- calibration semantics and physical-unit conversion;
+- notebook-friendly static `plot()` and `describe()` output, including Figure saving.
+
+Analyzer owns:
+
+- interactive review UI in VS Code;
+- playback, loops, mute, offsets, zoom/pan, and synchronized cursors;
+- multi-track comparison sessions, selections, annotations, comments, and review state;
+- GUI-oriented previews and PNG/CSV/Markdown evidence-report workflows;
+- PR, Issue, and review-system integration.
+
+The feature test is:
+
+1. Is the feature required to preserve or transform the analytical meaning of waveform
+   data? If yes, it belongs in Wandas.
+2. Is it state or presentation used by a person to explore, compare, or explain results
+   in an interactive GUI? If yes, it belongs in Analyzer.
+
+APIs such as `preview_waveform()`, `review_artifact()`, `comparison_session()`,
+`export_markdown_report()`, `timeline_state`, and `loop_range` therefore do not belong
+in Wandas.
+
+## Consequences
+
+`ChannelFrame.describe()` remains public but delegates presentation work to
+`wandas.visualization.describe` and optional notebook display work to
+`wandas.visualization.notebook`. Frame classes retain orchestration and metadata
+contracts, not IPython/Matplotlib lifecycle details.
+
+Analyzer may consume public Frame, Recipe JSON, WDF, and Figure contracts. Wandas does
+not add Analyzer-specific mutable state or a report/evidence compatibility layer.
+
+## 日本語要約
+
+Wandas は波形の解析上の意味、遅延処理、Recipe、I/O、校正、Notebook 上の静的可視化を担当します。Analyzer は再生、同期比較、選択・注釈、レビュー状態、GUI 向け証跡出力を担当します。解析意味論に必要なら Wandas、人が GUI で探索・比較・説明する状態なら Analyzer、という判定基準を採用します。

--- a/docs/src/api/visualization.md
+++ b/docs/src/api/visualization.md
@@ -9,3 +9,13 @@ Provides plotting functions for visualizing audio data.
 オーディオデータを視覚化するためのプロッティング関数を提供します。
 
 ::: wandas.visualization.plotting
+
+## Describe presentation / Describe presentation
+
+`ChannelFrame.describe()` is the public entry point. It delegates Figure creation,
+image saving, and lifecycle handling to `wandas.visualization.describe`; optional
+IPython Figure/Audio display is isolated in `wandas.visualization.notebook`.
+
+`ChannelFrame.describe()` が公開 entry point です。Figure 作成・画像保存・lifecycle は
+`wandas.visualization.describe`、optional IPython Figure/Audio display は
+`wandas.visualization.notebook` に分離されています。

--- a/docs/src/api/visualization.md
+++ b/docs/src/api/visualization.md
@@ -10,7 +10,7 @@ Provides plotting functions for visualizing audio data.
 
 ::: wandas.visualization.plotting
 
-## Describe presentation / Describe presentation
+## Describe presentation / Describe 表示
 
 `ChannelFrame.describe()` is the public entry point. It delegates Figure creation,
 image saving, and lifecycle handling to `wandas.visualization.describe`; optional

--- a/tests/frames/test_channel_frame_edge_contracts.py
+++ b/tests/frames/test_channel_frame_edge_contracts.py
@@ -234,8 +234,7 @@ def test_describe_closed_mode_displays_and_returns_none(monkeypatch: pytest.Monk
     interactive_display = MagicMock()
     audio = MagicMock(return_value=object())
     monkeypatch.setattr(
-        channel_mod,
-        "require_ipython_display",
+        "wandas.visualization.notebook.require_ipython_display",
         lambda _feature: (interactive_display, audio),
     )
 

--- a/tests/frames/test_channel_frame_edge_contracts.py
+++ b/tests/frames/test_channel_frame_edge_contracts.py
@@ -244,14 +244,23 @@ def test_describe_closed_mode_displays_and_returns_none(monkeypatch: pytest.Monk
 
 
 @pytest.mark.parametrize(
-    "legacy_config",
+    ("legacy_config", "expected_warning"),
     [
-        pytest.param({"axis_config": {"time_plot": {"xlabel": "Time"}}}, id="axis-config"),
-        pytest.param({"cbar_config": {"vmin": -80}}, id="colorbar-config"),
+        pytest.param(
+            {"axis_config": {"time_plot": {"xlabel": "Time"}}},
+            "axis_config is deprecated and will be removed in a future release",
+            id="axis-config",
+        ),
+        pytest.param(
+            {"cbar_config": {"vmin": -80}},
+            "cbar_config is deprecated and will be removed in a future release",
+            id="colorbar-config",
+        ),
     ],
 )
 def test_describe_legacy_config_logs_deprecation_warning(
     legacy_config: dict[str, object],
+    expected_warning: str,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with caplog.at_level("WARNING"):
@@ -262,7 +271,7 @@ def test_describe_legacy_config_logs_deprecation_warning(
 
     assert isinstance(figures, list)
     _close_figures(figures)
-    assert any("deprecated" in record.message.lower() for record in caplog.records)
+    assert any(expected_warning in record.message for record in caplog.records)
 
 
 def test_describe_combined_configuration_returns_structured_figure() -> None:

--- a/tests/visualization/test_describe.py
+++ b/tests/visualization/test_describe.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from typing import Any
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
 from wandas.frames.channel import ChannelFrame
 from wandas.visualization import describe as describe_module
+from wandas.visualization.notebook import NotebookDisplay
 
 
 def test_channel_describe_is_thin_visualization_facade(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -57,3 +59,40 @@ def test_describe_skips_axes_without_a_figure(monkeypatch: pytest.MonkeyPatch) -
     frame = ChannelFrame.from_numpy(np.arange(8, dtype=float).reshape(1, 8), 8.0)
 
     assert describe_module.describe_frame(frame, is_close=False) == []
+
+
+@pytest.mark.parametrize("failure_stage", ["audio-construction", "audio-display"])
+def test_describe_closed_mode_closes_figure_when_notebook_audio_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_stage: str,
+) -> None:
+    """Closed mode must release the Figure even when notebook audio presentation fails."""
+    figure, axes = plt.subplots()
+    audio_value = object()
+
+    def audio(*_args: Any, **_kwargs: Any) -> object:
+        if failure_stage == "audio-construction":
+            raise RuntimeError("audio construction failed")
+        return audio_value
+
+    def display(value: object) -> None:
+        if failure_stage == "audio-display" and value is audio_value:
+            raise RuntimeError("audio display failed")
+
+    monkeypatch.setattr(describe_module, "require_matplotlib_axes_type", lambda _operation: type(axes))
+    monkeypatch.setattr(describe_module, "require_matplotlib_pyplot", lambda _operation: plt)
+    monkeypatch.setattr(
+        describe_module.notebook,
+        "resolve_notebook_display",
+        lambda _feature: NotebookDisplay(display=display, audio=audio),
+    )
+    monkeypatch.setattr(ChannelFrame, "plot", lambda *_args, **_kwargs: axes)
+
+    frame = ChannelFrame.from_numpy(np.arange(8, dtype=float).reshape(1, 8), 8.0)
+    figure_number = figure.number
+
+    with pytest.raises(RuntimeError, match=r"audio (construction|display) failed"):
+        describe_module.describe_frame(frame, is_close=True)
+
+    assert not plt.fignum_exists(figure_number)
+    assert figure.axes == []

--- a/tests/visualization/test_describe.py
+++ b/tests/visualization/test_describe.py
@@ -1,0 +1,41 @@
+"""Contracts for the ChannelFrame.describe presentation boundary."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from wandas.frames.channel import ChannelFrame
+from wandas.visualization import describe as describe_module
+
+
+def test_channel_describe_is_thin_visualization_facade(monkeypatch: pytest.MonkeyPatch) -> None:
+    frame = ChannelFrame.from_numpy(np.arange(8, dtype=float).reshape(1, 8), 8.0)
+    captured: dict[str, Any] = {}
+
+    def fake_describe(receiver: ChannelFrame, **kwargs: Any) -> list[object]:
+        captured["receiver"] = receiver
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(describe_module, "describe_frame", fake_describe)
+
+    result = frame.describe(
+        normalize=False,
+        is_close=False,
+        fmin=1.0,
+        fmax=3.0,
+        cmap="magma",
+        waveform={"ylabel": "Amplitude"},
+    )
+
+    assert result == []
+    assert captured["receiver"] is frame
+    assert captured["normalize"] is False
+    assert captured["is_close"] is False
+    assert captured["fmin"] == 1.0
+    assert captured["fmax"] == 3.0
+    assert captured["cmap"] == "magma"
+    assert captured["waveform"] == {"ylabel": "Amplitude"}

--- a/tests/visualization/test_describe.py
+++ b/tests/visualization/test_describe.py
@@ -39,3 +39,21 @@ def test_channel_describe_is_thin_visualization_facade(monkeypatch: pytest.Monke
     assert captured["fmax"] == 3.0
     assert captured["cmap"] == "magma"
     assert captured["waveform"] == {"ylabel": "Amplitude"}
+
+
+def test_describe_skips_axes_without_a_figure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A backend result without a figure must not enter the display lifecycle."""
+
+    class AxesWithoutFigure:
+        figure = None
+
+    def fake_plot(_frame: ChannelFrame, *_args: Any, **_kwargs: Any) -> AxesWithoutFigure:
+        return AxesWithoutFigure()
+
+    monkeypatch.setattr(describe_module, "require_matplotlib_axes_type", lambda _operation: AxesWithoutFigure)
+    monkeypatch.setattr(describe_module, "require_matplotlib_pyplot", lambda _operation: object())
+    monkeypatch.setattr(ChannelFrame, "plot", fake_plot)
+
+    frame = ChannelFrame.from_numpy(np.arange(8, dtype=float).reshape(1, 8), 8.0)
+
+    assert describe_module.describe_frame(frame, is_close=False) == []

--- a/tests/visualization/test_types.py
+++ b/tests/visualization/test_types.py
@@ -20,9 +20,13 @@ def _suppress_display():
 
     Yields the mock_display object so callers can assert call counts.
     """
+    mock_display = mock.Mock()
+    mock_audio = mock.Mock(return_value=object())
     with (
-        mock.patch("wandas.frames.channel.display") as mock_display,
-        mock.patch("wandas.frames.channel.Audio"),
+        mock.patch(
+            "wandas.visualization.notebook.require_ipython_display",
+            return_value=(mock_display, mock_audio),
+        ),
         mock.patch("matplotlib.pyplot.close"),
     ):
         yield mock_display

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -14,16 +14,7 @@ from wandas.pipeline.decorators import OperationCapture, recipe_operation
 from wandas.processing.semantic import InputBinding
 from wandas.utils import validate_sampling_rate
 from wandas.utils.dask_helpers import da_from_array as _da_from_array
-from wandas.utils.optional_imports import (
-    require_ipython_display,
-    require_pandas,
-)
-from wandas.utils.optional_imports import (
-    require_matplotlib_axes_type as _matplotlib_axes_type,
-)
-from wandas.utils.optional_imports import (
-    require_matplotlib_pyplot as _matplotlib_pyplot,
-)
+from wandas.utils.optional_imports import require_pandas
 from wandas.utils.types import NDArrayReal
 
 from ..core.base_frame import BaseFrame
@@ -43,34 +34,6 @@ da_from_delayed = da.from_delayed
 
 
 S = TypeVar("S", bound="BaseFrame[Any]")
-
-
-class _LazyPyplot:
-    """Resolve pyplot only when a plotting attribute is first accessed."""
-
-    def __getattr__(self, name: str) -> Any:
-        """Delegate an attribute lookup to the optional pyplot module."""
-        return getattr(_matplotlib_pyplot("describe"), name)
-
-
-plt = _LazyPyplot()
-
-
-def _is_display_enabled(image_save: str | Path | None, is_close: bool) -> bool:
-    """Return whether plotting output should be displayed interactively."""
-    return image_save is None and is_close
-
-
-def display(*args: Any, **kwargs: Any) -> Any:
-    """Call IPython display after resolving the optional dependency lazily."""
-    interactive_display, _ = require_ipython_display("describe")
-    return interactive_display(*args, **kwargs)
-
-
-def Audio(*args: Any, **kwargs: Any) -> Any:  # noqa: N802
-    """Construct an IPython Audio display after lazy optional import."""
-    _, audio = require_ipython_display("describe")
-    return audio(*args, **kwargs)
 
 
 def _align_to_length(arr: DaArray, target_len: int, align: str, source_len: int) -> DaArray:
@@ -771,30 +734,6 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         rms_ch: ChannelFrame = self.rms_trend(Aw=Aw, dB=True)
         return rms_ch.plot(ax=ax, ylabel=ylabel, title=title, overlay=overlay, **kwargs)
 
-    @staticmethod
-    def _apply_deprecated_describe_kwargs(plot_kwargs: dict[str, Any]) -> None:
-        """Migrate deprecated ``axis_config`` / ``cbar_config`` into *plot_kwargs*."""
-        if "axis_config" in plot_kwargs:
-            logger.warning("axis_config is retained for backward compatibility but will be deprecated in the future.")
-            axis_config = plot_kwargs["axis_config"]
-            if "time_plot" in axis_config:
-                plot_kwargs["waveform"] = axis_config["time_plot"]
-            if "freq_plot" in axis_config:
-                if "xlim" in axis_config["freq_plot"]:
-                    vlim = axis_config["freq_plot"]["xlim"]
-                    plot_kwargs["vmin"] = vlim[0]
-                    plot_kwargs["vmax"] = vlim[1]
-                if "ylim" in axis_config["freq_plot"]:
-                    plot_kwargs["ylim"] = axis_config["freq_plot"]["ylim"]
-
-        if "cbar_config" in plot_kwargs:
-            logger.warning("cbar_config is retained for backward compatibility but will be deprecated in the future.")
-            cbar_config = plot_kwargs["cbar_config"]
-            if "vmin" in cbar_config:
-                plot_kwargs["vmin"] = cbar_config["vmin"]
-            if "vmax" in cbar_config:
-                plot_kwargs["vmax"] = cbar_config["vmax"]
-
     def describe(
         self,
         normalize: bool = True,
@@ -887,68 +826,25 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             >>> fig = figures[0]
             >>> fig.savefig("custom_output.png")  # Custom save with modifications
         """
-        # Prepare kwargs with explicit parameters
-        plot_kwargs: dict[str, Any] = {
-            "fmin": fmin,
-            "fmax": fmax,
-            "cmap": cmap,
-            "vmin": vmin,
-            "vmax": vmax,
-            "xlim": xlim,
-            "ylim": ylim,
-            "Aw": Aw,
-            "waveform": waveform or {},
-            "spectral": spectral or {},
-        }
-        # Merge with additional kwargs
-        plot_kwargs.update(kwargs)
+        from wandas.visualization.describe import describe_frame
 
-        self._apply_deprecated_describe_kwargs(plot_kwargs)
-
-        axes_cls = _matplotlib_axes_type("describe")
-        display_enabled = _is_display_enabled(image_save, is_close)
-        if display_enabled:
-            require_ipython_display("describe")
-
-        figures: list[Figure] = []
-
-        for ch_idx, ch in enumerate(self):
-            _ax = ch.plot("describe", title=f"{ch.label} {ch.labels[0]}", **plot_kwargs)
-            if isinstance(_ax, axes_cls):
-                ax = _ax
-            elif isinstance(_ax, Iterator):
-                ax = cast("Axes", next(_ax))
-            else:
-                raise TypeError(f"Unexpected type for plot result: {type(_ax)}. Expected Axes or Iterator[Axes].")
-            # Extract figure from axes (existing pattern)
-            fig = getattr(ax, "figure", None)
-
-            if fig is not None and not is_close:
-                figures.append(fig)
-
-            # Save image before closing if requested
-            if image_save is not None and fig is not None:
-                if self.n_channels > 1:
-                    save_path = Path(image_save)
-                    ch_path = save_path.parent / f"{save_path.stem}_{ch_idx}{save_path.suffix}"
-                    fig.savefig(ch_path, bbox_inches="tight")
-                else:
-                    fig.savefig(image_save, bbox_inches="tight")
-
-            if fig is not None and display_enabled:
-                display(fig)
-            if is_close and fig is not None:
-                fig.clf()  # Clear the figure to free memory
-                plt.close(fig)
-
-            # Play audio for each channel
-            if display_enabled:
-                display(Audio(ch.data, rate=ch.sampling_rate, normalize=normalize))
-
-        # Return figures only when is_close=False
-        if is_close:
-            return None
-        return figures
+        return describe_frame(
+            self,
+            normalize=normalize,
+            is_close=is_close,
+            fmin=fmin,
+            fmax=fmax,
+            cmap=cmap,
+            vmin=vmin,
+            vmax=vmax,
+            xlim=xlim,
+            ylim=ylim,
+            Aw=Aw,
+            waveform=waveform,
+            spectral=spectral,
+            image_save=image_save,
+            **kwargs,
+        )
 
     @classmethod
     def from_numpy(

--- a/wandas/visualization/describe.py
+++ b/wandas/visualization/describe.py
@@ -25,7 +25,9 @@ logger = logging.getLogger(__name__)
 def _apply_deprecated_describe_kwargs(plot_kwargs: dict[str, Any]) -> None:
     """Migrate deprecated ``axis_config`` and ``cbar_config`` settings."""
     if "axis_config" in plot_kwargs:
-        logger.warning("axis_config is retained for backward compatibility but will be deprecated in the future.")
+        logger.warning(
+            "axis_config is deprecated and will be removed in a future release; use waveform and spectral instead."
+        )
         axis_config = plot_kwargs["axis_config"]
         if "time_plot" in axis_config:
             plot_kwargs["waveform"] = axis_config["time_plot"]
@@ -38,7 +40,7 @@ def _apply_deprecated_describe_kwargs(plot_kwargs: dict[str, Any]) -> None:
                 plot_kwargs["ylim"] = axis_config["freq_plot"]["ylim"]
 
     if "cbar_config" in plot_kwargs:
-        logger.warning("cbar_config is retained for backward compatibility but will be deprecated in the future.")
+        logger.warning("cbar_config is deprecated and will be removed in a future release; use vmin and vmax instead.")
         cbar_config = plot_kwargs["cbar_config"]
         if "vmin" in cbar_config:
             plot_kwargs["vmin"] = cbar_config["vmin"]
@@ -107,21 +109,23 @@ def describe_frame(
         if figure is None:
             continue
 
-        if not is_close:
-            figures.append(figure)
-        if image_save is not None:
-            _save_figure(figure, image_save, channel=channel_index, channel_count=frame.n_channels)
-        if display_session is not None:
-            notebook.display_figure_and_audio(
-                display_session,
-                figure,
-                channel.data,
-                sampling_rate=channel.sampling_rate,
-                normalize=normalize,
-            )
-        if is_close:
-            figure.clf()
-            pyplot.close(figure)
+        try:
+            if not is_close:
+                figures.append(figure)
+            if image_save is not None:
+                _save_figure(figure, image_save, channel=channel_index, channel_count=frame.n_channels)
+            if display_session is not None:
+                notebook.display_figure_and_audio(
+                    display_session,
+                    figure,
+                    channel.data,
+                    sampling_rate=channel.sampling_rate,
+                    normalize=normalize,
+                )
+        finally:
+            if is_close:
+                figure.clf()
+                pyplot.close(figure)
 
     return None if is_close else figures
 

--- a/wandas/visualization/describe.py
+++ b/wandas/visualization/describe.py
@@ -1,0 +1,129 @@
+"""Composite static visualization workflow behind ``ChannelFrame.describe``."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+from wandas.utils.optional_imports import (
+    require_matplotlib_axes_type,
+    require_matplotlib_pyplot,
+)
+from wandas.visualization import notebook
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
+
+    from wandas.frames.channel import ChannelFrame
+
+logger = logging.getLogger(__name__)
+
+
+def _apply_deprecated_describe_kwargs(plot_kwargs: dict[str, Any]) -> None:
+    """Migrate deprecated ``axis_config`` and ``cbar_config`` settings."""
+    if "axis_config" in plot_kwargs:
+        logger.warning("axis_config is retained for backward compatibility but will be deprecated in the future.")
+        axis_config = plot_kwargs["axis_config"]
+        if "time_plot" in axis_config:
+            plot_kwargs["waveform"] = axis_config["time_plot"]
+        if "freq_plot" in axis_config:
+            if "xlim" in axis_config["freq_plot"]:
+                vlim = axis_config["freq_plot"]["xlim"]
+                plot_kwargs["vmin"] = vlim[0]
+                plot_kwargs["vmax"] = vlim[1]
+            if "ylim" in axis_config["freq_plot"]:
+                plot_kwargs["ylim"] = axis_config["freq_plot"]["ylim"]
+
+    if "cbar_config" in plot_kwargs:
+        logger.warning("cbar_config is retained for backward compatibility but will be deprecated in the future.")
+        cbar_config = plot_kwargs["cbar_config"]
+        if "vmin" in cbar_config:
+            plot_kwargs["vmin"] = cbar_config["vmin"]
+        if "vmax" in cbar_config:
+            plot_kwargs["vmax"] = cbar_config["vmax"]
+
+
+def _save_figure(figure: Figure, image_save: str | Path, *, channel: int, channel_count: int) -> None:
+    """Save one channel figure using the established suffix contract."""
+    if channel_count > 1:
+        save_path = Path(image_save)
+        target = save_path.parent / f"{save_path.stem}_{channel}{save_path.suffix}"
+    else:
+        target = image_save
+    figure.savefig(target, bbox_inches="tight")
+
+
+def describe_frame(
+    frame: ChannelFrame,
+    normalize: bool = True,
+    is_close: bool = True,
+    *,
+    fmin: float = 0,
+    fmax: float | None = None,
+    cmap: str = "jet",
+    vmin: float | None = None,
+    vmax: float | None = None,
+    xlim: tuple[float, float] | None = None,
+    ylim: tuple[float, float] | None = None,
+    Aw: bool = False,  # noqa: N803
+    waveform: dict[str, Any] | None = None,
+    spectral: dict[str, Any] | None = None,
+    image_save: str | Path | None = None,
+    **kwargs: Any,
+) -> list[Figure] | None:
+    """Create, save, optionally display, and close per-channel summaries."""
+    plot_kwargs: dict[str, Any] = {
+        "fmin": fmin,
+        "fmax": fmax,
+        "cmap": cmap,
+        "vmin": vmin,
+        "vmax": vmax,
+        "xlim": xlim,
+        "ylim": ylim,
+        "Aw": Aw,
+        "waveform": waveform or {},
+        "spectral": spectral or {},
+    }
+    plot_kwargs.update(kwargs)
+    _apply_deprecated_describe_kwargs(plot_kwargs)
+
+    axes_cls = require_matplotlib_axes_type("describe")
+    pyplot = require_matplotlib_pyplot("describe")
+    display_session = notebook.resolve_notebook_display("describe") if image_save is None and is_close else None
+    figures: list[Figure] = []
+
+    for channel_index, channel in enumerate(frame):
+        plotted = channel.plot("describe", title=f"{channel.label} {channel.labels[0]}", **plot_kwargs)
+        if isinstance(plotted, axes_cls):
+            axes = plotted
+        elif isinstance(plotted, Iterator):
+            axes = cast("Axes", next(plotted))
+        else:
+            raise TypeError(f"Unexpected type for plot result: {type(plotted)}. Expected Axes or Iterator[Axes].")
+        figure = cast("Figure | None", getattr(axes, "figure", None))
+        if figure is None:
+            continue
+
+        if not is_close:
+            figures.append(figure)
+        if image_save is not None:
+            _save_figure(figure, image_save, channel=channel_index, channel_count=frame.n_channels)
+        if display_session is not None:
+            notebook.display_figure_and_audio(
+                display_session,
+                figure,
+                channel.data,
+                sampling_rate=channel.sampling_rate,
+                normalize=normalize,
+            )
+        if is_close:
+            figure.clf()
+            pyplot.close(figure)
+
+    return None if is_close else figures
+
+
+__all__ = ["describe_frame"]

--- a/wandas/visualization/notebook.py
+++ b/wandas/visualization/notebook.py
@@ -1,0 +1,42 @@
+"""Optional notebook presentation helpers for static Frame descriptions."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from wandas.utils.optional_imports import require_ipython_display
+
+if TYPE_CHECKING:
+    from matplotlib.figure import Figure
+
+
+@dataclass(frozen=True)
+class NotebookDisplay:
+    """Resolved optional IPython display functions for one presentation call."""
+
+    display: Callable[..., Any]
+    audio: Callable[..., Any]
+
+
+def resolve_notebook_display(feature: str = "describe") -> NotebookDisplay:
+    """Resolve IPython display support before expensive plot generation."""
+    display, audio = require_ipython_display(feature)
+    return NotebookDisplay(display=display, audio=audio)
+
+
+def display_figure_and_audio(
+    session: NotebookDisplay,
+    figure: Figure,
+    data: Any,
+    *,
+    sampling_rate: float,
+    normalize: bool,
+) -> None:
+    """Present one static Figure followed by its matching audio channel."""
+    session.display(figure)
+    session.display(session.audio(data, rate=sampling_rate, normalize=normalize))
+
+
+__all__ = ["NotebookDisplay", "display_figure_and_audio", "resolve_notebook_display"]


### PR DESCRIPTION
## Summary

- Keep `ChannelFrame.describe()` as a thin public facade.
- Move describe rendering, deprecated configuration handling, image lifecycle, and Jupyter/IPython Figure and Audio display logic into `wandas.visualization`.
- Isolate the optional IPython dependency behind a dedicated display adapter.
- Preserve the existing describe API and behavior with focused contract tests.
- Guarantee Figure cleanup in closed mode even when IPython Audio construction/display fails.
- Add an ADR that separates Wandas' signal-data responsibilities from Analyzer's higher-level interpretation responsibilities.

## Review guide

1. `wandas/frames/channel.py` shows the reduced facade.
2. `wandas/visualization/describe.py` owns representation construction and Figure lifecycle.
3. `wandas/visualization/notebook.py` displays each Figure and a playable Audio control inline in Jupyter/IPython environments; it does not integrate with laptop hardware.
4. Tests cover public behavior, backend/display failures, and optional-dependency isolation.
5. The responsibility ADR records what belongs in Wandas versus Analyzer.

## Review feedback addressed

- Close and clear Figures when Audio construction or display raises.
- Clarify the current deprecation/removal guidance for `axis_config` and `cbar_config`.
- Correct the bilingual visualization documentation heading.
- Replace ambiguous "notebook integration" wording with the concrete Jupyter/IPython Figure and Audio display behavior.

## Validation

- full GitHub Actions matrix: Linux/Windows × Python 3.10–3.13 — passed
- focused frame/visualization/optional-dependency tests — 106 passed
- `uv run ruff check wandas tests --config=pyproject.toml`
- `uv run ty check wandas tests`
- `uv run mkdocs build --strict -f docs/mkdocs.yml`

## Review/merge order

Independent from #305 and the #308 → #309 → #310 stack; safe to merge in parallel.