### PR TITLE
chore: add scalability benchmark agent harness

### DIFF
--- a/.agents/skills/wandas-scalability-benchmark/SKILL.md
+++ b/.agents/skills/wandas-scalability-benchmark/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: wandas-scalability-benchmark
+description: Use when deciding, running, comparing, or recording representative Wandas scalability evidence for changes affecting WDF save/load, whole-Frame materialization, Dask chunking or graph task counts, AudioOperation.process, benchmark semantics, or Dask/xarray/HDF5 dependencies.
+---
+
+# Wandas Scalability Benchmark
+
+Treat [`AGENTS.md`](../../../AGENTS.md) as the repository source of truth. Use the
+repository benchmark for manual before/after evidence supporting the
+[scalability contract](../../../docs/src/explanation/scalability-contract.md); treat
+[`test_scalability_benchmark.py`](../../../tests/test_scalability_benchmark.py) as
+schema and smoke coverage only.
+
+## Decide whether representative evidence is required
+
+1. Identify whether the change can affect a metric emitted by
+   [`scalability_benchmark.py`](../../../scripts/scalability_benchmark.py) or a measured
+   materialization boundary.
+2. Require representative base/candidate evidence for an affected path.
+3. Otherwise record why the changed paths cannot affect the benchmark.
+
+## Prepare comparable revisions
+
+- Record the base and candidate commit SHAs before either run.
+- Use the same machine, operating system, Python version, and dependency lock.
+- When dependencies intentionally change, record both lock identities and treat their
+  effect as part of the result.
+- Use separate clean worktrees when switching revisions would disturb active work.
+- If the base has an incompatible benchmark schema, use a bridge command accepted by
+  both revisions and identify non-comparable fields. If it has no benchmark, state that
+  no before comparison exists.
+
+## Run schema version 2
+
+Run the representative matrix, which isolates every sample-count/chunk-size pair:
+
+```bash
+uv run --frozen --no-dev --extra io python scripts/scalability_benchmark.py --channels 2 --samples 480000 4800000 --chunk-samples 48000 480000 --sampling-rate 48000
+```
+
+Use a small matrix only for smoke or debugging:
+
+```bash
+uv run --frozen --no-dev --extra io python scripts/scalability_benchmark.py --channels 2 --samples 8000 --chunk-samples 1000 4000 --sampling-rate 48000
+```
+
+Compare fixed data size across chunk sizes and fixed chunk size across data sizes.
+Compare task counts and WDF file sizes exactly when their definitions are unchanged.
+Compare timings and absolute worker-lifetime RSS only within the same environment.
+Rerun a material timing or RSS difference to distinguish it from ordinary noise. Do
+not invent a repository-wide pass/fail budget.
+
+## Record the evidence
+
+Record base and candidate SHAs, exact commands, environment, lock identity, raw JSON,
+reruns, non-comparable fields, and a concise conclusion. When skipped, record the
+specific reason. Do not commit transient benchmark JSON unless it is an intentional
+fixture.

--- a/.agents/skills/wandas-scalability-benchmark/SKILL.md
+++ b/.agents/skills/wandas-scalability-benchmark/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wandas-scalability-benchmark
-description: Use when deciding, running, comparing, or recording representative Wandas scalability evidence for changes affecting WDF save/load, whole-Frame materialization, Dask chunking or graph task counts, AudioOperation.process, benchmark semantics, or Dask/xarray/HDF5 dependencies.
+description: Use when deciding, running, comparing, or recording representative Wandas scalability evidence for changes affecting WDF save/load, whole-Frame materialization, Dask chunking or graph task counts, RecipePlan extraction or recipe node counts, AudioOperation.process, benchmark semantics, or Dask/xarray/HDF5 dependencies.
 ---
 
 # Wandas Scalability Benchmark

