### PR TITLE
Consolidate Frame data access around frame.data

### DIFF
--- a/docs/src/explanation/public-api-stability.md
+++ b/docs/src/explanation/public-api-stability.md
@@ -7,8 +7,9 @@ the 1.0 compatibility promise.
 
 - Top level: `read`, `from_numpy`, `from_folder`, `load`, `supported_formats`.
 - Built-in Frame types and their primary workflow: immutable typed transforms,
-  metadata/channel views, `frame.data` as the NumPy-value boundary, `plot`,
-  `describe`, and `BaseFrame.save`.
+  metadata/channel views, `frame.data` as the canonical NumPy-value boundary,
+  `to_numpy()` and NumPy's array protocol as equivalent interoperability APIs,
+  `plot`, `describe`, and `BaseFrame.save`.
 - `RecipePlan.from_frame`, `apply`, `to_dict`, `from_dict`, `save`, and `load`.
 - WDF 0.4 typed round-trip and Recipe schema 2 strict JSON.
 
@@ -20,8 +21,6 @@ Changes to this surface require tests, documentation, and a deprecation period. 
 
 - Recipe extension registries/decorators used to declare third-party operations.
 - sklearn adapters in `wandas.pipeline.sklearn`.
-- Backend/interoperability surfaces outside the primary Frame workflow, including
-  `xr`, `to_xarray()`, `compute()`, and `persist()`.
 - Internal xarray/Dask storage helpers and private attributes such as `_xr` and
   `_data`.
 

--- a/docs/src/release-notes/v0.6.0.md
+++ b/docs/src/release-notes/v0.6.0.md
@@ -22,7 +22,18 @@ scalability, and explicit API/schema contracts.
 
 WDF 0.4 intentionally provides no compatibility shim for older WDF formats. Resave an
 artifact with a compatible Wandas version before loading it with 0.6.0. A lazily loaded
-Frame retains access to its source WDF. Use the NumPy array returned by `frame.data`, or
-replace the Frame with `frame = frame.persist()`, before moving, deleting, or replacing
-the source file. `operation_history` remains display-only; use a separate Recipe JSON
-artifact for replay.
+Frame retains access to its source WDF. Read the NumPy array returned by `frame.data`
+before moving, deleting, or replacing the source file. `operation_history` remains
+display-only; use a separate Recipe JSON artifact for replay.
+
+The experimental backend-facing Frame APIs were removed without deprecation shims.
+Use the following migration paths:
+
+| Removed API | Migration |
+| --- | --- |
+| `compute()` | Use `frame.data`. A single channel no longer retains its singleton channel axis. |
+| `persist()` | Before changing a source, capture `values = frame.data`. Wandas does not expose a public Frame-detach API. |
+| `xr` / `to_xarray()` | Construct xarray or another container from `frame.data` plus the public axes and metadata you need. Wandas does not guarantee an xarray schema. |
+
+`to_numpy()` and `np.asarray(frame)` remain supported interoperability boundaries and
+return the same values, shape, and dtype as `frame.data`.

--- a/learning-path/02_working_with_data.py
+++ b/learning-path/02_working_with_data.py
@@ -531,7 +531,7 @@ def _(pathlib_path, audio, np, sensor_data, sf, stereo_audio, wd):
     wav_subtype = sf.info(wav_output).subtype
     assert wav_subtype == "FLOAT"
     assert round_trip_audio.data.dtype == np.float64
-    np.testing.assert_array_equal(round_trip_audio.to_numpy(), audio.to_numpy())
+    np.testing.assert_array_equal(round_trip_audio.data, audio.data)
     print(f"✅ WAV保存: {wav_output} (subtype={wav_subtype}, dtype={round_trip_audio.data.dtype})")
     print("   FLOAT符号化でfull-scale値を保ったまま再読込できました")
 

--- a/tests/core/test_base_frame.py
+++ b/tests/core/test_base_frame.py
@@ -1046,6 +1046,26 @@ class TestBaseFrameInitialization:
         assert result_data.ndim == 2
         assert result_data.shape == (3, 16000)
 
+    @pytest.mark.parametrize(
+        "source",
+        [
+            np.array([[1.0, 2.0, 3.0]]),
+            np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
+        ],
+    )
+    def test_data_returns_detached_snapshot(self, source: np.ndarray) -> None:
+        """Mutating a public data snapshot cannot change later Frame values."""
+        frame = ChannelFrame.from_numpy(source, sampling_rate=self.sample_rate)
+        first = frame.data
+        expected = first.copy()
+
+        first[...] = -999.0
+        second = frame.data
+
+        assert second is not first
+        assert not np.shares_memory(second, first)
+        np.testing.assert_array_equal(second, expected)
+
 
 class TestBaseFrameRelabelChannels:
     """Test _relabel_channels method."""

--- a/tests/core/test_base_frame.py
+++ b/tests/core/test_base_frame.py
@@ -9,6 +9,7 @@ import pytest
 from dask.array.core import Array as DaArray
 
 import wandas as wd
+from tests.frame_helpers import channel_first_values
 from wandas.core.metadata import ChannelMetadata
 from wandas.frames.channel import ChannelFrame
 from wandas.utils.dask_helpers import da_from_array
@@ -48,7 +49,7 @@ class TestBaseFrameArithmeticOperations:
         assert result.operation_history[0]["params"]["operand"] == 2
 
         # Pillar 4: Numerical correctness — deterministic expected value
-        computed = result.compute()
+        computed = channel_first_values(result)
         expected = self.data**2
         np.testing.assert_array_equal(computed, expected)  # Same algorithm, exact match
 
@@ -78,7 +79,7 @@ class TestBaseFrameArithmeticOperations:
         assert len(result.lineage.inputs) == 2
 
         # Pillar 4: Numerical correctness
-        computed = result.compute()
+        computed = channel_first_values(result)
         expected = self.data**exponent_data
         np.testing.assert_array_equal(computed, expected)  # Same algorithm, exact match
 
@@ -101,7 +102,7 @@ class TestBaseFrameArithmeticOperations:
         assert result.lineage.inputs[1] is None
 
         # Pillar 4: Numerical correctness
-        computed = result.compute()
+        computed = channel_first_values(result)
         expected = self.data**exponent_array
         np.testing.assert_array_equal(computed, expected)  # Same algorithm, exact match
 
@@ -125,7 +126,7 @@ class TestBaseFrameArithmeticOperations:
         assert result.lineage.inputs[1] is None
 
         # Pillar 4: Numerical correctness — sqrt of deterministic ramp
-        computed = result.compute()
+        computed = channel_first_values(result)
         expected = self.data**exponent_data
         np.testing.assert_array_equal(computed, expected)  # Same algorithm, exact match
 
@@ -178,17 +179,17 @@ class TestBaseFrameArithmeticOperations:
         # Squaring: 2^2=4, 3^2=9, 4^2=16, ...
         squared = known_frame**2
         assert isinstance(squared._data, DaArray)
-        np.testing.assert_array_equal(squared.compute(), known_data**2)  # Exact match, same algorithm
+        np.testing.assert_array_equal(channel_first_values(squared), known_data**2)  # Exact match, same algorithm
 
         # Square root: sqrt(4)=2, sqrt(9)=3, ...
         sqrt_result = known_frame**0.5
         assert isinstance(sqrt_result._data, DaArray)
-        np.testing.assert_array_equal(sqrt_result.compute(), np.sqrt(known_data))  # Exact match
+        np.testing.assert_array_equal(channel_first_values(sqrt_result), np.sqrt(known_data))  # Exact match
 
         # Cube root: 8^(1/3)=2, 27^(1/3)=3, ...
         cuberoot_result = known_frame ** (1.0 / 3.0)
         assert isinstance(cuberoot_result._data, DaArray)
-        np.testing.assert_array_equal(cuberoot_result.compute(), known_data ** (1.0 / 3.0))  # Exact match
+        np.testing.assert_array_equal(channel_first_values(cuberoot_result), known_data ** (1.0 / 3.0))  # Exact match
 
     def test_pow_operator_single_channel_correct_result(self) -> None:
         """Test __pow__ with single channel returns correct result."""
@@ -200,7 +201,7 @@ class TestBaseFrameArithmeticOperations:
         assert result.sampling_rate == self.sample_rate
         assert isinstance(result._data, DaArray)
 
-        computed = result.compute()
+        computed = channel_first_values(result)
         expected = self.data[0:1] ** 3
         np.testing.assert_array_equal(computed, expected)
 
@@ -220,7 +221,7 @@ class TestBaseFrameArithmeticOperations:
 
         assert isinstance(magnitude, ChannelFrame)
         assert isinstance(magnitude._data, DaArray)
-        computed_magnitude = magnitude.compute()
+        computed_magnitude = channel_first_values(magnitude)
         expected_magnitude = np.sqrt(x_data**2 + y_data**2)
         np.testing.assert_array_equal(computed_magnitude.squeeze(), expected_magnitude)
 
@@ -656,15 +657,6 @@ class TestBaseFrameUtilityMethods:
         assert "1: wandas.operator.add" in captured.out
         assert "2: wandas.operator.multiply" in captured.out
 
-    def test_persist_returns_new_instance_with_dask(self) -> None:
-        """Test persist method returns new ChannelFrame with Dask data."""
-        persisted = self.channel_frame.persist()
-        assert isinstance(persisted, ChannelFrame)
-        assert persisted is not self.channel_frame
-        assert persisted.sampling_rate == self.sample_rate
-        assert persisted.n_channels == 2
-        assert isinstance(persisted._data, DaArray)
-
     def test_visualize_graph_with_filename(self) -> None:
         """Test visualize_graph with custom filename."""
         with mock.patch.object(DaArray, "visualize") as mock_visualize:
@@ -792,7 +784,7 @@ class TestBaseFrameIndexing:
         result = self.channel_frame["ch1"]
 
         assert result.n_channels == 1
-        np.testing.assert_array_equal(result.compute(), self.data[1:2])
+        np.testing.assert_array_equal(channel_first_values(result), self.data[1:2])
 
     def test_getitem_with_list_of_strings(self) -> None:
         """Test __getitem__ with list of string labels."""
@@ -809,7 +801,7 @@ class TestBaseFrameIndexing:
         assert result is not self.channel_frame
         assert result.n_channels == 3
         assert isinstance(result._data, DaArray)
-        np.testing.assert_array_equal(result.compute(), self.data[[0, 2, 3]])
+        np.testing.assert_array_equal(channel_first_values(result), self.data[[0, 2, 3]])
 
     def test_getitem_with_empty_list_error(self) -> None:
         """Test __getitem__ with empty list raises ValueError."""
@@ -826,14 +818,14 @@ class TestBaseFrameIndexing:
         indices = np.array([0, 2])
         result = self.channel_frame[indices]
         assert result.n_channels == 2
-        np.testing.assert_array_equal(result.compute(), self.data[[0, 2]])
+        np.testing.assert_array_equal(channel_first_values(result), self.data[[0, 2]])
 
     def test_getitem_with_numpy_bool_array(self) -> None:
         """Test __getitem__ with NumPy boolean array."""
         mask = np.array([True, False, True, False])
         result = self.channel_frame[mask]
         assert result.n_channels == 2
-        np.testing.assert_array_equal(result.compute(), self.data[[0, 2]])
+        np.testing.assert_array_equal(channel_first_values(result), self.data[[0, 2]])
 
     def test_getitem_with_bool_mask_wrong_length(self) -> None:
         """Test __getitem__ with wrong length boolean mask raises ValueError."""
@@ -853,7 +845,7 @@ class TestBaseFrameIndexing:
         assert result is not self.channel_frame
         assert result.n_channels == 2
         assert isinstance(result._data, DaArray)
