### PR TITLE
Run Butterworth filters channel-wise

### DIFF
--- a/docs/src/explanation/audio-operation-execution.md
+++ b/docs/src/explanation/audio-operation-execution.md
@@ -43,7 +43,8 @@ channels depend on one another.
 | `normalize` | Parameter-dependent: `axis=-1` is independent; `axis=None` or a channel axis is cross-channel | Whole selected norm axis | Whole-frame |
 | `trim`, `fix_length` | Independent | Indexed/padded time-local transform with output-shape change | Whole-frame |
 | `fade` | Independent | Needs the full signal length to define the envelope | Whole-frame |
-| high-pass, low-pass, band-pass, A-weighting | Independent | Stateful/whole continuous time series per channel | Whole-frame |
+| high-pass, low-pass, band-pass | Independent | Stateful/whole continuous time series per channel | **Channel-wise** |
+| A-weighting | Independent | Stateful/whole continuous time series per channel | Whole-frame |
 | resampling | Independent | Stateful/whole continuous time series per channel | Whole-frame |
 | RMS trend, sound level | Independent | Window/overlap-sensitive; weighting can add filter state | Whole-frame |
 | FFT, IFFT, cepstrum, lifter, spectral envelope, N-octave analysis/synthesis | Independent | Whole transform axis per channel | Whole-frame |
@@ -77,6 +78,24 @@ before execution as before.
 Unsupported and cross-channel operations retain the default graph builder. This
 fail-safe default is also used by third-party `AudioOperation` subclasses, so the
 prototype does not silently reinterpret existing kernels as channel-independent.
+
+## Adopted family: Butterworth filters
+
+The shared `_ButterworthFilter` kernel used by the high-pass, low-pass, and band-pass
+operations applies `scipy.signal.filtfilt(..., axis=1)`. Each output row depends on one
+complete input row but not on any other channel, so the family uses the existing
+channel-independent specialization without a new graph-builder contract. Filter
+coefficients, output shape and `float64` dtype, Frame metadata, lineage, and Recipe
+declarations are unchanged.
+
+The LowPass prototype for issue #343 compared 1, 2, 4, and 8 channels with 1,000,000
+samples each in three isolated processes per path. At eight channels, task count
+increased from 20 to 56, median graph construction increased from about 1.6 ms to
+8.0 ms, median operation time was effectively unchanged (0.1186 s versus 0.1178 s),
+and same-environment median peak RSS decreased from about 524 MiB to 425 MiB. Every
+paired numerical checksum was equal, and focused tests require exact array equality
+with forced whole-frame execution for all three filters. These values describe the
+observed memory/task tradeoff; they are not a portable performance threshold.
 
 ## Benchmark interpretation
 

--- a/docs/src/explanation/audio-operation-execution.md
+++ b/docs/src/explanation/audio-operation-execution.md
@@ -88,14 +88,18 @@ channel-independent specialization without a new graph-builder contract. Filter
 coefficients, output shape and `float64` dtype, Frame metadata, lineage, and Recipe
 declarations are unchanged.
 
-The LowPass prototype for issue #343 compared 1, 2, 4, and 8 channels with 1,000,000
-samples each in three isolated processes per path. At eight channels, task count
-increased from 20 to 56, median graph construction increased from about 1.6 ms to
-8.0 ms, median operation time was effectively unchanged (0.1186 s versus 0.1178 s),
-and same-environment median peak RSS decreased from about 524 MiB to 425 MiB. Every
-paired numerical checksum was equal, and focused tests require exact array equality
-with forced whole-frame execution for all three filters. These values describe the
-observed memory/task tradeoff; they are not a portable performance threshold.
+The final LowPass comparison for issue #343 used the normal materialization path:
+`BaseFrame.data` calls `BaseFrame._compute()`, which calls Dask Array `compute()`
+without overriding its default threaded scheduler. Eight channels with 1,000,000
+float64 samples each ran whole-frame and channel-wise in alternating order across five
+isolated processes per path, without explicitly setting the scheduler, worker count,
+or native thread count. Median end-to-end time decreased from 121.1 ms to 52.1 ms
+(56.9%), median process peak RSS decreased from 508.4 MiB to 469.9 MiB (7.6%), and
+task count increased from 36 to 56. Numerical values, shape, dtype, chunks, Frame and
+Recipe behavior, and fallback behavior were unchanged; focused tests require exact
+array equality with forced whole-frame execution for all three filters. These
+same-environment measurements explain the adoption decision, not a portable
+performance guarantee.
 
 ## Benchmark interpretation
 

