### PR TITLE
Canonicalize external reads as full-scale float64

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -85,7 +85,7 @@ sample_source = (
     else "https://raw.githubusercontent.com/kasahart/wandas/main/learning-path/sample_audio.wav"
 )
 
-recording = wd.read(sample_source, end=15, normalize=True)
+recording = wd.read(sample_source, end=15)
 recording.describe(fmin=20, fmax=8_000, vmin=-80, vmax=-20, image_save="readme_sample_audio_describe.png")
 ```
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ sample_source = (
     else "https://raw.githubusercontent.com/kasahart/wandas/main/learning-path/sample_audio.wav"
 )
 
-recording = wd.read(sample_source, end=15, normalize=True)
+recording = wd.read(sample_source, end=15)
 recording.describe(fmin=20, fmax=8_000, vmin=-80, vmax=-20, image_save="readme_sample_audio_describe.png")
 ```
 

--- a/docs/src/api/frames.md
+++ b/docs/src/api/frames.md
@@ -16,6 +16,30 @@ modifying the source frame. Calibrated physical values are available from
 `frame.data` as a NumPy array; users do not need to manage the internal array
 backend.
 
+For a recorded reference event, use exactly one known scalar target:
+
+```python
+microphone_calibration = microphone_reference.derive_calibration(
+    target_level=94.0,
+    unit="Pa",
+)
+acceleration_calibration = acceleration_reference.derive_calibration(
+    target_rms=1.0,
+    unit="m/s^2",
+)
+measurement = measurement.with_calibration(
+    {**microphone_calibration, **acceleration_calibration}
+)
+```
+
+The scalar is broadcast to every channel in that reference event. References
+with different targets, units, or recording times are separate events whose
+label mappings can be combined. Derivation always uses the current
+`frame.data`/`frame.rms`, including an existing factor, and does not inspect or
+change operation history. It requires unique non-empty labels. The reference
+and measurement recording chain—including amplifier gain—must represent the
+same physical scale.
+
 ### `get_channel(..., validate_query_keys: bool = True)` parameter
 
 - **validate_query_keys**: When `True` (default), dict-style `query` arguments are validated against the known channel metadata fields and any existing `extra` keys. Unknown keys raise `KeyError` with the message "Unknown channel metadata key". Set to `False` to skip this pre-validation and allow queries that reference keys not present on the model; in that case, normal matching proceeds and a no-match will raise the usual `KeyError` for no results.

--- a/docs/src/api/io.md
+++ b/docs/src/api/io.md
@@ -14,6 +14,43 @@ Wandas native WDF ファイルには `wd.load(...)` を使います。
 `read_wav()` and `read_csv()` remain available for compatibility, but new documentation and examples prefer `read()`.
 互換性のため `read_wav()` と `read_csv()` は残りますが、新しいドキュメントと例では `read()` を優先します。
 
+## Canonical numeric contract / 正規化数値契約
+
+Built-in readers always produce lazy, channel-first `float64` data. Equal file
+content has equal values whether it comes from a local path, URL, bytes,
+`bytearray`, `memoryview`, or a file-like object.
+
+built-in readerは常に遅延実行のchannel-first `float64`を返します。同じファイル内容なら、
+local path、URL、bytes、`bytearray`、`memoryview`、file-like objectのどれから読んでも値は同じです。
+
+| Input / 入力 | `wd.read()` numeric rule / 数値規則 |
+| --- | --- |
+| WAV (`PCM_U8`, `PCM_16`, `PCM_24`, `PCM_32`) | libsndfile full-scale conversion; unsigned 8-bit PCM is zero-centered / libsndfileのfull-scale変換、符号なし8-bit PCMもゼロ中心 |
+| WAV (`FLOAT`, `DOUBLE`) | Values are preserved as `float64`; no clipping, so values may exceed ±1 / 値を`float64`で保持し、クリップしないため±1を超える場合がある |
+| FLAC, OGG, AIFF/AIF, SND | libsndfile full-scale `float64` audio / libsndfileのfull-scale `float64`音声 |
+| CSV | Non-time numeric values are preserved and cast to `float64`; non-numeric channels are rejected / 時間列以外の数値を維持して`float64`化し、非数値chは拒否 |
+
+This is decode normalization, not peak normalization: Wandas never divides by
+the maximum value of an individual waveform. `frame.normalize()` and playback's
+`normalize` option remain separate processing and presentation features.
+
+これは波形ごとの最大値で割るpeak normalizationではなく、decode時の正規化です。
+`frame.normalize()`と再生時の`normalize`は別の処理・表示機能です。
+
+### Migration / 移行
+
+Local integer WAV files previously defaulted to raw PCM counts cast to
+`float32`. They now use the same full-scale `float64` decoding as every other
+transport. Calibration factors derived for raw counts must be derived again
+from a reference recording read under the new contract. `wd.load()` preserves
+the dtype stored in WDF, and `wd.from_numpy()` preserves the user-selected
+array dtype; neither contract changes here.
+
+従来local integer WAVはraw PCM countを`float32`へcastしていましたが、今後は他の
+transportと同じfull-scale `float64`です。raw count向けの既知係数は、新契約で読んだ
+参照収録から再導出してください。`wd.load()`はWDF保存dtype、`wd.from_numpy()`は
+利用者指定dtypeを維持し、これらの契約は変更しません。
+
 ## File Readers / ファイルリーダー
 
 Provides functionality to read data from various file formats.

--- a/learning-path/07_per_channel_calibration.py
+++ b/learning-path/07_per_channel_calibration.py
@@ -14,33 +14,81 @@ def _():
     import marimo as mo
     import numpy as np
     import pandas as pd
+    import soundfile as sf
 
     import wandas as wd
     from wandas import pipeline as pipeline_api
 
-    return io, mo, np, pathlib, pd, pipeline_api, tempfile, wd
+    return io, mo, np, pathlib, pd, pipeline_api, sf, tempfile, wd
 
 
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    # 既知の校正値をチャンネルへ設定する
+    # 参照信号から校正し、既知の校正値もチャンネルへ設定する
 
-    マイクや加速度計の校正値は、同時に収録した校正信号ではなく、センサ証明書、
-    設備台帳、CSVなどで別々に管理されていることがあります。`with_calibration()`を使うと、
-    その既知係数をチャンネルへ対応付け、元のFrameを変更せずに物理値を計算できます。
+    マイクや加速度計は、既知の物理入力を別々に収録して校正できます。
+    `derive_calibration()`で参照収録から係数を導出し、`with_calibration()`で測定へ適用します。
+    証明書、設備台帳、CSVですでに管理された係数にも同じ適用APIを使えます。
 
     この教材では次を確認します。
 
-    1. 音と加速度へ異なる単位・基準値・係数を設定する
-    2. CSVをラベル辞書へ変換し、並び順に依存せず適用する
-    3. 係数列のNumPy配列と100chの管理表を一括適用する
+    1. 別録りの94 dBマイク参照と1 m/s²加速度参照を`wd.read()`で読む
+    2. 導出したlabel mappingを結合し、多ch測定へ適用する
+    3. CSVやlistで管理された既知係数も適用する
     4. 校正後の値を`frame.data`で取得し、RecipeやWDFでも再現する
 
-    Wandasは、ここで渡す係数を校正信号から推定しません。証明書や管理系で確定した
-    **収録値から物理値への変換係数**をFrameへ設定するところから始めます。
+    Wandasが保証するのはdecode規則とtransport間の同一性です。参照収録と測定収録で
+    アンプgainを含む収録系が同じことは、利用者が満たす物理的前提です。
     """)
     return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""
+    ## 別々の参照イベントから係数を導出する
+
+    1回の導出は「1つの既知物理targetを持つ校正イベント」です。マイクと加速度計は
+    target、unit、収録時刻が異なるため別ファイルとして読み、導出結果をラベルで結合します。
+    同じtargetで同時に収録した多ch参照なら、scalar targetが全chへbroadcastされます。
+    """)
+    return
+
+
+@app.cell
+def _(mo, np, pathlib, pd, sf, tempfile, wd):
+    # 3つの別録り音声を作り、公開readerだけで参照と測定を読む
+    _calibration_directory = tempfile.TemporaryDirectory()
+    _calibration_root = pathlib.Path(_calibration_directory.name)
+    _microphone_path = _calibration_root / "microphone-reference.wav"
+    _acceleration_path = _calibration_root / "acceleration-reference.wav"
+    _measurement_path = _calibration_root / "measurement.wav"
+    sf.write(_microphone_path, np.array([0.5, -0.5]), 8_000, subtype="DOUBLE")
+    sf.write(_acceleration_path, np.array([0.25, -0.25]), 8_000, subtype="DOUBLE")
+    sf.write(_measurement_path, np.array([[1.0, 2.0], [-1.0, -2.0]]), 8_000, subtype="DOUBLE")
+
+    microphone_reference = wd.read(_microphone_path, ch_labels=["microphone"])
+    acceleration_reference = wd.read(_acceleration_path, ch_labels=["accelerometer"])
+    multichannel_measurement = wd.read(
+        _measurement_path,
+        ch_labels=["microphone", "accelerometer"],
+    )
+    _derived_by_label = {
+        **microphone_reference.derive_calibration(target_level=94.0, unit="Pa"),
+        **acceleration_reference.derive_calibration(target_rms=1.0, unit="m/s^2"),
+    }
+    derived_measurement = multichannel_measurement.with_calibration(_derived_by_label)
+    _derived_summary = pd.DataFrame(
+        {
+            "channel": derived_measurement.labels,
+            "factor": [channel.calibration.factor for channel in derived_measurement.channels],
+            "unit": [channel.unit for channel in derived_measurement.channels],
+            "physical first sample": derived_measurement.data[:, 0],
+        }
+    )
+    mo.vstack([mo.md("**別イベントの係数を結合した結果**"), _derived_summary])
+    return (derived_measurement,)
 
 
 @app.cell(hide_code=True)