--- a/.agents/skills/wandas-scalability-benchmark/SKILL.md
+++ b/.agents/skills/wandas-scalability-benchmark/SKILL.md
@@ -35,13 +35,13 @@ schema and smoke coverage only.
 Run the representative matrix, which isolates every sample-count/chunk-size pair:
 
 ```bash
-uv run --frozen --no-dev --extra io python scripts/scalability_benchmark.py --channels 2 --samples 480000 4800000 --chunk-samples 48000 480000 --sampling-rate 48000
+uv run --locked --no-dev --extra io python scripts/scalability_benchmark.py --channels 2 --samples 480000 4800000 --chunk-samples 48000 480000 --sampling-rate 48000
 ```
 
 Use a small matrix only for smoke or debugging:
 
 ```bash
-uv run --frozen --no-dev --extra io python scripts/scalability_benchmark.py --channels 2 --samples 8000 --chunk-samples 1000 4000 --sampling-rate 48000
+uv run --locked --no-dev --extra io python scripts/scalability_benchmark.py --channels 2 --samples 8000 --chunk-samples 1000 4000 --sampling-rate 48000
 ```
 
 Compare fixed data size across chunk sizes and fixed chunk size across data sizes.

--- a/.agents/skills/wandas-scalability-benchmark/agents/openai.yaml
+++ b/.agents/skills/wandas-scalability-benchmark/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Run Wandas Scalability Benchmark"
+  short_description: "Compare Wandas scalability evidence reproducibly"
+  default_prompt: "Use $wandas-scalability-benchmark to compare scalability-sensitive Wandas changes and record reproducible evidence."

--- a/.github/instructions/scalability-benchmark.instructions.md
+++ b/.github/instructions/scalability-benchmark.instructions.md
@@ -1,6 +1,6 @@
 ---
 description: "Route scalability-sensitive Wandas changes to representative benchmark validation"
-applyTo: "scripts/scalability_benchmark.py,tests/test_scalability_benchmark.py,docs/src/explanation/scalability-contract.md,wandas/core/base_frame.py,wandas/io/wdf_frames.py,wandas/io/wdf_io.py,wandas/processing/base.py,wandas/processing/effects.py,wandas/processing/semantic.py,wandas/frames/channel.py,wandas/frames/mixins/channel_processing_mixin.py,wandas/pipeline/decorators.py,wandas/pipeline/model.py,pyproject.toml,uv.lock"
+applyTo: "scripts/scalability_benchmark.py,tests/test_scalability_benchmark.py,docs/src/explanation/scalability-contract.md,wandas/core/base_frame.py,wandas/io/wdf_frames.py,wandas/io/wdf_io.py,wandas/processing/base.py,wandas/processing/effects.py,wandas/processing/semantic.py,wandas/frames/channel.py,wandas/frames/mixins/channel_processing_mixin.py,wandas/pipeline/builtins.py,wandas/pipeline/compiler.py,wandas/pipeline/decorators.py,wandas/pipeline/model.py,wandas/pipeline/registry.py,pyproject.toml,uv.lock"
 ---
 # Wandas Scalability Benchmark
 

--- a/.github/instructions/scalability-benchmark.instructions.md
+++ b/.github/instructions/scalability-benchmark.instructions.md
@@ -1,6 +1,6 @@
 ---
 description: "Route code or dependency changes that may affect representative scalability measurements"
-applyTo: "scripts/scalability_benchmark.py,tests/test_scalability_benchmark.py,docs/src/explanation/scalability-contract.md,wandas/core/base_frame.py,wandas/io/wdf_frames.py,wandas/io/wdf_io.py,wandas/processing/**,wandas/frames/**,wandas/pipeline/**,pyproject.toml,uv.lock"
+applyTo: "scripts/scalability_benchmark.py,tests/test_scalability_benchmark.py,docs/src/explanation/scalability-contract.md,wandas/**,pyproject.toml,uv.lock"
 ---
 # Wandas Scalability Benchmark
 

--- a/.github/instructions/scalability-benchmark.instructions.md
+++ b/.github/instructions/scalability-benchmark.instructions.md
@@ -1,0 +1,10 @@
+---
+description: "Route scalability-sensitive Wandas changes to representative benchmark validation"
+applyTo: "scripts/scalability_benchmark.py,tests/test_scalability_benchmark.py,docs/src/explanation/scalability-contract.md,wandas/core/base_frame.py,wandas/io/wdf_frames.py,wandas/io/wdf_io.py,wandas/processing/base.py,wandas/processing/effects.py,wandas/processing/semantic.py,wandas/frames/channel.py,wandas/frames/mixins/channel_processing_mixin.py,wandas/pipeline/decorators.py,wandas/pipeline/model.py,pyproject.toml,uv.lock"
+---
+# Wandas Scalability Benchmark
+
+Use the repo-shared
+[`wandas-scalability-benchmark`](../../.agents/skills/wandas-scalability-benchmark/SKILL.md)
+skill to decide, run, compare, and record representative scalability evidence. Treat
+the benchmark pytest as smoke coverage only.

