### PR TITLE
refactor: centralize channel metadata storage keys

### DIFF
--- a/tests/core/test_channel_metadata_xarray.py
+++ b/tests/core/test_channel_metadata_xarray.py
@@ -34,6 +34,16 @@ def test_channel_metadata_storage_schema_is_xarray_backed() -> None:
         "c0": {"sensitivity": 50.0},
         "c1": {"sensitivity": 48.5},
     }
+    assert (
+        not {
+            "channel_ids",
+            "channel_label",
+            "channel_unit",
+            "channel_ref",
+            "channel_calibration_factor",
+        }
+        & frame._xr.attrs.keys()
+    )
 
 
 def test_channel_indexer_reads_and_writes_xarray_storage() -> None:

--- a/tests/core/test_channel_schema.py
+++ b/tests/core/test_channel_schema.py
@@ -1,0 +1,29 @@
+from wandas.core._channel_schema import (
+    _CHANNEL_CALIBRATION_FACTOR_KEY,
+    _CHANNEL_COORD_FALLBACK_ATTRS,
+    _CHANNEL_EXTRA_ATTR,
+    _CHANNEL_IDS_ATTR,
+    _CHANNEL_LABEL_KEY,
+    _CHANNEL_REF_KEY,
+    _CHANNEL_UNIT_KEY,
+)
+
+
+def test_private_channel_storage_keys_preserve_existing_schema() -> None:
+    assert _CHANNEL_IDS_ATTR == "channel_ids"
+    assert _CHANNEL_LABEL_KEY == "channel_label"
+    assert _CHANNEL_UNIT_KEY == "channel_unit"
+    assert _CHANNEL_REF_KEY == "channel_ref"
+    assert _CHANNEL_CALIBRATION_FACTOR_KEY == "channel_calibration_factor"
+    assert _CHANNEL_EXTRA_ATTR == "channel_extra"
+
+
+def test_channel_coord_fallback_attrs_exclude_canonical_extra_storage() -> None:
+    assert _CHANNEL_COORD_FALLBACK_ATTRS == (
+        "channel_ids",
+        "channel_label",
+        "channel_unit",
+        "channel_ref",
+        "channel_calibration_factor",
+    )
+    assert "channel_extra" not in _CHANNEL_COORD_FALLBACK_ATTRS

--- a/wandas/core/_channel_schema.py
+++ b/wandas/core/_channel_schema.py
@@ -1,0 +1,20 @@
+"""Private storage keys for xarray-backed channel metadata."""
+
+from typing import Final
+
+_CHANNEL_IDS_ATTR: Final[str] = "channel_ids"
+_CHANNEL_LABEL_KEY: Final[str] = "channel_label"
+_CHANNEL_UNIT_KEY: Final[str] = "channel_unit"
+_CHANNEL_REF_KEY: Final[str] = "channel_ref"
+_CHANNEL_CALIBRATION_FACTOR_KEY: Final[str] = "channel_calibration_factor"
+_CHANNEL_EXTRA_ATTR: Final[str] = "channel_extra"
+
+# Vector metadata uses coordinates on channel-aware Frames and attrs only as a
+# fallback. ``channel_extra`` remains an attr in both representations.
+_CHANNEL_COORD_FALLBACK_ATTRS: Final[tuple[str, ...]] = (
+    _CHANNEL_IDS_ATTR,
+    _CHANNEL_LABEL_KEY,
+    _CHANNEL_UNIT_KEY,
+    _CHANNEL_REF_KEY,
+    _CHANNEL_CALIBRATION_FACTOR_KEY,
+)

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -27,6 +27,15 @@ from wandas.utils import validate_sampling_rate
 from wandas.utils.optional_imports import require_dependency, require_pandas
 from wandas.utils.types import NDArrayComplex, NDArrayReal
 
+from ._channel_schema import (
+    _CHANNEL_CALIBRATION_FACTOR_KEY,
+    _CHANNEL_COORD_FALLBACK_ATTRS,
+    _CHANNEL_EXTRA_ATTR,
+    _CHANNEL_IDS_ATTR,
+    _CHANNEL_LABEL_KEY,
+    _CHANNEL_REF_KEY,
+    _CHANNEL_UNIT_KEY,
+)
 from .channel_metadata import ChannelMetadataIndexer
 from .metadata import ChannelCalibration, ChannelMetadata
 