--- a/learning-path/07_per_channel_calibration.py
+++ b/learning-path/07_per_channel_calibration.py
@@ -59,8 +59,8 @@ def _(mo):
 @app.cell
 def _(mo, np, pathlib, pd, sf, tempfile, wd):
     # 3つの別録り音声を作り、公開readerだけで参照と測定を読む
-    _calibration_directory = tempfile.TemporaryDirectory()
-    _calibration_root = pathlib.Path(_calibration_directory.name)
+    calibration_directory = tempfile.TemporaryDirectory()
+    _calibration_root = pathlib.Path(calibration_directory.name)
     _microphone_path = _calibration_root / "microphone-reference.wav"
     _acceleration_path = _calibration_root / "acceleration-reference.wav"
     _measurement_path = _calibration_root / "measurement.wav"
@@ -88,7 +88,7 @@ def _(mo, np, pathlib, pd, sf, tempfile, wd):
         }
     )
     mo.vstack([mo.md("**別イベントの係数を結合した結果**"), _derived_summary])
-    return (derived_measurement,)
+    return calibration_directory, derived_measurement
 
 
 @app.cell(hide_code=True)

--- a/tests/docs/test_readme_examples.py
+++ b/tests/docs/test_readme_examples.py
@@ -216,7 +216,7 @@ def test_readme_sample_audio_supports_checkout_and_installed_users() -> None:
         block = _python_block_containing(path, "sample_source")
         assert 'Path("learning-path/sample_audio.wav")' in block
         assert expected_url in block
-        assert "recording = wd.read(sample_source, end=15, normalize=True)" in block
+        assert "recording = wd.read(sample_source, end=15)" in block
 
 
 def test_readme_documents_frame_context_and_boundaries() -> None:

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -863,8 +863,8 @@ class TestChannelFrameFileIO:
         assert cf.sampling_rate == sampling_rate
         assert cf.n_channels == 2
         computed_data = cf.compute()
-        np.testing.assert_allclose(computed_data[0], data_left, rtol=1e-5)  # int16->float32 normalization rounding
-        np.testing.assert_allclose(computed_data[1], data_right, rtol=1e-5)  # int16->float32 normalization rounding
+        np.testing.assert_array_equal(computed_data[0], data_left)
+        np.testing.assert_array_equal(computed_data[1], data_right)
 
     def test_from_file_bytes_csv(self) -> None:
         """Test from_file with in-memory CSV bytes."""
@@ -935,8 +935,8 @@ class TestChannelFrameFileIO:
         assert cf.n_channels == 2
         assert cf.label == "source"
         computed_data = cf.compute()
-        np.testing.assert_allclose(computed_data[0], data_left, rtol=1e-5)  # int16->float32 normalization rounding
-        np.testing.assert_allclose(computed_data[1], data_right, rtol=1e-5)  # int16->float32 normalization rounding
+        np.testing.assert_array_equal(computed_data[0], data_left)
+        np.testing.assert_array_equal(computed_data[1], data_right)
 
     def test_from_file_wav_is_full_scale_float64(self, tmp_path: Path) -> None:
         """from_file returns canonical full-scale float64."""

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -938,8 +938,8 @@ class TestChannelFrameFileIO:
         np.testing.assert_allclose(computed_data[0], data_left, rtol=1e-5)  # int16->float32 normalization rounding
         np.testing.assert_allclose(computed_data[1], data_right, rtol=1e-5)  # int16->float32 normalization rounding
 
-    def test_from_file_wav_normalize_false(self, tmp_path: Path) -> None:
-        """Test that from_file returns int16 data cast to float32 by default (normalize=False)."""
+    def test_from_file_wav_is_full_scale_float64(self, tmp_path: Path) -> None:
+        """from_file returns canonical full-scale float64."""
         filepath = tmp_path / "int16.wav"
         sampling_rate = 16000
         num_samples = 100
@@ -951,43 +951,9 @@ class TestChannelFrameFileIO:
         cf = ChannelFrame.from_file(filepath)
         computed = cf.compute()
 
-        np.testing.assert_array_equal(computed[0], np.full(num_samples, 16384, dtype=np.float32))
-        np.testing.assert_array_equal(computed[1], np.full(num_samples, -16384, dtype=np.float32))
-        assert computed.dtype == np.float32
-
-    def test_from_file_wav_normalize_true(self, tmp_path: Path) -> None:
-        """Test that from_file normalizes to float32 when normalize=True."""
-        filepath = tmp_path / "int16_norm.wav"
-        sampling_rate = 16000
-        num_samples = 100
-        int16_data = np.column_stack(
-            [np.full(num_samples, 16384, dtype=np.int16), np.full(num_samples, -16384, dtype=np.int16)]
-        )
-        wavfile.write(str(filepath), sampling_rate, int16_data)
-
-        cf = ChannelFrame.from_file(filepath, normalize=True)
-        computed = cf.compute()
-
-        np.testing.assert_allclose(computed[0], 0.5, rtol=1e-4)  # int16 quantization: 16384/32768 ~= 0.5
-        np.testing.assert_allclose(computed[1], -0.5, rtol=1e-4)  # int16 quantization: 16384/32768 ~= 0.5
-        assert computed.dtype == np.float32
-
-    def test_read_wav_normalize_true(self, tmp_path: Path) -> None:
-        """Test that read_wav normalizes to float32 when normalize=True."""
-        filepath = tmp_path / "int16_norm.wav"
-        sampling_rate = 16000
-        num_samples = 100
-        int16_data = np.column_stack(
-            [np.full(num_samples, 16384, dtype=np.int16), np.full(num_samples, -16384, dtype=np.int16)]
-        )
-        wavfile.write(str(filepath), sampling_rate, int16_data)
-
-        cf = ChannelFrame.read_wav(str(filepath), normalize=True)
-        computed = cf.compute()
-
-        np.testing.assert_allclose(computed[0], 0.5, rtol=1e-4)  # int16 quantization: 16384/32768 ~= 0.5
-        np.testing.assert_allclose(computed[1], -0.5, rtol=1e-4)  # int16 quantization: 16384/32768 ~= 0.5
-        assert computed.dtype == np.float32
+        np.testing.assert_array_equal(computed[0], 0.5)
+        np.testing.assert_array_equal(computed[1], -0.5)
+        assert computed.dtype == np.float64
 
 
 class TestChannelFrameUtilities:
@@ -1025,9 +991,7 @@ class TestChannelFrameUtilities:
         with mock.patch.object(ChannelFrame, "from_file") as mock_from_file:
             mock_from_file.return_value = self.channel_frame
             result = ChannelFrame.read_wav("test.wav", labels=["left", "right"])
-            mock_from_file.assert_called_with(
-                "test.wav", ch_labels=["left", "right"], normalize=False, file_type=None, source_name=None
-            )
+            mock_from_file.assert_called_with("test.wav", ch_labels=["left", "right"], file_type=None, source_name=None)
             assert result is self.channel_frame
 
     def test_read_wav_stream_source_name(self) -> None:
@@ -1043,7 +1007,6 @@ class TestChannelFrameUtilities:
             mock_from_file.assert_called_with(
                 stream,
                 ch_labels=None,
-                normalize=False,
                 file_type=".wav",
                 source_name="path/to/audio.wav",
             )
@@ -1059,7 +1022,6 @@ class TestChannelFrameUtilities:
             mock_from_file.assert_called_with(
                 stream,
                 ch_labels=None,
-                normalize=False,
                 file_type=".wav",
                 source_name=None,
             )

--- a/tests/frames/test_channel_frame_edge_contracts.py
+++ b/tests/frames/test_channel_frame_edge_contracts.py
@@ -93,6 +93,21 @@ def test_from_file_get_data_not_ndarray_raises(monkeypatch):
         cf.compute()
 
 
+@pytest.mark.parametrize(
+    ("data", "message"),
+    [
+        (np.ones((1, 3)), "unexpected channel-first shape"),
+        (np.ones((2, 3), dtype=np.complex128), "real channel-first numeric array"),
+    ],
+)
+def test_from_file_validates_custom_reader_boundary(monkeypatch, data, message):
+    monkeypatch.setattr(channel_mod, "get_file_reader", lambda *args, **kwargs: FakeReader(data=data))
+    frame = ChannelFrame.from_file(b"data", file_type=".wav")
+
+    with pytest.raises((TypeError, ValueError), match=message):
+        frame.compute()
+
+
 def test_from_file_channel_out_of_range_and_invalid_type(monkeypatch):
     fake = FakeReader(sr=100, channels=2, frames=4)
     monkeypatch.setattr(channel_mod, "get_file_reader", lambda *args, **kwargs: fake)