--- a/tests/frames/test_channelwise_execution.py
+++ b/tests/frames/test_channelwise_execution.py
@@ -8,14 +8,17 @@ from wandas.core.metadata import ChannelCalibration, ChannelMetadata
 from wandas.frames.channel import ChannelFrame
 
 
-def _calibrated_frame() -> ChannelFrame:
+def _calibrated_frame(*, repeats: int = 1) -> ChannelFrame:
     return ChannelFrame(
         da.from_array(
-            np.array(
-                [
-                    [1.0, 2.0, 4.0, 8.0],
-                    [8.0, 4.0, 2.0, 1.0],
-                ]
+            np.tile(
+                np.array(
+                    [
+                        [1.0, 2.0, 4.0, 8.0],
+                        [8.0, 4.0, 2.0, 1.0],
+                    ]
+                ),
+                (1, repeats),
             ),
             chunks=(1, -1),
         ),
@@ -85,3 +88,41 @@ def test_remove_dc_empty_frame_preserves_audio_operation_contract() -> None:
     assert result.shape == (0, 4)
     np.testing.assert_array_equal(result.data, np.empty((0, 4)))
     assert result.operation_history == [{"operation": "wandas.audio.remove_dc", "version": 1, "params": {}}]
+
+
+def test_low_pass_channel_wise_execution_preserves_frame_contract() -> None:
+    source = _calibrated_frame(repeats=16)
+    source_values = source.data.copy()
+    source_metadata = source.metadata.copy()
+    source_history = source.operation_history.copy()
+
+    result = source.low_pass_filter(cutoff=1_000, order=2)
+
+    assert result is not source
+    assert isinstance(result._data, DaArray)
+    np.testing.assert_array_equal(source.data, source_values)
+    assert source.metadata == source_metadata
+    assert source.operation_history == source_history
+
+    assert result.shape == source.shape
+    assert result._data.dtype == np.dtype(np.float64)
+    assert result._data.chunks == ((1, 1), (64,))
+    assert result.sampling_rate == source.sampling_rate
+    assert result.metadata == source.metadata
+    assert [channel.id for channel in result.channels] == ["sensor-mic", "sensor-acc"]
+    assert result.labels == ["lpf(microphone)", "lpf(accelerometer)"]
+    assert [channel.calibration.factor for channel in result.channels] == [1.0, 1.0]
+    assert [channel.unit for channel in result.channels] == ["Pa", "m/s^2"]
+    assert [channel.ref for channel in result.channels] == [2e-5, 1.0]
+    assert [channel.extra for channel in result.channels] == [
+        {"serial": "mic-1"},
+        {"serial": "acc-1"},
+    ]
+    np.testing.assert_array_equal(result.source_time_offset, np.array([0.25, 0.5]))
+    assert result.operation_history == [
+        {
+            "operation": "wandas.audio.lowpass_filter",
+            "version": 1,
+            "params": {"cutoff": 1_000, "order": 2},
+        }
+    ]

--- a/tests/pipeline/test_recipe_execution.py
+++ b/tests/pipeline/test_recipe_execution.py
@@ -72,6 +72,34 @@ def test_remove_dc_channel_wise_execution_recipe_roundtrip_replays_lazily() -> N
     np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(processed))
 
 
+def test_low_pass_channel_wise_execution_recipe_roundtrip_replays_lazily() -> None:
+    time_axis = np.arange(64) / 8_000
+    source = ChannelFrame(
+        da.from_array(
+            np.stack(
+                [
+                    np.sin(2 * np.pi * 200 * time_axis),
+                    np.sin(2 * np.pi * 2_000 * time_axis),
+                ]
+            ),
+            chunks=(1, 16),
+        ),
+        sampling_rate=8_000,
+        source_time_offset=[0.25, 0.5],
+    )
+    processed = source.low_pass_filter(cutoff=1_000, order=2)
+
+    plan = RecipePlan.from_frame(processed, input_names=("signal",))
+    replayed = RecipePlan.from_dict(plan.to_dict()).apply({"signal": source})
+
+    assert [node.operation for node in plan.nodes] == ["wandas.audio.lowpass_filter"]
+    assert isinstance(replayed._data, DaArray)
+    assert replayed.shape == processed.shape
+    assert replayed._data.chunks == processed._data.chunks
+    np.testing.assert_array_equal(replayed.source_time_offset, processed.source_time_offset)
+    np.testing.assert_array_equal(channel_first_values(replayed), channel_first_values(processed))
+
+
 def test_typed_transition_after_true_frame_merge_replays() -> None:
     left = _frame(1.0)
     right = _frame(2.0)

--- a/tests/processing/test_filter_channelwise_execution.py
+++ b/tests/processing/test_filter_channelwise_execution.py
@@ -1,0 +1,97 @@
+"""Channel-wise execution contracts for the Butterworth filter family."""
+
+from collections.abc import Callable
+from typing import Any
+
+import dask.array as da
+import numpy as np
+import pytest
+from dask.array.core import Array as DaArray
+
+from wandas.processing.base import AudioOperation
+from wandas.processing.filters import BandPassFilter, HighPassFilter, LowPassFilter
+from wandas.utils.dask_helpers import da_from_array
+
+FilterFactory = Callable[[], AudioOperation[Any, Any]]
+
+
+def _low_pass() -> LowPassFilter:
+    return LowPassFilter(8_000, cutoff=1_000, order=2)
+
+
+def _high_pass() -> HighPassFilter:
+    return HighPassFilter(8_000, cutoff=1_000, order=2)
+
+
+def _band_pass() -> BandPassFilter:
+    return BandPassFilter(8_000, low_cutoff=500, high_cutoff=1_500, order=2)
+
+
+def _deterministic_input(channels: int) -> DaArray:
+    time_axis = np.arange(256) / 8_000
+    values = np.stack(
+        [
+            np.sin(2 * np.pi * (200 + 100 * index) * time_axis) + 0.25 * np.sin(2 * np.pi * 2_000 * time_axis)
+            for index in range(channels)
+        ]
+    )
+    return da_from_array(values, chunks=(1, 64))
+
+
+@pytest.mark.parametrize("factory", [_low_pass, _high_pass, _band_pass])
+@pytest.mark.parametrize("channels", [1, 2, 4, 8])
+def test_butterworth_channel_wise_kernel_matches_whole_frame_exactly(
+    monkeypatch: pytest.MonkeyPatch,
+    factory: FilterFactory,
+    channels: int,
+) -> None:
+    source = _deterministic_input(channels)
+    operation = factory()
+    original_process = operation._process
+    kernel_shapes: list[tuple[int, ...]] = []
+
+    def observed_process(values: np.ndarray) -> np.ndarray:
+        kernel_shapes.append(values.shape)
+        return original_process(values)
+
+    monkeypatch.setattr(operation, "_process", observed_process)
+    channel_wise = operation.process(source)
+    whole_frame = operation._build_whole_frame_graph(
+        source,
+        (),
+        output_shape=source.shape,
+        output_dtype=np.dtype(np.float64),
+    )
+
+    assert channel_wise.shape == source.shape
+    assert channel_wise.dtype == np.dtype(np.float64)
+    assert channel_wise.chunks == (channels * (1,), (256,))
+    channel_values = channel_wise.compute(scheduler="synchronous")
+    assert kernel_shapes == channels * [(1, 256)]
+
+    kernel_shapes.clear()
+    whole_values = whole_frame.compute(scheduler="synchronous")
+    assert kernel_shapes == [(channels, 256)]
+    # Both paths call the same scipy.signal.filtfilt kernel on independent rows.
+    np.testing.assert_array_equal(channel_values, whole_values)
+
+
+def test_butterworth_zero_channel_input_uses_whole_frame_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operation = _low_pass()
+    original_process = operation._process
+    kernel_shapes: list[tuple[int, ...]] = []
+
+    def observed_process(values: np.ndarray) -> np.ndarray:
+        kernel_shapes.append(values.shape)
+        return original_process(values)
+
+    monkeypatch.setattr(operation, "_process", observed_process)
+    source = da.from_array(np.empty((0, 64)), chunks=(0, 64))
+
+    result = operation.process(source)
+
+    np.testing.assert_array_equal(result.compute(scheduler="synchronous"), np.empty((0, 64)))
+    assert kernel_shapes == [(0, 64)]
+    assert result.chunks == ((0,), (64,))

--- a/wandas/processing/filters.py
+++ b/wandas/processing/filters.py
@@ -4,7 +4,11 @@ from typing import Any
 import numpy as np
 from scipy import signal
 
-from wandas.processing.base import AudioOperation, register_operation
+from wandas.processing.base import (
+    AudioOperation,
+    _ChannelIndependentAudioOperation,
+    register_operation,
+)
 from wandas.processing.weighting import A_weight
 from wandas.utils.types import NDArrayReal
 
@@ -44,7 +48,7 @@ def _validate_cutoff(cutoff: float, sampling_rate: float, label: str = "Cutoff")
         )
 
 
