### PR TITLE
Split add_channel and concat_frame by input contract

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -103,7 +103,7 @@ recording.describe(fmin=20, fmax=8_000, vmin=-80, vmax=-20, image_save="readme_s
 
 次は、答えが分かっている信号で、コードと解析結果が一致することを確かめます。`wd.from_numpy()` を使えば、NumPy 配列にサンプリング周波数、チャンネル名、単位を与えて `ChannelFrame` を作れます。
 
-この例では、750 Hz / 1500 Hz と DC オフセットを含むモノラル信号を作ります。DC 除去と 1 kHz ローパスフィルターを 1 つのメソッドチェインで適用し、`add_channel()` で元信号と加工後をまとめて波形と FFT を重ね書きします。
+この例では、750 Hz / 1500 Hz と DC オフセットを含むモノラル信号を作ります。DC 除去と 1 kHz ローパスフィルターを 1 つのメソッドチェインで適用し、`concat_frame()` で元信号と加工後をまとめて波形と FFT を重ね書きします。
 
 ```python
 import numpy as np
@@ -133,7 +133,7 @@ processed = (
     .low_pass_filter(cutoff=1_000)
     .rename_channels({0: "After DC removal + 1 kHz low-pass"})
 )
-comparison = signal.add_channel(processed)
+comparison = signal.concat_frame(processed)
 
 comparison.plot(
     overlay=True,
@@ -150,7 +150,7 @@ spectrum_ax.set_ylim(30, 90)
 
 メソッドチェインは元の `signal` を書き換えず、新しい `ChannelFrame` を返します。`processed.previous` から直前の frame をたどれ、`processed.operation_history` には `remove_dc()` と `low_pass_filter()` が残ります。
 
-`signal.add_channel(processed)` は元信号と加工後を 2 チャンネルの比較 frame にまとめます。波形の重ね書きでは、DC オフセットが消え、フィルター後の波形が変化していることを確認できます。
+`signal.concat_frame(processed)` は元信号と加工後を 2 チャンネルの比較 frame にまとめます。波形の重ね書きでは、DC オフセットが消え、フィルター後の波形が変化していることを確認できます。
 
 ![元信号と DC 除去・ローパス後を重ね書きした Wandas 波形プロット](https://raw.githubusercontent.com/kasahart/wandas/main/images/readme_known_signal_waveform.png)
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The workflow stays method-centered from here. Call `recording.remove_dc()` to re
 
 Next, verify that the code and analysis result agree for a signal whose answer is known. `wd.from_numpy()` creates a `ChannelFrame` from a NumPy array while attaching the sampling rate, channel names, and units.
 
-This example creates one mono signal containing 750 Hz and 1500 Hz tones plus a DC offset. It removes DC, applies a 1 kHz low-pass filter in one method chain, and combines the result with the original through `add_channel()` for overlaid waveform and FFT views.
+This example creates one mono signal containing 750 Hz and 1500 Hz tones plus a DC offset. It removes DC, applies a 1 kHz low-pass filter in one method chain, and combines the result with the original through `concat_frame()` for overlaid waveform and FFT views.
 
 ```python
 import numpy as np
@@ -133,7 +133,7 @@ processed = (
     .low_pass_filter(cutoff=1_000)
     .rename_channels({0: "After DC removal + 1 kHz low-pass"})
 )
-comparison = signal.add_channel(processed)
+comparison = signal.concat_frame(processed)
 
 comparison.plot(
     overlay=True,
@@ -150,7 +150,7 @@ spectrum_ax.set_ylim(30, 90)
 
 The method chain returns a new `ChannelFrame` without changing the original `signal`. `processed.previous` follows the preceding frame, while `processed.operation_history` records both `remove_dc()` and `low_pass_filter()`.
 
-`signal.add_channel(processed)` combines the original and processed signals into a two-channel comparison frame. In the waveform overlay, the DC offset disappears and the filtered waveform changes shape.
+`signal.concat_frame(processed)` combines the original and processed signals into a two-channel comparison frame. In the waveform overlay, the DC offset disappears and the filtered waveform changes shape.
 
 ![Overlaid Wandas waveforms for the original signal and the DC-removed low-pass result](https://raw.githubusercontent.com/kasahart/wandas/main/images/readme_known_signal_waveform.png)
 

--- a/docs/src/api/frames.md
+++ b/docs/src/api/frames.md
@@ -20,6 +20,21 @@ new unit's default. Chain `.with_unit(...).with_ref(...)` for a custom reference
 
 ::: wandas.frames.channel.ChannelFrame
 
+### Combining channels / チャンネルの結合
+
+Use `frame.add_channel(array, ...)` to append exactly one channel from a NumPy or
+Dask array. Use `frame.concat_frame(other, ...)` to append every channel from another
+`ChannelFrame` while preserving its channel metadata, calibration, and source-time
+offsets. `add_channel(ChannelFrame)` is no longer supported; migrate its `label=`
+prefix to `concat_frame(..., label_prefix=...)`.
+
+NumPyまたはDask配列から1チャンネルを追加する場合は
+`frame.add_channel(array, ...)`を使用します。別の`ChannelFrame`の全チャンネルを、
+channel metadata、calibration、source-time offsetとともに追加する場合は
+`frame.concat_frame(other, ...)`を使用します。`add_channel(ChannelFrame)`は
+サポートされないため、従来の`label=` prefixは
+`concat_frame(..., label_prefix=...)`へ移行してください。
+
 Use the <a href="../learning-path/07_per_channel_calibration.html">per-channel
 calibration learning app</a> to configure known conversion factors without
 modifying the source frame. Calibrated physical values are available from

--- a/docs/src/how-to/pipeline-recipes.md
+++ b/docs/src/how-to/pipeline-recipes.md
@@ -41,7 +41,8 @@ Supported operation shapes are:
 | `mix()` | `base` plus a `frame` or `array` input |
 | NumPy/Dask arithmetic | ordered `frame` and `array` inputs |
 | indexing | one `frame`; selector stored as a parameter |
-| `add_channel()` | `base` plus a `frame` or `array` input |
+| `add_channel()` | `frame` plus an `array` input |
+| `concat_frame()` | `frame` plus another `frame` input |
 
 ## Save and load a standalone artifact
 

--- a/docs/src/release-notes/v0.6.1.md
+++ b/docs/src/release-notes/v0.6.1.md
@@ -38,6 +38,22 @@ Wandas 0.6.1は、metadataの所有権の明確化と、復旧可能なrelease a
 
 ## Compatibility / 互換性
 
+`ChannelFrame.add_channel()` now accepts only one raw NumPy or Dask channel.
+To concatenate another `ChannelFrame`, replace
+`frame.add_channel(other, label="prefix")` with
+`frame.concat_frame(other, label_prefix="prefix")`. Existing valid
+`wandas.channel.add_channel` version 1 Recipes remain replayable, while new array
+calls emit version 2 and new Frame concatenations emit
+`wandas.channel.concat_frame` version 1.
+
+`ChannelFrame.add_channel()`はNumPyまたはDaskの生配列1チャンネルだけを受け取ります。
+別の`ChannelFrame`を連結する場合は、
+`frame.add_channel(other, label="prefix")`を
+`frame.concat_frame(other, label_prefix="prefix")`へ置き換えてください。
+既存の有効な`wandas.channel.add_channel` version 1 Recipeは引き続き再生でき、
+新しい配列呼び出しはversion 2、Frame連結は
+`wandas.channel.concat_frame` version 1を生成します。
+
 This release does not change the public numerical-data boundary: use `frame.data`.
 WDF 0.4 and Recipe schema 2 remain unchanged. Cross-repository agent notification
 requires the documented `WANDAS_AGENT_TOKEN`. When the token is unavailable, the

--- a/learning-path/01_getting_started.py
+++ b/learning-path/01_getting_started.py
@@ -306,7 +306,7 @@ def _(wd):
     processed.print_operation_history()
 
     # 処理前後の比較 - 信号処理の効果を視覚的に確認
-    combined_signal = complex_signal.add_channel(processed, suffix_on_dup="_processed")
+    combined_signal = complex_signal.concat_frame(processed, label_prefix="processed")
 
     # TypedDictを使用した詳細設定 - 型安全な設定方法
     from wandas.visualization.types import DescribeParams
@@ -371,7 +371,7 @@ def _(wd):
         -------
         ChannelFrame
             元の信号とフィルタ済み信号が結合されたChannelFrame。
-            チャンネル名は元の信号が "signal"、フィルタ済みが "signal_filtered" となります。
+            チャンネル名は元の信号が "signal"、フィルタ済みが "filtered_signal" となります。
 
         Examples
         --------
@@ -395,7 +395,7 @@ def _(wd):
         filtered = signal.low_pass_filter(cutoff=filter_cutoff)
 
         # 処理した信号を元の信号のchannel frameに追加 - 比較のため
-        combined = signal.add_channel(filtered, suffix_on_dup="_filtered")
+        combined = signal.concat_frame(filtered, label_prefix="filtered")
         return combined
 
     # デフォルトパラメータで実行 - 基本的な実験

--- a/tests/docs/test_readme_examples.py
+++ b/tests/docs/test_readme_examples.py
@@ -174,8 +174,8 @@ def test_readme_leads_with_wav_describe_and_verified_signal_figures() -> None:
     assert "1500 Hz component" in english
     assert "750 Hz 成分" in japanese
     assert "1500 Hz 成分" in japanese
-    assert "signal.add_channel" in english
-    assert "signal.add_channel" in japanese
+    assert "signal.concat_frame" in english
+    assert "signal.concat_frame" in japanese
     assert "signal = wd.from_numpy" in japanese
     for figure in README_FIGURES:
         assert figure.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")

--- a/tests/frames/test_channel_collection.py
+++ b/tests/frames/test_channel_collection.py
@@ -36,7 +36,7 @@ class TestChannelFrameCollection:
         assert cf2._data.shape == (2, 8)
         assert cf2.operation_history[-1] == {
             "operation": "wandas.channel.add_channel",
-            "version": 1,
+            "version": 2,
             "params": {"align": "pad", "label": "B"},
         }
         cf3 = cf.add_channel(np.arange(10), label="C", align="truncate")
@@ -44,7 +44,7 @@ class TestChannelFrameCollection:
         assert cf3._data.shape == (2, 8)
         assert cf3.operation_history[-1] == {
             "operation": "wandas.channel.add_channel",
-            "version": 1,
+            "version": 2,
             "params": {"align": "truncate", "label": "C"},
         }
         with pytest.raises(ValueError):
@@ -69,7 +69,7 @@ class TestChannelFrameCollection:
         arr2 = np.arange(8, 16)
         cf1 = ChannelFrame.from_numpy(arr1, sampling_rate=1000, ch_labels=["A"])
         cf2 = ChannelFrame.from_numpy(arr2, sampling_rate=1000, ch_labels=["B"])
-        cf3 = cf1.add_channel(cf2)
+        cf3 = cf1.concat_frame(cf2)
         assert cf3 is not cf1  # Pillar 1: immutability
         assert cf1.n_channels == 1  # Pillar 1: original unchanged
         assert cf3.n_channels == 2
@@ -83,8 +83,8 @@ class TestChannelFrameCollection:
         cf1 = ChannelFrame.from_numpy(arr1, sampling_rate=1000, ch_labels=["A"])
         cf2 = ChannelFrame.from_numpy(arr2, sampling_rate=1000, ch_labels=["A"])
         with pytest.raises(ValueError):
-            cf1.add_channel(cf2)
-        cf3 = cf1.add_channel(cf2, suffix_on_dup="_dup")
+            cf1.concat_frame(cf2)
+        cf3 = cf1.concat_frame(cf2, suffix_on_dup="_dup")
         assert cf3._channel_metadata[1].label == "A_dup"
 
     def test_add_channel_frame_length_mismatch(self):
@@ -93,10 +93,10 @@ class TestChannelFrameCollection:
         cf1 = ChannelFrame.from_numpy(arr1, sampling_rate=1000, ch_labels=["A"])
         cf2 = ChannelFrame.from_numpy(arr2, sampling_rate=1000, ch_labels=["B"])
         with pytest.raises(ValueError):
-            cf1.add_channel(cf2, align="strict")
-        cf3 = cf1.add_channel(cf2, align="pad")
+            cf1.concat_frame(cf2, align="strict")
+        cf3 = cf1.concat_frame(cf2, align="pad")
         assert cf3._data.shape == (2, 8)
-        cf4 = cf1.add_channel(cf2, align="truncate")
+        cf4 = cf1.concat_frame(cf2, align="truncate")
         assert cf4._data.shape == (2, 8)
 
     def test_add_channel_sampling_rate_mismatch(self):
@@ -105,7 +105,7 @@ class TestChannelFrameCollection:
         cf1 = ChannelFrame.from_numpy(arr1, sampling_rate=1000, ch_labels=["A"])
         cf2 = ChannelFrame.from_numpy(arr2, sampling_rate=2000, ch_labels=["B"])
         with pytest.raises(ValueError):
-            cf1.add_channel(cf2)
+            cf1.concat_frame(cf2)
 
     def test_add_channel_type_error(self):
         arr = np.arange(8)
@@ -230,7 +230,7 @@ class TestChannelFrameCollection:
         cf2 = ChannelFrame.from_numpy(arr2, sampling_rate=1000, ch_labels=["B"], metadata=metadata2)
 
         # add_channelでChannelFrameを追加
-        cf3 = cf1.add_channel(cf2)
+        cf3 = cf1.concat_frame(cf2)
 
         # 元のフレーム(cf1)のmetadataのみが保持されることを確認
         assert cf3.metadata == metadata1
@@ -265,7 +265,7 @@ class TestChannelFrameCollection:
         )
 
         # 2つのChannelFrameを順次追加
-        cf_combined = cf1.add_channel(cf2).add_channel(cf3)
+        cf_combined = cf1.concat_frame(cf2).concat_frame(cf3)
 
         # すべてのチャンネルが存在することを確認
         assert cf_combined.n_channels == 3
@@ -302,7 +302,7 @@ class TestChannelFrameCollection:
         cf1 = ChannelFrame.from_numpy(arr1, sampling_rate=1000, ch_labels=["A"], ch_units="Pa")
         cf2 = ChannelFrame.from_numpy(arr2, sampling_rate=1000, ch_labels=["B"], ch_units="V")
 
-        cf3 = cf1.add_channel(cf2)
+        cf3 = cf1.concat_frame(cf2)
 
         # 両方のチャンネルのextraが空のdictであることを確認
         assert cf3._channel_metadata[0].extra == {}
@@ -352,7 +352,7 @@ class TestChannelFrameCollection:
         cf2 = ChannelFrame.from_numpy(arr2, sampling_rate=1000, ch_labels=["added"], ch_units="V")
         cf2 = cf2.with_channel_extra(0, {"other": "info"})
 
-        combined = cf1.add_channel(cf2)
+        combined = cf1.concat_frame(cf2)
 
         # 両方のチャンネルのChannelMetadataが保持され、元のフレームは変更されないことを確認
         assert cf1.n_channels == 1

--- a/tests/frames/test_channel_collection_mixin.py
+++ b/tests/frames/test_channel_collection_mixin.py
@@ -138,6 +138,10 @@ class TestChannelCollectionMixin:
         with pytest.raises(NotImplementedError):
             incomplete.add_channel(np.ones(10), label="test")
 
+        # Test concat_frame method
+        with pytest.raises(NotImplementedError):
+            incomplete.concat_frame(incomplete)
+
         # Test remove_channel method
         with pytest.raises(NotImplementedError):
             incomplete.remove_channel(0)

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -578,7 +578,7 @@ def test_add_channel_align_strict_length_mismatch_raises() -> None:
     other = ChannelFrame(data=_da_from_array(np.zeros((1, 5)), chunks=(1, -1)), sampling_rate=16000)
 
     with pytest.raises(ValueError, match=r"Data length mismatch"):
-        base.add_channel(other)  # default align='strict'
+        base.concat_frame(other)  # default align='strict'
 
 
 def test_add_channel_duplicate_label_without_suffix_raises() -> None:
@@ -601,7 +601,7 @@ def test_add_channel_returns_new_frame_without_mutating_original() -> None:
     assert added.labels == ["ch0", "new_ch"]
     assert added.operation_history[-1] == {
         "operation": "wandas.channel.add_channel",
-        "version": 1,
+        "version": 2,
         "params": {"label": "new_ch"},
     }
 
@@ -670,7 +670,7 @@ def test_add_channel_dask_raw_uses_explicit_source_time_offset_and_stays_lazy() 
     assert added.operation_history == [
         {
             "operation": "wandas.channel.add_channel",
-            "version": 1,
+            "version": 2,
             "params": {"label": "new_ch", "source_time_offset": [5.0]},
         }
     ]
@@ -711,13 +711,13 @@ def test_add_channel_frame_preserves_per_channel_source_time_offsets() -> None:
         source_time_offset=[5.0, 8.0],
     )
 
-    added = base.add_channel(other)
+    added = base.concat_frame(other)
 
     np.testing.assert_array_equal(added.source_time_offset, np.array([2.5, 5.0, 8.0]))
     np.testing.assert_array_equal(added.source_time[:, 0], np.array([2.5, 5.0, 8.0]))
 
 
-def test_add_channel_frame_rejects_explicit_source_time_offset() -> None:
+def test_add_channel_frame_rejected_with_migration_message() -> None:
     base = ChannelFrame(
         data=_da_from_array(np.zeros((1, 6)), chunks=(1, -1)),
         sampling_rate=16000,
@@ -730,14 +730,20 @@ def test_add_channel_frame_rejects_explicit_source_time_offset() -> None:
         source_time_offset=5.0,
     )
 
-    with pytest.raises(ValueError, match="source_time_offset cannot be used when adding a ChannelFrame"):
-        base.add_channel(other, source_time_offset=9.0)
+    with pytest.raises(TypeError, match=r"use concat_frame\(other, label_prefix=\.\.\.\) instead"):
+        base.add_channel(other)  # ty: ignore[invalid-argument-type]
 
 
 def test_add_channel_unsupported_type_raises() -> None:
     base = ChannelFrame(data=_da_from_array(np.zeros((1, 4)), chunks=(1, -1)), sampling_rate=16000)
-    with pytest.raises(TypeError, match=r"data must be a ChannelFrame, NumPy array, or Dask array"):
+    with pytest.raises(TypeError, match=r"data must be a NumPy array or Dask array"):
         base.add_channel(12345)  # unsupported type  # ty: ignore[invalid-argument-type]
+
+
+def test_concat_frame_unsupported_type_raises() -> None:
+    base = ChannelFrame(data=_da_from_array(np.zeros((1, 4)), chunks=(1, -1)), sampling_rate=16000)
+    with pytest.raises(TypeError, match=r"other must be a ChannelFrame"):
+        base.concat_frame(np.zeros(4))  # ty: ignore[invalid-argument-type]
 
 
 def test_add_channel_with_channelframe_align_pad_and_truncate() -> None:
@@ -749,13 +755,13 @@ def test_add_channel_with_channelframe_align_pad_and_truncate() -> None:
         sampling_rate=16000,
         channel_metadata=[{"label": "other_ch"}],
     )