--- a/.github/instructions/scalability-benchmark.instructions.md
+++ b/.github/instructions/scalability-benchmark.instructions.md
@@ -1,6 +1,6 @@
 ---
 description: "Route scalability-sensitive Wandas changes to representative benchmark validation"
-applyTo: "scripts/scalability_benchmark.py,tests/test_scalability_benchmark.py,docs/src/explanation/scalability-contract.md,wandas/core/base_frame.py,wandas/io/wdf_frames.py,wandas/io/wdf_io.py,wandas/processing/base.py,wandas/processing/effects.py,wandas/processing/semantic.py,wandas/frames/channel.py,wandas/frames/mixins/channel_processing_mixin.py,wandas/pipeline/builtins.py,wandas/pipeline/compiler.py,wandas/pipeline/decorators.py,wandas/pipeline/model.py,wandas/pipeline/registry.py,pyproject.toml,uv.lock"
+applyTo: "scripts/scalability_benchmark.py,tests/test_scalability_benchmark.py,docs/src/explanation/scalability-contract.md,wandas/core/base_frame.py,wandas/io/wdf_frames.py,wandas/io/wdf_io.py,wandas/processing/__init__.py,wandas/processing/base.py,wandas/processing/effects.py,wandas/processing/semantic.py,wandas/frames/channel.py,wandas/frames/mixins/channel_processing_mixin.py,wandas/pipeline/__init__.py,wandas/pipeline/builtins.py,wandas/pipeline/compiler.py,wandas/pipeline/decorators.py,wandas/pipeline/model.py,wandas/pipeline/registry.py,pyproject.toml,uv.lock"
 ---
 # Wandas Scalability Benchmark
 

--- a/.github/instructions/scalability-benchmark.instructions.md
+++ b/.github/instructions/scalability-benchmark.instructions.md
@@ -1,6 +1,6 @@
 ---
-description: "Route scalability-sensitive Wandas changes to representative benchmark validation"
-applyTo: "scripts/scalability_benchmark.py,tests/test_scalability_benchmark.py,docs/src/explanation/scalability-contract.md,wandas/core/base_frame.py,wandas/io/wdf_frames.py,wandas/io/wdf_io.py,wandas/processing/__init__.py,wandas/processing/base.py,wandas/processing/effects.py,wandas/processing/semantic.py,wandas/frames/channel.py,wandas/frames/mixins/channel_processing_mixin.py,wandas/pipeline/__init__.py,wandas/pipeline/builtins.py,wandas/pipeline/compiler.py,wandas/pipeline/decorators.py,wandas/pipeline/model.py,wandas/pipeline/registry.py,pyproject.toml,uv.lock"
+description: "Route code or dependency changes that may affect representative scalability measurements"
+applyTo: "scripts/scalability_benchmark.py,tests/test_scalability_benchmark.py,docs/src/explanation/scalability-contract.md,wandas/core/base_frame.py,wandas/io/wdf_frames.py,wandas/io/wdf_io.py,wandas/processing/**,wandas/frames/**,wandas/pipeline/**,pyproject.toml,uv.lock"
 ---
 # Wandas Scalability Benchmark
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,10 +33,8 @@ Load detailed procedures only when the task calls for them:
   [`wandas-test-authoring`](.agents/skills/wandas-test-authoring/SKILL.md)
 - I/O readers, writers, and format contracts:
   [I/O contracts](docs/src/contributing/io-contracts.md)
