### PR TITLE
chore: integrate and prepare Wandas 0.6.0 release

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -111,6 +111,8 @@ nav:
       - Public API Stability: explanation/public-api-stability.md
       - Pipeline Recipe Design: explanation/pipeline-recipe-design.md
       - Pipeline Recipe Developer Guide: explanation/pipeline-recipe-developer-guide.md
+  - Release Notes:
+      - Wandas 0.6.0: release-notes/v0.6.0.md
   - Contributing:
       - Overview: contributing.md
       - Repository Agent Harness: contributing/agent-harness.md

--- a/docs/src/release-notes/v0.6.0.md
+++ b/docs/src/release-notes/v0.6.0.md
@@ -22,6 +22,7 @@ scalability, and explicit API/schema contracts.
 
 WDF 0.4 intentionally provides no compatibility shim for older WDF formats. Resave an
 artifact with a compatible Wandas version before loading it with 0.6.0. A lazily loaded
-Frame retains access to its source WDF; call `compute()` or `persist()` before moving,
-deleting, or replacing that file. `operation_history` remains display-only; use a
-separate Recipe JSON artifact for replay.
+Frame retains access to its source WDF. Use the NumPy array returned by `frame.data`, or
+replace the Frame with `frame = frame.persist()`, before moving, deleting, or replacing
+the source file. `operation_history` remains display-only; use a separate Recipe JSON
+artifact for replay.

--- a/docs/src/release-notes/v0.6.0.md
+++ b/docs/src/release-notes/v0.6.0.md
@@ -1,0 +1,27 @@
+# Wandas 0.6.0
+
+Wandas 0.6.0 focuses on typed persistence, reproducible processing, calibration,
+scalability, and explicit API/schema contracts.
+
+## Highlights
+
+- WDF 0.4 round-trips all seven built-in Frame types with semantic dimensions,
+  constructor state, channel metadata and calibration, represented coordinates, and
+  display history.
+- WDF 0.4 accepts exactly format version 0.4, rejects versions 0.1–0.3 and unsupported
+  future versions explicitly, saves Dask chunks without precomputing the complete
+  tensor, and loads backend-backed lazy data with a documented source-file lifetime.
+- `RecipePlan.save()` and `RecipePlan.load()` use independent strict
+  `wandas.recipe` schema 2 JSON artifacts for portable operation intent.
+- Per-channel calibration metadata applies known sensor coefficients lazily and
+  survives Recipe replay and WDF round-trips.
+- The scalability and public API stability contracts distinguish chunked WDF writer
+  behavior from the current whole-Frame `AudioOperation` materialization boundary.
+
+## Compatibility
+
+WDF 0.4 intentionally provides no compatibility shim for older WDF formats. Resave an
+artifact with a compatible Wandas version before loading it with 0.6.0. A lazily loaded
+Frame retains access to its source WDF; call `compute()` or `persist()` before moving,
+deleting, or replacing that file. `operation_history` remains display-only; use a
+separate Recipe JSON artifact for replay.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wandas"
-version = "0.5.0"
+version = "0.6.0"
 description = "Wandas is an open source library for efficient signal analysis in Python"
 authors = [{name = "kasahart", email="kasahart66@gmail.com"}]
 maintainers = [

--- a/uv.lock
+++ b/uv.lock
@@ -3938,7 +3938,7 @@ wheels = [
 
 [[package]]
 name = "wandas"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "cattrs" },


### PR DESCRIPTION
## Summary

- Rebase #310-specific release preparation onto latest `main` after #309 and #318 merged.
- Bump Wandas and the committed lock to 0.6.0.
- Add 0.6.0 release notes and MkDocs release navigation.
- Carry the corrected benchmark source-chunk fixture, `frame.data` public boundary, and stale-lock rejection through the release stack.

The integration intentionally excludes #308 history already merged to `main` and the Cepstral/Cepstrogram WDF codec fixes already supplied by the shared mainline validator. #310-specific changes remain limited to version/lock, release notes, and release navigation.

## Release scope

The release notes cover WDF 0.4, exact version rejection, Frame-owned lazy source lifetime and chunked save, Recipe schema 2, calibration, and scalability/API stability contracts. xarray, Dask collections, chunk topology, and backend ownership remain Frame implementation details; user examples obtain NumPy values through `frame.data`.

## Merge order

1. #309 — merged
2. #318 — merged
3. #310 last — rebased onto the resulting `main`

The required order is complete; #310 remains the final release PR.

## Validation

- Current rebased head: the full GitHub Actions test matrix passed on Ubuntu and Windows for Python 3.10–3.13.
- Parent #309 focused validation — 157 passed, 2 warnings.
- `uv run --locked ruff check .` / `uv run --locked ruff format --check .` — passed locally and in CI.
- `uv run --locked ty check` — passed locally and in CI.
- `uv run --locked mkdocs build -f docs/mkdocs.yml --strict` — passed locally and in CI.
- `uv lock --check` — passed.
- `uv build --wheel` plus Python 3.12 exact core-only installed-wheel smoke — passed locally and in CI.
- Representative schema-v2 evidence remains owned by merged #309; it was not rerun because #310 changes only release metadata, navigation, and notes and cannot affect benchmark metrics.

## Current heads

- #309 merged into `main` as `be0b50c1`.
- #318 merged into `main` as `8572450c`.
- #310: `33152d5e`, rebased directly onto `8572450c`.

No source issue is closed by this aggregate release PR; #309 owns the #306 closing relationship. Backend-facing Frame API consolidation is tracked separately in #324.