### PR TITLE
fix: make optional agent notification non-fatal

### DIFF
--- a/.github/workflows/notify-agent.yml
+++ b/.github/workflows/notify-agent.yml
@@ -51,18 +51,22 @@ jobs:
           printf 'valid=true\ntag=%s\n' "${tag}" >> "$GITHUB_OUTPUT"
 
       - name: Validate notification credential
+        id: credential
         if: steps.release.outputs.valid == 'true'
         env:
           WANDAS_AGENT_TOKEN: ${{ secrets.WANDAS_AGENT_TOKEN }}
         shell: bash
         run: |
           if [[ -z "${WANDAS_AGENT_TOKEN}" ]]; then
-            echo "::error title=Missing WANDAS_AGENT_TOKEN::Configure a fine-grained token scoped only to kasahart/wandas-agent with Contents: Read and write, then store it as the WANDAS_AGENT_TOKEN repository secret."
-            exit 1
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=wandas-agent notification skipped::WANDAS_AGENT_TOKEN is not configured. The release remains valid; reconcile the downstream submodule manually or configure the least-privilege repository secret."
+            exit 0
           fi
 
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+
       - name: Trigger wandas-agent submodule update
-        if: steps.release.outputs.valid == 'true'
+        if: steps.release.outputs.valid == 'true' && steps.credential.outputs.enabled == 'true'
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
         with:
           token: ${{ secrets.WANDAS_AGENT_TOKEN }}

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -156,14 +156,13 @@ tokenをコマンドラインへ含めずに保存または更新します:
 gh secret set WANDAS_AGENT_TOKEN --repo kasahart/wandas
 ```
 
-If the secret is missing, notification is disabled and the workflow
-intentionally fails before dispatch with a repository-owned
-`Missing WANDAS_AGENT_TOKEN` diagnostic. After correcting a credential or
-delivery problem, replay an existing tag explicitly:
-secretが存在しない場合、
-通知は無効であり、workflowはdispatch前にrepository側の
-`Missing WANDAS_AGENT_TOKEN` 診断を出して意図的に失敗します。credentialや
-配信問題を修正した後は、既存タグを明示して再送できます:
+If the secret is missing, the optional notification is skipped with a
+repository-owned warning so that a successful package release does not produce a
+failed workflow. Reconcile the downstream submodule manually, or configure the
+credential and replay an existing tag explicitly:
+secretが存在しない場合、任意の通知はrepository側のwarningを出してskipされ、
+package releaseが成功しているのにworkflowが失敗扱いになることを避けます。
+下流submoduleを手動で同期するか、credentialを設定して既存タグを明示的に再送します:
 
 ```bash
 gh workflow run notify-agent.yml \

--- a/docs/src/release-notes/v0.6.1.md
+++ b/docs/src/release-notes/v0.6.1.md
@@ -2,22 +2,50 @@
 
 Wandas 0.6.1 is a maintenance release focused on explicit metadata ownership and
 recoverable release automation.
+Wandas 0.6.1は、metadataの所有権の明確化と、復旧可能なrelease automationに
+重点を置いたmaintenance releaseです。
 
-## Highlights
+## Highlights / ハイライト
 
 - Private channel-metadata storage keys now have a single internal owner without
   adding a public xarray API or changing WDF 0.4 serialized names.
+  privateなchannel-metadata storage keyの内部所有者を一箇所に集約しました。
+  public xarray APIおよびWDF 0.4のserialized nameは変更していません。
 - Frame derivation and calibration avoid redundant nested metadata copies while
   preserving source/result independence, metadata/history, Recipe behavior, and Dask
   laziness.
+  Frameの派生とcalibrationで不要なnested metadata copyを避けつつ、source/resultの
+  独立性、metadata/history、Recipeの挙動、Dask lazinessを維持します。
 - Release notifications to `kasahart/wandas-agent` now validate strict `vX.Y.Z` tags,
-  support explicit replay, and report a clear repository-owned diagnostic when the
+  support explicit replay, and provide a clear repository-owned warning when the
   least-privilege credential is unavailable.
+  `kasahart/wandas-agent`へのrelease通知は、厳密な`vX.Y.Z` tagを検証し、明示的な
+  replayをサポートします。least-privilege credentialが利用できない場合は、
+  repository側の明確なwarningを表示します。
 