--- a/tests/frames/test_reference_signal_calibration.py
+++ b/tests/frames/test_reference_signal_calibration.py
@@ -1,0 +1,84 @@
+"""Reference-signal calibration contracts."""
+
+from collections.abc import Mapping
+
+import dask.array as da
+import numpy as np
+import pytest
+
+from wandas.core.metadata import ChannelCalibration, ChannelMetadata
+from wandas.frames.channel import ChannelFrame
+
+
+def _frame(data: np.ndarray, labels: list[str], factors: list[float] | None = None) -> ChannelFrame:
+    factors = factors or [1.0] * len(labels)
+    return ChannelFrame(
+        da.from_array(data, chunks=(1, -1)),
+        sampling_rate=8_000,
+        channel_metadata=[
+            ChannelMetadata(label=label, calibration=ChannelCalibration(factor))
+            for label, factor in zip(labels, factors, strict=True)
+        ],
+    )
+
+
+def test_separate_reference_events_combine_for_measurement() -> None:
+    microphone = _frame(np.array([[0.5, -0.5]]), ["microphone"])
+    accelerometer = _frame(np.array([[0.25, -0.25]]), ["accelerometer"])
+    measurement = _frame(np.array([[1.0, -1.0], [2.0, -2.0]]), ["microphone", "accelerometer"])
+
+    calibrations: Mapping[str | int, float | ChannelCalibration] = {
+        **microphone.derive_calibration(target_level=94.0, unit="Pa"),
+        **accelerometer.derive_calibration(target_rms=1.0, unit="m/s^2"),
+    }
+    calibrated = measurement.with_calibration(calibrations)
+
+    microphone_factor = 2e-5 * 10 ** (94.0 / 20.0) / 0.5
+    np.testing.assert_allclose(calibrated.data, [[microphone_factor, -microphone_factor], [8.0, -8.0]])
+
+
+def test_common_target_broadcast_and_many_event_aggregation() -> None:
+    reference = _frame(np.array([[1.0, -1.0], [2.0, -2.0]]), ["a", "b"])
+    factors = reference.derive_calibration(target_rms=1.0, unit="m/s^2")
+    assert factors == {
+        "a": ChannelCalibration(1.0, "m/s^2"),
+        "b": ChannelCalibration(0.5, "m/s^2"),
+    }
+
+    aggregated: dict[str, ChannelCalibration] = {}
+    for index in range(100):
+        event = _frame(np.array([[index + 1.0, -(index + 1.0)]]), [f"sensor-{index:03d}"])
+        aggregated.update(event.derive_calibration(target_rms=1.0, unit="m/s^2"))
+    assert len(aggregated) == 100
+
+
+def test_existing_factor_and_processed_data_produce_absolute_factor() -> None:
+    reference = _frame(np.array([[0.5, -0.5]]), ["sensor"], factors=[2.0]).remove_dc()
+    original_data = reference.data.copy()
+    original_history = reference.operation_history.copy()
+
+    result = reference.derive_calibration(target_rms=4.0, unit="Pa")
+
+    assert result == {reference.labels[0]: ChannelCalibration(4.0, "Pa")}
+    np.testing.assert_array_equal(reference.data, original_data)
+    assert reference.operation_history == original_history
+
+
+@pytest.mark.parametrize("value", [True, 1 + 0j, [1.0], np.array([1.0]), np.ma.array(1.0), np.nan, np.inf])
+def test_target_is_narrow_finite_real_scalar(value: object) -> None:
+    reference = _frame(np.array([[1.0, -1.0]]), ["sensor"])
+    with pytest.raises((TypeError, ValueError), match="target_rms"):
+        reference.derive_calibration(target_rms=value, unit="Pa")  # ty: ignore[invalid-argument-type]
+
+
+def test_invalid_rms_labels_and_target_choice_are_rejected() -> None:
+    with pytest.raises(ValueError, match="Reference RMS"):
+        _frame(np.zeros((1, 2)), ["sensor"]).derive_calibration(target_rms=1.0, unit="Pa")
+    with pytest.raises(ValueError, match="unique non-empty"):
+        _frame(np.ones((2, 2)), ["sensor", "sensor"]).derive_calibration(target_rms=1.0, unit="Pa")
+    with pytest.raises(ValueError, match="unique non-empty"):
+        _frame(np.ones((1, 2)), [""]).derive_calibration(target_rms=1.0, unit="Pa")
+    with pytest.raises(ValueError, match="Exactly one"):
+        _frame(np.ones((1, 2)), ["sensor"]).derive_calibration(unit="Pa")
+    with pytest.raises(ValueError, match="Exactly one"):
+        _frame(np.ones((1, 2)), ["sensor"]).derive_calibration(target_rms=1.0, target_level=94.0, unit="Pa")

--- a/tests/io/test_canonical_float64_read.py
+++ b/tests/io/test_canonical_float64_read.py
@@ -1,0 +1,82 @@
+"""Canonical external-reader numeric contracts."""
+
+import io
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import soundfile as sf
+from scipy.io import wavfile
+
+import wandas as wd
+from wandas.frames.channel import ChannelFrame
+
+
+@pytest.mark.parametrize("subtype", ["PCM_U8", "PCM_16", "PCM_24", "PCM_32"])
+def test_wav_integer_subtypes_match_soundfile_full_scale(tmp_path: Path, subtype: str) -> None:
+    path = tmp_path / f"integer-{subtype}.wav"
+    source = np.array([[-0.75], [0.0], [0.5]], dtype=np.float64)
+    sf.write(path, source, 8_000, subtype=subtype)
+    expected, _ = sf.read(path, dtype="float64", always_2d=True)
+
+    frame = wd.read(path)
+
+    assert frame._data.dtype == np.dtype("float64")
+    assert frame.compute().dtype == np.dtype("float64")
+    np.testing.assert_array_equal(frame.compute(), expected.T)
+
+
+@pytest.mark.parametrize("subtype", ["FLOAT", "DOUBLE"])
+def test_wav_float_subtypes_preserve_values_above_full_scale(tmp_path: Path, subtype: str) -> None:
+    path = tmp_path / f"float-{subtype}.wav"
+    source = np.array([[-2.0], [0.25], [1.5]], dtype=np.float64)
+    sf.write(path, source, 8_000, subtype=subtype)
+
+    frame = wd.read(path)
+
+    np.testing.assert_allclose(frame.compute(), source.T, rtol=0.0, atol=1e-7 if subtype == "FLOAT" else 0.0)
+    assert frame.compute().dtype == np.dtype("float64")
+
+
+def test_pcm_u8_is_zero_centered(tmp_path: Path) -> None:
+    path = tmp_path / "unsigned.wav"
+    wavfile.write(path, 8_000, np.array([0, 128, 255], dtype=np.uint8))
+
+    np.testing.assert_array_equal(wd.read(path).compute(), [[-1.0, 0.0, 127.0 / 128.0]])
+
+
+def test_same_audio_content_matches_across_path_and_memory_transports(tmp_path: Path) -> None:
+    path = tmp_path / "transport.wav"
+    sf.write(path, np.array([[-0.5], [0.0], [0.5]]), 8_000, subtype="PCM_16")
+    content = path.read_bytes()
+    expected = wd.read(path).compute()
+
+    for source in (content, bytearray(content), memoryview(content), io.BytesIO(content)):
+        np.testing.assert_array_equal(wd.read(source, file_type=".wav").compute(), expected)
+
+
+def test_csv_preserves_numeric_values_as_float64_and_rejects_text(tmp_path: Path) -> None:
+    valid = tmp_path / "valid.csv"
+    pd.DataFrame({"time": [0.0, 0.5], "count": [1, 2], "value": [1.25, -3.5]}).to_csv(valid, index=False)
+    frame = wd.read(valid)
+
+    assert frame._data.dtype == np.dtype("float64")
+    np.testing.assert_array_equal(frame.compute(), [[1.0, 2.0], [1.25, -3.5]])
+
+    invalid = tmp_path / "invalid.csv"
+    pd.DataFrame({"time": [0.0, 0.5], "sensor": ["ok", "bad"]}).to_csv(invalid, index=False)
+    with pytest.raises(ValueError, match="CSV data channels must be numeric"):
+        wd.read(invalid).compute()
+
+
+def test_read_time_normalize_argument_is_removed(tmp_path: Path) -> None:
+    path = tmp_path / "audio.wav"
+    sf.write(path, np.zeros((2, 1)), 8_000)
+
+    with pytest.raises(TypeError, match="normalize"):
+        wd.read(path, normalize=True)  # ty: ignore[unknown-argument]
+    with pytest.raises(TypeError, match="normalize"):
+        ChannelFrame.from_file(path, normalize=True)  # ty: ignore[unknown-argument]
+    with pytest.raises(TypeError, match="normalize"):
+        ChannelFrame.read_wav(path, normalize=True)  # ty: ignore[unknown-argument]