-        np.testing.assert_array_equal(result.compute(), self.data[1:3])
+        np.testing.assert_array_equal(channel_first_values(result), self.data[1:3])
 
     @pytest.mark.parametrize(
         ("selector", "expected_indices"),
@@ -875,7 +867,7 @@ class TestBaseFrameIndexing:
         assert result is not self.channel_frame
         assert isinstance(result._data, DaArray)
         assert result.labels == [self.channel_frame.labels[index] for index in expected_indices]
-        np.testing.assert_array_equal(result.compute(), self.data[expected_indices])
+        np.testing.assert_array_equal(channel_first_values(result), self.data[expected_indices])
 
     def test_getitem_with_negative_out_of_range_index_raises(self) -> None:
         """A negative index beyond the channel axis raises IndexError."""
@@ -901,7 +893,7 @@ class TestBaseFrameIndexing:
         assert result is not self.channel_frame
         assert isinstance(result._data, DaArray)
         assert result.labels == [self.channel_frame.labels[index] for index in expected_indices]
-        np.testing.assert_array_equal(result.compute(), self.data[expected_indices])
+        np.testing.assert_array_equal(channel_first_values(result), self.data[expected_indices])
 
     def test_getitem_with_tuple_channel_and_time_preserves_dask(self) -> None:
         """Test __getitem__ with tuple for multidimensional indexing."""
@@ -910,7 +902,7 @@ class TestBaseFrameIndexing:
         assert result.n_channels == 1
         assert result.n_samples == 100
         assert isinstance(result._data, DaArray)
-        np.testing.assert_array_equal(result.compute(), self.data[0:1, 100:200])
+        np.testing.assert_array_equal(channel_first_values(result), self.data[0:1, 100:200])
 
     def test_getitem_with_tuple_list_and_time_preserves_dask(self) -> None:
         """Test __getitem__ with list of channels and time slice."""
@@ -919,7 +911,7 @@ class TestBaseFrameIndexing:
         assert result.n_channels == 2
         assert result.n_samples == 100
         assert isinstance(result._data, DaArray)
-        np.testing.assert_array_equal(result.compute(), self.data[[0, 2], 100:200])
+        np.testing.assert_array_equal(channel_first_values(result), self.data[[0, 2], 100:200])
 
     def test_source_time_slice_context_without_time_key_returns_none(self) -> None:
         """No source offset update is needed when tuple indexing omits the time key."""
@@ -950,7 +942,7 @@ class TestBaseFrameIndexing:
         """Test get_channel with negative index."""
         result = self.channel_frame.get_channel(-1)
         assert result.n_channels == 1
-        np.testing.assert_array_equal(result.compute(), self.data[-1:])
+        np.testing.assert_array_equal(channel_first_values(result), self.data[-1:])
 
     def test_get_channel_with_tuple(self) -> None:
         """Test get_channel with tuple of indices."""
@@ -1118,7 +1110,7 @@ class TestBaseFrameEdgeCases:
 
         with mock.patch.object(DaArray, "compute", return_value="not_an_array"):
             with pytest.raises(ValueError, match="Computed result is not a np.ndarray"):
-                frame.compute()
+                channel_first_values(frame)
 
     def test_slice_single_channel_returns_metadata_as_list(self) -> None:
         """Test that slicing a single channel still returns metadata as list."""

--- a/tests/core/test_base_frame.py
+++ b/tests/core/test_base_frame.py
@@ -560,6 +560,31 @@ class TestBaseFrameSpecialMethods:
         # float64→float32 conversion tolerance
         np.testing.assert_allclose(arr, self.data.astype(np.float32), rtol=1e-6)
 
+    def test_array_matching_dtype_avoids_additional_copy_by_default(self) -> None:
+        """A matching dtype does not copy the already-materialized ndarray again."""
+        materialized = self.data.copy()
+        with mock.patch.object(self.channel_frame, "_compute", return_value=materialized):
+            result = self.channel_frame.__array__(dtype=np.float64)
+
+        assert result is materialized
+
+    def test_array_copy_true_returns_independent_array(self) -> None:
+        """An explicit copy request returns an independent ndarray."""
+        materialized = self.data.copy()
+        with mock.patch.object(self.channel_frame, "_compute", return_value=materialized):
+            result = self.channel_frame.__array__(copy=True)
+
+        assert result is not materialized
+        np.testing.assert_array_equal(result, materialized)
+
+    def test_array_copy_false_rejects_before_materializing(self) -> None:
+        """A lazy Frame cannot satisfy NumPy's strict zero-copy request."""
+        with mock.patch.object(self.channel_frame, "_compute") as compute:
+            with pytest.raises(ValueError, match="cannot provide a zero-copy NumPy array"):
+                np.asarray(self.channel_frame, copy=False)
+
+        compute.assert_not_called()
+
     def test_to_numpy_returns_correct_array(self) -> None:
         """Test to_numpy method."""
         arr = self.channel_frame.to_numpy()

--- a/tests/core/test_base_frame_internal_contracts.py
+++ b/tests/core/test_base_frame_internal_contracts.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
+from tests.frame_helpers import channel_first_values
 from wandas.core.base_frame import BaseFrame
 from wandas.core.metadata import ChannelMetadata
 from wandas.frames.channel import ChannelFrame
@@ -261,10 +262,8 @@ def test_axisless_frame_stores_source_time_offset_in_attrs() -> None:
     data = da_from_array(np.arange(4, dtype=float), chunks=(4,))
     frame = SingleChannelAxislessFrame(data, sampling_rate=100.0, source_time_offset=2.5)
 
-    xr_data = frame.to_xarray()
-
-    assert "source_time_offset" not in xr_data.coords
-    np.testing.assert_array_equal(xr_data.attrs["source_time_offset"], np.array([2.5]))
+    assert "source_time_offset" not in frame._xr.coords
+    np.testing.assert_array_equal(frame._xr.attrs["source_time_offset"], np.array([2.5]))
     np.testing.assert_array_equal(frame.source_time_offset, np.array([2.5]))
 
 
@@ -468,7 +467,7 @@ def test_lineage_keeps_semantic_operation_without_runtime_operation_state():
     with pytest.raises(AttributeError):
         setattr(op, "params", freeze_params({"norm": 2.0}))
 
-    np.testing.assert_allclose(result.compute(), data / 4.0)
+    np.testing.assert_allclose(channel_first_values(result), data / 4.0)
 
 
 def test_none_valued_config_reassignment_is_blocked_and_delayed_result_is_stable():
@@ -483,7 +482,7 @@ def test_none_valued_config_reassignment_is_blocked_and_delayed_result_is_stable
         setattr(op, "params", freeze_params({"norm": np.inf}))
 
     assert thaw_params(op.params)["norm"] is None
-    np.testing.assert_allclose(result.compute(), data)
+    np.testing.assert_allclose(channel_first_values(result), data)
 
 
 def test_power_operation_exp_alias_reassignment_does_not_change_delayed_result():
@@ -498,7 +497,7 @@ def test_power_operation_exp_alias_reassignment_does_not_change_delayed_result()
         setattr(op, "params", freeze_params({"exponent": 3.0}))
 
     assert thaw_params(op.params)["exponent"] == 2.0
-    np.testing.assert_allclose(result.compute(), data**2)
+    np.testing.assert_allclose(channel_first_values(result), data**2)
 
 
 def test_channel_metadata_update_paths_preserve_operations_lineage():
@@ -512,7 +511,7 @@ def test_channel_metadata_update_paths_preserve_operations_lineage():
         "wandas.audio.normalize",
         "wandas.channel.rename_channels",
     ]
-    np.testing.assert_allclose(result.compute(), data / 4.0)
+    np.testing.assert_allclose(channel_first_values(result), data / 4.0)
 
 
 def test_indexing_variants_cover_base_frame_selection_paths():
@@ -540,13 +539,10 @@ def test_indexing_variants_cover_base_frame_selection_paths():
         _ = f[cast(Any, (1.5, slice(None)))]
 
 
-def test_public_xarray_and_array_protocol_paths():
+def test_array_protocol_matches_data():
     f = make_frame(np.arange(6).reshape(2, 3), label="raw")
 
-    exported = f.xr
-    assert exported.name == "raw"
-    assert exported.attrs["wandas_frame_type"] == "DummyFrame"
-    np.testing.assert_array_equal(f.__array__(), np.arange(6).reshape(2, 3))
+    np.testing.assert_array_equal(np.asarray(f), f.data)
 
 
 def test_channel_frame_binary_op_frame_success_and_remaining_operand_formats():
@@ -573,7 +569,7 @@ def test_channel_frame_binary_op_frame_success_and_remaining_operand_formats():
         "version": 1,
         "params": {},
     }
-    np.testing.assert_array_equal(added.compute(), left.compute() + right.compute())
+    np.testing.assert_array_equal(channel_first_values(added), channel_first_values(left) + channel_first_values(right))
     assert powered.operation_history[-1]["params"]["operand"] == 2
     assert BaseFrame._format_operand_str(np.zeros((2, 3))) == "ndarray(2, 3)"
     assert BaseFrame._format_operand_str(da_from_array(np.zeros((2, 3)), chunks=(1, -1))) == "dask.array(2, 3)"
@@ -618,11 +614,8 @@ def test_base_frame_remaining_coordinate_and_indexing_edges():
 
     cf = ChannelFrame(da_from_array(np.arange(6).reshape(2, 3), chunks=(1, -1)), sampling_rate=100.0)
     cf._set_channel_coord_value("channel_label", 0, "front")
-    exported = cf.to_xarray()
-    exported.coords["channel_label"].values[0] = "mutated"
-
     assert cf.channels[0].label == "front"
-    assert exported.attrs["wandas_frame_type"] == "ChannelFrame"
+    assert cf._xr.coords["channel_label"].values[0] == "front"
 
 
 def test_xarray_coords_are_omitted_when_pending_metadata_length_mismatches():

--- a/tests/core/test_base_frame_lineage.py
+++ b/tests/core/test_base_frame_lineage.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 from dask.array.core import Array as DaArray
 
+from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
 from wandas.pipeline import RecipePlan
 from wandas.processing.semantic import FrozenMap, LineageNode
@@ -70,7 +71,7 @@ def test_frame_binary_operation_preserves_operand_order_and_both_parents() -> No
         ("right", "frame"),
     ]
     assert result.lineage.inputs == (left.lineage, right.lineage)
-    np.testing.assert_allclose(result.compute(), 3.0)
+    np.testing.assert_allclose(channel_first_values(result), 3.0)
 
 
 def test_external_array_binary_operation_has_no_array_lineage_parent() -> None:
