### PR TITLE
chore: prepare Wandas 0.6.1 release

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
       - Pipeline Recipe Design: explanation/pipeline-recipe-design.md
       - Pipeline Recipe Developer Guide: explanation/pipeline-recipe-developer-guide.md
   - Release Notes:
+      - Wandas 0.6.1: release-notes/v0.6.1.md
       - Wandas 0.6.0: release-notes/v0.6.0.md
   - Contributing:
       - Overview: contributing.md

--- a/docs/src/release-notes/v0.6.1.md
+++ b/docs/src/release-notes/v0.6.1.md
@@ -1,0 +1,23 @@
+# Wandas 0.6.1
+
+Wandas 0.6.1 is a maintenance release focused on explicit metadata ownership and
+recoverable release automation.
+
+## Highlights
+
+- Private channel-metadata storage keys now have a single internal owner without
+  adding a public xarray API or changing WDF 0.4 serialized names.
+- Frame derivation and calibration avoid redundant nested metadata copies while
+  preserving source/result independence, metadata/history, Recipe behavior, and Dask
+  laziness.
+- Release notifications to `kasahart/wandas-agent` now validate strict `vX.Y.Z` tags,
+  support explicit replay, and report a clear repository-owned diagnostic when the
+  least-privilege credential is unavailable.
+
+## Compatibility
+
+This release does not change the public numerical-data boundary: use `frame.data`.
+WDF 0.4 and Recipe schema 2 remain unchanged. Cross-repository agent notification
+requires the documented `WANDAS_AGENT_TOKEN`; when notification is disabled, the
+workflow fails explicitly before dispatch and an existing release tag can be replayed
+after configuration is corrected.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wandas"
-version = "0.6.0"
+version = "0.6.1"
 description = "Wandas is an open source library for efficient signal analysis in Python"
 authors = [{name = "kasahart", email="kasahart66@gmail.com"}]
 maintainers = [

--- a/uv.lock
+++ b/uv.lock
@@ -3938,7 +3938,7 @@ wheels = [
 
 [[package]]
 name = "wandas"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "cattrs" },


### PR DESCRIPTION
## Summary

- bump the package and lockfile version from 0.6.0 to 0.6.1
- add the v0.6.1 release note and documentation navigation entry
- document the internal metadata-ownership improvements and recoverable release notification behavior
- retain `frame.data` as the public numerical-data boundary; no public xarray API, WDF schema, or Recipe schema change

## Release scope

- #330 centralizes private channel metadata storage keys
- #331 makes metadata ownership explicit and removes redundant copies
- #332 restores recoverable wandas-agent notifications
- #333 simplifies generated-artifact cleanup lifecycle guidance

## Validation

- `uv run --locked pytest -n auto --cov=wandas --cov-report=term-missing` (2407 passed, 3 skipped; 99%)
- `uv run --locked ruff format --check wandas tests scripts`
- `uv run --locked ruff check wandas tests scripts`
- `uv run --locked ty check`
- `uv lock --check`
- `uv run --locked mkdocs build --strict -f docs/mkdocs.yml`
- `uv build` produced `wandas-0.6.1.tar.gz` and `wandas-0.6.1-py3-none-any.whl`
- isolated wheel install/import verified distribution version 0.6.1

The `v0.6.1` tag is absent and the GitHub Release remains a draft targeting `main`. Ignored validation artifacts are retained until post-merge worktree cleanup.