--- a/tests/io/test_canonical_float64_read.py
+++ b/tests/io/test_canonical_float64_read.py
@@ -30,12 +30,13 @@ def test_wav_integer_subtypes_match_soundfile_full_scale(tmp_path: Path, subtype
 @pytest.mark.parametrize("subtype", ["FLOAT", "DOUBLE"])
 def test_wav_float_subtypes_preserve_values_above_full_scale(tmp_path: Path, subtype: str) -> None:
     path = tmp_path / f"float-{subtype}.wav"
-    source = np.array([[-2.0], [0.25], [1.5]], dtype=np.float64)
+    source = np.array([[-2.0], [0.1], [1.5]], dtype=np.float64)
     sf.write(path, source, 8_000, subtype=subtype)
+    encoded = source.astype(np.float32).astype(np.float64) if subtype == "FLOAT" else source
 
     frame = wd.read(path)
 
-    np.testing.assert_allclose(frame.compute(), source.T, rtol=0.0, atol=1e-7 if subtype == "FLOAT" else 0.0)
+    np.testing.assert_array_equal(frame.compute(), encoded.T)
     assert frame.compute().dtype == np.dtype("float64")
 
 

--- a/tests/io/test_file_readers.py
+++ b/tests/io/test_file_readers.py
@@ -252,6 +252,42 @@ class TestCSVFileReader:
         assert info["samplerate"] == 100, f"Expected 100Hz, got {info['samplerate']}"
         assert info["channels"] == 2, f"Expected 2 channels, got {info['channels']}"
 
+    def test_time_column_in_middle_aligns_info_and_data(self, tmp_path: Path) -> None:
+        """A named time column is excluded regardless of its physical position."""
+        path = tmp_path / "middle_time.csv"
+        pd.DataFrame(
+            {
+                "left": [1.0, 2.0],
+                "time": [0.0, 0.5],
+                "right": [3.0, 4.0],
+            }
+        ).to_csv(path, index=False)
+
+        info = self.reader.get_file_info(path, time_column="time")
+        data = self.reader.get_data(path, channels=[], start_idx=0, frames=2, time_column="time")
+
+        assert info["ch_labels"] == ["left", "right"]
+        assert info["channels"] == 2
+        np.testing.assert_array_equal(data, [[1.0, 2.0], [3.0, 4.0]])
+
+    @pytest.mark.parametrize("time_column", [99, -5, "missing"])
+    @pytest.mark.parametrize("method", ["get_file_info", "get_data"])
+    def test_invalid_time_column_reports_available_columns(self, time_column: int | str, method: str) -> None:
+        """Both CSV read phases reject missing time columns with one clear contract."""
+        with pytest.raises(ValueError, match="Invalid CSV time column") as exc_info:
+            if method == "get_file_info":
+                self.reader.get_file_info(self.test_file, time_column=time_column)
+            else:
+                self.reader.get_data(
+                    self.test_file,
+                    channels=[],
+                    start_idx=0,
+                    frames=self.N_ROWS,
+                    time_column=time_column,
+                )
+
+        assert "Available columns: ['time', 'ch1', 'ch2', 'ch3']" in str(exc_info.value)
+
     def test_get_file_info_single_row(self) -> None:
         """
         Test behavior with a CSV file containing only one row.

--- a/tests/io/test_file_readers.py
+++ b/tests/io/test_file_readers.py
@@ -53,9 +53,9 @@ def test_read_supported_audio_format_matches_soundfile_reference(
     # Explicit containers keep aliases such as .aif and .snd independent of
     # libsndfile's extension inference.
     sf.write(path, source, sample_rate, format=file_format, subtype=subtype)
-    expected, expected_sample_rate = sf.read(path, dtype="float32", always_2d=True)
+    expected, expected_sample_rate = sf.read(path, dtype="float64", always_2d=True)
 
-    frame = wd.read(path, normalize=True)
+    frame = wd.read(path)
 
     assert isinstance(frame, ChannelFrame)
     assert frame.sampling_rate == expected_sample_rate
@@ -79,11 +79,11 @@ def test_read_supported_audio_format_accepts_uppercase_extension(
     path = tmp_path / f"silence{extension.upper()}"
     sf.write(path, source, sample_rate, format=file_format, subtype=subtype)
 
-    frame = wd.read(path, normalize=True)
+    frame = wd.read(path)
 
     assert frame.sampling_rate == sample_rate
     assert frame.n_channels == 1
-    np.testing.assert_array_equal(frame.data, np.zeros(80, dtype=np.float32))
+    np.testing.assert_array_equal(frame.data, np.zeros(80, dtype=np.float64))
 
 
 class TestSoundFileReader:
@@ -109,7 +109,7 @@ class TestSoundFileReader:
 
     def test_get_data_full_file(self) -> None:
         """Test reading the entire audio file."""
-        data = self.reader.get_data(self.test_file, channels=[0, 1], start_idx=0, frames=self.N_SAMPLES, normalize=True)
+        data = self.reader.get_data(self.test_file, channels=[0, 1], start_idx=0, frames=self.N_SAMPLES)
 
         assert isinstance(data, np.ndarray), f"Expected ndarray, got {type(data)}"
         assert data.shape == (self.N_CHANNELS, self.N_SAMPLES), f"Shape mismatch: {data.shape}"
@@ -117,7 +117,7 @@ class TestSoundFileReader:
 
     def test_get_data_single_channel(self) -> None:
         """Test reading a single channel."""
-        data = self.reader.get_data(self.test_file, channels=[0], start_idx=0, frames=self.N_SAMPLES, normalize=True)
+        data = self.reader.get_data(self.test_file, channels=[0], start_idx=0, frames=self.N_SAMPLES)
 
         assert isinstance(data, np.ndarray), f"Expected ndarray, got {type(data)}"
         assert data.shape == (1, self.N_SAMPLES), f"Shape mismatch: {data.shape}"
@@ -131,7 +131,6 @@ class TestSoundFileReader:
             channels=[0, 1],
             start_idx=offset,
             frames=self.N_SAMPLES - offset,
-            normalize=True,
         )
 
         assert isinstance(data, np.ndarray), f"Expected ndarray, got {type(data)}"
@@ -142,7 +141,7 @@ class TestSoundFileReader:
     @pytest.mark.parametrize("frames", [500, 2000], ids=["frames_500", "frames_2000"])
     def test_get_data_frame_limit(self, frames: int) -> None:
         """Test reading with various frame limits returns correct shape and data."""
-        data = self.reader.get_data(self.test_file, channels=[0, 1], start_idx=0, frames=frames, normalize=True)
+        data = self.reader.get_data(self.test_file, channels=[0, 1], start_idx=0, frames=frames)
 
         assert isinstance(data, np.ndarray), f"Expected ndarray, got {type(data)}"
         assert data.shape == (self.N_CHANNELS, frames), f"Shape mismatch: {data.shape}"
@@ -335,10 +334,7 @@ class TestCSVFileReader:
     def test_get_data_unexpected_array_type(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test error when unexpected data type is returned."""
 
-        class FakeValues:
-            T = [[1.0, 2.0], [3.0, 4.0]]
-
-        monkeypatch.setattr(pd.DataFrame, "values", property(lambda _self: FakeValues()))
+        monkeypatch.setattr(pd.DataFrame, "to_numpy", lambda *_args, **_kwargs: [[1.0]])
 
         with pytest.raises(ValueError, match="Unexpected data type after reading file"):
             self.reader.get_data(self.test_file, channels=[0, 1], start_idx=0, frames=self.N_ROWS)

--- a/tests/io/test_file_readers.py
+++ b/tests/io/test_file_readers.py
@@ -63,7 +63,7 @@ def test_read_supported_audio_format_matches_soundfile_reference(
     assert frame._data.shape == (2, n_samples)
     assert isinstance(frame._data, DaArray)
     # Wrapper equivalence: Wandas and the authoritative SoundFile read must agree.
-    np.testing.assert_allclose(frame.data, expected.T)
+    np.testing.assert_array_equal(frame.data, expected.T)
 
 
 @pytest.mark.parametrize(("extension", "file_format", "subtype"), SUPPORTED_AUDIO_CASES)
@@ -113,7 +113,7 @@ class TestSoundFileReader:
 
         assert isinstance(data, np.ndarray), f"Expected ndarray, got {type(data)}"
         assert data.shape == (self.N_CHANNELS, self.N_SAMPLES), f"Shape mismatch: {data.shape}"
-        np.testing.assert_allclose(np.asarray(data), np.asarray(self.expected_data))
+        np.testing.assert_array_equal(np.asarray(data), np.asarray(self.expected_data))
 
     def test_get_data_single_channel(self) -> None:
         """Test reading a single channel."""
@@ -121,7 +121,7 @@ class TestSoundFileReader:
 
         assert isinstance(data, np.ndarray), f"Expected ndarray, got {type(data)}"
         assert data.shape == (1, self.N_SAMPLES), f"Shape mismatch: {data.shape}"
-        np.testing.assert_allclose(np.asarray(data), np.asarray(self.expected_data[0:1]))
+        np.testing.assert_array_equal(np.asarray(data), np.asarray(self.expected_data[0:1]))
 
     @pytest.mark.parametrize("offset", [200, 1000], ids=["offset_200", "offset_1000"])
     def test_get_data_with_offset(self, offset: int) -> None:
@@ -136,7 +136,7 @@ class TestSoundFileReader:
         assert isinstance(data, np.ndarray), f"Expected ndarray, got {type(data)}"
         assert data.shape == (self.N_CHANNELS, self.N_SAMPLES - offset), f"Shape mismatch: {data.shape}"
         # Exact match: same reader, same file, data slice comparison
-        np.testing.assert_allclose(np.asarray(data), np.asarray(self.expected_data[:, offset:]))
+        np.testing.assert_array_equal(np.asarray(data), np.asarray(self.expected_data[:, offset:]))
 
     @pytest.mark.parametrize("frames", [500, 2000], ids=["frames_500", "frames_2000"])
     def test_get_data_frame_limit(self, frames: int) -> None:
@@ -146,7 +146,7 @@ class TestSoundFileReader:
         assert isinstance(data, np.ndarray), f"Expected ndarray, got {type(data)}"
         assert data.shape == (self.N_CHANNELS, frames), f"Shape mismatch: {data.shape}"
         # Exact match: same reader, same file, frame-limited comparison
-        np.testing.assert_allclose(np.asarray(data), np.asarray(self.expected_data[:, :frames]))
+        np.testing.assert_array_equal(np.asarray(data), np.asarray(self.expected_data[:, :frames]))
 
     def test_get_data_file_not_found(self) -> None:
         """Test error handling when file doesn't exist."""
@@ -190,7 +190,8 @@ class TestCSVFileReader:
         )
         df.to_csv(self.test_file, index=False)
 
-        self.expected_data: NDArrayReal = data_values.T  # (channels, samples)
+        encoded = pd.read_csv(self.test_file).iloc[:, 1:].to_numpy(dtype=np.float64)
+        self.expected_data: NDArrayReal = encoded.T  # (channels, samples)
 
     def test_get_file_info_basic(self) -> None:
         """Test basic functionality of get_file_info method."""
@@ -339,7 +340,7 @@ class TestCSVFileReader:
 
         assert isinstance(data, np.ndarray), f"Expected ndarray, got {type(data)}"
         assert data.shape == (self.N_CHANNELS, self.N_ROWS), f"Shape mismatch: {data.shape}"
-        np.testing.assert_allclose(np.asarray(data), np.asarray(self.expected_data))
+        np.testing.assert_array_equal(np.asarray(data), np.asarray(self.expected_data))
 
     def test_csv_channel_count_equals_data_columns_minus_time(self) -> None:
         """CSV channel count = number of data columns excluding time column (I/O Policy).
@@ -360,7 +361,7 @@ class TestCSVFileReader:
 
         assert isinstance(data, np.ndarray), f"Expected ndarray, got {type(data)}"
         assert data.shape == (len(channels), self.N_ROWS), f"Shape mismatch: {data.shape}"
-        np.testing.assert_allclose(np.asarray(data), np.asarray(self.expected_data[channels]))
+        np.testing.assert_array_equal(np.asarray(data), np.asarray(self.expected_data[channels]))
 
     def test_get_data_channel_out_of_range(self) -> None:
         """Test error when requesting out-of-range channels."""

--- a/tests/io/test_wav_io.py
+++ b/tests/io/test_wav_io.py
@@ -39,7 +39,7 @@ def test_wav_float_roundtrip(known_signal_frame, tmp_path) -> None:
     """Float WAV round-trip: write -> read -> compare (I/O Policy requirement).
 
     ChannelFrame.to_wav writes IEEE FLOAT when max(abs(data)) <= 1.
-    Reading back with normalize=True should recover data within atol=1e-6
+    Reading back as canonical float64 should recover data within atol=1e-6
     (windowing/format conversion tolerance).
     """
     wav_path = tmp_path / "float_roundtrip.wav"
@@ -52,7 +52,7 @@ def test_wav_float_roundtrip(known_signal_frame, tmp_path) -> None:
         known_signal_frame.compute(), original_data, err_msg="to_wav must not mutate original frame data"
     )
 
-    loaded = ChannelFrame.read_wav(str(wav_path), normalize=True)
+    loaded = ChannelFrame.read_wav(str(wav_path))
 
     assert loaded.sampling_rate == known_signal_frame.sampling_rate
     assert loaded.n_channels == known_signal_frame.n_channels
@@ -252,7 +252,7 @@ def test_from_file_url_pcm_wav_preserves_normalized_samples() -> None:
     wav_bytes = _make_wav_bytes(sr, pcm_data)
 
     with mock_urlopen_stream(wav_bytes):
-        cf = ChannelFrame.from_file(url, normalize=False)
+        cf = ChannelFrame.from_file(url)
 
     expected = pcm_data.astype(np.float32) / 32768.0
     np.testing.assert_allclose(cf.compute()[0], expected, rtol=0, atol=1e-7)
@@ -519,13 +519,8 @@ def test_read_wav_stream_nonseekable() -> None:
     np.testing.assert_allclose(computed[1], data_right, rtol=1e-5)
 
 
-def test_read_wav_int16_pcm_raw_values_preserved(tmp_path) -> None:
-    """PCM round-trip: int16 WAV values preserved as float32 (Pillar 4).
-
-    When normalize=False (default), scipy's raw int16 samples are cast to
-    float32 with magnitudes preserved (e.g. 16384 -> 16384.0).
-    Exact match expected since this is a dtype cast, not a transform.
-    """
+def test_read_wav_int16_pcm_is_full_scale_float64(tmp_path) -> None:
+    """PCM int16 is decoded with libsndfile's full-scale convention."""
     filepath = tmp_path / "int16_test.wav"
     sr = 16000
     n_samples = 100
@@ -537,34 +532,9 @@ def test_read_wav_int16_pcm_raw_values_preserved(tmp_path) -> None:
     cf = ChannelFrame.read_wav(str(filepath))
     computed = cf.compute()
 
-    # Exact match: raw int16 values cast to float32 (same algorithm, no transform)
-    np.testing.assert_array_equal(computed[0], int16_left.astype(np.float32))
-    np.testing.assert_array_equal(computed[1], int16_right.astype(np.float32))
-    assert computed.dtype == np.float32, f"Expected float32, got {computed.dtype}"
-
-
-def test_read_wav_int16_normalized_to_float_range(tmp_path) -> None:
-    """PCM normalization: int16 16384 -> 0.5 after dividing by 32768 (Pillar 4).
-
-    With normalize=True, int16 samples are divided by 32768 to produce
-    float32 values in [-1.0, 1.0]. 16384/32768 = 0.5 exactly.
-    Tolerance: rtol=1e-4 accounts for float32 precision.
-    """
-    filepath = tmp_path / "int16_norm_test.wav"
-    sr = 16000
-    n_samples = 100
-    int16_left = np.full(n_samples, 16384, dtype=np.int16)
-    int16_right = np.full(n_samples, -16384, dtype=np.int16)
-    stereo_data = np.column_stack((int16_left, int16_right))
-    wavfile.write(str(filepath), sr, stereo_data)
-
-    cf = ChannelFrame.read_wav(str(filepath), normalize=True)
-    computed = cf.compute()
-
-    # Theoretical: 16384 / 32768 = 0.5 exactly; rtol=1e-4 for float32 rounding
-    np.testing.assert_allclose(computed[0], 0.5, rtol=1e-4)
-    np.testing.assert_allclose(computed[1], -0.5, rtol=1e-4)
-    assert computed.dtype == np.float32, f"Expected float32, got {computed.dtype}"
+    np.testing.assert_array_equal(computed[0], 0.5)
+    np.testing.assert_array_equal(computed[1], -0.5)
+    assert computed.dtype == np.float64
 
 
 def test_write_wav_roundtrip_preserves_shape_and_sr(tmp_path) -> None:

--- a/tests/io/test_wav_io.py
+++ b/tests/io/test_wav_io.py
@@ -39,8 +39,7 @@ def test_wav_float_roundtrip(known_signal_frame, tmp_path) -> None:
     """Float WAV round-trip: write -> read -> compare (I/O Policy requirement).
 
     ChannelFrame.to_wav writes IEEE FLOAT when max(abs(data)) <= 1.
-    Reading back as canonical float64 should recover data within atol=1e-6
-    (windowing/format conversion tolerance).
+    Reading back as canonical float64 returns the exact encoded FLOAT samples.
     """
     wav_path = tmp_path / "float_roundtrip.wav"
     # Capture original data before write to verify immutability (Pillar 1)
@@ -56,13 +55,8 @@ def test_wav_float_roundtrip(known_signal_frame, tmp_path) -> None:
 
     assert loaded.sampling_rate == known_signal_frame.sampling_rate
     assert loaded.n_channels == known_signal_frame.n_channels
-    # Float WAV preserves data with high fidelity (atol=1e-6 for format conversion)
-    np.testing.assert_allclose(
-        loaded.compute(),
-        known_signal_frame.compute(),
-        atol=1e-6,
-        err_msg="Float WAV round-trip data mismatch",
-    )
+    encoded = known_signal_frame.compute().astype(np.float32).astype(np.float64)
+    np.testing.assert_array_equal(loaded.compute(), encoded, err_msg="Float WAV round-trip data mismatch")
 
 
 def test_read_wav_stereo_dc_signal(tmp_path) -> None:
@@ -88,8 +82,8 @@ def test_read_wav_stereo_dc_signal(tmp_path) -> None:
     assert isinstance(cf._data, dask.array.core.Array), "WAV load must produce Dask array"
     computed = cf.compute()
     # DC signal values must be preserved exactly through float64 WAV round-trip
-    np.testing.assert_allclose(computed[0], 0.5, rtol=1e-7, err_msg="Left channel DC level mismatch")
-    np.testing.assert_allclose(computed[1], 1.0, rtol=1e-7, err_msg="Right channel DC level mismatch")
+    np.testing.assert_array_equal(computed[0], data_left, err_msg="Left channel DC level mismatch")
+    np.testing.assert_array_equal(computed[1], data_right, err_msg="Right channel DC level mismatch")
 
 
 def test_read_wav_stereo_channel_count(create_test_wav) -> None:
@@ -127,8 +121,7 @@ def test_read_wav_custom_labels_propagated(tmp_path) -> None:
 def test_read_wav_bytes_dc_signal() -> None:
     """Test reading a WAV from in-memory bytes with known DC signal.
 
-    Uses float32 DC signals to verify byte-based read path preserves
-    sample values. rtol=1e-5 for float32 precision tolerance.
+    Uses FLOAT WAV samples to verify byte-based reads preserve encoded values.
     """
     sr = 32000
     n_samples = 3200  # 0.1 seconds
@@ -142,9 +135,8 @@ def test_read_wav_bytes_dc_signal() -> None:
     assert cf.sampling_rate == sr, f"SR mismatch: {cf.sampling_rate}"
     assert len(cf) == 2, f"Expected 2 channels, got {len(cf)}"
     computed = cf.compute()
-    # Float32 DC signal: rtol=1e-5 accounts for float32 precision
-    np.testing.assert_allclose(computed[0], data_left, rtol=1e-5)
-    np.testing.assert_allclose(computed[1], data_right, rtol=1e-5)
+    np.testing.assert_array_equal(computed[0], data_left)
+    np.testing.assert_array_equal(computed[1], data_right)
 
 
 def test_read_wav_from_url_via_requests_mock() -> None:
@@ -173,9 +165,8 @@ def test_read_wav_from_url_via_requests_mock() -> None:
     assert len(cf) == 2, f"Expected 2 channels, got {len(cf)}"
     assert cf.sampling_rate == sr, f"SR mismatch: {cf.sampling_rate}"
     computed = cf.compute()
-    # Verify all samples, not just first element (rtol=1e-5 for float32)
-    np.testing.assert_allclose(computed[0], data_left, rtol=1e-5)
-    np.testing.assert_allclose(computed[1], data_right, rtol=1e-5)
+    np.testing.assert_array_equal(computed[0], data_left)
+    np.testing.assert_array_equal(computed[1], data_right)
 
 
 def test_from_file_url_wav() -> None:
@@ -200,9 +191,8 @@ def test_from_file_url_wav() -> None:
     # Verify Dask lazy loading from URL path (Pillar 1)
     assert isinstance(cf._data, dask.array.core.Array), "URL load must produce Dask array"
     computed = cf.compute()
-    # Float32 DC signal: rtol=1e-5 for float32 precision
-    np.testing.assert_allclose(computed[0], data_left, rtol=1e-5)
-    np.testing.assert_allclose(computed[1], data_right, rtol=1e-5)
+    np.testing.assert_array_equal(computed[0], data_left)
+    np.testing.assert_array_equal(computed[1], data_right)
     # Provenance metadata (Pillar 2)
     assert cf.metadata["_source_file"] == url, "source file metadata not preserved"
     assert cf.label == "sample"
@@ -224,7 +214,7 @@ def test_from_file_url_wav_streams_in_chunks() -> None:
         cf = ChannelFrame.from_file(url)
 
     assert cf.sampling_rate == sr
-    np.testing.assert_allclose(cf.compute()[0], mono_data, rtol=1e-5)
+    np.testing.assert_array_equal(cf.compute()[0], mono_data)
 
 
 def test_download_read_is_capped_by_remaining_budget() -> None:
@@ -245,7 +235,7 @@ def test_download_read_is_capped_by_remaining_budget() -> None:
 
 
 def test_from_file_url_pcm_wav_preserves_normalized_samples() -> None:
-    """URL PCM WAV loads preserve the historical normalized-float contract."""
+    """URL PCM WAV loads use the canonical full-scale float64 contract."""
     url = "https://example.com/audio/pcm.wav"
     sr = 8000
     pcm_data = np.array([0, 16384, -16384, 32767, -32768], dtype=np.int16)
@@ -254,8 +244,8 @@ def test_from_file_url_pcm_wav_preserves_normalized_samples() -> None:
     with mock_urlopen_stream(wav_bytes):
         cf = ChannelFrame.from_file(url)
 
-    expected = pcm_data.astype(np.float32) / 32768.0
-    np.testing.assert_allclose(cf.compute()[0], expected, rtol=0, atol=1e-7)
+    expected = pcm_data.astype(np.float64) / 32768.0
+    np.testing.assert_array_equal(cf.compute()[0], expected)
 
 
 def test_from_file_url_http_scheme() -> None:
@@ -514,9 +504,8 @@ def test_read_wav_stream_nonseekable() -> None:
     assert cf.sampling_rate == sr, f"SR mismatch: {cf.sampling_rate}"
     assert len(cf) == 2, f"Expected 2 channels, got {len(cf)}"
     computed = cf.compute()
-    # Float32 DC signal: rtol=1e-5 for float32 precision
-    np.testing.assert_allclose(computed[0], data_left, rtol=1e-5)
-    np.testing.assert_allclose(computed[1], data_right, rtol=1e-5)
+    np.testing.assert_array_equal(computed[0], data_left)
+    np.testing.assert_array_equal(computed[1], data_right)
 
 
 def test_read_wav_int16_pcm_is_full_scale_float64(tmp_path) -> None:
@@ -541,7 +530,6 @@ def test_write_wav_roundtrip_preserves_shape_and_sr(tmp_path) -> None:
     """Write/read WAV round-trip: shape and sampling rate are preserved.
 
     Uses DC signals (0.5, 0.8) within [-1, 1] to trigger IEEE FLOAT subtype.
-    rtol=1e-2 accounts for potential PCM quantization if FLOAT is not used.
     """
     sr = 44100
     n_samples = 4410  # 0.1 seconds
@@ -570,8 +558,7 @@ def test_write_wav_roundtrip_preserves_shape_and_sr(tmp_path) -> None:
     assert isinstance(loaded._data, dask.array.core.Array), "WAV load must produce Dask array"
 
     computed = loaded.compute()
-    # rtol=1e-2: WAV format may involve float->PCM->float conversion
-    np.testing.assert_allclose(computed, wav_data.T, rtol=1e-2)
+    np.testing.assert_array_equal(computed, wav_data.T)
 
 
 def test_write_wav_mono_data_squeezed_to_1d() -> None:

--- a/tests/processing/test_calibration.py
+++ b/tests/processing/test_calibration.py
@@ -4,7 +4,21 @@ import dask.array as da
 import numpy as np
 import pytest
 
-from wandas.processing.calibration import apply_channel_factors
+from wandas.processing.calibration import _derive_absolute_calibration_factors, apply_channel_factors
+
+
+def test_absolute_calibration_helper_rejects_unrepresentable_results() -> None:
+    with pytest.raises(ValueError, match="target_level must produce"):
+        _derive_absolute_calibration_factors([1.0], [1.0], target_level=10_000.0, ref=1.0)
+    with pytest.raises(ValueError, match="same non-zero length"):
+        _derive_absolute_calibration_factors([], [], target_rms=1.0, ref=1.0)
+    with pytest.raises(ValueError, match="Derived calibration factor"):
+        _derive_absolute_calibration_factors(
+            [float(np.nextafter(0.0, 1.0))],
+            [float(np.finfo(float).max)],
+            target_rms=float(np.finfo(float).max),
+            ref=1.0,
+        )
 
 
 def test_apply_channel_factors_broadcasts_across_every_non_channel_axis() -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -259,7 +259,7 @@ def test_read_loads_wav_bytes_without_file_type() -> None:
     assert isinstance(signal, ChannelFrame)
     assert signal.sampling_rate == sr
     assert signal.n_channels == 1
-    np.testing.assert_allclose(signal.compute(), data.T, atol=1e-4)
+    np.testing.assert_array_equal(signal.compute(), data.T)
 
 
 def test_read_loads_named_csv_file_like_without_file_type(tmp_path: Path) -> None:

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -12,6 +12,7 @@ from dask.array.core import Array as DaArray
 from dask.array.core import concatenate
 
 from wandas.pipeline.decorators import OperationCapture, recipe_operation
+from wandas.processing.calibration import _derive_absolute_calibration_factors
 from wandas.processing.semantic import InputBinding
 from wandas.utils import validate_sampling_rate
 from wandas.utils.dask_helpers import da_from_array as _da_from_array
@@ -599,6 +600,34 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         calibrations = {self._channel_id_at(index): calibration for index, calibration in updates}
         return self._with_calibration_by_id(calibrations)
 
+    def derive_calibration(
+        self,
+        *,
+        target_rms: float | None = None,
+        target_level: float | None = None,
+        unit: str,
+    ) -> dict[str, ChannelCalibration]:
+        """Derive absolute per-channel calibration from this reference event.
+
+        Exactly one known physical scalar is broadcast to every channel. The
+        frame is not changed and no operation is added to its history.
+        """
+        labels = self.labels
+        if any(not label for label in labels) or len(set(labels)) != len(labels):
+            raise ValueError("Calibration derivation requires unique non-empty channel labels")
+        domain = ChannelCalibration(factor=1.0, unit=unit)
+        factors = _derive_absolute_calibration_factors(
+            self.rms,
+            [channel.calibration.factor for channel in self.channels],
+            target_rms=target_rms,
+            target_level=target_level,
+            ref=domain.ref,
+        )
+        return {
+            label: ChannelCalibration(factor=factor, unit=domain.unit, ref=domain.ref)
+            for label, factor in zip(labels, factors, strict=True)
+        }
+
     @property
     def _float_data(self) -> DaArray:
         """Return data cast to float64 if not already floating-point.
@@ -1146,7 +1175,6 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         header: int | None = 0,
         file_type: str | None = None,
         source_name: str | None = None,
-        normalize: bool = False,
         timeout: float = 10.0,
     ) -> "ChannelFrame":
         """Create a ChannelFrame from an audio file or URL.
@@ -1179,12 +1207,6 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             file_type: File extension for in-memory data or URLs without a
                 recognisable extension (e.g. ".wav", ".csv").
             source_name: Optional source name for in-memory data. Used in metadata.
-            normalize: When False (default), local WAV paths return raw integer
-                PCM samples cast to float32 (for example, 16384 stays 16384.0).
-                URL WAV inputs preserve their historical normalized float32
-                behavior even when False. When True, normalize WAV samples to
-                float32 in [-1.0, 1.0]. Non-WAV formats always use soundfile
-                (normalized).
             timeout: Timeout in seconds for HTTP/HTTPS URL downloads. Default is
                 10.0 seconds. Has no effect for local files or in-memory data.
 
@@ -1198,10 +1220,8 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
 
         Examples:
             >>> import wandas as wd
-            >>> # Load WAV file (raw integer samples cast to float32 by default)
+            >>> # Load WAV file as full-scale float64 audio
             >>> cf = wd.read("audio.wav")
-            >>> # Load WAV file normalized to float32 [-1.0, 1.0]
-            >>> cf = wd.read("audio.wav", normalize=True)
             >>> # Load specific channels
             >>> cf = wd.read("audio.wav", channel=[0, 2])
             >>> # Load CSV file
@@ -1237,17 +1257,11 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
 
         # Build kwargs for reader
         reader_kwargs: dict[str, Any] = {}
-        is_wav_file = (path_obj is not None and path_obj.suffix.lower() == ".wav") or (normalized_file_type == ".wav")
         if (path_obj is not None and path_obj.suffix.lower() == ".csv") or (normalized_file_type == ".csv"):
             reader_kwargs["time_column"] = time_column
             reader_kwargs["delimiter"] = delimiter
             if header is not None:
                 reader_kwargs["header"] = header
-        if is_wav_file:
-            # URL WAV inputs historically went through the in-memory soundfile
-            # path, which returns normalized float samples. Preserve that
-            # contract now that remote files are backed by temporary paths.
-            reader_kwargs["normalize"] = normalize or downloaded_from_url
 
         try:
             info = reader.get_file_info(source_obj, **reader_kwargs)
@@ -1304,7 +1318,15 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             )
             if not isinstance(out, np.ndarray):
                 raise ValueError("Unexpected data type after reading file")