-## Compatibility
+## Changes / 変更内容
+
+- [#330](https://github.com/kasahart/wandas/pull/330): Centralize private channel-metadata storage keys.
+  privateなchannel-metadata storage keyを一箇所に集約しました。
+- [#331](https://github.com/kasahart/wandas/pull/331): Make channel-metadata ownership explicit.
+  channel-metadataの所有権を明確化しました。
+- [#332](https://github.com/kasahart/wandas/pull/332): Restore recoverable `wandas-agent` notifications.
+  復旧可能な`wandas-agent`通知を整備しました。
+- [#333](https://github.com/kasahart/wandas/pull/333): Simplify the generated-artifact cleanup lifecycle.
+  生成artifactのcleanup lifecycleを簡素化しました。
+- [#334](https://github.com/kasahart/wandas/pull/334): Prepare the Wandas 0.6.1 release.
+  Wandas 0.6.1のrelease準備を行いました。
+
+## Compatibility / 互換性
 
 This release does not change the public numerical-data boundary: use `frame.data`.
 WDF 0.4 and Recipe schema 2 remain unchanged. Cross-repository agent notification
-requires the documented `WANDAS_AGENT_TOKEN`; when notification is disabled, the
-workflow fails explicitly before dispatch and an existing release tag can be replayed
-after configuration is corrected.
+requires the documented `WANDAS_AGENT_TOKEN`. When the token is unavailable, the
+optional notification is skipped without invalidating the package release; the
+downstream submodule can be reconciled manually or the tag can be replayed after
+configuration is corrected.
+このreleaseでもpublicな数値data境界は変わりません。`frame.data`を使用してください。
+WDF 0.4とRecipe schema 2も変更していません。repository間のAgent通知には、文書化された
+`WANDAS_AGENT_TOKEN`が必要です。tokenが利用できない場合、package releaseを失敗扱いに
+せず任意の通知をskipします。下流submoduleは手動で同期でき、設定修正後にtagをreplay
+することもできます。

--- a/tests/docs/test_notify_agent_workflow.py
+++ b/tests/docs/test_notify_agent_workflow.py
@@ -109,21 +109,22 @@ def test_notify_agent_resolves_only_existing_strict_release_tags() -> None:
     assert "::error title=Unknown release tag::" in script
 
 
-def test_notify_agent_reports_missing_least_privilege_credential() -> None:
+def test_notify_agent_skips_missing_least_privilege_credential() -> None:
     credential = _steps_by_name()["Validate notification credential"]
     script = credential["run"]
 
+    assert credential["id"] == "credential"
     assert credential["if"] == "steps.release.outputs.valid == 'true'"
     assert credential["env"] == {"WANDAS_AGENT_TOKEN": "${{ secrets.WANDAS_AGENT_TOKEN }}"}
-    assert "::error title=Missing WANDAS_AGENT_TOKEN::" in script
-    assert "scoped only to kasahart/wandas-agent" in script
-    assert "Contents: Read and write" in script
+    assert "::warning title=wandas-agent notification skipped::" in script
+    assert 'echo "enabled=false" >> "$GITHUB_OUTPUT"' in script
+    assert 'echo "enabled=true" >> "$GITHUB_OUTPUT"' in script
 
 
 def test_notify_agent_dispatches_the_resolved_tag() -> None:
     dispatch = _steps_by_name()["Trigger wandas-agent submodule update"]
 
-    assert dispatch["if"] == "steps.release.outputs.valid == 'true'"
+    assert dispatch["if"] == ("steps.release.outputs.valid == 'true' && steps.credential.outputs.enabled == 'true'")
     assert dispatch["uses"] == ("peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0")
     assert dispatch["with"] == {
         "token": "${{ secrets.WANDAS_AGENT_TOKEN }}",
@@ -224,16 +225,23 @@ def test_notify_agent_manual_replay_rejects_unknown_tag(tmp_path: Path) -> None:
     assert "::error title=Unknown release tag::" in result.stdout
 
 
-@pytest.mark.parametrize(("token", "expected_status"), [("", 1), ("secret-value", 0)])
+@pytest.mark.parametrize(
+    ("token", "expected_outputs"),
+    [("", {"enabled": "false"}), ("secret-value", {"enabled": "true"})],
+)
 @BASH_WORKFLOW_ONLY
-def test_notify_agent_credential_preflight(tmp_path: Path, token: str, expected_status: int) -> None:
+def test_notify_agent_credential_preflight(
+    tmp_path: Path,
+    token: str,
+    expected_outputs: dict[str, str],
+) -> None:
     script = _steps_by_name()["Validate notification credential"]["run"]
 
     result, outputs = _run_script(tmp_path, script, token=token)
 
-    assert result.returncode == expected_status
-    assert outputs == {}
+    assert result.returncode == 0
+    assert outputs == expected_outputs
     if token:
         assert token not in result.stdout + result.stderr
     else:
-        assert "::error title=Missing WANDAS_AGENT_TOKEN::" in result.stdout
+        assert "::warning title=wandas-agent notification skipped::" in result.stdout


### PR DESCRIPTION
## Summary / 概要

- publish the v0.6.1 release notes in English and Japanese
- document missing WANDAS_AGENT_TOKEN as a warning-and-skip condition
- skip only the downstream dispatch when the optional credential is absent
- keep strict-tag validation and real dispatch failures actionable

v0.6.1 release noteを日英併記にし、任意の通知credentialがない場合はrelease全体を失敗扱いにせず、warningを出してdispatchのみskipします。

Follow-up to #329.

## Validation / 検証

- uv run pytest tests/docs/test_notify_agent_workflow.py (15 passed)
- uv run ruff check wandas tests --config=pyproject.toml
- uv run ty check wandas tests
- uv run mkdocs build --strict -f docs/mkdocs.yml
- pre-commit ruff check, ruff format, ty

## Release state / 公開状態

The existing v0.6.1 GitHub Release body has already been updated to the same bilingual content. The failed historical run remains immutable; this change prevents the same missing-secret condition from making future tag workflows red.

公開済みv0.6.1のGitHub Release本文も同じ日英併記へ更新済みです。過去の失敗run自体は変更できませんが、今後はsecret未設定だけを理由にtag workflowが赤くなりません。