-    out = base.add_channel(other_short, align="pad")
+    out = base.concat_frame(other_short, align="pad")
     assert out is not base  # Pillar 1: immutability
     assert out.n_samples == base.n_samples
     assert out.n_channels == 2
     assert base.n_channels == 1  # Pillar 1: original unchanged
     assert out.operation_history[-1] == {
-        "operation": "wandas.channel.add_channel",
+        "operation": "wandas.channel.concat_frame",
         "version": 1,
         "params": {"align": "pad"},
     }
@@ -766,12 +772,12 @@ def test_add_channel_with_channelframe_align_pad_and_truncate() -> None:
         sampling_rate=16000,
         channel_metadata=[{"label": "other_ch_long"}],
     )
-    out2 = base.add_channel(other_long, align="truncate")
+    out2 = base.concat_frame(other_long, align="truncate")
     assert out2 is not base  # Pillar 1: immutability
     assert out2.n_samples == base.n_samples
     assert out2.n_channels == 2
     assert out2.operation_history[-1] == {
-        "operation": "wandas.channel.add_channel",
+        "operation": "wandas.channel.concat_frame",
         "version": 1,
         "params": {"align": "truncate"},
     }

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -755,6 +755,8 @@ def test_channel_collection_type_guards_survive_nested_semantic_context() -> Non
         pytest.raises(TypeError, match="data must be a NumPy array or Dask array"),
     ):
         base.add_channel(12345)  # ty: ignore[invalid-argument-type]