-            return out
+            if out.shape != expected_shape:
+                raise ValueError(
+                    "Reader returned an unexpected channel-first shape\n"
+                    f"  Got: {out.shape}\n"
+                    f"  Expected: {expected_shape}"
+                )
+            if not np.issubdtype(out.dtype, np.number) or np.issubdtype(out.dtype, np.complexfloating):
+                raise TypeError("Readers must return a real channel-first numeric array")
+            return out.astype(np.float64, copy=False)
 
         logger.debug(f"Creating delayed dask task with expected shape: {expected_shape}")
 
@@ -1316,7 +1338,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             # Create dask array from delayed computation and ensure channel-wise
             # chunks. The sample axis (1) uses -1 by default to avoid forcing
             # a sample chunk length here.
-            dask_array = da_from_delayed(delayed_data, shape=expected_shape, dtype=np.float32)
+            dask_array = da_from_delayed(delayed_data, shape=expected_shape, dtype=np.float64)
 
             # Ensure channel-wise chunks
             dask_array = dask_array.rechunk((1, -1))
@@ -1369,17 +1391,12 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         cls,
         filename: str | Path | bytes | bytearray | memoryview | BinaryIO,
         labels: list[str] | None = None,
-        normalize: bool = False,
     ) -> "ChannelFrame":
         """Utility method to read a WAV file.
 
         Args:
             filename: Path to the WAV file or in-memory bytes/stream.
             labels: Labels to set for each channel.
-            normalize: When False (default) and the source is a WAV file path,
-                return raw integer PCM samples cast to float32 (magnitudes preserved).
-                For in-memory sources, always uses soundfile (normalized float32).
-                When True, normalize to float32 in [-1.0, 1.0].
 
         Returns:
             A new ChannelFrame containing the data (lazy loading).
@@ -1393,7 +1410,6 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         cf = ChannelFrame.from_file(
             filename,
             ch_labels=labels,
-            normalize=normalize,
             file_type=".wav" if is_in_memory else None,
             source_name=source_name,
         )

--- a/wandas/io/read.py
+++ b/wandas/io/read.py
@@ -87,7 +87,6 @@ def read(
     header: int | None = 0,
     file_type: str | None = None,
     source_name: str | None = None,
-    normalize: bool = False,
     timeout: float = 10.0,
 ) -> "ChannelFrame":
     """Read external source data into a ChannelFrame.