@@ -116,7 +117,7 @@ def test_reverse_scalar_operations_preserve_public_intent(
 
     assert result.lineage.operation is not None
     assert result.lineage.operation.operation_id == operation_id
-    np.testing.assert_allclose(result.compute(), expected)
+    np.testing.assert_allclose(channel_first_values(result), expected)
 
 
 def test_depth_first_history_deduplicates_shared_source_nodes() -> None:
@@ -188,16 +189,6 @@ def test_public_operation_and_history_access_do_not_compute() -> None:
 
     assert len(history) == 2
     assert len(plan.nodes) == 2
-
-
-def test_persist_preserves_same_lineage_authority() -> None:
-    result = _frame().normalize()
-    expected = result.operation_history
-
-    persisted = result.persist()
-
-    assert persisted.lineage is result.lineage
-    assert persisted.operation_history == expected
 
 
 def test_indexing_uses_one_semantic_node_for_multidimensional_selection() -> None:
@@ -281,4 +272,4 @@ def test_multidimensional_label_and_mask_selectors_replay(selector: tuple[object
     replayed = plan.apply({"signal": source})
 
     assert replayed.shape == selected.shape
-    np.testing.assert_array_equal(replayed.compute(), selected.compute())
+    np.testing.assert_array_equal(channel_first_values(replayed), channel_first_values(selected))

--- a/tests/core/test_base_frame_tensor.py
+++ b/tests/core/test_base_frame_tensor.py
@@ -216,3 +216,19 @@ class TestToNumpy:
 
         assert result.dtype == np.int32
         np.testing.assert_array_equal(result, int_data)
+
+
+@pytest.mark.parametrize(
+    ("values", "factors"),
+    [
+        (np.array([[1, 2, 3]], dtype=np.int32), [1.0]),
+        (np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64), [2.0, 0.5]),
+    ],
+)
+def test_numpy_interop_matches_data_values_shape_and_dtype(values, factors) -> None:
+    frame = ChannelFrame.from_numpy(values, sampling_rate=2.0).with_calibration(factors)
+
+    for materialized in (frame.to_numpy(), np.asarray(frame)):
+        np.testing.assert_array_equal(materialized, frame.data)
+        assert materialized.shape == frame.data.shape
+        assert materialized.dtype == frame.data.dtype

--- a/tests/core/test_channel_metadata_xarray.py
+++ b/tests/core/test_channel_metadata_xarray.py
@@ -162,36 +162,20 @@ def test_channel_metadata_snapshots_are_value_objects() -> None:
     assert frame.channels[0].extra["sensitivity"] == 50.0
 
 
-def test_to_xarray_exports_channel_metadata_without_sharing_attrs() -> None:
+def test_private_storage_retains_channel_metadata_coordinates() -> None:
     frame = _frame()
 
-    exported = frame.to_xarray()
-
-    assert exported is not frame._xr
-    assert exported.coords["channel"].values.tolist() == ["c0", "c1"]
-    assert exported.coords["channel_label"].values.tolist() == ["left", "right"]
-    assert exported.coords["channel_unit"].values.tolist() == ["Pa", "V"]
-    assert exported.coords["channel_ref"].values.tolist() == [2e-5, 0.5]
-    assert exported.attrs["channel_extra"] == copy.deepcopy(frame._xr.attrs["channel_extra"])
-
-    exported.attrs["channel_extra"]["c0"]["sensitivity"] = 1.0
-    exported.coords["channel_label"].values[0] = "exported-left"
-    exported.coords["channel_unit"].values[0] = "Hz"
-    exported.coords["channel_ref"].values[0] = 1.0
-
-    assert frame.channels[0].extra["sensitivity"] == 50.0
-    assert frame.channels[0].label == "left"
-    assert frame.channels[0].unit == "Pa"
-    assert frame.channels[0].ref == 2e-5
+    assert frame._xr.coords["channel"].values.tolist() == ["c0", "c1"]
+    assert frame._xr.coords["channel_label"].values.tolist() == ["left", "right"]
+    assert frame._xr.coords["channel_unit"].values.tolist() == ["Pa", "V"]
+    assert frame._xr.coords["channel_ref"].values.tolist() == [2e-5, 0.5]
+    assert frame._xr.attrs["channel_extra"] == copy.deepcopy(frame._xr.attrs["channel_extra"])
 
 
-def test_to_xarray_exports_effective_data_with_identity_calibration_factors() -> None:
+def test_data_applies_private_storage_calibration_factors() -> None:
     frame = _frame().with_calibration([2.0, 0.5])
 
-    exported = frame.to_xarray()
-
-    np.testing.assert_allclose(exported.compute().values, [[2.0, 4.0], [1.5, 2.0]])
-    assert exported.coords["channel_calibration_factor"].values.tolist() == [1.0, 1.0]
+    np.testing.assert_allclose(frame.data, [[2.0, 4.0], [1.5, 2.0]])
     assert frame._xr.coords["channel_calibration_factor"].values.tolist() == [2.0, 0.5]
 
 

--- a/tests/core/test_channel_metadata_xarray.py
+++ b/tests/core/test_channel_metadata_xarray.py
@@ -1,4 +1,3 @@
-import copy
 from collections.abc import Sequence
 from typing import Any, cast
 
@@ -169,7 +168,10 @@ def test_private_storage_retains_channel_metadata_coordinates() -> None:
     assert frame._xr.coords["channel_label"].values.tolist() == ["left", "right"]
     assert frame._xr.coords["channel_unit"].values.tolist() == ["Pa", "V"]
     assert frame._xr.coords["channel_ref"].values.tolist() == [2e-5, 0.5]
-    assert frame._xr.attrs["channel_extra"] == copy.deepcopy(frame._xr.attrs["channel_extra"])
+    assert frame._xr.attrs["channel_extra"] == {
+        "c0": {"sensitivity": 50.0},
+        "c1": {"sensitivity": 48.5},
+    }
 
 
 def test_data_applies_private_storage_calibration_factors() -> None:

--- a/tests/core/test_xarray_storage_only.py
+++ b/tests/core/test_xarray_storage_only.py
@@ -6,6 +6,7 @@ import xarray as xr
 from dask import array as da
 from dask import delayed
 
+from tests.frame_helpers import channel_first_values
 from wandas import ChannelFrame
 from wandas.core.base_frame import BaseFrame
 from wandas.core.metadata import ChannelMetadata
@@ -443,16 +444,15 @@ def test_add_channel_returns_new_xarray_without_compute() -> None:
     assert list(result._xr.coords["channel_label"].values) == ["ch0", "extra"]
 
 
-def test_construction_and_xarray_export_do_not_compute() -> None:
+def test_construction_and_private_storage_access_do_not_compute() -> None:
     calls: list[str] = []
     frame = _lazy_frame_with_counter(calls)
 
     _ = frame._data
-    exported = frame.to_xarray()
-    _ = frame.xr
+    stored = frame._xr
 
     assert calls == []
-    assert exported.data is frame._data
+    assert stored.data is frame._data
 
 
 def test_selection_and_operation_do_not_compute_until_compute() -> None:
@@ -464,7 +464,7 @@ def test_selection_and_operation_do_not_compute_until_compute() -> None:
 
     assert calls == []
 
-    result = normalized.compute()
+    result = channel_first_values(normalized)
 
     assert calls == ["computed"]
     assert result.shape == (1, 4)
@@ -514,7 +514,7 @@ def test_remove_channel_returns_new_xarray_without_compute() -> None:
     assert list(result._xr.coords["channel_label"].values) == ["right"]
 
 
-def test_to_xarray_returns_public_shallow_copy_with_export_attrs() -> None:
+def test_private_xarray_storage_retains_frame_attrs() -> None:
     frame = ChannelFrame(
         data=da.from_array(np.array([[1.0, 2.0]]), chunks=(1, -1)),
         sampling_rate=2.0,
@@ -523,22 +523,15 @@ def test_to_xarray_returns_public_shallow_copy_with_export_attrs() -> None:
         lineage=source_lineage([{"operation": "wandas.audio.normalize", "version": 1, "params": {}}]),
     )
 
-    exported = frame.to_xarray()
-
-    assert isinstance(exported, xr.DataArray)
-    assert exported is not frame._xr
-    assert exported.data is frame._data
-    assert exported.attrs["wandas_frame_type"] == "ChannelFrame"
-    assert exported.attrs["sampling_rate"] == 2.0
-    assert exported.attrs["label"] == "exported"
-    assert exported.attrs["metadata"] == {"source": "unit-test"}
-    assert "operation_history" not in exported.attrs
-
-    exported.attrs["label"] = "changed-export"
-    assert frame.label == "exported"
+    assert isinstance(frame._xr, xr.DataArray)
+    assert frame._xr.data is frame._data
+    assert frame._xr.attrs["sampling_rate"] == 2.0
+    assert frame._xr.attrs["label"] == "exported"
+    assert frame._xr.attrs["metadata"] == {"source": "unit-test"}
+    assert "operation_history" not in frame._xr.attrs
 
 
-def test_to_xarray_uses_attrs_backed_label_for_name() -> None:
+def test_private_storage_uses_attrs_backed_label() -> None:
     frame = ChannelFrame.from_numpy(
         np.array([1.0, 2.0]),
         sampling_rate=2.0,
@@ -546,11 +539,8 @@ def test_to_xarray_uses_attrs_backed_label_for_name() -> None:
     )
     frame._xr.attrs["label"] = "mutated"
 
-    exported = frame.to_xarray()
-
     assert frame.label == "mutated"
-    assert exported.name == "mutated"
-    assert exported.attrs["label"] == "mutated"
+    assert frame._xr.attrs["label"] == "mutated"
 
 
 def test_metadata_setter_deep_copies_input_dict() -> None:
@@ -567,32 +557,14 @@ def test_metadata_setter_deep_copies_input_dict() -> None:
     assert frame.metadata == {"nested": {"x": 1}, "tags": ["raw"]}
 
 
-def test_to_xarray_deep_copies_exported_metadata_dict() -> None:
-    frame = ChannelFrame.from_numpy(
-        np.array([[1.0, 2.0, 3.0]]),
-        sampling_rate=3.0,
-        metadata={"nested": {"x": 1}, "_source_file": "input.wav"},
-    )
-
-    exported = frame.to_xarray()
-    exported.attrs["metadata"]["nested"]["x"] = 99
-    exported.attrs["metadata"]["_source_file"] = "changed.wav"
-
-    assert type(frame.metadata) is dict
-    assert frame.metadata["nested"]["x"] == 1
-    assert frame.metadata["_source_file"] == "input.wav"
-
-
-def test_to_xarray_omits_operation_history() -> None:
+def test_private_storage_omits_operation_history() -> None:
     frame = ChannelFrame(
         data=da.from_array(np.array([[1.0, 2.0]]), chunks=(1, -1)),
         sampling_rate=2.0,
         lineage=source_lineage([{"operation": "wandas.audio.normalize", "version": 1, "params": {}}]),
     )
 
-    exported = frame.to_xarray()
-
-    assert "operation_history" not in exported.attrs
+    assert "operation_history" not in frame._xr.attrs
     assert frame.operation_history[0]["operation"] == "wandas.audio.normalize"
 
 
@@ -650,11 +622,16 @@ def test_frame_state_property_setters_validate_inputs() -> None:
         frame.operation_history = {"operation": "bad"}  # ty: ignore[invalid-assignment]
 
 
-def test_xr_property_matches_to_xarray_contract() -> None:
+def test_removed_backend_api_is_absent() -> None:
     frame = ChannelFrame.from_numpy(np.array([1.0, 2.0]), sampling_rate=2.0)
 
-    exported = frame.xr
-
-    assert isinstance(exported, xr.DataArray)
-    assert exported is not frame._xr
-    assert exported.data is frame._data
+    representatives = (
+        frame,
+        frame.fft(n_fft=2),
+        frame.stft(n_fft=2, hop_length=1),
+        frame.cepstrum(n_fft=2),
+        frame.stft(n_fft=2, hop_length=1).cepstrum(),
+    )
+    for representative in representatives:
+        for name in ("compute", "persist", "xr", "to_xarray"):
+            assert not hasattr(representative, name)

--- a/tests/frame_helpers.py
+++ b/tests/frame_helpers.py
@@ -1,0 +1,15 @@
+"""Shared helpers for assertions against private Frame storage contracts."""
+
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from wandas.core.base_frame import BaseFrame
+
+
+def channel_first_values(frame: BaseFrame[Any]) -> NDArray[Any]:
+    """Materialize calibrated Frame values with the internal channel axis intact."""
+    values = frame._compute()
+    assert isinstance(values, np.ndarray)
+    return values

--- a/tests/frames/test_cepstral_frame.py
+++ b/tests/frames/test_cepstral_frame.py
@@ -6,6 +6,7 @@ import dask.array as da
 import numpy as np
 import pytest
 
+from tests.frame_helpers import channel_first_values
 from wandas.core.metadata import ChannelMetadata
 from wandas.frames.cepstral import CepstralFrame
 from wandas.frames.channel import ChannelFrame
@@ -42,7 +43,7 @@ def _cepstral_frame() -> CepstralFrame:
 def test_channel_cepstrum_returns_lazy_typed_frame_with_atomic_state() -> None:
     source = _source_frame()
     source_history = source.operation_history
-    source_data = source.compute().copy()
+    source_data = channel_first_values(source).copy()
 
     result = source.cepstrum(n_fft=32, window="boxcar", floor=1e-9)
 
@@ -65,7 +66,7 @@ def test_channel_cepstrum_returns_lazy_typed_frame_with_atomic_state() -> None:
         }
     ]
     assert source.operation_history == source_history
-    np.testing.assert_array_equal(source.compute(), source_data)
+    np.testing.assert_array_equal(channel_first_values(source), source_data)
 
 
 def test_channel_cepstrum_rejects_complex_input_before_building_lineage() -> None:
@@ -106,8 +107,8 @@ def test_cepstral_workflow_preserves_metadata_and_matches_fft_envelope() -> None
     assert len(liftered.operation_history) == 2
     assert len(envelope.operation_history) == 3
 
-    expected = np.abs(source.fft(n_fft=32, window="boxcar").compute())
-    unfiltered = cepstrum.to_spectral_envelope().compute().real
+    expected = np.abs(channel_first_values(source.fft(n_fft=32, window="boxcar")))
+    unfiltered = channel_first_values(cepstrum.to_spectral_envelope()).real
     # FFT/IFFT round-off is the only expected error in the analytical round trip.
     np.testing.assert_allclose(unfiltered, expected, rtol=1e-12, atol=1e-12)
 
@@ -132,7 +133,7 @@ def test_cepstral_axes_survive_selection_and_derived_frames() -> None:
     np.testing.assert_array_equal(selected.quefrencies, expected)
     np.testing.assert_array_equal(shifted.quefrencies, expected)
     np.testing.assert_array_equal(selected.to_dataframe().index.to_numpy(), expected)
-    assert selected.to_xarray().dims == ("channel", "quefrency")
+    assert selected._xr.dims == ("channel", "quefrency")
 
 
 @pytest.mark.parametrize("method_name", ["lifter", "to_spectral_envelope"])
@@ -146,14 +147,10 @@ def test_cepstral_transform_on_sliced_axis_raises_value_error(method_name: str) 
             selected.to_spectral_envelope()
 
 
-def test_cepstral_xarray_export_isolates_quefrency_coordinates() -> None:
+def test_cepstral_private_storage_retains_quefrency_coordinates() -> None:
     frame = _cepstral_frame()
     expected = frame.quefrencies
-    exported = frame.to_xarray()
-
-    exported.coords["quefrency"].values[0] = 1.0
-
-    np.testing.assert_array_equal(frame.quefrencies, expected)
+    np.testing.assert_array_equal(frame._xr.coords["quefrency"].values, expected)
 
     with pytest.raises(AttributeError, match=r"sampling_rate is immutable"):
         frame.sampling_rate = _SAMPLING_RATE / 2
@@ -211,7 +208,7 @@ def test_cepstral_plot_uses_quefrency_axis_and_coefficients() -> None:
     axis = cast(Any, frame.plot())
 
     np.testing.assert_array_equal(np.asarray(axis.lines[0].get_xdata()), frame.quefrencies)
-    np.testing.assert_allclose(np.asarray(axis.lines[0].get_ydata()), frame.compute()[0])
+    np.testing.assert_allclose(np.asarray(axis.lines[0].get_ydata()), channel_first_values(frame)[0])
     assert axis.get_xlabel() == "Quefrency [s]"
     assert axis.get_legend() is not None
     with pytest.raises(ValueError, match=r"supports only plot_type='quefrency'"):

--- a/tests/frames/test_cepstrogram_frame.py
+++ b/tests/frames/test_cepstrogram_frame.py
@@ -73,7 +73,7 @@ def test_spectrogram_cepstrum_returns_lazy_typed_frame_with_atomic_state() -> No
     np.testing.assert_allclose(result.times, spectrogram.times)
     np.testing.assert_allclose(result.source_times, result.source_time_offset[:, None] + result.times[None, :])
     assert result.n_frames == spectrogram.n_frames
-    assert result.to_xarray().dims == ("channel", "quefrency", "time")
+    assert result._xr.dims == ("channel", "quefrency", "time")
     rebuilt_coords = result._xarray_coords(result._data)
     np.testing.assert_allclose(rebuilt_coords["quefrency"][1], result.quefrencies)
     np.testing.assert_allclose(rebuilt_coords["time"][1], result.times)

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -13,6 +13,7 @@ from matplotlib.axes import Axes
 from scipy.io import wavfile
 
 import wandas as wd
+from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
 from wandas.pipeline import RecipePlan
 from wandas.utils.types import NDArrayReal
@@ -87,10 +88,10 @@ class TestChannelFrame:
         expected_noise_scale = 10 ** (-6.0 / 20.0)
         np.testing.assert_allclose(result.data, np.full(8, 1.0 + expected_noise_scale))
 
-    def test_compute_method(self) -> None:
-        """Test explicit compute method."""
+    def test_private_compute_preserves_channel_axis(self) -> None:
+        """The internal materialization contract is channel-first."""
         with mock.patch.object(DaArray, "compute", return_value=self.data) as mock_compute:
-            result: NDArrayReal = self.channel_frame.compute()
+            result: NDArrayReal = channel_first_values(self.channel_frame)
             mock_compute.assert_called_once()
             np.testing.assert_array_equal(result, self.data)
 
@@ -108,9 +109,8 @@ class TestChannelFrame:
 
         np.testing.assert_array_equal(cf.source_time_offset, np.array([2.5, 2.5]))
         np.testing.assert_array_equal(cf.source_time, cf.time[None, :] + np.array([[2.5], [2.5]]))
