### PR TITLE
fix: restore recoverable wandas-agent notifications

### DIFF
--- a/.github/workflows/notify-agent.yml
+++ b/.github/workflows/notify-agent.yml
@@ -4,30 +4,68 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing strict SemVer tag to notify or replay (vX.Y.Z)"
+        required: true
+        type: string
 
 permissions: {}
 
 jobs:
   notify:
     runs-on: ubuntu-latest
-    if: github.event.deleted == false
+    if: github.event_name == 'workflow_dispatch' || github.event.deleted == false
     steps:
-      - name: Validate strict SemVer tag
-        id: validate
+      - name: Resolve strict SemVer release tag
+        id: release
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          PUSH_TAG: ${{ github.ref_name }}
         shell: bash
         run: |
-          if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "valid=true" >> "$GITHUB_OUTPUT"
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            tag="${INPUT_TAG}"
           else
-            echo "valid=false" >> "$GITHUB_OUTPUT"
-            echo "Tag '${{ github.ref_name }}' is not a strict vX.Y.Z release; skipping dispatch."
+            tag="${PUSH_TAG}"
+          fi
+
+          if [[ ! "${tag}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+              echo "::error title=Invalid release tag::Manual notification requires an existing strict vX.Y.Z tag; got '${tag}'."
+              exit 1
+            fi
+            printf 'valid=false\n' >> "$GITHUB_OUTPUT"
+            echo "Tag '${tag}' is not a strict vX.Y.Z release; skipping dispatch."
+            exit 0
+          fi
+
+          if [[ "${EVENT_NAME}" == "workflow_dispatch" ]] &&
+             ! git ls-remote --exit-code --tags "https://github.com/${GITHUB_REPOSITORY}.git" "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "::error title=Unknown release tag::Tag '${tag}' does not exist in ${GITHUB_REPOSITORY}."
+            exit 1
+          fi
+
+          printf 'valid=true\ntag=%s\n' "${tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate notification credential
+        if: steps.release.outputs.valid == 'true'
+        env:
+          WANDAS_AGENT_TOKEN: ${{ secrets.WANDAS_AGENT_TOKEN }}
+        shell: bash
+        run: |
+          if [[ -z "${WANDAS_AGENT_TOKEN}" ]]; then
+            echo "::error title=Missing WANDAS_AGENT_TOKEN::Configure a fine-grained token scoped only to kasahart/wandas-agent with Contents: Read and write, then store it as the WANDAS_AGENT_TOKEN repository secret."
+            exit 1
           fi
 
       - name: Trigger wandas-agent submodule update
-        if: steps.validate.outputs.valid == 'true'
-        uses: peter-evans/repository-dispatch@v3
+        if: steps.release.outputs.valid == 'true'
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ secrets.WANDAS_AGENT_TOKEN }}
           repository: kasahart/wandas-agent
           event-type: wandas-updated