+    with semantic_lineage(base.lineage), pytest.raises(TypeError, match="use concat_frame"):
+        base.add_channel(base)  # ty: ignore[invalid-argument-type]
     with semantic_lineage(base.lineage), pytest.raises(TypeError, match="other must be a ChannelFrame"):
         base.concat_frame(np.zeros(4))  # ty: ignore[invalid-argument-type]
 

--- a/tests/frames/test_channel_frame.py
+++ b/tests/frames/test_channel_frame.py
@@ -16,6 +16,7 @@ import wandas as wd
 from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
 from wandas.pipeline import RecipePlan
+from wandas.processing.semantic import semantic_lineage
 from wandas.utils.types import NDArrayReal
 
 _da_from_array = da.from_array
@@ -743,6 +744,18 @@ def test_add_channel_unsupported_type_raises() -> None:
 def test_concat_frame_unsupported_type_raises() -> None:
     base = ChannelFrame(data=_da_from_array(np.zeros((1, 4)), chunks=(1, -1)), sampling_rate=16000)
     with pytest.raises(TypeError, match=r"other must be a ChannelFrame"):
+        base.concat_frame(np.zeros(4))  # ty: ignore[invalid-argument-type]
+
+
+def test_channel_collection_type_guards_survive_nested_semantic_context() -> None:
+    base = ChannelFrame(data=_da_from_array(np.zeros((1, 4)), chunks=(1, -1)), sampling_rate=16000)
+
+    with (
+        semantic_lineage(base.lineage),
+        pytest.raises(TypeError, match="data must be a NumPy array or Dask array"),
+    ):
+        base.add_channel(12345)  # ty: ignore[invalid-argument-type]
+    with semantic_lineage(base.lineage), pytest.raises(TypeError, match="other must be a ChannelFrame"):
         base.concat_frame(np.zeros(4))  # ty: ignore[invalid-argument-type]
 
 

--- a/tests/frames/test_channel_label_updates.py
+++ b/tests/frames/test_channel_label_updates.py
@@ -386,7 +386,7 @@ class TestAddChannelWithLabelPrefix:
         )
 
         # Add with label prefix
-        result = frame1.add_channel(frame2, label="ref")
+        result = frame1.concat_frame(frame2, label_prefix="ref")
 
         # Existing channels should remain unchanged
         assert len(result.labels) == 4
@@ -416,7 +416,7 @@ class TestAddChannelWithLabelPrefix:
             ],
         )
 
-        result = frame1.add_channel(frame2)  # No label parameter
+        result = frame1.concat_frame(frame2)  # No label prefix
 
         assert result.labels == ["left", "right", "vocals", "instrumental"]
 
@@ -435,11 +435,11 @@ class TestAddChannelWithLabelPrefix:
         )
 
         # With label prefix, should not conflict
-        result = frame1.add_channel(frame2, label="ref")
+        result = frame1.concat_frame(frame2, label_prefix="ref")
         assert result.labels == ["ch0", "ch1", "ref_ch0", "ref_ch1"]
 
         # Without label, would conflict and use suffix_on_dup
-        result2 = frame1.add_channel(frame2, suffix_on_dup="_dup")
+        result2 = frame1.concat_frame(frame2, suffix_on_dup="_dup")
         assert result2.labels == ["ch0", "ch1", "ch0_dup", "ch1_dup"]
 
 

--- a/tests/pipeline/test_channel_recipe_contract.py
+++ b/tests/pipeline/test_channel_recipe_contract.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from contextlib import nullcontext
 from copy import deepcopy
 from fractions import Fraction
-from typing import Any
+from typing import Any, overload
 
 import dask.array as da
 import numpy as np
@@ -13,6 +14,30 @@ from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
 from wandas.pipeline import RecipeExecutionError, RecipePlan
 from wandas.processing.semantic import freeze_value, semantic_lineage, value_to_json