-class _ButterworthFilter(AudioOperation[NDArrayReal, NDArrayReal]):
+class _ButterworthFilter(_ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
     """Shared base for single-cutoff Butterworth filters (high-pass/low-pass)."""
 
     _btype: str  # "high" or "low" — set by subclasses


### PR DESCRIPTION
## Summary

- adopt the existing `_ChannelIndependentAudioOperation` execution path for the shared Butterworth filter family
- keep each SciPy `filtfilt` kernel on one complete time series while separating independent channels
- add LowPass/HighPass/BandPass kernel-boundary and exact whole-frame parity tests
- preserve Frame metadata, calibration, lineage, laziness, and complete Recipe serialization/replay behavior
- update the execution classification and record the operation-specific prototype tradeoff

## Design decision

The LowPass prototype established classification **A: supported by the current contract**. `_ButterworthFilter._process()` is unary, channel-axis-preserving, `float64`-producing, and calls `scipy.signal.filtfilt(..., axis=1)`. Channels are independent, but each channel still requires its complete continuous time axis.

The implementation therefore changes only the shared private base inheritance. It adds no graph-builder abstraction, parameter-dependent eligibility, public API, or operation-specific Recipe behavior. Existing conservative fallback remains in effect for zero/unknown channel counts, additional inputs, and channel-axis-changing outputs.

## Numerical and Frame/Recipe contracts

Focused tests cover LowPass, HighPass, and BandPass at 1, 2, 4, and 8 channels. Every delayed numerical kernel receives `(1, full_time_length)`. Because both paths call the same SciPy kernel on independent rows, the accepted tolerance is zero: channel-wise output must satisfy `assert_array_equal` against forced whole-frame output.

Output shape and `float64` dtype remain known before compute. Channel IDs and metadata, user metadata, labels, calibration consumption, units/references, sampling rate, source offsets, immutability, laziness, and exactly one lineage/history node remain on the existing Frame path. LowPass also passes the complete `RecipePlan.from_frame -> to_dict -> from_dict -> apply` probe.

## Prototype performance tradeoff

Three isolated same-environment runs per path used 1,000,000 float64 samples per channel at 48 kHz with the single-threaded scheduler. At 8 channels:

- tasks: 20 → 56
- median graph construction: about 1.6 ms → 8.0 ms
- median compute: 0.1186 s → 0.1178 s
- median peak RSS: about 524 MiB → 425 MiB

All paired checksums were equal. This supports the memory/task tradeoff but does not define a portable RSS or timing threshold. The existing repository scalability harness remains RemoveDC-specific, so this PR does not broaden it or commit transient benchmark output.

## Validation

- `uv run pytest tests/processing/test_filter_channelwise_execution.py tests/processing/test_filter_operations.py tests/frames/test_channelwise_execution.py tests/pipeline/test_recipe_execution.py tests/pipeline/test_recipe_behavior_parity.py -q` — 91 passed
- `uv run pytest -q` — 2521 passed, 3 skipped
- `uv run ruff check wandas tests scripts`
- `uv run ruff format --check wandas tests scripts`
- `uv run ty check wandas tests`
- `uv run mkdocs build --strict -f docs/mkdocs.yml`

## Scope

This PR is limited to the tightly shared HighPass/LowPass/BandPass family. A-weighting, STFT, resampling, normalization, sound level, multi-input operations, time-axis chunking, overlap, filter-state propagation, scheduler controls, and public API changes remain out of scope. Follow-on operation cycles are evaluated in independent branches and PRs; they do not depend on this PR unless explicitly stated.

Closes #343
Related to #328
Builds on #339

## Threaded scheduler reevaluation (2026-07-26)

Final decision: **adopt**. The normal `Frame.data` path calls Dask Array
`compute()` without a scheduler override, so Dask's threaded Array scheduler is
used. The comparison ran at this PR head, switching only the graph builder to a
benchmark-only whole-frame subclass. No benchmark code or result file is
committed.

Environment: Linux 7.0.0-28-generic x86_64, 24 logical CPUs, CPython 3.10.20,
NumPy 2.2.6, SciPy 1.15.3, Dask 2025.11.0. Input was fixed-seed float64,
8 channels × 1,000,000 samples at 48 kHz; LowPass cutoff was 8 kHz. Each path
ran in five alternating, isolated processes. Default runs did not alter Dask or
native-thread settings. Worker sensitivity used the threaded scheduler with
native thread pools fixed to one thread. Values are median (IQR).

| Scheduler | E2E ms, whole → channel | Peak RSS MiB, whole → channel | Relative E2E | Relative RSS |
| --- | ---: | ---: | ---: | ---: |
| default | 121.1 (4.5) → 52.1 (2.9) | 508.4 (0.5) → 469.9 (3.9) | -56.9% | -7.6% |
| threads, 1 worker | 126.9 → 119.9 | 508.9 → 409.8 | -5.5% | -19.5% |
| threads, 2 workers | 126.8 → 79.4 | 508.4 → 432.5 | -37.4% | -14.9% |
| threads, 4 workers | 122.3 → 64.5 | 508.5 → 478.1 | -47.3% | -6.0% |
| threads, 8 workers | 124.3 → 51.0 | 509.1 → 463.3 | -59.0% | -9.0% |

Default graph construction was 4.7 → 8.6 ms and compute was 116.3 → 43.7 ms.
Tasks increased 36 → 56. Channel-wise E2E and RSS improved in all five default
runs. Checksums, shape, dtype, and chunks were identical for every scheduler
condition. Focused exact-parity, kernel-boundary, HighPass/LowPass/BandPass,
Frame, Recipe, and fallback tests passed (42 tests).

The normal threaded path provides a large, stable time improvement without an
RSS regression, while the one-worker result remains within the accepted time
budget and materially lowers RSS. This confirms that the small shared-base
change is worth retaining. The earlier single-threaded result remains
descriptive and is not used as the threaded decision result.