@@ -365,10 +374,10 @@ class BaseFrame(ABC, Generic[T]):
             return {}
         return {
             self._CHANNEL_DIM: (self._CHANNEL_DIM, channel_ids),
-            "channel_label": (self._CHANNEL_DIM, [ch.label for ch in metadata]),
-            "channel_unit": (self._CHANNEL_DIM, [ch.unit for ch in metadata]),
-            "channel_ref": (self._CHANNEL_DIM, [ch.ref for ch in metadata]),
-            "channel_calibration_factor": (
+            _CHANNEL_LABEL_KEY: (self._CHANNEL_DIM, [ch.label for ch in metadata]),
+            _CHANNEL_UNIT_KEY: (self._CHANNEL_DIM, [ch.unit for ch in metadata]),
+            _CHANNEL_REF_KEY: (self._CHANNEL_DIM, [ch.ref for ch in metadata]),
+            _CHANNEL_CALIBRATION_FACTOR_KEY: (
                 self._CHANNEL_DIM,
                 [ch.calibration.factor for ch in metadata],
             ),
@@ -466,13 +475,13 @@ class BaseFrame(ABC, Generic[T]):
         """Return channel identifiers from xarray coordinates or legacy attrs."""
         if self._CHANNEL_DIM in self._xr.coords:
             return [str(value) for value in self._xr.coords[self._CHANNEL_DIM].values.tolist()]
-        return [str(value) for value in self._xr.attrs.get("channel_ids", [])]
+        return [str(value) for value in self._xr.attrs.get(_CHANNEL_IDS_ATTR, [])]
 
     def _channel_id_at(self, index: int) -> str:
         """Return the stable identifier for one channel position."""
         if self._CHANNEL_DIM in self._xr.coords:
             return str(self._xr.coords[self._CHANNEL_DIM].values[index])
-        return str(self._xr.attrs["channel_ids"][index])
+        return str(self._xr.attrs[_CHANNEL_IDS_ATTR][index])
 
     def _get_channel_coord_value(self, coord_name: str, index: int) -> Any:
         """Read one channel metadata value from coordinates or legacy attrs."""
@@ -523,9 +532,9 @@ class BaseFrame(ABC, Generic[T]):
         if not isinstance(calibration, ChannelCalibration):
             raise TypeError("calibration must be a ChannelCalibration")
         updates = {
-            "channel_calibration_factor": calibration.factor,
-            "channel_unit": calibration.unit,
-            "channel_ref": calibration.ref,
+            _CHANNEL_CALIBRATION_FACTOR_KEY: calibration.factor,
+            _CHANNEL_UNIT_KEY: calibration.unit,
+            _CHANNEL_REF_KEY: calibration.ref,
         }
         if self._CHANNEL_DIM in self._xr.dims:
             coords: dict[str, Any] = {}
@@ -557,33 +566,27 @@ class BaseFrame(ABC, Generic[T]):
         refs = [ch.ref for ch in normalized]
         factors = [ch.calibration.factor for ch in normalized]
         channel_extra = {channel_id: copy.deepcopy(ch.extra) for channel_id, ch in zip(ids, normalized, strict=True)}
-        self._xr.attrs["channel_extra"] = channel_extra
+        self._xr.attrs[_CHANNEL_EXTRA_ATTR] = channel_extra
         if self._CHANNEL_DIM in self._xr.dims:
             self._xr = self._xr.assign_coords(
                 {
                     self._CHANNEL_DIM: (self._CHANNEL_DIM, ids),
-                    "channel_label": (self._CHANNEL_DIM, labels),
-                    "channel_unit": (self._CHANNEL_DIM, units),
-                    "channel_ref": (self._CHANNEL_DIM, refs),
-                    "channel_calibration_factor": (self._CHANNEL_DIM, factors),
+                    _CHANNEL_LABEL_KEY: (self._CHANNEL_DIM, labels),
+                    _CHANNEL_UNIT_KEY: (self._CHANNEL_DIM, units),
+                    _CHANNEL_REF_KEY: (self._CHANNEL_DIM, refs),
+                    _CHANNEL_CALIBRATION_FACTOR_KEY: (self._CHANNEL_DIM, factors),
                 }
             )
-            for name in (
-                "channel_ids",
-                "channel_label",
-                "channel_unit",
-                "channel_ref",
-                "channel_calibration_factor",
-            ):
+            for name in _CHANNEL_COORD_FALLBACK_ATTRS:
                 self._xr.attrs.pop(name, None)
             return
         self._xr.attrs.update(
             {
-                "channel_ids": ids,
-                "channel_label": labels,
-                "channel_unit": units,
-                "channel_ref": refs,
-                "channel_calibration_factor": factors,
+                _CHANNEL_IDS_ATTR: ids,
+                _CHANNEL_LABEL_KEY: labels,
+                _CHANNEL_UNIT_KEY: units,
+                _CHANNEL_REF_KEY: refs,
+                _CHANNEL_CALIBRATION_FACTOR_KEY: factors,
             }
         )
 

--- a/wandas/core/channel_metadata.py
+++ b/wandas/core/channel_metadata.py
@@ -5,6 +5,13 @@ import numbers
 from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, Any, cast, overload
 
+from ._channel_schema import (
+    _CHANNEL_CALIBRATION_FACTOR_KEY,
+    _CHANNEL_EXTRA_ATTR,
+    _CHANNEL_LABEL_KEY,
+    _CHANNEL_REF_KEY,
+    _CHANNEL_UNIT_KEY,
+)
 from .metadata import ChannelCalibration, ChannelMetadata
 
 if TYPE_CHECKING:
@@ -28,18 +35,18 @@ class ChannelMetadataView(ChannelMetadata):
             if name == "id":
                 return frame._channel_id_at(index)
             if name == "label":
-                return str(frame._get_channel_coord_value("channel_label", index))
+                return str(frame._get_channel_coord_value(_CHANNEL_LABEL_KEY, index))
             if name == "calibration":
                 return ChannelCalibration(
-                    factor=frame._get_channel_coord_value("channel_calibration_factor", index),
-                    unit=str(frame._get_channel_coord_value("channel_unit", index)),
-                    ref=frame._get_channel_coord_value("channel_ref", index),
+                    factor=frame._get_channel_coord_value(_CHANNEL_CALIBRATION_FACTOR_KEY, index),
+                    unit=str(frame._get_channel_coord_value(_CHANNEL_UNIT_KEY, index)),
+                    ref=frame._get_channel_coord_value(_CHANNEL_REF_KEY, index),
                 )
             if name == "unit":
                 return self.calibration.unit
             if name == "ref":
                 return self.calibration.ref
-            channel_extra = frame._xr.attrs.setdefault("channel_extra", {})
+            channel_extra = frame._xr.attrs.setdefault(_CHANNEL_EXTRA_ATTR, {})
             channel_id = frame._channel_id_at(index)
             existing = channel_extra.setdefault(channel_id, {})
             if not isinstance(existing, dict):
@@ -67,7 +74,7 @@ class ChannelMetadataView(ChannelMetadata):
         if name == "label":
             if not isinstance(value, str):
                 raise TypeError("ChannelMetadata label must be a string")
-            self._frame._set_channel_coord_value("channel_label", self._index, value)
+            self._frame._set_channel_coord_value(_CHANNEL_LABEL_KEY, self._index, value)
             return
         if name == "calibration":
             raise AttributeError(
@@ -96,7 +103,7 @@ class ChannelMetadataView(ChannelMetadata):
         if name == "extra":
             if not isinstance(value, dict):
                 raise TypeError("channel extra must be a dictionary")
-            self._frame._xr.attrs.setdefault("channel_extra", {})[self.id] = value
+            self._frame._xr.attrs.setdefault(_CHANNEL_EXTRA_ATTR, {})[self.id] = value
             return
         super().__setattr__(name, value)
 


### PR DESCRIPTION
## Summary

- centralize private channel metadata xarray/attrs fallback keys in a dependency-free `_channel_schema` module
- keep canonical channel dimensions, constructor keywords, and WDF 0.4 serialized names under their existing separate owners
- preserve explicit storage construction while sharing only the cleanup group that has a real consumer
- keep `channel_extra` as canonical attr storage and outside coordinate-fallback cleanup

This is an internal refactor only. `frame.data`, public exports, serialized files, and WDF behavior are unchanged.

## Validation

- TDD red: the new private schema contract test initially failed at collection before the module existed
- `uv run --locked pytest tests/core/test_channel_schema.py tests/core/test_channel_metadata_xarray.py -q`: 21 passed
- focused BaseFrame/xarray/calibration/WDF suite: 214 passed
- `uv run --locked pytest -n auto --cov=wandas --cov-report=term-missing`: 2371 passed, 3 skipped; total coverage 99%, new module 100%
- `uv run --locked ruff format --check wandas tests`: passed (160 files)
- `uv run --locked ruff check wandas tests`: passed
- `uv run --locked ty check wandas tests`: passed
- `uv lock --check`: passed
- commit hooks: Ruff check, Ruff format, and ty passed
- independent review: approved with no critical, style, or required enhancement findings

Documentation build was not rerun because no public API or documentation changed. Existing WDF raw-literal tests remain the serialized-schema compatibility oracle.

## Issue triage

Closes #313
Related: #312
Related: #311

#313 is fully satisfied by this PR. #312 remains open because metadata ownership/copy-boundary optimization is intentionally a separate follow-up.