@@ -112,6 +111,5 @@ def read(
         header=header,
         file_type=file_type,
         source_name=source_name,
-        normalize=normalize,
         timeout=timeout,
     )

--- a/wandas/io/readers.py
+++ b/wandas/io/readers.py
@@ -209,6 +209,25 @@ class SoundFileReader(FileReader):
         return result
 
 
+def _resolve_csv_time_column(columns: list[Any], time_column: int | str) -> int:
+    """Resolve one CSV time column to an unambiguous position."""
+    available = list(columns)
+    if isinstance(time_column, str):
+        matches = [index for index, label in enumerate(available) if label == time_column]
+        if len(matches) == 1:
+            return matches[0]
+    elif type(time_column) is int:
+        index = time_column + len(available) if time_column < 0 else time_column
+        if 0 <= index < len(available):
+            return index
+    raise ValueError(
+        "Invalid CSV time column\n"
+        f"  Got: {time_column!r}\n"
+        f"  Available columns: {available!r}\n"
+        "Use one unique column label or an in-range integer index."
+    )
+
+
 class CSVFileReader(FileReader):
     """CSV file reader for time series data."""
 
@@ -261,11 +280,11 @@ class CSVFileReader(FileReader):
         # Read first few lines to determine structure
         pd = require_pandas("CSV file reading")
         df = pd.read_csv(_prepare_file_source(path), delimiter=delimiter, header=header)