-        xr = cf.to_xarray()
-        np.testing.assert_array_equal(xr.coords["source_time_offset"].values, np.array([2.5, 2.5]))
-        assert "source_time_offset" not in xr.attrs
+        np.testing.assert_array_equal(cf._xr.coords["source_time_offset"].values, np.array([2.5, 2.5]))
+        assert "source_time_offset" not in cf._xr.attrs
 
     def test_source_time_offset_accepts_per_channel_values(self) -> None:
         """source_time_offset is stored per channel."""
@@ -187,7 +187,7 @@ class TestChannelFrame:
 
         result = left + right
 
-        np.testing.assert_array_equal(result.compute(), self.data + self.data)
+        np.testing.assert_array_equal(channel_first_values(result), self.data + self.data)
         np.testing.assert_array_equal(result.source_time_offset, np.array([2.0, 2.0]))
 
     def test_channel_difference_allows_per_channel_source_time_offset_mismatch(self) -> None:
@@ -201,7 +201,7 @@ class TestChannelFrame:
         result = frame.channel_difference(other_channel=0)
 
         expected = self.data - self.data[0]
-        np.testing.assert_array_equal(result.compute(), expected)
+        np.testing.assert_array_equal(channel_first_values(result), expected)
         np.testing.assert_array_equal(result.source_time_offset, np.array([2.0, 7.0]))
 
     def test_operations_are_lazy(self) -> None:
@@ -227,18 +227,10 @@ class TestChannelFrame:
         result = result * 2
 
         # Compute and check results
-        computed: NDArrayReal = result.compute()
+        computed: NDArrayReal = channel_first_values(result)
         expected: NDArrayReal = (self.data + 1) * 2
         # Scalar arithmetic on float64 — decimal=6 default (exact match expected)
         np.testing.assert_array_almost_equal(computed, expected)
-
-    def test_persist(self) -> None:
-        """Test that persist triggers computation but returns a new ChannelFrame."""
-        with mock.patch.object(DaArray, "persist", return_value=self.dask_data) as mock_persist:
-            result: ChannelFrame = self.channel_frame.persist()
-            mock_persist.assert_called_once()
-            assert isinstance(result, ChannelFrame)
-            assert result is not self.channel_frame
 
     def test_channel_extraction(self) -> None:
         """Test extracting a channel works lazily."""
@@ -459,12 +451,11 @@ class TestChannelFrame:
             mock_strategy: mock.MagicMock = mock.MagicMock()
             mock_get_strategy.return_value = mock_strategy
 
-            # Create a mock for the compute method
-            with mock.patch.object(self.channel_frame, "compute", return_value=self.data) as mock_compute:
+            with mock.patch.object(self.channel_frame, "_compute", return_value=self.data) as mock_compute:
                 mock_ax: mock.MagicMock = mock.MagicMock()
                 _: Axes | Any = self.channel_frame.plot(plot_type="waveform", ax=mock_ax)
 
-                # Verify compute was called
+                # Plot construction remains lazy until the strategy accesses values.
                 mock_compute.assert_not_called()
 
                 # Verify the strategy's plot method was called
@@ -489,7 +480,7 @@ class TestChannelFrame:
         try:
             # Test with multi-channel data
             with mock.patch("soundfile.write") as mock_write:
-                with mock.patch.object(self.channel_frame, "compute", return_value=self.data):
+                with mock.patch.object(self.channel_frame, "_compute", return_value=self.data):
                     self.channel_frame.to_wav(temp_filename)
                     mock_write.assert_called_once()
 
@@ -507,7 +498,7 @@ class TestChannelFrame:
                     self.sample_rate,
                 )
 
-                with mock.patch.object(channel_frame, "compute", return_value=single_channel_data):
+                with mock.patch.object(channel_frame, "_compute", return_value=single_channel_data):
                     channel_frame.to_wav(temp_filename)
                     mock_write.assert_called_once()
 
@@ -533,7 +524,7 @@ class TestChannelFrame:
 
     def test_array_method(self) -> None:
         """Test __array__ method for numpy conversion."""
-        with mock.patch.object(self.channel_frame, "compute", return_value=self.data) as mock_compute:
+        with mock.patch.object(self.channel_frame, "_compute", return_value=self.data) as mock_compute:
             # Test with default dtype
             array = np.array(self.channel_frame)
             mock_compute.assert_called_once()
@@ -862,7 +853,7 @@ class TestChannelFrameFileIO:
 
         assert cf.sampling_rate == sampling_rate
         assert cf.n_channels == 2
-        computed_data = cf.compute()
+        computed_data = channel_first_values(cf)
         np.testing.assert_array_equal(computed_data[0], data_left)
         np.testing.assert_array_equal(computed_data[1], data_right)
 
@@ -934,7 +925,7 @@ class TestChannelFrameFileIO:
         assert cf.sampling_rate == sampling_rate
         assert cf.n_channels == 2
         assert cf.label == "source"
-        computed_data = cf.compute()
+        computed_data = channel_first_values(cf)
         np.testing.assert_array_equal(computed_data[0], data_left)
         np.testing.assert_array_equal(computed_data[1], data_right)
 
@@ -949,7 +940,7 @@ class TestChannelFrameFileIO:
         wavfile.write(str(filepath), sampling_rate, int16_data)
 
         cf = ChannelFrame.from_file(filepath)
-        computed = cf.compute()
+        computed = channel_first_values(cf)
 
         np.testing.assert_array_equal(computed[0], 0.5)
         np.testing.assert_array_equal(computed[1], -0.5)
@@ -1071,7 +1062,7 @@ class TestChannelFrameRMS:
         """Computing rms must leave the underlying frame data unchanged."""
         original = self.stereo_data.copy()
         _ = self.cf_stereo.rms
-        np.testing.assert_array_equal(self.cf_stereo.compute(), original)
+        np.testing.assert_array_equal(channel_first_values(self.cf_stereo), original)
 
     def test_rms_does_not_mutate_operation_history(self) -> None:
         """Computing rms must not append to operation_history."""
@@ -1559,7 +1550,7 @@ class TestChannelFrameBinaryFallback:
         assert isinstance(result, ChannelFrame)
         assert isinstance(result._data, DaArray)
         assert result.label == f"({signal.label} + CustomNumeric)"
-        np.testing.assert_array_equal(result.compute(), signal.compute())
+        np.testing.assert_array_equal(channel_first_values(result), channel_first_values(signal))
 
 
 class TestChannelFrameCrestFactor:
@@ -1579,7 +1570,7 @@ class TestChannelFrameCrestFactor:
         """Computing crest_factor must leave the underlying frame data unchanged."""
         original = self.stereo_data.copy()
         _ = self.cf_stereo.crest_factor
-        np.testing.assert_array_equal(self.cf_stereo.compute(), original)
+        np.testing.assert_array_equal(channel_first_values(self.cf_stereo), original)
 
     def test_crest_factor_does_not_mutate_operation_history(self) -> None:
         """Computing crest_factor must not append to operation_history."""

--- a/tests/frames/test_channel_frame_edge_contracts.py
+++ b/tests/frames/test_channel_frame_edge_contracts.py
@@ -11,6 +11,7 @@ import pytest
 from matplotlib.figure import Figure
 
 import wandas.frames.channel as channel_mod
+from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame, _resolve_channels
 from wandas.pipeline import RecipePlan
 
@@ -90,7 +91,7 @@ def test_from_file_get_data_not_ndarray_raises(monkeypatch):
     cf = ChannelFrame.from_file(b"data", file_type=".wav")
     # The read error is raised when the delayed task is computed
     with pytest.raises(ValueError, match=r"Unexpected data type after reading file"):
-        cf.compute()
+        channel_first_values(cf)
 
 
 @pytest.mark.parametrize(
@@ -105,7 +106,7 @@ def test_from_file_validates_custom_reader_boundary(monkeypatch, data, message):
     frame = ChannelFrame.from_file(b"data", file_type=".wav")
 
     with pytest.raises((TypeError, ValueError), match=message):
-        frame.compute()
+        channel_first_values(frame)
 
 
 def test_from_file_channel_out_of_range_and_invalid_type(monkeypatch):

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 from dask.array.core import Array as DaArray
 
+from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame, ChannelMetadata
 from wandas.frames.spectral import SpectralFrame
 from wandas.processing.semantic import source_lineage, thaw_params
@@ -116,7 +117,7 @@ class TestChannelProcessing:
         # Function should not run before compute
         assert func.call_count == 0
 
-        computed = result.compute()
+        computed = channel_first_values(result)
         # Custom apply: scalar addition — decimal=6 default (exact match)
         np.testing.assert_array_almost_equal(computed, self.data + 1.5)
         assert func.call_count == 1
@@ -136,7 +137,7 @@ class TestChannelProcessing:
         with pytest.raises(AttributeError):
             setattr(op, "func", lambda x: x * 0)
 
-        np.testing.assert_array_equal(result.compute(), self.data + 1.0)
+        np.testing.assert_array_equal(channel_first_values(result), self.data + 1.0)
 
     def test_apply_custom_function_rejects_pure_reserved_argument(self) -> None:
         frame = ChannelFrame(
@@ -201,7 +202,7 @@ class TestChannelProcessing:
         params = thaw_params(op.params)
         params["gain"] = 0.0
 
-        np.testing.assert_array_equal(result.compute(), self.data * 2.0)
+        np.testing.assert_array_equal(channel_first_values(result), self.data * 2.0)
         assert result.operation_history[-1]["params"] == {"gain": 2.0}
 
     def test_apply_custom_function_mutating_nested_param_does_not_change_history_or_compute(self) -> None:
@@ -219,8 +220,8 @@ class TestChannelProcessing:
 
         result = frame.apply(mutating_scale, output_shape_func=lambda shape: shape, config={"gain": 2.0})
 
-        np.testing.assert_array_equal(result.compute(), self.data * 2.0)
-        np.testing.assert_array_equal(result.compute(), self.data * 2.0)
+        np.testing.assert_array_equal(channel_first_values(result), self.data * 2.0)
+        np.testing.assert_array_equal(channel_first_values(result), self.data * 2.0)
         assert result.operation_history[-1]["params"] == {"config": {"gain": 2.0}}
 
     def test_compute_scalar_metric_uses_direct_operation_kernel(self) -> None:
@@ -299,7 +300,7 @@ class TestChannelProcessing:
         result = frame.apply(needs_sr, output_shape_func=lambda shape: shape, sr=self.sample_rate)
 
         # Verify it computed correctly
-        computed = result.compute()
+        computed = channel_first_values(result)
         expected = self.data * (self.sample_rate / 1000.0)
         # map_blocks scalar multiply — decimal=6 default (exact match)
         np.testing.assert_array_almost_equal(computed, expected)
@@ -366,7 +367,7 @@ class TestChannelProcessing:
         ]
         assert result.shape == (2, self.data.shape[1] // 2 + 1)
 
-        computed = result.compute()
+        computed = channel_first_values(result)
         expected = np.fft.rfft(self.data, axis=-1)
         # Same np.fft.rfft algorithm — default rtol=1e-7 (exact match)
         np.testing.assert_allclose(computed, expected)
@@ -477,7 +478,7 @@ class TestChannelProcessing:
 
         with mock.patch("wandas.processing.create_operation", side_effect=record_create_operation):
             result = frame.sound_level(dB=True)
-            computed = result.compute()
+            computed = channel_first_values(result)
 
         assert len(recorded_calls) == 1
         assert recorded_calls[0]["name"] == "sound_level"
@@ -529,7 +530,7 @@ class TestChannelProcessing:
 
         # Test correctness of computation result
         sum_cf = self.channel_frame.sum()
-        sum_data = sum_cf.compute()
+        sum_data = channel_first_values(sum_cf)
         expected_sum = self.data.sum(axis=-2, keepdims=True)
         # Direct numpy sum — decimal=6 default (exact match)
         np.testing.assert_array_almost_equal(sum_data, expected_sum)
@@ -556,7 +557,7 @@ class TestChannelProcessing:
 
         # Compute and check results
         mean_cf = self.channel_frame.mean()
-        mean_data = mean_cf.compute()
+        mean_data = channel_first_values(mean_cf)
         expected_mean = self.data.mean(axis=-2, keepdims=True)
         # Direct numpy mean — decimal=6 default (exact match)
         np.testing.assert_array_almost_equal(mean_data, expected_mean)
@@ -597,14 +598,14 @@ class TestChannelProcessing:
 
         # Test correctness of computation result
         diff_cf = self.channel_frame.channel_difference(other_channel=0)
-        computed = diff_cf.compute()
+        computed = channel_first_values(diff_cf)
         expected = self.data - self.data[0:1]
         # Element-wise subtraction — decimal=6 default (exact match)
         np.testing.assert_array_almost_equal(computed, expected)
 
         # Test that channel_difference with other_channel=0 works correctly
         diff_cf = self.channel_frame.channel_difference(other_channel="ch0")
-        computed = diff_cf.compute()
+        computed = channel_first_values(diff_cf)
         expected = self.data - self.data[0:1]
         # Element-wise subtraction — decimal=6 default (exact match)
         np.testing.assert_array_almost_equal(computed, expected)
@@ -671,8 +672,8 @@ class TestChannelProcessing:
             "version": 1,
             "params": {"start": 0.2, "end": 0.5},
         }
-        np.testing.assert_array_equal(trimmed_frame.compute(), data[:, 2:5])
-        np.testing.assert_array_equal(frame.compute(), data)
+        np.testing.assert_array_equal(channel_first_values(trimmed_frame), data[:, 2:5])
+        np.testing.assert_array_equal(channel_first_values(frame), data)
 
     def test_hpss_operations(self) -> None:
         """Test HPSS (Harmonic-Percussive Source Separation) methods."""
@@ -742,7 +743,7 @@ class TestChannelProcessing:
         assert len(result.operation_history) > len(signal_cf.operation_history)
 
         # 実際の計算をトリガー
-        computed = result.compute()
+        computed = channel_first_values(result)
 
         # SNRを考慮した加算の結果を確認
         # 実際の結果はSNRの具体的な実装によって異なりますが、型と形状は確認可能
@@ -752,7 +753,7 @@ class TestChannelProcessing:
         # 負のSNR値もテスト
         # 値が適用されることを確認する
         neg_result = signal_cf.mix(noise_cf, snr_db=-10.0)
-        neg_computed = neg_result.compute()
+        neg_computed = channel_first_values(neg_result)
         assert isinstance(neg_computed, np.ndarray)
         assert neg_computed.shape == (2, 16000)
 
@@ -806,7 +807,7 @@ class TestChannelProcessing:
         result = signal.mix(noise, snr_db=6.0)
 
         assert result.n_channels == 2
-        assert result.compute().shape == signal_data.shape
+        assert channel_first_values(result).shape == signal_data.shape
 
     def test_mix_preserves_subclass_and_lineage(self) -> None:
         class LegacyChannelFrame(ChannelFrame):
@@ -865,7 +866,7 @@ class TestChannelProcessing:
         }
         assert result.lineage is not None
         assert result.lineage.inputs[1] is None