-- Scalability-sensitive changes affecting WDF save/load, whole-Frame
-  materialization, Dask chunking or graph task counts, RecipePlan extraction or
-  recipe node counts, `AudioOperation.process`, benchmark semantics, or
-  Dask/xarray/HDF5 dependencies:
+- Code or dependency changes that can affect representative scalability
+  benchmark metrics or measured materialization boundaries:
   [`wandas-scalability-benchmark`](.agents/skills/wandas-scalability-benchmark/SKILL.md)
 - Learning materials and executable notebooks:
   [`wandas-learning-material-authoring`](.agents/skills/wandas-learning-material-authoring/SKILL.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ Load detailed procedures only when the task calls for them:
   [`wandas-test-authoring`](.agents/skills/wandas-test-authoring/SKILL.md)
 - I/O readers, writers, and format contracts:
   [I/O contracts](docs/src/contributing/io-contracts.md)
+- Scalability-sensitive WDF, Dask, or whole-Frame materialization changes:
+  [`wandas-scalability-benchmark`](.agents/skills/wandas-scalability-benchmark/SKILL.md)
 - Learning materials and executable notebooks:
   [`wandas-learning-material-authoring`](.agents/skills/wandas-learning-material-authoring/SKILL.md)
 - Ambiguous, high-risk, cross-cutting, or related-finding changes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,8 @@ Load detailed procedures only when the task calls for them:
   [`wandas-test-authoring`](.agents/skills/wandas-test-authoring/SKILL.md)
 - I/O readers, writers, and format contracts:
   [I/O contracts](docs/src/contributing/io-contracts.md)
-- Scalability-sensitive WDF, Dask, or whole-Frame materialization changes:
+- Scalability-sensitive WDF, Dask, whole-Frame materialization, RecipePlan
+  extraction, or recipe node count changes:
   [`wandas-scalability-benchmark`](.agents/skills/wandas-scalability-benchmark/SKILL.md)
 - Learning materials and executable notebooks:
   [`wandas-learning-material-authoring`](.agents/skills/wandas-learning-material-authoring/SKILL.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,10 @@ Load detailed procedures only when the task calls for them:
   [`wandas-test-authoring`](.agents/skills/wandas-test-authoring/SKILL.md)
 - I/O readers, writers, and format contracts:
   [I/O contracts](docs/src/contributing/io-contracts.md)
-- Scalability-sensitive WDF, Dask, whole-Frame materialization, RecipePlan
-  extraction, or recipe node count changes:
+- Scalability-sensitive changes affecting WDF save/load, whole-Frame
+  materialization, Dask chunking or graph task counts, RecipePlan extraction or
+  recipe node counts, `AudioOperation.process`, benchmark semantics, or
+  Dask/xarray/HDF5 dependencies:
   [`wandas-scalability-benchmark`](.agents/skills/wandas-scalability-benchmark/SKILL.md)
 - Learning materials and executable notebooks:
   [`wandas-learning-material-authoring`](.agents/skills/wandas-learning-material-authoring/SKILL.md)

--- a/tests/docs/test_github_agent_guidance.py
+++ b/tests/docs/test_github_agent_guidance.py
@@ -198,32 +198,22 @@ def test_scalability_benchmark_has_one_skill_owned_route() -> None:
     assert set(adapter_data) == {"description", "applyTo"}
     apply_to = adapter_data["applyTo"].split(",")
     assert len(apply_to) == len(set(apply_to))
-    assert all((REPO_ROOT / path).is_file() for path in apply_to)
-    assert {
+    assert set(apply_to) == {
+        "docs/src/explanation/scalability-contract.md",
+        "pyproject.toml",
         "scripts/scalability_benchmark.py",
-        "wandas/pipeline/__init__.py",
-        "wandas/pipeline/builtins.py",
-        "wandas/pipeline/compiler.py",
-        "wandas/pipeline/decorators.py",
-        "wandas/pipeline/model.py",
-        "wandas/pipeline/registry.py",
-        "wandas/processing/__init__.py",
-        "wandas/processing/semantic.py",
-    } <= set(apply_to)
+        "tests/test_scalability_benchmark.py",
+        "uv.lock",
+        "wandas/core/base_frame.py",
+        "wandas/frames/**",
+        "wandas/io/wdf_frames.py",
+        "wandas/io/wdf_io.py",
+        "wandas/pipeline/**",
+        "wandas/processing/**",
+    }
+    assert all(any(REPO_ROOT.glob(path)) for path in apply_to)
     assert SCALABILITY_SKILL_PATH.resolve() in _local_link_targets(SCALABILITY_ADAPTER_PATH)
     assert SCALABILITY_SKILL_PATH.resolve() in _local_link_targets(CANONICAL_PATH)
-    canonical_text = " ".join(_read(CANONICAL_PATH).split())
-    trigger_phrases = (
-        "WDF save/load",
-        "whole-Frame materialization",
-        "Dask chunking or graph task counts",
-        "RecipePlan extraction or recipe node counts",
-        "AudioOperation.process",
-        "benchmark semantics",
-        "Dask/xarray/HDF5 dependencies",
-    )
-    assert all(phrase in data["description"] for phrase in trigger_phrases)
-    assert all(phrase in canonical_text for phrase in trigger_phrases)
 
     skill_targets = set(_local_link_targets(SCALABILITY_SKILL_PATH))
     assert {

--- a/tests/docs/test_github_agent_guidance.py
+++ b/tests/docs/test_github_agent_guidance.py
@@ -204,12 +204,7 @@ def test_scalability_benchmark_has_one_skill_owned_route() -> None:
         "scripts/scalability_benchmark.py",
         "tests/test_scalability_benchmark.py",
         "uv.lock",
-        "wandas/core/base_frame.py",
-        "wandas/frames/**",
-        "wandas/io/wdf_frames.py",
-        "wandas/io/wdf_io.py",
-        "wandas/pipeline/**",
-        "wandas/processing/**",
+        "wandas/**",
     }
     assert all(any(REPO_ROOT.glob(path)) for path in apply_to)
     assert SCALABILITY_SKILL_PATH.resolve() in _local_link_targets(SCALABILITY_ADAPTER_PATH)

--- a/tests/docs/test_github_agent_guidance.py
+++ b/tests/docs/test_github_agent_guidance.py
@@ -213,8 +213,17 @@ def test_scalability_benchmark_has_one_skill_owned_route() -> None:
     assert SCALABILITY_SKILL_PATH.resolve() in _local_link_targets(SCALABILITY_ADAPTER_PATH)
     assert SCALABILITY_SKILL_PATH.resolve() in _local_link_targets(CANONICAL_PATH)
     canonical_text = " ".join(_read(CANONICAL_PATH).split())
-    assert "RecipePlan extraction" in canonical_text
-    assert "recipe node count changes" in canonical_text
+    trigger_phrases = (
+        "WDF save/load",
+        "whole-Frame materialization",
+        "Dask chunking or graph task counts",
+        "RecipePlan extraction or recipe node counts",
+        "AudioOperation.process",
+        "benchmark semantics",
+        "Dask/xarray/HDF5 dependencies",
+    )
+    assert all(phrase in data["description"] for phrase in trigger_phrases)
+    assert all(phrase in canonical_text for phrase in trigger_phrases)
 
     skill_targets = set(_local_link_targets(SCALABILITY_SKILL_PATH))
     assert {

--- a/tests/docs/test_github_agent_guidance.py
+++ b/tests/docs/test_github_agent_guidance.py
@@ -181,6 +181,7 @@ def test_scalability_benchmark_has_one_skill_owned_route() -> None:
     data, body = _frontmatter(SCALABILITY_SKILL_PATH)
     assert set(data) == {"name", "description"}
     assert data["name"] == "wandas-scalability-benchmark"
+    assert "RecipePlan extraction or recipe node counts" in data["description"]
     assert "schema version 2" in body
     assert "--chunk-samples 48000 480000" in body
     assert body.count("uv run --locked") == 2
@@ -198,6 +199,15 @@ def test_scalability_benchmark_has_one_skill_owned_route() -> None:
     apply_to = adapter_data["applyTo"].split(",")
     assert len(apply_to) == len(set(apply_to))
     assert all((REPO_ROOT / path).is_file() for path in apply_to)
+    assert {
+        "scripts/scalability_benchmark.py",
+        "wandas/pipeline/builtins.py",
+        "wandas/pipeline/compiler.py",
+        "wandas/pipeline/decorators.py",
+        "wandas/pipeline/model.py",
+        "wandas/pipeline/registry.py",
+        "wandas/processing/semantic.py",
+    } <= set(apply_to)
     assert SCALABILITY_SKILL_PATH.resolve() in _local_link_targets(SCALABILITY_ADAPTER_PATH)
     assert SCALABILITY_SKILL_PATH.resolve() in _local_link_targets(CANONICAL_PATH)
 

--- a/tests/docs/test_github_agent_guidance.py
+++ b/tests/docs/test_github_agent_guidance.py
@@ -201,11 +201,13 @@ def test_scalability_benchmark_has_one_skill_owned_route() -> None:
     assert all((REPO_ROOT / path).is_file() for path in apply_to)
     assert {
         "scripts/scalability_benchmark.py",
+        "wandas/pipeline/__init__.py",
         "wandas/pipeline/builtins.py",
         "wandas/pipeline/compiler.py",
         "wandas/pipeline/decorators.py",
         "wandas/pipeline/model.py",
         "wandas/pipeline/registry.py",
+        "wandas/processing/__init__.py",
         "wandas/processing/semantic.py",
     } <= set(apply_to)
     assert SCALABILITY_SKILL_PATH.resolve() in _local_link_targets(SCALABILITY_ADAPTER_PATH)

--- a/tests/docs/test_github_agent_guidance.py
+++ b/tests/docs/test_github_agent_guidance.py
@@ -210,6 +210,9 @@ def test_scalability_benchmark_has_one_skill_owned_route() -> None:
     } <= set(apply_to)
     assert SCALABILITY_SKILL_PATH.resolve() in _local_link_targets(SCALABILITY_ADAPTER_PATH)
     assert SCALABILITY_SKILL_PATH.resolve() in _local_link_targets(CANONICAL_PATH)
+    canonical_text = " ".join(_read(CANONICAL_PATH).split())
+    assert "RecipePlan extraction" in canonical_text
+    assert "recipe node count changes" in canonical_text
 
     skill_targets = set(_local_link_targets(SCALABILITY_SKILL_PATH))
     assert {

--- a/tests/docs/test_github_agent_guidance.py
+++ b/tests/docs/test_github_agent_guidance.py
@@ -23,6 +23,8 @@ PR_TEMPLATE_PATH = GITHUB_DIR / "PULL_REQUEST_TEMPLATE.md"
 TEST_SKILL_DIR = SKILLS_DIR / "wandas-test-authoring"
 TEST_SKILL_PATH = TEST_SKILL_DIR / "SKILL.md"
 TEST_REFERENCE_DIR = TEST_SKILL_DIR / "references"
+SCALABILITY_SKILL_PATH = SKILLS_DIR / "wandas-scalability-benchmark" / "SKILL.md"
+SCALABILITY_ADAPTER_PATH = GITHUB_DIR / "instructions" / "scalability-benchmark.instructions.md"
 
 TEST_ADAPTER_ROUTES = {
     "test-grand-policy.instructions.md": ("tests/**", "grand-policy.md"),
@@ -173,6 +175,45 @@ def test_test_authoring_skill_has_complete_references_and_codex_metadata() -> No
     assert set(interface) == {"display_name", "short_description", "default_prompt"}
     assert all(isinstance(value, str) and value for value in interface.values())
     assert "$wandas-test-authoring" in interface["default_prompt"]
+
+
+def test_scalability_benchmark_has_one_skill_owned_route() -> None:
+    data, body = _frontmatter(SCALABILITY_SKILL_PATH)
+    assert set(data) == {"name", "description"}
+    assert data["name"] == "wandas-scalability-benchmark"
+    assert "schema version 2" in body
+    assert "--chunk-samples 48000 480000" in body
+    assert "base and candidate commit SHAs" in body
+    assert "raw JSON" in body
+
+    metadata = yaml.safe_load(_read(SCALABILITY_SKILL_PATH.parent / "agents" / "openai.yaml"))
+    assert set(metadata) == {"interface"}
+    assert set(metadata["interface"]) == {"display_name", "short_description", "default_prompt"}
+    assert "$wandas-scalability-benchmark" in metadata["interface"]["default_prompt"]
+
+    adapter_data, adapter_body = _frontmatter(SCALABILITY_ADAPTER_PATH)
+    assert set(adapter_data) == {"description", "applyTo"}
+    apply_to = adapter_data["applyTo"].split(",")
+    assert len(apply_to) == len(set(apply_to))
+    assert all((REPO_ROOT / path).is_file() for path in apply_to)
+    assert SCALABILITY_SKILL_PATH.resolve() in _local_link_targets(SCALABILITY_ADAPTER_PATH)
+    assert SCALABILITY_SKILL_PATH.resolve() in _local_link_targets(CANONICAL_PATH)
+
+    skill_targets = set(_local_link_targets(SCALABILITY_SKILL_PATH))
+    assert {
+        CANONICAL_PATH.resolve(),
+        (REPO_ROOT / "docs/src/explanation/scalability-contract.md").resolve(),
+        (REPO_ROOT / "scripts/scalability_benchmark.py").resolve(),
+        (REPO_ROOT / "tests/test_scalability_benchmark.py").resolve(),
+    } <= skill_targets
+
+    duplicated_surfaces = [
+        GITHUB_DIR / "agents" / "wandas-planner.agent.md",
+        GITHUB_DIR / "agents" / "wandas-reviewer.agent.md",
+        GITHUB_DIR / "instructions" / "agent-maintenance.instructions.md",
+    ]
+    assert all("--chunk-samples" not in _read(path) for path in duplicated_surfaces)
+    assert not (GITHUB_DIR / "agents" / "wandas-implementer.agent.md").exists()
 
 
 def test_change_coherence_has_one_canonical_route_and_structural_guardrail() -> None:

--- a/tests/docs/test_github_agent_guidance.py
+++ b/tests/docs/test_github_agent_guidance.py
@@ -183,6 +183,8 @@ def test_scalability_benchmark_has_one_skill_owned_route() -> None:
     assert data["name"] == "wandas-scalability-benchmark"
     assert "schema version 2" in body
     assert "--chunk-samples 48000 480000" in body
+    assert body.count("uv run --locked") == 2
+    assert "uv run --frozen" not in body
     assert "base and candidate commit SHAs" in body
     assert "raw JSON" in body
 


### PR DESCRIPTION
## Summary

- Add one repo-shared `wandas-scalability-benchmark` Skill and generated `agents/openai.yaml` metadata.
- Add one thin path-scoped Copilot adapter and one `AGENTS.md` procedure route.
- Add deterministic discovery, frontmatter, link, `applyTo`, single-ownership, and locked-command tests.
- Use `uv run --locked` for representative and smoke commands so stale committed locks fail before evidence is collected.

The current single-owner harness is preserved: the removed implementer agent is not restored, and benchmark procedure text is not copied into planner, reviewer, or agent-maintenance surfaces. The benchmark remains repository-internal and does not define a public xarray/Dask Frame API.

## Skill contract

The Skill owns the schema-v2 representative command, base/candidate SHAs, same-environment and dependency-lock requirements, fixed-data/chunk and fixed-chunk/data-size comparisons, reruns, skip reasons, and raw JSON recording.

## Validation

- `uv run pytest tests/docs -q` — passed.
- `uv run pytest tests/docs/test_github_agent_guidance.py tests/test_scalability_benchmark.py -q` — passed.
- `uv run python /home/vscode/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/wandas-scalability-benchmark` — passed.
- Schema-v2 `--locked` smoke matrix (`8000` samples; `1000 4000` chunks) — passed.
- `uv run ruff check .` / `uv run ruff format --check .` — passed.
- `uv run ty check` — passed.
- Fresh-context forward-test using only the Skill — passed: it recovered the `--locked` representative matrix, provenance, two comparison axes, raw JSON record, rerun rules, and valid skip conditions without modifying files or running the representative workload.
- Representative benchmark — supplied by parent PR #309 and rerun on aggregate PR #310.

## Stack

- #309 merged into `main` as merge commit `be0b50c1`.
- Rebased onto current `main`; current head is `c33b994b`.
- Merge #318, then restack #310 onto latest `main`, then merge #310.

Related: #309