-          client-payload: '{"tag": "${{ github.ref_name }}"}'
+          client-payload: '{"tag": "${{ steps.release.outputs.tag }}"}'

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -129,6 +129,54 @@ Documentation is built with MkDocs.
   uv run mkdocs serve -f docs/mkdocs.yml
   ```
 
+## Release-to-Agent Notification / リリースからAgentへの通知
+
+When `WANDAS_AGENT_TOKEN` is configured, every strict `vX.Y.Z` tag dispatches
+`wandas-updated` to `kasahart/wandas-agent`, which updates its Wandas submodule
+to that exact tag. `WANDAS_AGENT_TOKEN` が設定されている場合、厳密な
+`vX.Y.Z` タグを作成すると、`kasahart/wandas-agent` へ `wandas-updated` が
+送信され、Wandas submoduleがそのタグへ更新されます。
+
+The cross-repository dispatch requires the `WANDAS_AGENT_TOKEN` repository
+secret. Use a fine-grained personal access token scoped only to
+`kasahart/wandas-agent`, with **Contents: Read and write** permission. GitHub
+documents this as the required permission for the
+[repository dispatch endpoint](https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event).
+Cross-repository dispatchにはrepository secret `WANDAS_AGENT_TOKEN` が必要です。
+`kasahart/wandas-agent` のみに限定し、**Contents: Read and write** 権限を与えた
+fine-grained personal access tokenを使用してください。GitHubが
+[repository dispatch endpoint](https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event)
+に必要な権限として定義しています。
+
+Store or rotate the token without putting it on the command line:
+tokenをコマンドラインへ含めずに保存または更新します:
+
+```bash
+gh secret set WANDAS_AGENT_TOKEN --repo kasahart/wandas
+```
+
+If the secret is missing, notification is disabled and the workflow
+intentionally fails before dispatch with a repository-owned
+`Missing WANDAS_AGENT_TOKEN` diagnostic. After correcting a credential or
+delivery problem, replay an existing tag explicitly: secretが存在しない場合、
+通知は無効であり、workflowはdispatch前にrepository側の
+`Missing WANDAS_AGENT_TOKEN` 診断を出して意図的に失敗します。credentialや
+配信問題を修正した後は、既存タグを明示して再送できます:
+
+```bash
+gh workflow run notify-agent.yml \
+  --repo kasahart/wandas \
+  --ref main \
+  -f tag=v0.6.0
+```
+
+The manual input must be an existing strict SemVer tag. Verify both the source
+workflow and the resulting `Update wandas submodule` run in
+`kasahart/wandas-agent` before considering notification complete.
+手動入力には、実在する厳密なSemVerタグが必要です。通知完了と判断する前に、
+送信元workflowと`kasahart/wandas-agent`側の`Update wandas submodule` runの
+両方を確認してください。
+
 ## Extending Frames and Operations / Frame・Operation の拡張
 
 When adding a new Frame family, numerical Operation, public Frame method, or its

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -133,7 +133,8 @@ Documentation is built with MkDocs.
 
 When `WANDAS_AGENT_TOKEN` is configured, every strict `vX.Y.Z` tag dispatches
 `wandas-updated` to `kasahart/wandas-agent`, which updates its Wandas submodule
-to that exact tag. `WANDAS_AGENT_TOKEN` が設定されている場合、厳密な
+to that exact tag.
+`WANDAS_AGENT_TOKEN` が設定されている場合、厳密な
 `vX.Y.Z` タグを作成すると、`kasahart/wandas-agent` へ `wandas-updated` が
 送信され、Wandas submoduleがそのタグへ更新されます。
 
@@ -158,7 +159,8 @@ gh secret set WANDAS_AGENT_TOKEN --repo kasahart/wandas
 If the secret is missing, notification is disabled and the workflow
 intentionally fails before dispatch with a repository-owned
 `Missing WANDAS_AGENT_TOKEN` diagnostic. After correcting a credential or
-delivery problem, replay an existing tag explicitly: secretが存在しない場合、
+delivery problem, replay an existing tag explicitly:
+secretが存在しない場合、
 通知は無効であり、workflowはdispatch前にrepository側の
 `Missing WANDAS_AGENT_TOKEN` 診断を出して意図的に失敗します。credentialや
 配信問題を修正した後は、既存タグを明示して再送できます:

--- a/tests/docs/test_notify_agent_workflow.py
+++ b/tests/docs/test_notify_agent_workflow.py
@@ -10,6 +10,10 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "notify-agent.yml"
+BASH_WORKFLOW_ONLY = pytest.mark.skipif(
+    os.name == "nt",
+    reason="notify-agent runs with Bash on ubuntu-latest, not Windows bash.exe/WSL",
+)
 
 
 def _workflow() -> dict[str, Any]:
@@ -129,6 +133,7 @@ def test_notify_agent_dispatches_the_resolved_tag() -> None:
     }
 
 
+@BASH_WORKFLOW_ONLY
 def test_notify_agent_shell_scripts_are_valid_bash() -> None:
     steps = _steps_by_name()
 
@@ -160,6 +165,7 @@ def test_notify_agent_shell_scripts_are_valid_bash() -> None:
         ("push", "", "v1.2.3-rc.1", "", {"valid": "false"}),
     ],
 )
+@BASH_WORKFLOW_ONLY
 def test_notify_agent_resolver_accepts_or_skips_expected_tags(
     tmp_path: Path,
     event_name: str,
@@ -184,6 +190,7 @@ def test_notify_agent_resolver_accepts_or_skips_expected_tags(
 
 
 @pytest.mark.parametrize("tag", ["v01.2.3", "v1.02.3", "v1.2.03", "v1.2"])
+@BASH_WORKFLOW_ONLY
 def test_notify_agent_manual_replay_rejects_non_strict_tags(tmp_path: Path, tag: str) -> None:
     script = _steps_by_name()["Resolve strict SemVer release tag"]["run"]
 
@@ -200,6 +207,7 @@ def test_notify_agent_manual_replay_rejects_non_strict_tags(tmp_path: Path, tag:
     assert "::error title=Invalid release tag::" in result.stdout
 
 
+@BASH_WORKFLOW_ONLY
 def test_notify_agent_manual_replay_rejects_unknown_tag(tmp_path: Path) -> None:
     script = _steps_by_name()["Resolve strict SemVer release tag"]["run"]
 
@@ -217,6 +225,7 @@ def test_notify_agent_manual_replay_rejects_unknown_tag(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(("token", "expected_status"), [("", 1), ("secret-value", 0)])
+@BASH_WORKFLOW_ONLY
 def test_notify_agent_credential_preflight(tmp_path: Path, token: str, expected_status: int) -> None:
     script = _steps_by_name()["Validate notification credential"]["run"]
 

--- a/tests/docs/test_notify_agent_workflow.py
+++ b/tests/docs/test_notify_agent_workflow.py
@@ -1,0 +1,230 @@
+"""Contract tests for cross-repository release notification."""
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "notify-agent.yml"
+
+
+def _workflow() -> dict[str, Any]:
+    data = yaml.load(WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    assert isinstance(data, dict)
+    return data
+
+
+def _steps_by_name() -> dict[str, dict[str, Any]]:
+    steps = _workflow()["jobs"]["notify"]["steps"]
+    assert isinstance(steps, list)
+    return {str(step["name"]): step for step in steps}
+
+
+def _run_script(
+    tmp_path: Path,
+    script: str,
+    *,
+    event_name: str = "push",
+    input_tag: str = "",
+    push_tag: str = "",
+    existing_tag: str = "",
+    token: str = "",
+) -> tuple[subprocess.CompletedProcess[str], dict[str, str]]:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_git = fake_bin / "git"
+    fake_git.write_text(
+        """#!/usr/bin/env bash
+if [[ "$*" == *"refs/tags/${EXISTING_TAG}"* && -n "${EXISTING_TAG}" ]]; then
+  exit 0
+fi
+exit 2
+""",
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+    output_path = tmp_path / "github-output"
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "EVENT_NAME": event_name,
+        "INPUT_TAG": input_tag,
+        "PUSH_TAG": push_tag,
+        "EXISTING_TAG": existing_tag,
+        "GITHUB_OUTPUT": str(output_path),
+        "GITHUB_REPOSITORY": "kasahart/wandas",
+        "WANDAS_AGENT_TOKEN": token,
+    }
+    result = subprocess.run(
+        ["bash"],
+        input=script,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+    outputs = {}
+    if output_path.exists():
+        outputs = dict(line.split("=", maxsplit=1) for line in output_path.read_text(encoding="utf-8").splitlines())
+    return result, outputs
+
+
+def test_notify_agent_accepts_tag_push_and_explicit_replay() -> None:
+    workflow = _workflow()
+    triggers = workflow["on"]
+
+    assert triggers["push"]["tags"] == ["v*.*.*"]
+    replay = triggers["workflow_dispatch"]["inputs"]["tag"]
+    assert replay == {
+        "description": "Existing strict SemVer tag to notify or replay (vX.Y.Z)",
+        "required": "true",
+        "type": "string",
+    }
+    assert workflow["jobs"]["notify"]["if"] == (
+        "github.event_name == 'workflow_dispatch' || github.event.deleted == false"
+    )
+
+
+def test_notify_agent_resolves_only_existing_strict_release_tags() -> None:
+    resolve = _steps_by_name()["Resolve strict SemVer release tag"]
+    script = resolve["run"]
+
+    assert resolve["id"] == "release"
+    assert resolve["env"] == {
+        "EVENT_NAME": "${{ github.event_name }}",
+        "INPUT_TAG": "${{ inputs.tag }}",
+        "PUSH_TAG": "${{ github.ref_name }}",
+    }
+    assert "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$" in script
+    assert "git ls-remote --exit-code --tags" in script
+    assert "::error title=Invalid release tag::" in script
+    assert "::error title=Unknown release tag::" in script
+
+
+def test_notify_agent_reports_missing_least_privilege_credential() -> None:
+    credential = _steps_by_name()["Validate notification credential"]
+    script = credential["run"]
+
+    assert credential["if"] == "steps.release.outputs.valid == 'true'"
+    assert credential["env"] == {"WANDAS_AGENT_TOKEN": "${{ secrets.WANDAS_AGENT_TOKEN }}"}
+    assert "::error title=Missing WANDAS_AGENT_TOKEN::" in script
+    assert "scoped only to kasahart/wandas-agent" in script
+    assert "Contents: Read and write" in script
+
+
+def test_notify_agent_dispatches_the_resolved_tag() -> None:
+    dispatch = _steps_by_name()["Trigger wandas-agent submodule update"]
+
+    assert dispatch["if"] == "steps.release.outputs.valid == 'true'"
+    assert dispatch["uses"] == ("peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0")
+    assert dispatch["with"] == {
+        "token": "${{ secrets.WANDAS_AGENT_TOKEN }}",
+        "repository": "kasahart/wandas-agent",
+        "event-type": "wandas-updated",
+        "client-payload": '{"tag": "${{ steps.release.outputs.tag }}"}',
+    }
+
+
+def test_notify_agent_shell_scripts_are_valid_bash() -> None:
+    steps = _steps_by_name()
+
+    for name in (
+        "Resolve strict SemVer release tag",
+        "Validate notification credential",
+    ):
+        result = subprocess.run(
+            ["bash", "-n"],
+            input=steps[name]["run"],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    ("event_name", "input_tag", "push_tag", "existing_tag", "expected_outputs"),
+    [
+        (
+            "workflow_dispatch",
+            "v0.6.0",
+            "main",
+            "v0.6.0",
+            {"valid": "true", "tag": "v0.6.0"},
+        ),
+        ("push", "", "v1.2.3", "", {"valid": "true", "tag": "v1.2.3"}),
+        ("push", "", "v1.2.3-rc.1", "", {"valid": "false"}),
+    ],
+)
+def test_notify_agent_resolver_accepts_or_skips_expected_tags(
+    tmp_path: Path,
+    event_name: str,
+    input_tag: str,
+    push_tag: str,
+    existing_tag: str,
+    expected_outputs: dict[str, str],
+) -> None:
+    script = _steps_by_name()["Resolve strict SemVer release tag"]["run"]
+
+    result, outputs = _run_script(
+        tmp_path,
+        script,
+        event_name=event_name,
+        input_tag=input_tag,
+        push_tag=push_tag,
+        existing_tag=existing_tag,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert outputs == expected_outputs
+
+
+@pytest.mark.parametrize("tag", ["v01.2.3", "v1.02.3", "v1.2.03", "v1.2"])
+def test_notify_agent_manual_replay_rejects_non_strict_tags(tmp_path: Path, tag: str) -> None:
+    script = _steps_by_name()["Resolve strict SemVer release tag"]["run"]
+
+    result, outputs = _run_script(
+        tmp_path,
+        script,
+        event_name="workflow_dispatch",
+        input_tag=tag,
+        existing_tag=tag,
+    )
+
+    assert result.returncode == 1
+    assert outputs == {}
+    assert "::error title=Invalid release tag::" in result.stdout
+
+
+def test_notify_agent_manual_replay_rejects_unknown_tag(tmp_path: Path) -> None:
+    script = _steps_by_name()["Resolve strict SemVer release tag"]["run"]
+
+    result, outputs = _run_script(
+        tmp_path,
+        script,
+        event_name="workflow_dispatch",
+        input_tag="v0.6.1",
+        existing_tag="v0.6.0",
+    )
+
+    assert result.returncode == 1
+    assert outputs == {}
+    assert "::error title=Unknown release tag::" in result.stdout
+
+
+@pytest.mark.parametrize(("token", "expected_status"), [("", 1), ("secret-value", 0)])
+def test_notify_agent_credential_preflight(tmp_path: Path, token: str, expected_status: int) -> None:
+    script = _steps_by_name()["Validate notification credential"]["run"]
+
+    result, outputs = _run_script(tmp_path, script, token=token)
+
+    assert result.returncode == expected_status
+    assert outputs == {}
+    if token:
+        assert token not in result.stdout + result.stderr
+    else:
+        assert "::error title=Missing WANDAS_AGENT_TOKEN::" in result.stdout


### PR DESCRIPTION
## Summary

- add an explicit replay path for existing strict `vX.Y.Z` tags
- fail before repository dispatch with a repository-owned diagnostic when `WANDAS_AGENT_TOKEN` is unavailable
- document the least-privilege credential and disabled-notification contract
- pin the dispatch action and execute the workflow Bash contracts in tests

## v0.6.0 reconciliation

The missed v0.6.0 update was reconciled through the target repository manual fallback:

- target run: https://github.com/kasahart/wandas-agent/actions/runs/29835685224
- target commit: https://github.com/kasahart/wandas-agent/commit/fb5d6262381997911c48bf303d858ba433b910a6
- verified submodule SHA: `7d28a09eb464d4416aa3685a49677c9d2475ab3b` (`v0.6.0`)

## Validation

- `uv run --locked pytest -n auto --cov=wandas --cov-report=term-missing` (2407 passed, 3 skipped; 99%)
- `uv run --locked ruff format --check wandas tests scripts`
- `uv run --locked ruff check wandas tests scripts`
- `uv run --locked ty check`
- `uv lock --check`
- `uv run --locked mkdocs build --strict -f docs/mkdocs.yml`

Closes #329