+        time_index = _resolve_csv_time_column(df.columns.tolist(), time_column)
 
-        # Estimate sampling rate from first column (assuming it's time)
+        # Estimate sampling rate from the selected time column.
         try:
-            # Get time column as Series
-            time_series = df[time_column] if isinstance(time_column, str) else df.iloc[:, time_column]
+            time_series = df.iloc[:, time_index]
             time_values = np.array(time_series.values)
             time_start = float(time_values[0]) if len(time_values) > 0 else 0.0
             if len(time_values) > 1:
@@ -277,8 +296,7 @@ class CSVFileReader(FileReader):
             estimated_sr = 0  # Default if can't calculate
             time_start = 0.0
 
-        time_label = time_column if isinstance(time_column, str) else df.columns[time_column]
-        channel_labels = [column for column in df.columns if column != time_label]
+        channel_labels = [column for index, column in enumerate(df.columns) if index != time_index]
         frames = df.shape[0]
         duration = frames / estimated_sr if estimated_sr else None
 
@@ -344,9 +362,10 @@ class CSVFileReader(FileReader):
         # Read the CSV file
         pd = require_pandas("CSV file reading")
         df = pd.read_csv(_prepare_file_source(path), delimiter=delimiter, header=header)
+        time_index = _resolve_csv_time_column(df.columns.tolist(), time_column)
 
         # Remove time column
-        df = df.drop(columns=[time_column] if isinstance(time_column, str) else df.columns[time_column])
+        df = df.iloc[:, [index for index in range(df.shape[1]) if index != time_index]]
 
         # Select requested channels - adjust indices to account for time column removal
         if channels:

--- a/wandas/io/readers.py
+++ b/wandas/io/readers.py
@@ -376,9 +376,6 @@ class CSVFileReader(FileReader):
                 "Convert every channel column to real numeric values before reading."
             ) from exc
 
-        if not isinstance(result, np.ndarray):
-            raise ValueError("Unexpected data type after reading file")
-
         _shape = result.shape
         logger.debug(f"CSV read complete, returning data with shape {_shape}")
         return result

--- a/wandas/io/readers.py
+++ b/wandas/io/readers.py
@@ -10,7 +10,6 @@ from typing import Any, BinaryIO, ClassVar, TypedDict, cast
 import numpy as np
 import soundfile as sf
 from numpy.typing import ArrayLike
-from scipy.io import wavfile
 
 from wandas.utils.optional_imports import require_pandas
 
@@ -82,7 +81,11 @@ class CSVGetDataParams(TypedDict, total=False):
 
 
 class FileReader(ABC):
-    """Base class for audio file readers."""
+    """Base class for external data readers.
+
+    Implementations return real channel-first arrays. Audio readers must apply
+    full-scale decoding before returning values.
+    """
 
     # Class attribute for supported file extensions
     supported_extensions: ClassVar[list[str]] = []