-        computed = result.compute()
+        computed = channel_first_values(result)
         added_noise = computed - signal_data
         added_noise_rms = calculate_rms(added_noise)
 
@@ -887,12 +888,12 @@ class TestChannelProcessing:
         noise_branch = noise_cf.low_pass_filter(cutoff=1200)
         result = signal.mix(noise_branch, snr_db=6.0)
 
-        clean_input = signal.compute()
-        noise_input = noise_branch.compute()
+        clean_input = channel_first_values(signal)
+        noise_input = channel_first_values(noise_branch)
         desired_noise_rms = calculate_rms(clean_input) / (10 ** (6.0 / 20))
         expected = clean_input + noise_input * (desired_noise_rms / calculate_rms(noise_input))
 
-        np.testing.assert_allclose(result.compute(), expected)
+        np.testing.assert_allclose(channel_first_values(result), expected)
         assert result.operation_history[-1] == {
             "operation": "wandas.audio.mix",
             "version": 1,
@@ -945,7 +946,7 @@ class TestChannelProcessing:
         assert isinstance(result, ChannelFrame)
         assert result.n_samples == signal_cf.n_samples
 
-        computed = result.compute()
+        computed = channel_first_values(result)
         added_noise = computed - signal_data
         added_noise_rms = calculate_rms(added_noise)
 
@@ -973,7 +974,7 @@ class TestChannelProcessing:
 
         # 短いフレームを標準フレームに加算（パディングが必要）
         result_short = self.channel_frame.mix(short_cf, align="pad")
-        computed_short = result_short.compute()
+        computed_short = channel_first_values(result_short)
 
         # 結果の形状が元のフレームと同じであることを確認
         assert computed_short.shape == self.data.shape
@@ -986,7 +987,7 @@ class TestChannelProcessing:
 
         # 長いフレームを標準フレームに加算（切り詰めが必要）
         result_long = self.channel_frame.mix(long_cf, align="truncate")
-        computed_long = result_long.compute()
+        computed_long = channel_first_values(result_long)
 
         # 結果の形状が元のフレームと同じであることを確認
         assert computed_long.shape == self.data.shape
@@ -1296,7 +1297,7 @@ class TestRoughnessOperations:
         assert result.lineage.operation.operation_id == "wandas.audio.roughness_dw_spec"
 
         # Compare with MoSQITo direct calculation
-        computed_data = result.compute()
+        computed_data = channel_first_values(result)
         _, r_spec_direct, _, _ = roughness_dw_mosqito(self.data[0], self.sample_rate, overlap=0.5)
         np.testing.assert_array_equal(
             computed_data,

--- a/tests/frames/test_channel_transform.py
+++ b/tests/frames/test_channel_transform.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 from dask.array.core import Array as DaArray
 
+from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
 from wandas.frames.noct import NOctFrame
 from wandas.frames.spectral import SpectralFrame
@@ -385,7 +386,7 @@ class TestChannelTransform:
         assert csd_frame.lineage.operation.operation_id == "wandas.audio.csd"
 
         # 実際のデータを取得するために計算
-        csd_data = csd_frame.compute()
+        csd_data = channel_first_values(csd_frame)
 
         # 形状を確認
         assert csd_data.shape == (4, n_fft // 2 + 1)
@@ -518,7 +519,7 @@ class TestChannelTransform:
         tf_frame = cf.transfer_function(n_fft=n_fft, win_length=win_length, hop_length=hop_length, window="hamming")
 
         # 実際のデータを取得するために計算
-        tf_data = tf_frame.compute()
+        tf_data = channel_first_values(tf_frame)
 
         # 形状を確認
         assert tf_data.shape == (4, n_fft // 2 + 1)
@@ -583,7 +584,7 @@ class TestChannelTransform:
         assert coherence_frame.lineage.operation.operation_id == "wandas.audio.coherence"
 
         # 実際のデータを取得するために計算
-        coherence_data = coherence_frame.compute()
+        coherence_data = channel_first_values(coherence_frame)
 
         # 形状を確認
         assert coherence_data.shape == (4, n_fft // 2 + 1)

--- a/tests/frames/test_roughness_frame.py
+++ b/tests/frames/test_roughness_frame.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 from dask.array.core import Array as DaArray
 
+from tests.frame_helpers import channel_first_values
 from wandas.frames.roughness import RoughnessFrame
 from wandas.processing.semantic import source_lineage
 
@@ -115,8 +116,8 @@ class TestRoughnessFrame:
         assert isinstance(result._data, DaArray)
         assert result.lineage is not None
         assert result.lineage.operation.operation_id == "wandas.operator.reverse_add"
-        np.testing.assert_allclose(result.compute(), 2.0 + frame.compute())
-        np.testing.assert_allclose(numpy_scalar_result.compute(), 2.0 + frame.compute())
+        np.testing.assert_allclose(channel_first_values(result), 2.0 + channel_first_values(frame))
+        np.testing.assert_allclose(channel_first_values(numpy_scalar_result), 2.0 + channel_first_values(frame))
 
     def test_initialization_validates_dimensions(self) -> None:
         """Test that initialization validates data dimensions."""

--- a/tests/io/test_canonical_float64_read.py
+++ b/tests/io/test_canonical_float64_read.py
@@ -10,6 +10,7 @@ import soundfile as sf
 from scipy.io import wavfile
 
 import wandas as wd
+from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
 
 
@@ -23,8 +24,8 @@ def test_wav_integer_subtypes_match_soundfile_full_scale(tmp_path: Path, subtype
     frame = wd.read(path)
 
     assert frame._data.dtype == np.dtype("float64")
-    assert frame.compute().dtype == np.dtype("float64")
-    np.testing.assert_array_equal(frame.compute(), expected.T)
+    assert channel_first_values(frame).dtype == np.dtype("float64")
+    np.testing.assert_array_equal(channel_first_values(frame), expected.T)
 
 
 @pytest.mark.parametrize("subtype", ["FLOAT", "DOUBLE"])
@@ -36,25 +37,25 @@ def test_wav_float_subtypes_preserve_values_above_full_scale(tmp_path: Path, sub
 
     frame = wd.read(path)
 
-    np.testing.assert_array_equal(frame.compute(), encoded.T)
-    assert frame.compute().dtype == np.dtype("float64")
+    np.testing.assert_array_equal(channel_first_values(frame), encoded.T)
+    assert channel_first_values(frame).dtype == np.dtype("float64")
 
 
 def test_pcm_u8_is_zero_centered(tmp_path: Path) -> None:
     path = tmp_path / "unsigned.wav"
     wavfile.write(path, 8_000, np.array([0, 128, 255], dtype=np.uint8))
 
-    np.testing.assert_array_equal(wd.read(path).compute(), [[-1.0, 0.0, 127.0 / 128.0]])
+    np.testing.assert_array_equal(channel_first_values(wd.read(path)), [[-1.0, 0.0, 127.0 / 128.0]])
 
 
 def test_same_audio_content_matches_across_path_and_memory_transports(tmp_path: Path) -> None:
     path = tmp_path / "transport.wav"
     sf.write(path, np.array([[-0.5], [0.0], [0.5]]), 8_000, subtype="PCM_16")
     content = path.read_bytes()
-    expected = wd.read(path).compute()
+    expected = channel_first_values(wd.read(path))
 
     for source in (content, bytearray(content), memoryview(content), io.BytesIO(content)):
-        np.testing.assert_array_equal(wd.read(source, file_type=".wav").compute(), expected)
+        np.testing.assert_array_equal(channel_first_values(wd.read(source, file_type=".wav")), expected)
 
 
 def test_csv_preserves_numeric_values_as_float64_and_rejects_text(tmp_path: Path) -> None:
@@ -63,12 +64,12 @@ def test_csv_preserves_numeric_values_as_float64_and_rejects_text(tmp_path: Path
     frame = wd.read(valid)
 
     assert frame._data.dtype == np.dtype("float64")
-    np.testing.assert_array_equal(frame.compute(), [[1.0, 2.0], [1.25, -3.5]])
+    np.testing.assert_array_equal(channel_first_values(frame), [[1.0, 2.0], [1.25, -3.5]])
 
     invalid = tmp_path / "invalid.csv"
     pd.DataFrame({"time": [0.0, 0.5], "sensor": ["ok", "bad"]}).to_csv(invalid, index=False)
     with pytest.raises(ValueError, match="CSV data channels must be numeric"):
-        wd.read(invalid).compute()
+        channel_first_values(wd.read(invalid))
 
 
 def test_read_time_normalize_argument_is_removed(tmp_path: Path) -> None:

--- a/tests/io/test_wav_io.py
+++ b/tests/io/test_wav_io.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 from scipy.io import wavfile
 
+from tests.frame_helpers import channel_first_values
 from tests.io_helpers import mock_urlopen_stream
 from wandas.frames.channel import ChannelFrame
 from wandas.io import readers as io_readers
@@ -43,20 +44,20 @@ def test_wav_float_roundtrip(known_signal_frame, tmp_path) -> None:
     """
     wav_path = tmp_path / "float_roundtrip.wav"
     # Capture original data before write to verify immutability (Pillar 1)
-    original_data = known_signal_frame.compute().copy()
+    original_data = channel_first_values(known_signal_frame).copy()
     known_signal_frame.to_wav(str(wav_path))
 
     # Verify original frame is unchanged after write (Pillar 1: side-effect free)
     np.testing.assert_array_equal(
-        known_signal_frame.compute(), original_data, err_msg="to_wav must not mutate original frame data"
+        channel_first_values(known_signal_frame), original_data, err_msg="to_wav must not mutate original frame data"
     )
 
     loaded = ChannelFrame.read_wav(str(wav_path))
 
     assert loaded.sampling_rate == known_signal_frame.sampling_rate
     assert loaded.n_channels == known_signal_frame.n_channels
-    encoded = known_signal_frame.compute().astype(np.float32).astype(np.float64)
-    np.testing.assert_array_equal(loaded.compute(), encoded, err_msg="Float WAV round-trip data mismatch")
+    encoded = channel_first_values(known_signal_frame).astype(np.float32).astype(np.float64)
+    np.testing.assert_array_equal(channel_first_values(loaded), encoded, err_msg="Float WAV round-trip data mismatch")
 
 
 def test_read_wav_stereo_dc_signal(tmp_path) -> None:
@@ -80,7 +81,7 @@ def test_read_wav_stereo_dc_signal(tmp_path) -> None:
     assert cf.sampling_rate == sr
     # Verify Dask lazy loading (Pillar 1)
     assert isinstance(cf._data, dask.array.core.Array), "WAV load must produce Dask array"
-    computed = cf.compute()
+    computed = channel_first_values(cf)
     # DC signal values must be preserved exactly through float64 WAV round-trip
     np.testing.assert_array_equal(computed[0], data_left, err_msg="Left channel DC level mismatch")
     np.testing.assert_array_equal(computed[1], data_right, err_msg="Right channel DC level mismatch")
@@ -134,7 +135,7 @@ def test_read_wav_bytes_dc_signal() -> None:
 
     assert cf.sampling_rate == sr, f"SR mismatch: {cf.sampling_rate}"
     assert len(cf) == 2, f"Expected 2 channels, got {len(cf)}"
-    computed = cf.compute()
+    computed = channel_first_values(cf)
     np.testing.assert_array_equal(computed[0], data_left)
     np.testing.assert_array_equal(computed[1], data_right)
 
@@ -164,7 +165,7 @@ def test_read_wav_from_url_via_requests_mock() -> None:
     mock_get.assert_called_once_with(url)
     assert len(cf) == 2, f"Expected 2 channels, got {len(cf)}"
     assert cf.sampling_rate == sr, f"SR mismatch: {cf.sampling_rate}"
-    computed = cf.compute()
+    computed = channel_first_values(cf)
     np.testing.assert_array_equal(computed[0], data_left)
     np.testing.assert_array_equal(computed[1], data_right)
 
@@ -190,7 +191,7 @@ def test_from_file_url_wav() -> None:
     assert len(cf) == 2, f"Expected 2 channels, got {len(cf)}"
     # Verify Dask lazy loading from URL path (Pillar 1)
     assert isinstance(cf._data, dask.array.core.Array), "URL load must produce Dask array"
-    computed = cf.compute()
+    computed = channel_first_values(cf)
     np.testing.assert_array_equal(computed[0], data_left)
     np.testing.assert_array_equal(computed[1], data_right)
     # Provenance metadata (Pillar 2)
@@ -214,7 +215,7 @@ def test_from_file_url_wav_streams_in_chunks() -> None:
         cf = ChannelFrame.from_file(url)
 
     assert cf.sampling_rate == sr
-    np.testing.assert_array_equal(cf.compute()[0], mono_data)
+    np.testing.assert_array_equal(channel_first_values(cf)[0], mono_data)
 
 
 def test_download_read_is_capped_by_remaining_budget() -> None:
@@ -245,7 +246,7 @@ def test_from_file_url_pcm_wav_preserves_normalized_samples() -> None:
         cf = ChannelFrame.from_file(url)
 
     expected = pcm_data.astype(np.float64) / 32768.0
-    np.testing.assert_array_equal(cf.compute()[0], expected)
+    np.testing.assert_array_equal(channel_first_values(cf)[0], expected)
 
 
 def test_from_file_url_http_scheme() -> None:
@@ -503,7 +504,7 @@ def test_read_wav_stream_nonseekable() -> None:
 
     assert cf.sampling_rate == sr, f"SR mismatch: {cf.sampling_rate}"
     assert len(cf) == 2, f"Expected 2 channels, got {len(cf)}"
-    computed = cf.compute()
+    computed = channel_first_values(cf)
     np.testing.assert_array_equal(computed[0], data_left)
     np.testing.assert_array_equal(computed[1], data_right)
 
@@ -519,7 +520,7 @@ def test_read_wav_int16_pcm_is_full_scale_float64(tmp_path) -> None:
     wavfile.write(str(filepath), sr, stereo_data)
 
     cf = ChannelFrame.read_wav(str(filepath))
-    computed = cf.compute()
+    computed = channel_first_values(cf)
 
     np.testing.assert_array_equal(computed[0], 0.5)
     np.testing.assert_array_equal(computed[1], -0.5)
@@ -557,7 +558,7 @@ def test_write_wav_roundtrip_preserves_shape_and_sr(tmp_path) -> None:
     # Verify Dask lazy loading (Pillar 1)
     assert isinstance(loaded._data, dask.array.core.Array), "WAV load must produce Dask array"
 
-    computed = loaded.compute()
+    computed = channel_first_values(loaded)
     np.testing.assert_array_equal(computed, wav_data.T)
 
 

--- a/tests/io/test_wdf_io.py
+++ b/tests/io/test_wdf_io.py
@@ -14,6 +14,7 @@ import pytest
 import xarray as xr
 
 import wandas as wd
+from tests.frame_helpers import channel_first_values
 from wandas.core.base_frame import BaseFrame
 from wandas.frames.cepstral import CepstralFrame
 from wandas.frames.cepstrogram import CepstrogramFrame
@@ -79,7 +80,7 @@ def test_wdf_roundtrips_all_exact_builtin_types(frame: BaseFrame[Any], tmp_path:
     assert loaded._data.dtype == frame._data.dtype
     assert loaded._data.ndim == frame._data.ndim
     assert loaded._xr.dims == frame._xr.dims
-    np.testing.assert_array_equal(loaded.compute(), frame.compute())
+    np.testing.assert_array_equal(channel_first_values(loaded), channel_first_values(frame))
     assert loaded.sampling_rate == frame.sampling_rate
     assert loaded.label == frame.label
     assert loaded.metadata == frame.metadata
@@ -160,7 +161,7 @@ def test_wdf_roundtrips_real_analysis_tensors(factory: Callable[[], BaseFrame[An
     loaded = wd.load(path)
     assert type(loaded) is type(frame)
     assert np.issubdtype(loaded._data.dtype, np.floating)
-    np.testing.assert_allclose(loaded.compute(), frame.compute())
+    np.testing.assert_allclose(channel_first_values(loaded), channel_first_values(frame))
 
 
 @pytest.mark.parametrize("reverse", [False, True])
@@ -171,7 +172,7 @@ def test_wdf_roundtrips_sliced_dimension_coordinate(reverse: bool, tmp_path: Pat
     frame.save(path)
     loaded = cast(CepstralFrame, wd.load(path))
     np.testing.assert_array_equal(loaded.quefrencies, frame.quefrencies)
-    np.testing.assert_array_equal(loaded.compute(), frame.compute())
+    np.testing.assert_array_equal(channel_first_values(loaded), channel_first_values(frame))
 
 
 @pytest.mark.parametrize("frame_type", [NOctFrame, RoughnessFrame])
@@ -189,7 +190,7 @@ def test_wdf_roundtrips_supported_three_dimensional_domain_frames(
     loaded = wd.load(path)
     assert type(loaded) is frame_type
     assert loaded._xr.dims == frame._xr.dims
-    np.testing.assert_array_equal(loaded.compute(), frame.compute())
+    np.testing.assert_array_equal(channel_first_values(loaded), channel_first_values(frame))
 
 
 def test_save_does_not_call_frame_data_compute(tmp_path: Path) -> None:

--- a/tests/pipeline/test_recipe_behavior_parity.py
+++ b/tests/pipeline/test_recipe_behavior_parity.py
@@ -8,6 +8,7 @@ import dask.array as da
 import numpy as np
 import pytest
 
+from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
 from wandas.pipeline import RecipePlan
 
@@ -28,7 +29,7 @@ def _assert_replay(source: ChannelFrame, processed: Any) -> Any:
     assert replayed.shape == processed.shape
     assert replayed.sampling_rate == processed.sampling_rate
     assert replayed.labels == processed.labels
-    np.testing.assert_allclose(replayed.compute(), processed.compute())
+    np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(processed))
     np.testing.assert_allclose(replayed.source_time_offset, processed.source_time_offset)
     return replayed
 
@@ -211,7 +212,7 @@ def test_processed_parent_add_channel_external_dask_stays_lazy() -> None:
 
     assert isinstance(replayed._data, da.Array)
     assert [node.operation for node in plan.nodes] == ["wandas.audio.normalize", "wandas.channel.add_channel"]
-    np.testing.assert_allclose(replayed.compute(), processed.compute())
+    np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(processed))
 
 
 @pytest.mark.parametrize("method", ["coherence", "csd", "transfer_function"])
@@ -222,4 +223,4 @@ def test_cross_channel_typed_transitions_replay(method: str) -> None:
     replayed = RecipePlan.from_frame(processed, input_names=("signal",)).apply({"signal": base})
 
     assert type(replayed) is type(processed)
-    np.testing.assert_allclose(replayed.compute(), processed.compute())
+    np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(processed))

--- a/tests/pipeline/test_recipe_cepstral.py
+++ b/tests/pipeline/test_recipe_cepstral.py
@@ -6,6 +6,7 @@ import dask.array as da
 import numpy as np
 from dask.array.core import Array as DaArray
 
+from tests.frame_helpers import channel_first_values
 from tests.pipeline.recipe_test_helpers import RECIPE_SAMPLE_RATE, make_recipe_source
 from wandas.frames.cepstral import CepstralFrame
 from wandas.frames.spectral import SpectralFrame
@@ -42,7 +43,7 @@ def test_cepstral_workflow_extracts_serializes_loads_and_applies_without_compute
     assert replayed.n_fft == 32
     assert replayed.metadata == replay_source.metadata
     np.testing.assert_array_equal(replayed.source_time_offset, replay_source.source_time_offset)
-    np.testing.assert_allclose(replayed.compute(), expected.compute(), rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(expected), rtol=1e-12, atol=1e-12)
     assert [entry["operation"] for entry in replayed.operation_history] == [
         "wandas.audio.cepstrum",
         "wandas.cepstral.lifter",

--- a/tests/pipeline/test_recipe_cepstrogram.py
+++ b/tests/pipeline/test_recipe_cepstrogram.py
@@ -6,6 +6,7 @@ import dask.array as da
 import numpy as np
 from dask.array.core import Array as DaArray
 
+from tests.frame_helpers import channel_first_values
 from tests.pipeline.recipe_test_helpers import RECIPE_SAMPLE_RATE, make_recipe_source
 from wandas.frames.cepstrogram import CepstrogramFrame
 from wandas.frames.channel import ChannelFrame
@@ -39,7 +40,7 @@ def test_cepstrogram_workflow_serializes_and_replays_without_compute() -> None:
     assert isinstance(replayed._data, da.Array)
     assert replayed.metadata == replay_source.metadata
     np.testing.assert_array_equal(replayed.source_time_offset, replay_source.source_time_offset)
-    np.testing.assert_allclose(replayed.compute(), expected.compute(), rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(expected), rtol=1e-12, atol=1e-12)
     assert [entry["operation"] for entry in replayed.operation_history[-3:]] == [
         "wandas.spectrogram.cepstrum",
         "wandas.cepstrogram.lifter",

--- a/tests/pipeline/test_recipe_compiler.py
+++ b/tests/pipeline/test_recipe_compiler.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 from dask.array.core import Array as DaArray
 
+from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
 from wandas.frames.mixins.channel_processing_mixin import _capture_runtime_apply, _reject_runtime_apply_recipe
 from wandas.pipeline import RecipeExtractionError, RecipeOperation, RecipePlan, RecipeRegistry
@@ -43,7 +44,7 @@ def test_compiler_preserves_independent_frame_input_order() -> None:
 
     assert [item["name"] for item in plan.to_dict()["inputs"]] == ["left", "right"]
     replayed = plan.apply({"left": left, "right": right})
-    np.testing.assert_allclose(replayed.compute(), -1.0)
+    np.testing.assert_allclose(channel_first_values(replayed), -1.0)
 
 
 @pytest.mark.parametrize(
@@ -92,7 +93,7 @@ def test_runtime_only_apply_preserves_portable_history_beside_opaque_param() -> 
         "callback": {"recipe_portable": False},
         "gain": 2.0,
     }
-    np.testing.assert_allclose(processed.compute(), 2.0)
+    np.testing.assert_allclose(channel_first_values(processed), 2.0)
     with pytest.raises(RecipeExtractionError, match="runtime-only"):
         RecipePlan.from_frame(processed)
 

--- a/tests/pipeline/test_recipe_execution.py
+++ b/tests/pipeline/test_recipe_execution.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 from dask.array.core import Array as DaArray
 
+from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
 from wandas.pipeline import (
     RecipeExecutionError,
@@ -42,7 +43,7 @@ def test_fft_ifft_typed_transition_chain_replays() -> None:
     replayed = RecipePlan.from_dict(plan.to_dict()).apply({"signal": source})
 
     assert [node.operation for node in plan.nodes] == ["wandas.audio.fft", "wandas.spectral.ifft"]
-    np.testing.assert_allclose(replayed.compute(), processed.compute())
+    np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(processed))
 
 
 def test_typed_transition_after_true_frame_merge_replays() -> None:
@@ -51,7 +52,7 @@ def test_typed_transition_after_true_frame_merge_replays() -> None:
     processed = (left + right).fft(n_fft=16)
     replayed = RecipePlan.from_frame(processed, input_names=("left", "right")).apply({"left": left, "right": right})
 
-    np.testing.assert_allclose(replayed.compute(), processed.compute())
+    np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(processed))
 
 
 def test_external_numpy_and_dask_inputs_remain_lazy_until_user_compute() -> None:
@@ -88,7 +89,7 @@ def test_scalar_operator_roundtrip_preserves_operand_order(operation: Any, opera
     replayed = RecipePlan.from_dict(plan.to_dict()).apply({"signal": source})
 
     assert plan.nodes[-1].operation == operation_id
-    np.testing.assert_allclose(replayed.compute(), expected.compute())
+    np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(expected))
 
 
 @pytest.mark.parametrize("array_operation", [operator.sub, operator.mul, operator.truediv, operator.pow])
@@ -102,7 +103,7 @@ def test_nonadditive_external_array_roundtrip_stays_lazy(array_operation: Any) -
         replayed = RecipePlan.from_dict(plan.to_dict()).apply({"signal": source, "operand": operand})
 
         assert isinstance(replayed._data, DaArray)
-        np.testing.assert_allclose(replayed.compute(), expected.compute())
+        np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(expected))
 
 
 def test_mix_replays_true_multi_frame_operation_in_role_order() -> None:
@@ -113,7 +114,7 @@ def test_mix_replays_true_multi_frame_operation_in_role_order() -> None:
     replayed = plan.apply({"signal": signal, "noise": noise})
 
     assert plan.to_dict()["nodes"][-1]["operation"] == "wandas.audio.mix"
-    np.testing.assert_allclose(replayed.compute(), processed.compute(), rtol=1e-12, atol=0.0)
+    np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(processed), rtol=1e-12, atol=0.0)
 
 
 def test_executor_rejects_array_input_of_wrong_runtime_kind() -> None:

--- a/tests/pipeline/test_recipe_extensions.py
+++ b/tests/pipeline/test_recipe_extensions.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 
 import numpy as np
 
+from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
 from wandas.pipeline import (
     OperationCapture,
@@ -129,7 +130,7 @@ def test_unary_audio_operation_extension_runs_complete_public_path() -> None:
     replayed = _roundtrip(source.test_gain(3.0), {"signal": source})
 
     assert type(replayed) is ExtensionChannelFrame
-    np.testing.assert_allclose(replayed.compute(), 6.0)
+    np.testing.assert_allclose(channel_first_values(replayed), 6.0)
 
 
 def test_typed_frame_transition_extension_runs_complete_public_path() -> None:
@@ -137,7 +138,7 @@ def test_typed_frame_transition_extension_runs_complete_public_path() -> None:
     replayed = _roundtrip(source.to_typed(scale=4.0), {"signal": source})
 
     assert type(replayed) is TypedChannelFrame
-    np.testing.assert_allclose(replayed.compute(), 8.0)
+    np.testing.assert_allclose(channel_first_values(replayed), 8.0)
 
 
 def test_default_capture_uses_declared_unary_frame_role() -> None:
@@ -147,7 +148,7 @@ def test_default_capture_uses_declared_unary_frame_role() -> None:
 
     assert processed.lineage.operation is not None
     assert processed.lineage.operation.bindings == (InputBinding("signal", "frame"),)
-    np.testing.assert_allclose(replayed.compute(), source.compute())
+    np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(source))
 
 
 def test_true_multi_frame_extension_preserves_binding_order_end_to_end() -> None:
@@ -156,7 +157,7 @@ def test_true_multi_frame_extension_preserves_binding_order_end_to_end() -> None
     replayed = _roundtrip(left.difference(right, scale=2.0), {"left": left, "right": right})
 
     assert type(replayed) is ExtensionChannelFrame
-    np.testing.assert_allclose(replayed.compute(), 6.0)
+    np.testing.assert_allclose(channel_first_values(replayed), 6.0)
 
 
 def test_extension_registry_does_not_mutate_default_registry() -> None:
@@ -210,7 +211,7 @@ def test_parameter_validator_runs_once_per_public_plan_phase() -> None:
 
     replayed = loaded.apply({"signal": source}, registry=registry)
     assert calls == [{"gain": 3.0}, {"gain": 3.0}, {"gain": 3.0}]
-    np.testing.assert_allclose(replayed.compute(), 6.0)
+    np.testing.assert_allclose(channel_first_values(replayed), 6.0)
 
 
 def test_falsy_extension_hooks_are_not_discarded() -> None:
@@ -276,4 +277,4 @@ def test_falsy_extension_hooks_are_not_discarded() -> None:
     assert calls.count("capture") == 1
     assert calls.count("handler") == 1
     assert calls.count("validate") == 2
-    np.testing.assert_allclose(replayed.compute(), 6.0)
+    np.testing.assert_allclose(channel_first_values(replayed), 6.0)

--- a/tests/pipeline/test_recipe_review_regressions.py
+++ b/tests/pipeline/test_recipe_review_regressions.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 from dask.array.core import Array as DaArray
 
+from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
 from wandas.pipeline import RecipeExecutionError, RecipePlan
 
@@ -94,7 +95,7 @@ def test_multidimensional_index_roundtrip_preserves_data_metadata_and_offset() -
     plan = RecipePlan.from_frame(selected, input_names=("signal",))
     replayed = plan.apply({"signal": source})
 
-    np.testing.assert_allclose(replayed.compute(), selected.compute())
+    np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(selected))
     assert replayed.metadata == selected.metadata
     assert replayed.labels == selected.labels
     np.testing.assert_allclose(replayed.source_time_offset, selected.source_time_offset)
@@ -200,16 +201,6 @@ def test_public_call_extraction_and_apply_do_not_compute() -> None:
     assert isinstance(replayed._data, DaArray)
 
 
-def test_persist_keeps_one_lineage_authority_and_history() -> None:
-    processed = _frame().normalize().remove_dc()
-    expected = processed.operation_history
-
-    persisted = processed.persist()
-
-    assert persisted.lineage is processed.lineage
-    assert persisted.operation_history == expected
-
-
 def test_operation_history_returns_a_defensive_projection() -> None:
     processed = _frame().normalize(norm=2.0)
     returned = processed.operation_history
@@ -232,4 +223,4 @@ def test_all_index_forms_roundtrip_through_schema_2() -> None:
         expected = select(source)
         plan = RecipePlan.from_frame(expected, input_names=("signal",))
         replayed = RecipePlan.from_dict(plan.to_dict()).apply({"signal": source})
-        np.testing.assert_allclose(replayed.compute(), expected.compute())
+        np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(expected))

--- a/tests/pipeline/test_recipe_v2_characterization.py
+++ b/tests/pipeline/test_recipe_v2_characterization.py
@@ -7,6 +7,7 @@ import dask.array as da
 import numpy as np
 import pytest
 
+from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
 from wandas.pipeline import RecipePlan, recipe_definition
 
@@ -37,7 +38,7 @@ def test_mix_ignores_source_time_offsets_and_preserves_left_contract() -> None:
 
     mixed = left.mix(right)
 
-    np.testing.assert_allclose(mixed.compute(), 3.0)
+    np.testing.assert_allclose(channel_first_values(mixed), 3.0)
     np.testing.assert_allclose(mixed.source_time_offset, left.source_time_offset)
     assert mixed.metadata == left.metadata
     assert mixed.labels == left.labels
@@ -46,7 +47,7 @@ def test_mix_ignores_source_time_offsets_and_preserves_left_contract() -> None:
 def test_mix_mono_other_broadcasts_across_left_channels() -> None:
     mixed = _frame(1.0).mix(_frame(2.0, channels=1))
 
-    np.testing.assert_allclose(mixed.compute(), 3.0)
+    np.testing.assert_allclose(channel_first_values(mixed), 3.0)
     assert mixed.n_channels == 2
 
 
@@ -60,7 +61,7 @@ def test_mix_mono_other_broadcasts_across_left_channels() -> None:
 def test_mix_alignment_is_directional(align: str, other_samples: int, expected_tail: float) -> None:
     mixed = _frame(1.0).mix(_frame(2.0, samples=other_samples), align=align)
 
-    np.testing.assert_allclose(mixed.compute()[:, -1], expected_tail)
+    np.testing.assert_allclose(channel_first_values(mixed)[:, -1], expected_tail)
 
 
 @pytest.mark.parametrize(
@@ -93,7 +94,7 @@ def test_mix_array_input_roundtrips_as_external_array() -> None:
     replayed = plan.apply({"base": source, "other": other})
 
     assert [item["kind"] for item in plan.to_dict()["inputs"]] == ["frame", "array"]
-    np.testing.assert_allclose(replayed.compute(), 3.0)
+    np.testing.assert_allclose(channel_first_values(replayed), 3.0)
 
 
 def test_mix_with_silent_noise_is_finite_and_leaves_signal_unchanged() -> None:
@@ -103,9 +104,9 @@ def test_mix_with_silent_noise_is_finite_and_leaves_signal_unchanged() -> None:
     plan = RecipePlan.from_frame(processed, input_names=("signal", "noise"))
     replayed = RecipePlan.from_dict(plan.to_dict()).apply({"signal": source, "noise": silent_noise})
 
-    result = replayed.compute()
+    result = channel_first_values(replayed)
     assert np.isfinite(result).all()
-    np.testing.assert_allclose(result, source.compute())
+    np.testing.assert_allclose(result, channel_first_values(source))
 
 
 def test_binary_frame_operation_requires_exact_rate_shape_and_semantic_axes() -> None:

--- a/tests/pipeline/test_sklearn_adapter.py
+++ b/tests/pipeline/test_sklearn_adapter.py
@@ -8,6 +8,7 @@ from dask.array.core import Array as DaArray
 sklearn_pipeline = pytest.importorskip("sklearn.pipeline")
 Pipeline = sklearn_pipeline.Pipeline
 
+from tests.frame_helpers import channel_first_values  # noqa: E402
 from wandas.frames.channel import ChannelFrame  # noqa: E402
 from wandas.pipeline import RecipePlan  # noqa: E402
 from wandas.pipeline.sklearn import (  # noqa: E402
@@ -111,7 +112,7 @@ def test_named_transformer_uses_declared_public_recipe_operation() -> None:
     replayed = plan.apply({"signal": source})
 
     assert type(replayed) is ChannelFrame
-    np.testing.assert_allclose(replayed.compute(), result.compute())
+    np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(result))
 
 
 def test_generic_transformer_dispatches_declared_public_recipe_operation() -> None:
@@ -121,7 +122,7 @@ def test_generic_transformer_dispatches_declared_public_recipe_operation() -> No
     replayed = plan.apply({"signal": _frame()})
 
     assert type(replayed) is type(result)
-    np.testing.assert_allclose(replayed.compute(), result.compute())
+    np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(result))
 
 
 def test_generic_transformer_rejects_non_public_operation_name() -> None:

--- a/tests/processing/test_fade_operation.py
+++ b/tests/processing/test_fade_operation.py
@@ -129,4 +129,4 @@ class TestFade:
         }
 
         expected = sp_windows.tukey(200, alpha=Fade.calculate_tukey_alpha(20, 200)).reshape(1, -1)
-        np.testing.assert_allclose(result.compute(), expected, rtol=1e-10, atol=1e-12)
+        np.testing.assert_allclose(result.data, expected.squeeze(axis=0), rtol=1e-10, atol=1e-12)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,6 +7,7 @@ import pytest
 import soundfile as sf
 
 import wandas
+from tests.frame_helpers import channel_first_values
 from wandas.frames.cepstrogram import CepstrogramFrame
 from wandas.frames.channel import ChannelFrame
 from wandas.frames.noct import NOctFrame
@@ -259,7 +260,7 @@ def test_read_loads_wav_bytes_without_file_type() -> None:
     assert isinstance(signal, ChannelFrame)
     assert signal.sampling_rate == sr
     assert signal.n_channels == 1
-    np.testing.assert_array_equal(signal.compute(), data.T)
+    np.testing.assert_array_equal(channel_first_values(signal), data.T)
 
 
 def test_read_loads_named_csv_file_like_without_file_type(tmp_path: Path) -> None:
@@ -316,7 +317,7 @@ def test_load_reads_wdf(tmp_path: Path) -> None:
     assert isinstance(loaded, ChannelFrame)
     assert loaded.sampling_rate == sr
     assert loaded.labels == ["source"]
-    np.testing.assert_allclose(loaded.compute(), source.compute())
+    np.testing.assert_allclose(channel_first_values(loaded), channel_first_values(source))
 
 
 def test_channel_frame_dataset_attr() -> None:

--- a/tests/utils/test_frame_dataset.py
+++ b/tests/utils/test_frame_dataset.py
@@ -12,6 +12,7 @@ import soundfile as sf
 from matplotlib.axes import Axes
 
 # Import classes under test
+from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
 from wandas.frames.spectrogram import SpectrogramFrame
 from wandas.utils.frame_dataset import (
@@ -546,8 +547,8 @@ class TestChannelFrameDataset:
         assert original_frame0 is not None
         # Same algorithm (data reversal), exact match expected
         np.testing.assert_allclose(
-            transformed_frame0.compute(),
-            original_frame0.compute()[:, ::-1],
+            channel_first_values(transformed_frame0),
+            channel_first_values(original_frame0)[:, ::-1],
         )
 
     def test_apply_lazy_caches_transformed_frame(self, create_test_files: Path) -> None:
@@ -594,9 +595,9 @@ class TestChannelFrameDataset:
         assert original_frame0 is not None
         assert final_frame0 is not None
 
-        expected_data = (original_frame0.compute() * 2) + 1
+        expected_data = (channel_first_values(original_frame0) * 2) + 1
         # Same algorithm (elementwise ops), exact match expected
-        np.testing.assert_allclose(final_frame0.compute(), expected_data)
+        np.testing.assert_allclose(channel_first_values(final_frame0), expected_data)
 
     def test_apply_failing_transform_returns_none_and_logs(
         self, create_test_files: Path, caplog: pytest.LogCaptureFixture
@@ -690,7 +691,7 @@ class TestChannelFrameDataset:
         assert stft_frame.shape == expected_spec.shape
         # Wrapper equivalence: same STFT algorithm, exact match within float tolerance
         np.testing.assert_allclose(
-            stft_frame.compute(), expected_spec.compute(), atol=1e-6
+            channel_first_values(stft_frame), channel_first_values(expected_spec), atol=1e-6
         )  # Windowing/overlap tolerance
 
     def test_stft_lazy_caches_result(self, create_test_files: Path) -> None:
@@ -768,7 +769,7 @@ class TestChannelFrameDataset:
         sampled_frame = sampled[0]
         assert isinstance(sampled_frame, ChannelFrame)
         assert sampled_frame.label == original_frame.label
-        np.testing.assert_array_equal(sampled_frame.compute(), original_frame.compute())
+        np.testing.assert_array_equal(channel_first_values(sampled_frame), channel_first_values(original_frame))
 
     def test_sample_apply_transform_propagates(self, create_test_files: Path) -> None:
         """Apply on sampled dataset correctly chains transforms."""
@@ -788,9 +789,9 @@ class TestChannelFrameDataset:
         assert original_frame is not None
         final_frame = transformed[0]
         assert final_frame is not None
-        expected_data = original_frame.compute() * 2
+        expected_data = channel_first_values(original_frame) * 2
         # Same algorithm (elementwise mul), exact match expected
-        np.testing.assert_allclose(final_frame.compute(), expected_data)
+        np.testing.assert_allclose(channel_first_values(final_frame), expected_data)
 
     def test_get_metadata_lazy_unloaded_state(self, create_test_files: Path) -> None:
         """Metadata reflects unloaded state for lazy dataset."""
@@ -942,7 +943,7 @@ class TestSpectrogramFrameDataset:
         assert original_spec_frame is not None
         assert transformed_spec_frame is not None
         # Verify transformation (check if data changed)
-        assert not np.allclose(original_spec_frame.compute(), transformed_spec_frame.compute())
+        assert not np.allclose(channel_first_values(original_spec_frame), channel_first_values(transformed_spec_frame))
 
     @patch("matplotlib.pyplot.show")
     def test_plot_delegates_to_frame_plot(
@@ -1067,8 +1068,8 @@ class TestSampledFrameDataset:
         assert isinstance(sampled_frame_0, ChannelFrame)
         assert sampled_frame_0.label == original_frame_0.label
         np.testing.assert_array_equal(
-            sampled_frame_0.compute(),
-            original_frame_0.compute(),
+            channel_first_values(sampled_frame_0),
+            channel_first_values(original_frame_0),
             err_msg="Sampled dataset frame does not match original",
         )
 
@@ -1099,7 +1100,7 @@ class TestSampledFrameDataset:
         assert original_frame_1 is not None
         assert isinstance(sampled_frame_1, ChannelFrame)
         assert sampled_frame_1.label == original_frame_1.label
-        np.testing.assert_array_equal(sampled_frame_1.compute(), original_frame_1.compute())
+        np.testing.assert_array_equal(channel_first_values(sampled_frame_1), channel_first_values(original_frame_1))
 
     def test_getitem_out_of_range_raises_indexerror(self, create_test_files: Path) -> None:
         """__getitem__ with out-of-range index raises IndexError."""
@@ -1161,10 +1162,10 @@ class TestSampledFrameDataset:
 
         final_frame = transformed_sampled[0]
         assert final_frame is not None
-        expected_data = original_frame.compute() * 3
+        expected_data = channel_first_values(original_frame) * 3
         # Same algorithm (elementwise mul), exact match expected
         np.testing.assert_allclose(
-            final_frame.compute(),
+            channel_first_values(final_frame),
             expected_data,
             err_msg="Data mismatch after applying transform",
         )

--- a/tests/utils/test_generate_sample.py
+++ b/tests/utils/test_generate_sample.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 
+from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
 from wandas.utils.generate_sample import generate_sin
 
@@ -21,7 +22,7 @@ class TestGenerateSin:
         assert len(signal) == 1
         assert signal.channels[0].label == "Channel 1"
 
-        computed_data = signal.compute()
+        computed_data = channel_first_values(signal)
         expected_n_samples = int(sampling_rate * duration)
         assert computed_data.shape[1] == expected_n_samples
 
@@ -32,7 +33,7 @@ class TestGenerateSin:
         duration = 1.0
         signal = generate_sin(freqs=freq, sampling_rate=sampling_rate, duration=duration)
 
-        data = signal.compute()[0]  # Single channel
+        data = channel_first_values(signal)[0]  # Single channel
         n_samples = len(data)
         spectrum = np.abs(np.fft.rfft(data))
         freqs_axis = np.fft.rfftfreq(n_samples, d=1.0 / sampling_rate)
@@ -58,7 +59,7 @@ class TestGenerateSin:
         for idx, channel in enumerate(signal.channels):
             assert channel.label == f"Channel {idx + 1}"
 
-        computed_data = signal.compute()
+        computed_data = channel_first_values(signal)
         expected_n_samples = int(sampling_rate * duration)
         assert computed_data.shape[1] == expected_n_samples
 
@@ -69,7 +70,7 @@ class TestGenerateSin:
         duration = 1.0
         signal = generate_sin(freqs=freqs, sampling_rate=sampling_rate, duration=duration)
 
-        data = signal.compute()
+        data = channel_first_values(signal)
         n_samples = data.shape[1]
         freq_resolution = sampling_rate / n_samples  # 1 Hz for 1s at 16 kHz
 

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -1338,10 +1338,13 @@ class BaseFrame(ABC, Generic[T]):
 
     def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> NDArrayReal:
         """Implicit conversion to NumPy array"""
+        if copy is False:
+            raise ValueError("A Dask-backed Frame cannot provide a zero-copy NumPy array.")
+
         result = self.data
         if dtype is not None:
-            result = result.astype(dtype, copy=copy is not False)
-        elif copy:
+            result = result.astype(dtype, copy=copy is True)
+        elif copy is True:
             result = result.copy()
         return cast(NDArrayReal, result)
 

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -1161,7 +1161,7 @@ class BaseFrame(ABC, Generic[T]):
         frame returns an array without the singleton channel axis; multichannel
         frames preserve the channel axis.
         """
-        data = self.compute()
+        data = self._compute()
         if self.n_channels == 1:
             return cast(T, data.squeeze(axis=0))
         return data
@@ -1171,11 +1171,11 @@ class BaseFrame(ABC, Generic[T]):
         """Get a list of all channel labels."""
         return [ch.label for ch in self.channels]
 
-    def compute(self) -> T:
+    def _compute(self) -> T:
         """Return calibrated values while preserving every frame dimension.
 
-        For normal data access, use :attr:`data`. This method is useful when code
-        needs the singleton channel dimension to be retained.
+        This private materialization boundary is for internal code that requires
+        the channel-first representation, including its singleton channel axis.
 
         Returns
         -------
@@ -1195,37 +1195,6 @@ class BaseFrame(ABC, Generic[T]):
 
         logger.debug(f"Computation complete, result shape: {result.shape}")
         return cast(T, result)
-
-    def to_xarray(self) -> xr.DataArray:
-        """Return a public xarray view of this frame without changing Wandas ownership."""
-        exported = self._xr.copy(deep=False, data=self._effective_data)
-        for coord_name in (
-            self._CHANNEL_DIM,
-            "channel_label",
-            "channel_unit",
-            "channel_ref",
-            "channel_calibration_factor",
-            "source_time_offset",
-        ):
-            if coord_name in exported.coords:
-                coord = exported.coords[coord_name]
-                values = (
-                    np.ones(coord.shape, dtype=float)
-                    if coord_name == "channel_calibration_factor"
-                    else coord.values.copy()
-                )
-                exported = exported.assign_coords({coord_name: (coord.dims, values)})
-        exported.name = self.label
-        exported.attrs = copy.deepcopy(self._xr.attrs)
-        exported.attrs.pop("operation_history", None)
-        exported.attrs.pop("operation_graph", None)
-        exported.attrs["wandas_frame_type"] = type(self).__name__
-        return exported
-
-    @property
-    def xr(self) -> xr.DataArray:
-        """Return a public xarray view of this frame."""
-        return self.to_xarray()
 
     @abstractmethod
     def plot(self, plot_type: str = "default", ax: "Axes | None" = None, **kwargs: Any) -> "Axes | Iterator[Axes]":
@@ -1264,10 +1233,6 @@ class BaseFrame(ABC, Generic[T]):
             compress=compress,
             overwrite=overwrite,
         )
-
-    def persist(self: S) -> S:
-        """Persist the data in memory."""
-        return self._create_new_instance(data=self._data.persist())
 
     def _get_additional_init_kwargs(self) -> dict[str, Any]:
         """Return additional keyword arguments for ``_create_new_instance``.
@@ -1371,12 +1336,14 @@ class BaseFrame(ABC, Generic[T]):
             )
         return result
 
-    def __array__(self, dtype: npt.DTypeLike = None) -> NDArrayReal:
+    def __array__(self, dtype: npt.DTypeLike = None, copy: bool | None = None) -> NDArrayReal:
         """Implicit conversion to NumPy array"""
-        result = self.compute()
+        result = self.data
         if dtype is not None:
-            return result.astype(dtype)
-        return result
+            result = result.astype(dtype, copy=copy is not False)
+        elif copy:
+            result = result.copy()
+        return cast(NDArrayReal, result)
 
     def __array_ufunc__(self, ufunc: np.ufunc, method: str, *inputs: Any, **kwargs: Any) -> Any:
         """Handle NumPy scalar-left operators without forcing eager arrays."""

--- a/wandas/frames/cepstral.py
+++ b/wandas/frames/cepstral.py
@@ -7,7 +7,6 @@ from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
-import xarray as xr
 from dask.array.core import Array as DaArray
 
 from wandas.core.base_frame import BaseFrame
@@ -196,12 +195,6 @@ class CepstralFrame(BaseFrame[NDArrayReal]):
                 np.arange(int(data.shape[-1]), dtype=float) / sampling_rate,
             )
         return coords
-
-    def to_xarray(self) -> xr.DataArray:
-        """Return an isolated xarray view including copied quefrency coordinates."""
-        exported = super().to_xarray()
-        coordinate = exported.coords["quefrency"]
-        return exported.assign_coords(quefrency=(coordinate.dims, coordinate.values.copy()))
 
     def _create_new_instance(self, data: DaArray, **kwargs: Any) -> CepstralFrame:
         """Recreate the frame and retain represented coordinates when shape permits."""
@@ -395,7 +388,7 @@ class CepstralFrame(BaseFrame[NDArrayReal]):
         import matplotlib.pyplot as plt
 
         target = ax if ax is not None else plt.subplots()[1]
-        values = self.compute()
+        values = self._compute()
         for channel_index, label in enumerate(self.labels):
             target.plot(self.quefrencies, values[channel_index], label=label, **kwargs)
         if self.n_channels > 1:

--- a/wandas/frames/cepstrogram.py
+++ b/wandas/frames/cepstrogram.py
@@ -7,7 +7,6 @@ from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
-import xarray as xr
 from dask.array.core import Array as DaArray
 
 from wandas.core.base_frame import BaseFrame
@@ -271,14 +270,6 @@ class CepstrogramFrame(BaseFrame[NDArrayReal]):
             )
         return coords
 
-    def to_xarray(self) -> xr.DataArray:
-        """Return an isolated xarray view with copied domain coordinates."""
-        exported = super().to_xarray()
-        for coordinate_name in ("quefrency", "time"):
-            coordinate = exported.coords[coordinate_name]
-            exported = exported.assign_coords({coordinate_name: (coordinate.dims, coordinate.values.copy())})
-        return exported
-
     def _create_new_instance(self, data: DaArray, **kwargs: Any) -> CepstrogramFrame:
         """Recreate the frame while retaining a sliced quefrency coordinate."""
         result = cast("CepstrogramFrame", super()._create_new_instance(data=data, **kwargs))
@@ -446,8 +437,8 @@ class CepstrogramFrame(BaseFrame[NDArrayReal]):
         Raises
         ------
         NotImplementedError
-            Always raised. Use ``to_xarray()`` or materialize selected data when
-            a tabular representation is required.
+            Always raised. Materialize selected data when a tabular representation
+            is required.
         """
         raise NotImplementedError("DataFrame conversion is not supported for CepstrogramFrame.")
 
@@ -514,7 +505,7 @@ class CepstrogramFrame(BaseFrame[NDArrayReal]):
         if not np.any(represented):
             raise ValueError("The requested quefrency plot range contains no bins.")
 
-        values = self.compute()
+        values = self._compute()
         displayed_values = values[:, represented, :]
         scale_values = displayed_values
         if self.quefrencies[represented][0] == 0.0 and displayed_values.shape[-2] > 1:

--- a/wandas/frames/roughness.py
+++ b/wandas/frames/roughness.py
@@ -178,7 +178,7 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
         NDArrayReal
             Computed data array.
         """
-        return self.compute()
+        return self._compute()
 
     @property
     def n_bark_bands(self) -> int:
@@ -327,7 +327,7 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
 
         # Select data to plot (first channel for mono, mean for multi-channel)
         # self._data is Dask array, self.data is computed NumPy array
-        computed_data = self.compute()
+        computed_data = self._compute()
 
         # Select data to plot (first channel for mono, mean for multi-channel)
         data_to_plot = computed_data if computed_data.ndim == 2 else computed_data.mean(axis=0)

--- a/wandas/io/wav_io.py
+++ b/wandas/io/wav_io.py
@@ -35,7 +35,7 @@ def write_wav(filename: str, target: "ChannelFrame", format: str | None = None) 
         raise ValueError("target must be a ChannelFrame object.")
 
     logger.debug(f"Saving audio data to file: {filename} (will compute now)")
-    data = target.compute()
+    data = target._compute()
     data = data.T
     if data.shape[1] == 1:
         data = data.squeeze(axis=1)

--- a/wandas/io/wdf_io.py
+++ b/wandas/io/wdf_io.py
@@ -124,7 +124,7 @@ def _build_dataset(frame: BaseFrame[Any]) -> xr.Dataset:
         "operation_history_json": _dump_json(frame.operation_history, field="operation_history_json"),
     }
 
-    # Public to_xarray() contains calibrated values. WDF stores the raw tensor and
+    # Frame data access contains calibrated values. WDF stores the raw tensor and
     # calibration independently so a loaded Frame applies each factor exactly once.
     data_array = xr.DataArray(frame._data, dims=frame._xr.dims)
     variables: dict[str, Any] = {


### PR DESCRIPTION
## Summary

- make `frame.data` the canonical materialization boundary and keep `to_numpy()` / NumPy array conversion equivalent
- remove experimental `compute()`, `persist()`, `xr`, and `to_xarray()` APIs without compatibility shims
- retain channel-first materialization as private `_compute()` and migrate internal consumers/tests
- document v0.6.0 migration paths and keep xarray/Dask ownership internal

## Validation

- `uv lock --check`
- `uv run --locked pytest -q` (2367 passed, 3 skipped)
- `uv run --locked ruff format --check wandas tests`
- `uv run --locked ruff check wandas tests`
- `uv run --locked ty check wandas tests`
- `uv run --locked mkdocs build -f docs/mkdocs.yml --strict`
- `uv run --locked pytest tests/test_scalability_benchmark.py -q` (28 passed)
- `uv run --locked python scripts/scalability_benchmark.py --samples 8000 --chunk-samples 1000 4000`
- core-only Python 3.12 wheel install smoke

Closes #324
Related #309