+
+
+class _StatefulSingleOffset(Sequence[float]):
+    """Expose a different scalar on each indexed read."""
+
+    def __init__(self) -> None:
+        self.reads = 0
+
+    def __len__(self) -> int:
+        return 1
+
+    @overload
+    def __getitem__(self, index: int) -> float: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[float]: ...
+
+    def __getitem__(self, index: int | slice) -> float | Sequence[float]:
+        if isinstance(index, slice):
+            return [1.0][index]
+        if index != 0:
+            raise IndexError(index)
+        self.reads += 1
+        return float(self.reads)
 
 
 def _frame(
@@ -126,6 +151,21 @@ def test_add_channel_offset_outside_float_range_has_contract_error() -> None:
 
     with pytest.raises(ValueError, match="representable as a finite float"):
         base.add_channel(np.ones(8), source_time_offset=10**1000)
+
+
+def test_add_channel_uses_one_offset_snapshot_for_execution_and_lineage() -> None:
+    base = _frame(np.zeros((1, 8)), labels=["base"], offsets=[1.0])
+    array = np.ones(8)
+    offset = _StatefulSingleOffset()
+
+    result = base.add_channel(array, source_time_offset=offset)
+    payload = _payload(result, ("base", "array"))
+    replayed = RecipePlan.from_dict(payload).apply({"base": base, "array": array})
+
+    assert offset.reads == 1
+    assert result.operation_history[-1]["params"]["source_time_offset"] == 1.0
+    np.testing.assert_array_equal(result.source_time_offset, [1.0, 1.0])
+    np.testing.assert_array_equal(replayed.source_time_offset, [1.0, 1.0])
 
 
 def test_concat_frame_v1_round_trip_preserves_frame_contract() -> None:

--- a/tests/pipeline/test_channel_recipe_contract.py
+++ b/tests/pipeline/test_channel_recipe_contract.py
@@ -9,7 +9,7 @@ import pytest
 
 from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
-from wandas.pipeline import RecipePlan
+from wandas.pipeline import RecipeExecutionError, RecipePlan
 
 
 def _frame(
@@ -148,3 +148,21 @@ def test_legacy_add_channel_v1_recipes_load_and_replay(kind: str) -> None:
     expected_labels = ["base", "legacy_other"] if kind == "frame" else ["base", "legacy"]
     assert replayed.labels == expected_labels
     np.testing.assert_array_equal(replayed.source_time_offset, [1.0, 2.0])
+
+
+def test_legacy_add_channel_v1_rejects_frame_offset_that_was_never_valid() -> None:
+    base = _frame(np.zeros((1, 8)), labels=["base"])
+    other = _frame(np.ones((1, 8)), labels=["other"])
+    payload = _payload(base.concat_frame(other), ("base", "data"))
+    payload["nodes"][0]["operation"] = "wandas.channel.add_channel"
+    payload["nodes"][0]["params"]["entries"] = [
+        [
+            "source_time_offset",
+            {"$type": "number", "kind": "python-float", "data": "3ff0000000000000"},
+        ]
+    ]
+
+    loaded = RecipePlan.from_dict(payload)
+
+    with pytest.raises(RecipeExecutionError, match="source_time_offset is only supported for array input"):
+        loaded.apply({"base": base, "data": other})

--- a/tests/pipeline/test_channel_recipe_contract.py
+++ b/tests/pipeline/test_channel_recipe_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import nullcontext
 from copy import deepcopy
 from typing import Any
 
@@ -10,6 +11,7 @@ import pytest
 from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
 from wandas.pipeline import RecipeExecutionError, RecipePlan
+from wandas.processing.semantic import freeze_value, semantic_lineage, value_to_json
 
 
 def _frame(
@@ -28,6 +30,10 @@ def _frame(
 
 def _payload(result: ChannelFrame, names: tuple[str, ...]) -> dict[str, Any]:
     return RecipePlan.from_frame(result, input_names=names).to_dict()
+
+
+def _replace_params(payload: dict[str, Any], params: dict[str, Any]) -> None:
+    payload["nodes"][0]["params"] = value_to_json(freeze_value(params))
 
 
 def test_add_channel_v2_round_trip_replays_lazy_external_array() -> None:
@@ -57,6 +63,34 @@ def test_add_channel_v2_round_trip_accepts_explicit_default_offset() -> None:
 
     assert ["source_time_offset", None] in payload["nodes"][0]["params"]["entries"]
     np.testing.assert_array_equal(replayed.source_time_offset, [1.0, 0.0])
+
+
+@pytest.mark.parametrize("array_kind", ["numpy", "dask"])
+@pytest.mark.parametrize(
+    ("offset", "expected"),
+    [
+        (None, 0.0),
+        (1.25, 1.25),
+        ([1.5], 1.5),
+        (np.array([1.75]), 1.75),
+    ],
+)
+def test_add_channel_accepted_offsets_round_trip_for_array_kinds(
+    array_kind: str,
+    offset: Any,
+    expected: float,
+) -> None:
+    base = _frame(np.zeros((1, 8)), labels=["base"], offsets=[1.0])
+    array: Any = np.ones(8) if array_kind == "numpy" else da.ones(8, chunks=4)
+
+    result = base.add_channel(array, source_time_offset=offset)
+    payload = _payload(result, ("base", "array"))
+    loaded = RecipePlan.from_dict(payload)
+    replayed = loaded.apply({"base": base, "array": array})
+
+    assert payload["nodes"][0]["version"] == 2
+    np.testing.assert_array_equal(replayed.source_time_offset, [1.0, expected])
+    np.testing.assert_array_equal(channel_first_values(replayed), channel_first_values(result))
 
 
 def test_concat_frame_v1_round_trip_preserves_frame_contract() -> None:
@@ -98,6 +132,13 @@ def test_concat_frame_v1_round_trip_preserves_frame_contract() -> None:
         ("add", {"label": 1}),
         ("add", {"suffix_on_dup": 1}),
         ("add", {"source_time_offset": "invalid"}),
+        ("add", {"source_time_offset": []}),
+        ("add", {"source_time_offset": [1.0, 2.0]}),
+        ("add", {"source_time_offset": [[1.0]]}),
+        ("add", {"source_time_offset": True}),
+        ("add", {"source_time_offset": np.bool_(True)}),
+        ("add", {"source_time_offset": float("nan")}),
+        ("add", {"source_time_offset": float("inf")}),
         ("add", {"unknown": True}),
         ("concat", {"align": "invalid"}),
         ("concat", {"label_prefix": 1}),
@@ -114,13 +155,49 @@ def test_channel_recipe_params_are_rejected_at_load_time(method: str, params: di
     else:
         result = base.concat_frame(_frame(np.ones((1, 8)), labels=["other"]))
         payload = _payload(result, ("base", "other"))
-    payload["nodes"][0]["params"] = {
-        "$type": "map",
-        "entries": [[key, value] for key, value in sorted(params.items())],
-    }
+    _replace_params(payload, params)
 
     with pytest.raises(ValueError, match="params violate its registered contract"):
         RecipePlan.from_dict(payload)
+
+
+@pytest.mark.parametrize(
+    ("method", "params"),
+    [
+        ("add", {"align": "invalid"}),
+        ("add", {"label": 1}),
+        ("add", {"suffix_on_dup": 1}),
+        ("add", {"source_time_offset": []}),
+        ("add", {"source_time_offset": [1.0, 2.0]}),
+        ("add", {"source_time_offset": np.array([])}),
+        ("add", {"source_time_offset": np.array([1.0, 2.0])}),
+        ("add", {"source_time_offset": np.array([[1.0]])}),
+        ("add", {"source_time_offset": True}),
+        ("add", {"source_time_offset": np.bool_(True)}),
+        ("add", {"source_time_offset": "invalid"}),
+        ("add", {"source_time_offset": b"invalid"}),
+        ("add", {"source_time_offset": float("nan")}),
+        ("add", {"source_time_offset": float("-inf")}),
+        ("concat", {"align": "invalid"}),
+        ("concat", {"label_prefix": 1}),
+        ("concat", {"suffix_on_dup": 1}),
+    ],
+)
+@pytest.mark.parametrize("nested", [False, True], ids=["public", "active-lineage"])
+def test_channel_public_parameter_validation_is_independent_of_runtime_conditions(
+    method: str,
+    params: dict[str, Any],
+    nested: bool,
+) -> None:
+    base = _frame(np.zeros((1, 8)), labels=["base"])
+    context = semantic_lineage(base.lineage) if nested else nullcontext()
+
+    with context, pytest.raises((TypeError, ValueError)):
+        if method == "add":
+            base.add_channel(np.ones(8), **params)
+        else:
+            other = _frame(np.ones((1, 8)), labels=["other"])
+            base.concat_frame(other, **params)
 
 
 @pytest.mark.parametrize("kind", ["array", "frame"])

--- a/tests/pipeline/test_channel_recipe_contract.py
+++ b/tests/pipeline/test_channel_recipe_contract.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import dask.array as da
+import numpy as np
+import pytest
+
+from tests.frame_helpers import channel_first_values
+from wandas.frames.channel import ChannelFrame
+from wandas.pipeline import RecipePlan
+
+
+def _frame(
+    values: np.ndarray[Any, Any],
+    *,
+    labels: list[str],
+    offsets: list[float] | None = None,
+) -> ChannelFrame:
+    return ChannelFrame(
+        da.from_array(values, chunks=(1, -1)),
+        sampling_rate=8_000,
+        channel_metadata=[{"label": label} for label in labels],
+        source_time_offset=offsets if offsets is not None else [0.0] * len(labels),
+    )
+
+
+def _payload(result: ChannelFrame, names: tuple[str, ...]) -> dict[str, Any]:
+    return RecipePlan.from_frame(result, input_names=names).to_dict()
+
+
+def test_add_channel_v2_round_trip_replays_lazy_external_array() -> None:
+    base = _frame(np.zeros((1, 8)), labels=["base"], offsets=[1.0])
+    array = da.arange(8, chunks=4)
+    result = base.add_channel(array, label="raw", source_time_offset=2.5)
+
+    payload = _payload(result, ("base", "array"))
+    replayed = RecipePlan.from_dict(payload).apply({"base": base, "array": array})
+
+    assert payload["nodes"][0]["operation"] == "wandas.channel.add_channel"
+    assert payload["nodes"][0]["version"] == 2
+    assert [item["kind"] for item in payload["inputs"]] == ["frame", "array"]
+    assert isinstance(replayed._data, da.Array)
+    assert replayed.labels == ["base", "raw"]
+    np.testing.assert_array_equal(replayed.source_time_offset, [1.0, 2.5])
+    np.testing.assert_array_equal(channel_first_values(replayed), channel_first_values(result))
+
+
+def test_concat_frame_v1_round_trip_preserves_frame_contract() -> None:
+    base = _frame(np.zeros((1, 8)), labels=["base"], offsets=[1.0])
+    other = _frame(np.arange(16).reshape(2, 8), labels=["left", "right"], offsets=[2.0, 3.0])
+    other = other.with_calibration(
+        {
+            0: other.channels[0].calibration.with_ref(1e-6),
+            1: other.channels[1].calibration.with_ref(2e-6),
+        }
+    )
+    base_ids = list(base._channel_ids)
+    other_ids = list(other._channel_ids)
+
+    result = base.concat_frame(other, label_prefix="copy")
+    payload = _payload(result, ("base", "other"))
+    replayed = RecipePlan.from_dict(payload).apply({"base": base, "other": other})
+
+    concat_node = next(node for node in payload["nodes"] if node["operation"] == "wandas.channel.concat_frame")
+    assert concat_node["version"] == 1
+    assert [item["kind"] for item in payload["inputs"]] == ["frame", "frame"]
+    assert "source_time_offset" not in repr(concat_node["params"])
+    assert result.labels == ["base", "copy_left", "copy_right"]
+    assert [channel.calibration.ref for channel in result.channels] == [1.0, 1e-6, 2e-6]
+    assert base._channel_ids == base_ids
+    assert other._channel_ids == other_ids
+    assert result._channel_ids[:1] == base_ids
+    assert len(set(result._channel_ids)) == 3
+    assert sum(item["operation"] == "wandas.channel.concat_frame" for item in result.operation_history) == 1
+    assert isinstance(replayed._data, da.Array)
+    np.testing.assert_array_equal(replayed.source_time_offset, [1.0, 2.0, 3.0])
+    np.testing.assert_array_equal(channel_first_values(replayed), channel_first_values(result))
+
+
+@pytest.mark.parametrize(
+    ("method", "params"),
+    [
+        ("add", {"align": "invalid"}),
+        ("add", {"label": 1}),
+        ("add", {"suffix_on_dup": 1}),
+        ("add", {"source_time_offset": "invalid"}),
+        ("add", {"unknown": True}),
+        ("concat", {"align": "invalid"}),
+        ("concat", {"label_prefix": 1}),
+        ("concat", {"suffix_on_dup": 1}),
+        ("concat", {"source_time_offset": 1}),
+        ("concat", {"unknown": True}),
+    ],
+)
+def test_channel_recipe_params_are_rejected_at_load_time(method: str, params: dict[str, Any]) -> None:
+    base = _frame(np.zeros((1, 8)), labels=["base"])
+    if method == "add":
+        result = base.add_channel(np.ones(8))
+        payload = _payload(result, ("base", "array"))
+    else:
+        result = base.concat_frame(_frame(np.ones((1, 8)), labels=["other"]))
+        payload = _payload(result, ("base", "other"))
+    payload["nodes"][0]["params"] = {
+        "$type": "map",
+        "entries": [[key, value] for key, value in sorted(params.items())],
+    }
+
+    with pytest.raises(ValueError, match="params violate its registered contract"):
+        RecipePlan.from_dict(payload)
+
+
+@pytest.mark.parametrize("kind", ["array", "frame"])
+def test_legacy_add_channel_v1_recipes_load_and_replay(kind: str) -> None:
+    base = _frame(np.zeros((1, 8)), labels=["base"], offsets=[1.0])
+    if kind == "array":
+        external: Any = np.ones(8)
+        result = base.add_channel(external, label="legacy", source_time_offset=2.0)
+        payload = _payload(result, ("base", "data"))
+        payload["nodes"][0]["version"] = 1
+    else:
+        external = _frame(np.ones((1, 8)), labels=["other"], offsets=[2.0])
+        result = base.concat_frame(external, label_prefix="legacy")
+        payload = _payload(result, ("base", "data"))
+        payload["nodes"][0]["operation"] = "wandas.channel.add_channel"
+        payload["nodes"][0]["params"]["entries"] = [["label", "legacy"]]
+
+    loaded = RecipePlan.from_dict(deepcopy(payload))
+    replayed = loaded.apply({"base": base, "data": external})
+
+    assert loaded.nodes[0].version == 1
+    expected_labels = ["base", "legacy_other"] if kind == "frame" else ["base", "legacy"]
+    assert replayed.labels == expected_labels
+    np.testing.assert_array_equal(replayed.source_time_offset, [1.0, 2.0])

--- a/tests/pipeline/test_channel_recipe_contract.py
+++ b/tests/pipeline/test_channel_recipe_contract.py
@@ -47,6 +47,18 @@ def test_add_channel_v2_round_trip_replays_lazy_external_array() -> None:
     np.testing.assert_array_equal(channel_first_values(replayed), channel_first_values(result))
 
 
+def test_add_channel_v2_round_trip_accepts_explicit_default_offset() -> None:
+    base = _frame(np.zeros((1, 8)), labels=["base"], offsets=[1.0])
+    array = np.ones(8)
+    result = base.add_channel(array, source_time_offset=None)
+
+    payload = _payload(result, ("base", "array"))
+    replayed = RecipePlan.from_dict(payload).apply({"base": base, "array": array})
+
+    assert ["source_time_offset", None] in payload["nodes"][0]["params"]["entries"]
+    np.testing.assert_array_equal(replayed.source_time_offset, [1.0, 0.0])
+
+
 def test_concat_frame_v1_round_trip_preserves_frame_contract() -> None:
     base = _frame(np.zeros((1, 8)), labels=["base"], offsets=[1.0])
     other = _frame(np.arange(16).reshape(2, 8), labels=["left", "right"], offsets=[2.0, 3.0])
@@ -124,7 +136,10 @@ def test_legacy_add_channel_v1_recipes_load_and_replay(kind: str) -> None:
         result = base.concat_frame(external, label_prefix="legacy")
         payload = _payload(result, ("base", "data"))
         payload["nodes"][0]["operation"] = "wandas.channel.add_channel"
-        payload["nodes"][0]["params"]["entries"] = [["label", "legacy"]]
+        payload["nodes"][0]["params"]["entries"] = [
+            ["label", "legacy"],
+            ["source_time_offset", None],
+        ]
 
     loaded = RecipePlan.from_dict(deepcopy(payload))
     replayed = loaded.apply({"base": base, "data": external})

--- a/tests/pipeline/test_recipe_behavior_parity.py
+++ b/tests/pipeline/test_recipe_behavior_parity.py
@@ -190,7 +190,7 @@ def test_add_channel_preserves_metadata_and_source_time_contract() -> None:
     base = _frame()
     added = _frame()
     added = added.with_source_time_offset([2.5])
-    processed_frame = base.add_channel(added, label="frame-added")
+    processed_frame = base.concat_frame(added, label_prefix="frame-added")
     replayed_frame = RecipePlan.from_frame(processed_frame, input_names=("base", "added")).apply(
         {"base": base, "added": added}
     )
@@ -221,7 +221,7 @@ def test_processed_parent_add_channel_external_dask_stays_lazy() -> None:
 @pytest.mark.parametrize("method", ["coherence", "csd", "transfer_function"])
 def test_cross_channel_typed_transitions_replay(method: str) -> None:
     base = _frame()
-    source = base.add_channel(base, label="second")
+    source = base.concat_frame(base, label_prefix="second")
     processed = getattr(source, method)(n_fft=128, hop_length=32, win_length=128)
     replayed = RecipePlan.from_frame(processed, input_names=("signal",)).apply({"signal": base})
 

--- a/tests/pipeline/test_recipe_v2_characterization.py
+++ b/tests/pipeline/test_recipe_v2_characterization.py
@@ -126,21 +126,26 @@ def test_add_channel_raw_input_accepts_only_one_channel() -> None:
         base.add_channel(np.ones((2, 12)))
 
 
-def test_add_channel_frame_input_accepts_multiple_channels() -> None:
+def test_concat_frame_input_accepts_multiple_channels() -> None:
     base = _frame(channels=1)
     other = _frame(channels=2)
 
-    added = base.add_channel(other, label="other")
+    added = base.concat_frame(other, label_prefix="other")
 
     assert added.n_channels == 3
 
 
-def test_add_channel_declares_its_data_role() -> None:
-    definition = recipe_definition(ChannelFrame.add_channel)
+def test_channel_operations_declare_single_binding_patterns() -> None:
+    add_definition = recipe_definition(ChannelFrame.add_channel)
+    concat_definition = recipe_definition(ChannelFrame.concat_frame)
 
-    assert [[binding.role for binding in pattern] for pattern in definition.binding_patterns] == [
-        ["base", "data"],
-        ["base", "data"],
+    assert add_definition.version == 2
+    assert [[binding.kind for binding in pattern] for pattern in add_definition.binding_patterns] == [
+        ["frame", "array"]
+    ]
+    assert concat_definition.version == 1
+    assert [[binding.kind for binding in pattern] for pattern in concat_definition.binding_patterns] == [
+        ["frame", "frame"]
     ]
 
 

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -12,6 +12,7 @@ from dask.array.core import Array as DaArray
 from dask.array.core import concatenate
 
 from wandas.pipeline.decorators import OperationCapture, recipe_operation
+from wandas.pipeline.registry import RecipeOperation
 from wandas.processing.calibration import _derive_absolute_calibration_factors
 from wandas.processing.semantic import InputBinding, thaw_params
 from wandas.utils.dask_helpers import da_from_array as _da_from_array
@@ -73,7 +74,8 @@ def _channel_input_patterns(input_role: str) -> tuple[tuple[InputBinding, ...], 
 
 
 _MIX_INPUT_PATTERNS = _channel_input_patterns("other")
-_ADD_CHANNEL_INPUT_PATTERNS = _channel_input_patterns("data")
+_ADD_CHANNEL_BINDINGS = (InputBinding("frame", "frame"), InputBinding("array", "array"))
+_CONCAT_FRAME_BINDINGS = (InputBinding("frame", "frame"), InputBinding("other", "frame"))
 
 _WITH_CALIBRATION_BINDINGS = (InputBinding("frame", "frame"),)
 
@@ -151,6 +153,108 @@ def _mix_recipe(inputs: tuple[Any, ...], params: Mapping[str, Any]) -> Any:
 def _add_channel_recipe(inputs: tuple[Any, ...], params: Mapping[str, Any]) -> Any:
     """Replay channel insertion through :meth:`ChannelFrame.add_channel`."""
     return inputs[0].add_channel(inputs[1], **dict(params))
+
+
+def _concat_frame_recipe(inputs: tuple[Any, ...], params: Mapping[str, Any]) -> Any:
+    """Replay channel concatenation through :meth:`ChannelFrame.concat_frame`."""
+    return inputs[0].concat_frame(inputs[1], **dict(params))
+
+
+def _legacy_add_channel_recipe(inputs: tuple[Any, ...], params: Mapping[str, Any]) -> Any:
+    """Replay a valid pre-split add_channel Recipe through its replacement API."""
+    if isinstance(inputs[1], ChannelFrame):
+        legacy_params = dict(params)
+        label = legacy_params.pop("label", None)
+        return inputs[0].concat_frame(inputs[1], label_prefix=label, **legacy_params)
+    return inputs[0].add_channel(inputs[1], **dict(params))
+
+
+def _capture_add_channel(args: tuple[Any, ...], params: Mapping[str, Any]) -> OperationCapture:
+    """Capture the array-only add_channel v2 contract."""
+    data = params["data"]
+    if isinstance(data, ChannelFrame):
+        raise TypeError(
+            "add_channel() no longer accepts ChannelFrame input; use concat_frame(other, label_prefix=...) instead"
+        )
+    if not isinstance(data, np.ndarray | DaArray):
+        raise TypeError("add_channel() data must be a NumPy array or Dask array")
+    call_params = {key: value for key, value in params.items() if key != "data"}
+    offset = call_params.get("source_time_offset")
+    if isinstance(offset, np.ndarray):
+        call_params["source_time_offset"] = offset.tolist()
+    base = cast("ChannelFrame", args[0])
+    return OperationCapture(_ADD_CHANNEL_BINDINGS, (base.lineage, None), call_params)
+
+
+def _capture_concat_frame(args: tuple[Any, ...], params: Mapping[str, Any]) -> OperationCapture:
+    """Capture the Frame-only concat_frame v1 contract."""
+    other = params["other"]
+    if not isinstance(other, ChannelFrame):
+        raise TypeError("concat_frame() other must be a ChannelFrame")
+    base = cast("ChannelFrame", args[0])
+    call_params = {key: value for key, value in params.items() if key != "other"}
+    return OperationCapture(_CONCAT_FRAME_BINDINGS, (base.lineage, other.lineage), call_params)
+
+
+def _validate_common_channel_recipe_params(
+    params: Mapping[str, Any],
+    *,
+    label_name: str,
+    allow_source_time_offset: bool,
+) -> None:
+    """Validate persisted channel-operation parameters without runtime inputs."""
+    allowed = {label_name, "align", "suffix_on_dup"}
+    if allow_source_time_offset:
+        allowed.add("source_time_offset")
+    unknown = set(params) - allowed
+    if unknown:
+        raise ValueError(f"Unknown channel Recipe params: {sorted(unknown)!r}")
+    label = params.get(label_name)
+    if label is not None and not isinstance(label, str):
+        raise TypeError(f"{label_name} must be a string or None")
+    align = params.get("align", "strict")
+    if align not in {"strict", "pad", "truncate"}:
+        raise ValueError("align must be 'strict', 'pad', or 'truncate'")
+    suffix = params.get("suffix_on_dup")
+    if suffix is not None and not isinstance(suffix, str):
+        raise TypeError("suffix_on_dup must be a string or None")
+    if allow_source_time_offset and "source_time_offset" in params:
+        value = params["source_time_offset"]
+        values = value if isinstance(value, Sequence) and not isinstance(value, str | bytes) else (value,)
+        if not values or any(
+            not isinstance(item, numbers.Real) or isinstance(item, bool | np.bool_) or not np.isfinite(item)
+            for item in values
+        ):
+            raise ValueError("source_time_offset must contain finite numeric values")
+
+
+def _validate_add_channel_recipe(params: Mapping[str, Any]) -> None:
+    """Validate add_channel v2 persisted parameters."""
+    _validate_common_channel_recipe_params(params, label_name="label", allow_source_time_offset=True)
+
+
+def _validate_concat_frame_recipe(params: Mapping[str, Any]) -> None:
+    """Validate concat_frame v1 persisted parameters."""
+    _validate_common_channel_recipe_params(params, label_name="label_prefix", allow_source_time_offset=False)
+
+
+LEGACY_ADD_CHANNEL_RECIPE_OPERATION = RecipeOperation(
+    "wandas.channel.add_channel",
+    1,
+    _channel_input_patterns("data"),
+    _legacy_add_channel_recipe,
+)
+
+
+def _legacy_add_channel_recipe_declaration() -> None:
+    """Expose the replay-only v1 definition to built-in declaration collection."""
+
+
+setattr(
+    _legacy_add_channel_recipe_declaration,
+    "__wandas_recipe_operation__",
+    LEGACY_ADD_CHANNEL_RECIPE_OPERATION,
+)
 
 
 def _resolve_channels(channel: int | list[int] | None, n_channels: int) -> list[int]:
@@ -261,6 +365,8 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
     This frame represents channel-based data such as audio signals and time series data,
     with each channel containing data samples in the time domain.
     """
+
+    _legacy_add_channel_recipe_declaration = _legacy_add_channel_recipe_declaration
 
     _xarray_dim_suffix = ("channel", "time")
 
@@ -1476,13 +1582,15 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
 
     @recipe_operation(
         "wandas.channel.add_channel",
-        binding_patterns=_ADD_CHANNEL_INPUT_PATTERNS,
-        capture=_capture_channel_input("data"),
+        version=2,
+        bindings=_ADD_CHANNEL_BINDINGS,
+        capture=_capture_add_channel,
         handler=_add_channel_recipe,
+        validate_params=_validate_add_channel_recipe,
     )
     def add_channel(
         self,
-        data: "np.ndarray[Any, Any] | DaArray | ChannelFrame",
+        data: "np.ndarray[Any, Any] | DaArray",
         label: str | None = None,
         align: str = "strict",
         suffix_on_dup: str | None = None,
@@ -1491,22 +1599,16 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         """Add a new channel to the frame.
 
         Args:
-            data: Data to add as a new channel. Can be:
-                - numpy array (1D or 2D)
-                - dask array (1D or 2D)
-                - ChannelFrame (channels will be added)
+            data: NumPy or Dask data for exactly one channel. The accepted shapes
+                are ``(samples,)`` and ``(1, samples)``.
             label: Label for the new channel. If None, generates a default label.
-                When data is a ChannelFrame, acts as a prefix: each channel in
-                the input frame is renamed to ``"{label}_{original_label}"``.
-                If None (the default), the original channel labels are used as-is.
             align: How to handle length mismatches:
                 - "strict": Raise error if lengths don't match
                 - "pad": Pad shorter data with zeros
                 - "truncate": Truncate longer data to match
             suffix_on_dup: Suffix to add to duplicate labels. If None, raises error.
-            source_time_offset: Offset in seconds for raw numpy or dask input.
-                If None, raw input uses 0.0. When data is a ChannelFrame,
-                offsets are taken from that frame and this argument must be None.
+            source_time_offset: Offset in seconds for the new channel. If None,
+                the new channel uses 0.0.
 
         Returns:
             A new ChannelFrame.
@@ -1514,60 +1616,18 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         Raises:
             ValueError: If data length doesn't match and align="strict",
                 or if label is duplicate and suffix_on_dup is None.
-            TypeError: If data type is not supported.
+            TypeError: If data is not a NumPy or Dask array. Pass another
+                ChannelFrame to :meth:`concat_frame` instead.
 
         Examples:
             >>> cf = wd.read("audio.wav")
             >>> # Add a numpy array as a new channel
             >>> new_data = np.sin(2 * np.pi * 440 * cf.time)
             >>> cf_new = cf.add_channel(new_data, label="sine_440Hz")
-            >>> # Add another ChannelFrame's channels
+            >>> # Concatenate another ChannelFrame's channels
             >>> cf2 = wd.read("audio2.wav")
-            >>> cf_combined = cf.add_channel(cf2)
+            >>> cf_combined = cf.concat_frame(cf2)
         """
-        if isinstance(data, ChannelFrame):
-            if source_time_offset is not None:
-                raise ValueError(
-                    "source_time_offset cannot be used when adding a ChannelFrame\n"
-                    "  ChannelFrame input already carries per-channel offsets.\n"
-                    "Pass raw ndarray or dask data to set an explicit offset."
-                )
-            if self.sampling_rate != data.sampling_rate:
-                raise ValueError("sampling_rate mismatch")
-            arr = _align_to_length(data._data, self.n_samples, align, data.n_samples)
-            labels = self.labels
-            new_labels: list[str] = []
-            new_metadata_list = data._borrowed_channel_metadata_descriptors()
-            for descriptor, chmeta in zip(new_metadata_list, data.channels, strict=True):
-                new_label = f"{label}_{chmeta.label}" if label is not None else chmeta.label
-                if new_label in labels or new_label in new_labels:
-                    if suffix_on_dup:
-                        new_label += suffix_on_dup
-                    else:
-                        raise ValueError(
-                            f"Duplicate channel label\n"
-                            f"  Label: '{new_label}'\n"
-                            f"  Existing labels: {labels + new_labels}\n"
-                            f"Use suffix_on_dup parameter to automatically "
-                            f"rename duplicates."
-                        )
-                new_labels.append(new_label)
-                descriptor["label"] = new_label
-            new_data = concatenate([self._data, arr], axis=0)
-
-            new_chmeta = self._borrowed_channel_metadata_descriptors() + new_metadata_list
-            new_ids = self._channel_ids.copy()
-            for _ in new_metadata_list:
-                new_id = self._next_channel_id(new_ids)
-                new_ids.append(new_id)
-            new_offsets = np.concatenate([self.source_time_offset, data.source_time_offset])
-            return self._finalize_channel_update(
-                new_data,
-                new_chmeta,
-                new_ids,
-                new_offsets,
-                lineage=self._required_semantic_lineage(),
-            )
         if isinstance(data, np.ndarray):
             if data.ndim == 1:
                 data = data[None, :]
@@ -1581,8 +1641,6 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
                 arr = data
             else:
                 raise ValueError("Raw add_channel input must be 1-D or shaped (1, samples)")
-        else:
-            raise TypeError("add_channel: ndarray/dask/ChannelFrame")
         arr = _align_to_length(arr, self.n_samples, align, arr.shape[1])
         labels = self.labels
         new_label = label or f"ch{len(labels)}"
@@ -1604,6 +1662,75 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         raw_source_time_offset = 0.0 if source_time_offset is None else source_time_offset
         new_channel_offsets = self._normalize_source_time_offset(raw_source_time_offset, arr.shape[0])
         new_offsets = np.concatenate([self.source_time_offset, new_channel_offsets])
+        return self._finalize_channel_update(
+            new_data,
+            new_chmeta,
+            new_ids,
+            new_offsets,
+            lineage=self._required_semantic_lineage(),
+        )
+
+    @recipe_operation(
+        "wandas.channel.concat_frame",
+        bindings=_CONCAT_FRAME_BINDINGS,
+        capture=_capture_concat_frame,
+        handler=_concat_frame_recipe,
+        validate_params=_validate_concat_frame_recipe,
+    )
+    def concat_frame(
+        self,
+        other: "ChannelFrame",
+        label_prefix: str | None = None,
+        align: str = "strict",
+        suffix_on_dup: str | None = None,
+    ) -> "ChannelFrame":
+        """Concatenate all channels from another frame along the channel axis.
+
+        The result preserves ``other`` channel metadata, calibration, and
+        source-time offsets. Neither input frame is changed.
+
+        Args:
+            other: ChannelFrame whose channels are appended in their current order.
+            label_prefix: Optional prefix for appended labels, producing
+                ``"{label_prefix}_{original_label}"``.
+            align: ``"strict"`` rejects sample-length differences; ``"pad"`` and
+                ``"truncate"`` align the appended data to this frame's length.
+            suffix_on_dup: Suffix for duplicate labels. If None, duplicates raise.
+
+        Returns:
+            A new lazy ChannelFrame containing both channel collections.
+
+        Raises:
+            TypeError: If other is not a ChannelFrame.
+            ValueError: If sampling rates, lengths, or labels are incompatible.
+        """
+        if self.sampling_rate != other.sampling_rate:
+            raise ValueError("sampling_rate mismatch")
+        arr = _align_to_length(other._data, self.n_samples, align, other.n_samples)
+        labels = self.labels
+        new_labels: list[str] = []
+        new_metadata_list = other._borrowed_channel_metadata_descriptors()
+        for descriptor, chmeta in zip(new_metadata_list, other.channels, strict=True):
+            new_label = f"{label_prefix}_{chmeta.label}" if label_prefix is not None else chmeta.label
+            if new_label in labels or new_label in new_labels:
+                if suffix_on_dup:
+                    new_label += suffix_on_dup
+                else:
+                    raise ValueError(
+                        f"Duplicate channel label\n"
+                        f"  Label: '{new_label}'\n"
+                        f"  Existing labels: {labels + new_labels}\n"
+                        f"Use suffix_on_dup parameter to automatically "
+                        f"rename duplicates."
+                    )
+            new_labels.append(new_label)
+            descriptor["label"] = new_label
+        new_data = concatenate([self._data, arr], axis=0)
+        new_chmeta = self._borrowed_channel_metadata_descriptors() + new_metadata_list
+        new_ids = self._channel_ids.copy()
+        for _ in new_metadata_list:
+            new_ids.append(self._next_channel_id(new_ids))
+        new_offsets = np.concatenate([self.source_time_offset, other.source_time_offset])
         return self._finalize_channel_update(
             new_data,
             new_chmeta,

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -1628,6 +1628,10 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             >>> cf2 = wd.read("audio2.wav")
             >>> cf_combined = cf.concat_frame(cf2)
         """
+        if isinstance(data, ChannelFrame):
+            raise TypeError(
+                "add_channel() no longer accepts ChannelFrame input; use concat_frame(other, label_prefix=...) instead"
+            )
         if isinstance(data, np.ndarray):
             if data.ndim == 1:
                 data = data[None, :]
@@ -1641,6 +1645,8 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
                 arr = data
             else:
                 raise ValueError("Raw add_channel input must be 1-D or shaped (1, samples)")
+        else:
+            raise TypeError("add_channel() data must be a NumPy array or Dask array")
         arr = _align_to_length(arr, self.n_samples, align, arr.shape[1])
         labels = self.labels
         new_label = label or f"ch{len(labels)}"
@@ -1704,6 +1710,8 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             TypeError: If other is not a ChannelFrame.
             ValueError: If sampling rates, lengths, or labels are incompatible.
         """
+        if not isinstance(other, ChannelFrame):
+            raise TypeError("concat_frame() other must be a ChannelFrame")
         if self.sampling_rate != other.sampling_rate:
             raise ValueError("sampling_rate mismatch")
         arr = _align_to_length(other._data, self.n_samples, align, other.n_samples)

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -165,6 +165,9 @@ def _legacy_add_channel_recipe(inputs: tuple[Any, ...], params: Mapping[str, Any
     if isinstance(inputs[1], ChannelFrame):
         legacy_params = dict(params)
         label = legacy_params.pop("label", None)
+        source_time_offset = legacy_params.pop("source_time_offset", None)
+        if source_time_offset is not None:
+            raise TypeError("source_time_offset is only supported for array input")
         return inputs[0].concat_frame(inputs[1], label_prefix=label, **legacy_params)
     return inputs[0].add_channel(inputs[1], **dict(params))
 
@@ -220,12 +223,13 @@ def _validate_common_channel_recipe_params(
         raise TypeError("suffix_on_dup must be a string or None")
     if allow_source_time_offset and "source_time_offset" in params:
         value = params["source_time_offset"]
-        values = value if isinstance(value, Sequence) and not isinstance(value, str | bytes) else (value,)
-        if not values or any(
-            not isinstance(item, numbers.Real) or isinstance(item, bool | np.bool_) or not np.isfinite(item)
-            for item in values
-        ):
-            raise ValueError("source_time_offset must contain finite numeric values")
+        if value is not None:
+            values = value if isinstance(value, Sequence) and not isinstance(value, str | bytes) else (value,)
+            if not values or any(
+                not isinstance(item, numbers.Real) or isinstance(item, bool | np.bool_) or not np.isfinite(item)
+                for item in values
+            ):
+                raise ValueError("source_time_offset must contain finite numeric values")
 
 
 def _validate_add_channel_recipe(params: Mapping[str, Any]) -> None:

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -1,9 +1,11 @@
+import inspect
 import logging
 import numbers
 import warnings
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, BinaryIO, TypeVar, cast
+from typing import TYPE_CHECKING, Any, BinaryIO, ParamSpec, TypeVar, cast
 
 import dask
 import dask.array as da
@@ -36,6 +38,8 @@ da_from_delayed = da.from_delayed
 
 
 S = TypeVar("S", bound="BaseFrame[Any]")
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 def _align_to_length(arr: DaArray, target_len: int, align: str, source_len: int) -> DaArray:
@@ -229,6 +233,22 @@ def _normalize_single_source_time_offset(value: object) -> float:
     if not np.isfinite(normalized):
         raise ValueError("source_time_offset must be finite")
     return normalized
+
+
+def _normalize_add_channel_call(method: Callable[P, R]) -> Callable[P, R]:
+    """Snapshot caller-owned offset input before semantic capture and execution."""
+    signature = inspect.signature(method)
+
+    @wraps(method)
+    def normalized_call(*args: P.args, **kwargs: P.kwargs) -> R:
+        bound = signature.bind(*args, **kwargs)
+        if "source_time_offset" in bound.arguments:
+            bound.arguments["source_time_offset"] = _normalize_single_source_time_offset(
+                bound.arguments["source_time_offset"]
+            )
+        return method(*bound.args, **bound.kwargs)
+
+    return normalized_call
 
 
 def _normalize_channel_operation_params(
@@ -1611,6 +1631,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             )
         return loaded
 
+    @_normalize_add_channel_call
     @recipe_operation(
         "wandas.channel.add_channel",
         version=2,

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -199,13 +199,13 @@ def _capture_concat_frame(args: tuple[Any, ...], params: Mapping[str, Any]) -> O
     return OperationCapture(_CONCAT_FRAME_BINDINGS, (base.lineage, other.lineage), call_params)
 
 
-def _validate_common_channel_recipe_params(
+def _validate_channel_operation_params(
     params: Mapping[str, Any],
     *,
     label_name: str,
     allow_source_time_offset: bool,
 ) -> None:
-    """Validate persisted channel-operation parameters without runtime inputs."""
+    """Validate the value contract shared by public calls and Recipe loading."""
     allowed = {label_name, "align", "suffix_on_dup"}
     if allow_source_time_offset:
         allowed.add("source_time_offset")
@@ -224,22 +224,33 @@ def _validate_common_channel_recipe_params(
     if allow_source_time_offset and "source_time_offset" in params:
         value = params["source_time_offset"]
         if value is not None:
-            values = value if isinstance(value, Sequence) and not isinstance(value, str | bytes) else (value,)
-            if not values or any(
-                not isinstance(item, numbers.Real) or isinstance(item, bool | np.bool_) or not np.isfinite(item)
-                for item in values
-            ):
-                raise ValueError("source_time_offset must contain finite numeric values")
+            if isinstance(value, np.ndarray):
+                if value.ndim != 1:
+                    raise ValueError("source_time_offset must be a scalar or a 1D array")
+                if value.size != 1:
+                    raise ValueError("source_time_offset length must match number of channels")
+                values = value.tolist()
+            elif isinstance(value, Sequence) and not isinstance(value, str | bytes):
+                if len(value) != 1:
+                    raise ValueError("source_time_offset length must match number of channels")
+                values = value
+            else:
+                values = (value,)
+            item = values[0]
+            if not isinstance(item, numbers.Real) or isinstance(item, bool | np.bool_):
+                raise TypeError("source_time_offset must be a finite numeric value")
+            if not np.isfinite(item):
+                raise ValueError("source_time_offset must be finite")
 
 
 def _validate_add_channel_recipe(params: Mapping[str, Any]) -> None:
     """Validate add_channel v2 persisted parameters."""
-    _validate_common_channel_recipe_params(params, label_name="label", allow_source_time_offset=True)
+    _validate_channel_operation_params(params, label_name="label", allow_source_time_offset=True)
 
 
 def _validate_concat_frame_recipe(params: Mapping[str, Any]) -> None:
     """Validate concat_frame v1 persisted parameters."""
-    _validate_common_channel_recipe_params(params, label_name="label_prefix", allow_source_time_offset=False)
+    _validate_channel_operation_params(params, label_name="label_prefix", allow_source_time_offset=False)
 
 
 LEGACY_ADD_CHANNEL_RECIPE_OPERATION = RecipeOperation(
@@ -1611,8 +1622,9 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
                 - "pad": Pad shorter data with zeros
                 - "truncate": Truncate longer data to match
             suffix_on_dup: Suffix to add to duplicate labels. If None, raises error.
-            source_time_offset: Offset in seconds for the new channel. If None,
-                the new channel uses 0.0.
+            source_time_offset: Offset in seconds for the new channel. Accepts
+                a finite real scalar or a one-item 1-D sequence/NumPy array.
+                If None, the new channel uses 0.0.
 
         Returns:
             A new ChannelFrame.
@@ -1632,6 +1644,16 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             >>> cf2 = wd.read("audio2.wav")
             >>> cf_combined = cf.concat_frame(cf2)
         """
+        _validate_channel_operation_params(
+            {
+                "label": label,
+                "align": align,
+                "suffix_on_dup": suffix_on_dup,
+                "source_time_offset": source_time_offset,
+            },
+            label_name="label",
+            allow_source_time_offset=True,
+        )
         if isinstance(data, ChannelFrame):
             raise TypeError(
                 "add_channel() no longer accepts ChannelFrame input; use concat_frame(other, label_prefix=...) instead"
@@ -1714,6 +1736,15 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             TypeError: If other is not a ChannelFrame.
             ValueError: If sampling rates, lengths, or labels are incompatible.
         """
+        _validate_channel_operation_params(
+            {
+                "label_prefix": label_prefix,
+                "align": align,
+                "suffix_on_dup": suffix_on_dup,
+            },
+            label_name="label_prefix",
+            allow_source_time_offset=False,
+        )
         if not isinstance(other, ChannelFrame):
             raise TypeError("concat_frame() other must be a ChannelFrame")
         if self.sampling_rate != other.sampling_rate:

--- a/wandas/frames/mixins/channel_collection_mixin.py
+++ b/wandas/frames/mixins/channel_collection_mixin.py
@@ -17,7 +17,7 @@ T = TypeVar("T", bound="ChannelCollectionMixin")
 class ChannelCollectionMixin:
     def add_channel(
         self: T,
-        data: np.ndarray[Any, Any] | da.Array | T,
+        data: np.ndarray[Any, Any] | da.Array,
         label: str | None = None,
         align: Literal["strict", "pad", "truncate"] = "strict",
         suffix_on_dup: str | None = None,
@@ -27,7 +27,7 @@ class ChannelCollectionMixin:
         """
         Add a channel
         Args:
-            data: Channel to add (1ch ndarray/dask/ChannelFrame)
+            data: One channel of ndarray/dask data
             label: Label for the added channel
             align: Behavior when lengths don't match
             suffix_on_dup: Suffix when label is duplicated
@@ -38,6 +38,16 @@ class ChannelCollectionMixin:
             ValueError, TypeError
         """
         raise NotImplementedError("add_channel() must be implemented in subclasses")
+
+    def concat_frame(
+        self: T,
+        other: T,
+        label_prefix: str | None = None,
+        align: Literal["strict", "pad", "truncate"] = "strict",
+        suffix_on_dup: str | None = None,
+    ) -> T:
+        """Concatenate another channel collection without changing either input."""
+        raise NotImplementedError("concat_frame() must be implemented in subclasses")
 
     def remove_channel(
         self: T,


### PR DESCRIPTION
## Summary

- split the overloaded channel-collection API into `add_channel()` for one raw NumPy/Dask channel and `concat_frame()` for all channels from another `ChannelFrame`
- make `add_channel(ChannelFrame)` fail with a migration-oriented `TypeError` directing callers to `concat_frame(..., label_prefix=...)`
- declare single-pattern Recipe operations: `wandas.channel.add_channel` v2 (`frame`, `array`) and `wandas.channel.concat_frame` v1 (`frame`, `frame`)

This separation makes the public and persisted binding contracts unambiguous while retaining the existing channel alignment and finalization behavior.

## Recipe v1 compatibility

Valid legacy `wandas.channel.add_channel` v1 array and Frame Recipes remain replayable through a replay-only `RecipeOperation` owned by `wandas.frames.channel`. Its handler dispatches array input to the v2 public array path and Frame input to `concat_frame()`, translating the legacy `label` prefix to `label_prefix` and accepting the historically valid explicit `source_time_offset=None`. New public calls and Recipe extraction never emit v1. No binding-aware validator or operation-specific branch was added to Recipe model, compiler, validator, executor, or serializer layers.

## Validation ownership and symmetry

- one pure operation-owned normalizer validates `align`, label/prefix, duplicate suffix, and the one-channel offset value contract
- both public methods and capture paths call that normalizer before data-dependent alignment or duplicate-label handling, including when semantic capture is bypassed by an active lineage
- both Recipe `validate_params` callbacks reuse the same normalizer and additionally reject unknown persisted fields
- `source_time_offset` accepts `None`, a finite real scalar, or one finite real in a one-dimensional Sequence/NumPy array, then immediately normalizes it to one built-in `float`
- the public boundary snapshots caller-owned offset input exactly once and passes that same canonical float to capture and execution; explicit `None` becomes `0.0`, an omitted argument remains omitted, and newly captured v2 lineage/Recipes never retain caller container types
- family-level tests cover ordinary public calls, active-lineage calls, load-time rejection, canonical capture, and successful extract/serialize/load/apply across NumPy and Dask inputs

This establishes the invariant that a successful public call with portable inputs can be extracted, serialized, loaded, and applied.

## Preserved invariants

- both methods reuse the existing Dask alignment/concatenation and `_finalize_channel_update()` paths, so graph construction remains lazy
- channel metadata descriptors, calibration, source offsets, receiver metadata, channel order, and stable receiver-owned ID generation are preserved
- both input Frames remain unchanged; tests snapshot IDs and metadata and verify the result is a new Dask-backed Frame
- each public call is captured once by its own Recipe declaration and finalizes with `_required_semantic_lineage()`, producing exactly one semantic node for that call

## Validation

- channel-focused Frame/Recipe suite: `285 passed`
- full suite: `uv run pytest -q` — `2595 passed, 7 skipped, 6 warnings`
- `uv run marimo check learning-path/01_getting_started.py` — passed
- executable HTML export of `learning-path/01_getting_started.py` — passed without cell errors
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed (`167 files already formatted`)
- `uv run ty check` — passed
- `uv run mkdocs build --strict -f docs/mkdocs.yml` — passed
- `git diff --check` — passed

The warnings are pre-existing non-interactive plotting, WAV metadata, psychoacoustic silence, and introspection warnings; no validation command was skipped.

## Intentionally unchanged

- WDF persistence and serialized WDF names
- numerical processing kernels and unrelated Frame APIs
- Recipe schema/model/compiler/validator/executor/serializer contracts, including the `ParamValidator` signature
- sampling-rate semantics, Frame concrete types, and Dask graph behavior
- the valid legacy v1 compatibility boundary; its deliberate removal is tracked separately in #353
- historical design documents, including prior implementation context

Closes #341

Follow-up: #353