@@ -183,44 +186,15 @@ class SoundFileReader(FileReader):
         channels: list[int],
         start_idx: int,
         frames: int,
-        normalize: bool = False,
         **kwargs: Any,
     ) -> ArrayLike:
-        """Read audio data from the file.
-
-        Args:
-            normalize: When False (default) and the source is a WAV file path,
-                return raw integer PCM samples cast to float32 via
-                scipy.io.wavfile.read. For non-WAV formats or in-memory sources,
-                always uses soundfile (returning float32 normalized to [-1.0, 1.0]).
-                When True, return float32 data normalized to [-1.0, 1.0] via soundfile.
-        """
+        """Read full-scale float64 audio data from the file."""
         logger.debug(f"Reading {frames} frames from {path!r} starting at {start_idx}")
-
-        is_wav = isinstance(path, (str, Path)) and Path(path).suffix.lower() == ".wav"
-        if not normalize and is_wav:
-            # Use scipy to return raw integer samples (no normalization), cast to float32.
-            source = _prepare_file_source(path)
-            _sr, raw = wavfile.read(source)
-            raw = np.expand_dims(raw, axis=0) if raw.ndim == 1 else raw.T
-
-            # Only reindex channels when the requested selection is not the identity.
-            if channels != list(range(raw.shape[0])):
-                raw = raw[channels]
-
-            result: ArrayLike = raw[:, start_idx : start_idx + frames].astype(
-                np.float32,
-                copy=False,
-            )
-            if not isinstance(result, np.ndarray):
-                raise ValueError("Unexpected data type after reading file")
-            logger.debug(f"File read complete (raw), returning data with shape {result.shape}")
-            return result
 
         with sf.SoundFile(_prepare_file_source(path)) as f:
             if start_idx > 0:
                 f.seek(start_idx)
-            data = f.read(frames=frames, dtype="float32", always_2d=True)
+            data = f.read(frames=frames, dtype="float64", always_2d=True)
 
             # Select requested channels
             data = data[:, channels]
@@ -303,17 +277,19 @@ class CSVFileReader(FileReader):
             estimated_sr = 0  # Default if can't calculate
             time_start = 0.0
 
+        time_label = time_column if isinstance(time_column, str) else df.columns[time_column]
+        channel_labels = [column for column in df.columns if column != time_label]
         frames = df.shape[0]
         duration = frames / estimated_sr if estimated_sr else None
 
         # Return file info
         return {
             "samplerate": estimated_sr,
-            "channels": df.shape[1] - 1,  # Assuming first column is time
+            "channels": len(channel_labels),
             "frames": frames,
             "format": "CSV",
             "duration": duration,
-            "ch_labels": df.columns[1:].tolist(),  # Assuming first column is time
+            "ch_labels": channel_labels,
             "time_start": time_start,
         }
 
@@ -386,7 +362,19 @@ class CSVFileReader(FileReader):
         data_df = data_df.iloc[start_idx:end_idx]
 
         # Convert to numpy array and transpose to (channels, samples) format
-        result = data_df.values.T
+        try:
+            result = data_df.to_numpy(dtype=np.float64).T
+        except (AttributeError, TypeError, ValueError) as exc:
+            non_numeric = [
+                str(column) for column in data_df.columns if not pd.api.types.is_numeric_dtype(data_df[column])
+            ]
+            if not non_numeric:
+                raise ValueError("Unexpected data type after reading file") from exc
+            raise ValueError(
+                "CSV data channels must be numeric\n"
+                f"  Non-numeric channels: {non_numeric!r}\n"
+                "Convert every channel column to real numeric values before reading."
+            ) from exc
 
         if not isinstance(result, np.ndarray):
             raise ValueError("Unexpected data type after reading file")

--- a/wandas/processing/calibration.py
+++ b/wandas/processing/calibration.py
@@ -39,7 +39,7 @@ def _derive_absolute_calibration_factors(
     else:
         level = scalar(target_level, name="target_level", positive=False)
         with np.errstate(over="ignore", invalid="ignore"):
-            physical_target = reference * 10.0 ** (level / 20.0)
+            physical_target = float(reference * np.power(10.0, level / 20.0))
         if not math.isfinite(physical_target) or physical_target <= 0.0:
             raise ValueError("target_level must produce a positive finite RMS")
 

--- a/wandas/processing/calibration.py
+++ b/wandas/processing/calibration.py
@@ -9,6 +9,54 @@ from collections.abc import Sequence
 import numpy as np
 from dask.array.core import Array as DaArray
 
+from wandas.utils.types import NDArrayReal
+
+
+def _derive_absolute_calibration_factors(
+    measured_rms: Sequence[float] | NDArrayReal,
+    current_factors: Sequence[float],
+    *,
+    target_rms: float | None = None,
+    target_level: float | None = None,
+    ref: float,
+) -> tuple[float, ...]:
+    """Return absolute factors for one scalar-target calibration event."""
+    if (target_rms is None) == (target_level is None):
+        raise ValueError("Exactly one of target_rms or target_level is required")
+
+    def scalar(value: object, *, name: str, positive: bool) -> float:
+        if isinstance(value, bool | np.bool_) or not isinstance(value, numbers.Real):
+            raise TypeError(f"{name} must be a real scalar")
+        normalized = float(value)
+        if not math.isfinite(normalized) or (positive and normalized <= 0.0):
+            requirement = "positive and finite" if positive else "finite"
+            raise ValueError(f"{name} must be {requirement}")
+        return normalized
+
+    reference = scalar(ref, name="Calibration reference", positive=True)
+    if target_rms is not None:
+        physical_target = scalar(target_rms, name="target_rms", positive=True)
+    else:
+        level = scalar(target_level, name="target_level", positive=False)
+        with np.errstate(over="ignore", invalid="ignore"):
+            physical_target = reference * 10.0 ** (level / 20.0)
+        if not math.isfinite(physical_target) or physical_target <= 0.0:
+            raise ValueError("target_level must produce a positive finite RMS")
+
+    measured = tuple(measured_rms)
+    current = tuple(current_factors)
+    if not measured or len(measured) != len(current):
+        raise ValueError("RMS values and current factors must have the same non-zero length")
+    results: list[float] = []
+    for rms, factor in zip(measured, current, strict=True):
+        normalized_rms = scalar(rms, name="Reference RMS", positive=True)
+        normalized_factor = scalar(factor, name="Current calibration factor", positive=True)
+        absolute = normalized_factor * physical_target / normalized_rms
+        if not math.isfinite(absolute) or absolute <= 0.0:
+            raise ValueError("Derived calibration factor must be positive and finite")
+        results.append(absolute)
+    return tuple(results)
+
 
 def apply_channel_factors(data: DaArray, factors: Sequence[float]) -> DaArray:
     """Multiply channel-first data by one factor per channel without computing it."""


### PR DESCRIPTION
## Summary

- make every built-in external reader return lazy channel-first `float64`
- decode integer audio with libsndfile full-scale rules across local, URL, and in-memory transports
- preserve FLOAT/DOUBLE audio values without clipping and keep CSV numeric values unchanged apart from `float64` conversion
- validate CSV time-column labels and indices consistently across metadata and data reads
- remove the read-time `normalize` argument without a compatibility shim
- add scalar reference-event calibration derivation that composes existing factors and uses the current frame data regardless of history
- document the numeric contract and raw-count migration, and teach separate microphone/acceleration reference events through `wd.read()`

## Contract impact

Local integer WAV reads no longer expose raw PCM counts cast to `float32`; they now match every other transport as full-scale `float64`. Existing calibration factors defined against raw counts must be re-derived from a reference recording read under the canonical contract.

`wd.load()` continues to preserve WDF dtype, `from_numpy()` continues to preserve the caller's dtype, and `frame.normalize()` plus playback normalization remain separate features.

## Validation

- `uv run pytest -q` — 2287 passed, 3 skipped
- `uv run ruff check wandas tests learning-path/07_per_channel_calibration.py` — passed
- `uv run ruff format --check wandas tests learning-path/07_per_channel_calibration.py` — passed via commit hook
- `uv run ty check wandas tests learning-path/07_per_channel_calibration.py` — passed
- `uv run mkdocs build -f docs/mkdocs.yml --strict` — passed
- `uv run marimo check learning-path/07_per_channel_calibration.py` — passed
- `uv run marimo export html learning-path/07_per_channel_calibration.py -o /tmp/07_per_channel_calibration.html --no-include-code -f` — passed; exported output inspected without cell errors
- `git diff --check` — passed

## Review follow-up

- validated missing and out-of-range CSV `time_column` selectors before sampling-rate, channel-count, or data extraction
- included available columns in the error and shared the same positional resolution across `get_file_info()` and `get_data()`
- added regressions for invalid positive/negative indices, unknown labels, and a valid time column in the middle of the table
- resolved the actionable review thread after replying with commit and validation evidence
- tightened canonical reader assertions to exact encoded/parsed equality for PCM, FLOAT/DOUBLE, CSV, and transport-equivalence paths instead of retaining legacy float32 tolerances
- retained the calibration lesson's temporary-file owner in marimo cell state so its returned Dask Frame remains lazy and recomputable after the cell finishes

## Issue triage

Closes #315. The implementation satisfies the revised canonical reader and reference-calibration acceptance criteria without deferred provenance work.

Related to #311.
