### PR TITLE
Run resampling channel-wise

### DIFF
--- a/docs/src/explanation/audio-operation-execution.md
+++ b/docs/src/explanation/audio-operation-execution.md
@@ -62,7 +62,7 @@ channels depend on one another.
 | `fade` | Independent | Needs the full signal length to define the envelope | Whole-frame |
 | high-pass, low-pass, band-pass | Independent | Stateful/whole continuous time series per channel | **Channel-wise** |
 | A-weighting | Independent | Stateful/whole continuous time series per channel | Whole-frame |
-| resampling | Independent | Stateful/whole continuous time series per channel | Whole-frame |
+| resampling | Independent | Whole time series per channel for the resampling transform | **Channel-wise** |
 | RMS trend, sound level | Independent | Window/overlap-sensitive; weighting can add filter state | Whole-frame |
 | FFT, IFFT, cepstrum, lifter, spectral envelope, N-octave analysis/synthesis | Independent | Whole transform axis per channel | Whole-frame |
 | STFT, ISTFT, Welch, spectrogram cepstrum, HPSS | Independent | Window/overlap-sensitive or full analysis-axis context | Whole-frame |
@@ -117,6 +117,20 @@ Recipe behavior, and fallback behavior were unchanged; focused tests require exa
 array equality with forced whole-frame execution for all three filters. These
 same-environment measurements explain the adoption decision, not a portable
 performance guarantee.
+
+## Adopted operation: ReSampling
+
+`ReSampling` preserves channel count while changing the complete time-axis length and
+sampling-rate metadata. Its polyphase or exact-length fallback kernel is independent
+across channels, so each channel-wise task receives one complete time series. The
+existing exact output-length calculation, dtype rules, sampling-rate update, Frame
+time coordinates, source offsets, lineage, and Recipe declaration remain unchanged.
+
+The issue #346 evaluation used 1,000,000 samples per channel at 48 kHz resampled to
+16 kHz. At eight channels, tasks increased from 20 to 56, median compute time changed
+from 0.0659 s to 0.0729 s, and same-environment median peak RSS decreased from about
+299.5 MiB to 278.9 MiB. Every paired numerical checksum was equal. These measurements
+describe the task/time/memory tradeoff and do not define a portable performance limit.
 
 ## Benchmark interpretation
 

--- a/tests/frames/test_channelwise_execution.py
+++ b/tests/frames/test_channelwise_execution.py
@@ -126,3 +126,36 @@ def test_low_pass_channel_wise_execution_preserves_frame_contract() -> None:
             "params": {"cutoff": 1_000, "order": 2},
         }
     ]
+
+
+def test_resampling_channel_wise_execution_preserves_frame_contract() -> None:
+    source = _calibrated_frame()
+    source_values = source.data.copy()
+    source_metadata = source.metadata.copy()
+
+    result = source.resampling(target_sr=16_000)
+
+    assert result is not source
+    assert isinstance(result._data, DaArray)
+    np.testing.assert_array_equal(source.data, source_values)
+    assert source.metadata == source_metadata
+    assert source.operation_history == []
+    assert result.shape == (2, 8)
+    assert result._data.dtype == np.dtype(np.float64)
+    assert result._data.chunks == ((1, 1), (8,))
+    assert result.sampling_rate == 16_000
+    np.testing.assert_array_equal(result.time, np.arange(8) / 16_000)
+    assert result.metadata == source.metadata
+    assert [channel.id for channel in result.channels] == ["sensor-mic", "sensor-acc"]
+    assert result.labels == ["rs(microphone)", "rs(accelerometer)"]
+    assert [channel.calibration.factor for channel in result.channels] == [1.0, 1.0]
+    assert [channel.unit for channel in result.channels] == ["Pa", "m/s^2"]
+    assert [channel.ref for channel in result.channels] == [2e-5, 1.0]
+    np.testing.assert_array_equal(result.source_time_offset, np.array([0.25, 0.5]))
+    assert result.operation_history == [
+        {
+            "operation": "wandas.audio.resampling",
+            "version": 1,
+            "params": {"target_sr": 16_000},
+        }
+    ]

--- a/tests/pipeline/test_recipe_execution.py
+++ b/tests/pipeline/test_recipe_execution.py
@@ -112,6 +112,25 @@ def test_recipe_replay_rebuilds_receiver_side_previous_chain() -> None:
     assert replayed.previous.previous is replay_source
 
 
+def test_resampling_channel_wise_execution_recipe_roundtrip_replays_lazily() -> None:
+    source = ChannelFrame(
+        da.from_array(np.arange(2002, dtype=float).reshape(2, 1001), chunks=(1, 200)),
+        sampling_rate=44_100,
+        source_time_offset=[0.25, 0.5],
+    )
+    processed = source.resampling(target_sr=16_000)
+
+    plan = RecipePlan.from_frame(processed, input_names=("signal",))
+    replayed = RecipePlan.from_dict(plan.to_dict()).apply({"signal": source})
+
+    assert [node.operation for node in plan.nodes] == ["wandas.audio.resampling"]
+    assert isinstance(replayed._data, DaArray)
+    assert replayed.shape == processed.shape == (2, 364)
+    assert replayed.sampling_rate == processed.sampling_rate == 16_000
+    np.testing.assert_array_equal(replayed.source_time_offset, processed.source_time_offset)
+    np.testing.assert_array_equal(channel_first_values(replayed), channel_first_values(processed))
+
+
 def test_typed_transition_after_true_frame_merge_replays() -> None:
     left = _frame(1.0)
     right = _frame(2.0)

--- a/tests/processing/test_resampling_channelwise_execution.py
+++ b/tests/processing/test_resampling_channelwise_execution.py
@@ -1,0 +1,121 @@
+"""Channel-wise execution contracts for ReSampling."""
+
+import dask.array as da
+import numpy as np
+import pytest
+from dask.array.core import Array as DaArray
+
+import wandas.processing.temporal as temporal
+from wandas.processing.temporal import ReSampling
+from wandas.utils.dask_helpers import da_from_array
+
+
+def _source(channels: int, samples: int = 1001) -> DaArray:
+    time_axis = np.arange(samples) / 44_100
+    values = np.stack([np.sin(2 * np.pi * (440 + 20 * index) * time_axis) for index in range(channels)])
+    return da_from_array(values, chunks=(1, 200))
+
+
+@pytest.mark.parametrize("channels", [1, 2, 4, 8])
+def test_resampling_channel_wise_kernel_matches_whole_frame_exactly(
+    monkeypatch: pytest.MonkeyPatch,
+    channels: int,
+) -> None:
+    source = _source(channels)
+    operation = ReSampling(44_100, target_sr=16_000)
+    original_process = operation._process
+    kernel_shapes: list[tuple[int, ...]] = []
+
+    def observed_process(values: np.ndarray) -> np.ndarray:
+        kernel_shapes.append(values.shape)
+        return original_process(values)
+
+    monkeypatch.setattr(operation, "_process", observed_process)
+    channel_wise = operation.process(source)
+    output_shape = operation.calculate_output_shape(source.shape)
+    whole_frame = operation._build_whole_frame_graph(
+        source,
+        (),
+        output_shape=output_shape,
+        output_dtype=operation.calculate_output_dtype(source.dtype),
+    )
+
+    assert output_shape == (channels, 364)
+    assert channel_wise.shape == output_shape
+    assert channel_wise.dtype == np.dtype(np.float64)
+    assert channel_wise.chunks == (channels * (1,), (364,))
+    channel_values = channel_wise.compute(scheduler="synchronous")
+    assert kernel_shapes == channels * [(1, 1001)]
+
+    kernel_shapes.clear()
+    whole_values = whole_frame.compute(scheduler="synchronous")
+    assert kernel_shapes == [(channels, 1001)]
+    np.testing.assert_array_equal(channel_values, whole_values)
+
+
+def test_resampling_zero_channel_input_uses_whole_frame_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operation = ReSampling(44_100, target_sr=16_000)
+    original_process = operation._process
+    kernel_shapes: list[tuple[int, ...]] = []
+
+    def observed_process(values: np.ndarray) -> np.ndarray:
+        kernel_shapes.append(values.shape)
+        return original_process(values)
+
+    monkeypatch.setattr(operation, "_process", observed_process)
+    source = da.from_array(np.empty((0, 1001)), chunks=(0, 1001))
+
+    result = operation.process(source)
+
+    np.testing.assert_array_equal(result.compute(scheduler="synchronous"), np.empty((0, 364)))
+    assert kernel_shapes == [(0, 1001)]
+    assert result.chunks == ((0,), (364,))
+
+
+def test_resampling_exact_length_fft_fallback_matches_whole_frame_exactly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source(2)
+    operation = ReSampling(1_000.0, target_sr=1_000.0001)
+    original_process = operation._process
+    original_resample = temporal.resample
+    kernel_shapes: list[tuple[int, ...]] = []
+    fallback_shapes: list[tuple[int, ...]] = []
+
+    def observed_process(values: np.ndarray) -> np.ndarray:
+        kernel_shapes.append(values.shape)
+        return original_process(values)
+
+    def observed_resample(values: np.ndarray, *args: object, **kwargs: object) -> np.ndarray:
+        fallback_shapes.append(values.shape)
+        return original_resample(values, *args, **kwargs)
+
+    monkeypatch.setattr(operation, "_process", observed_process)
+    monkeypatch.setattr(temporal, "resample", observed_resample)
+    channel_wise = operation.process(source)
+    output_shape = operation.calculate_output_shape(source.shape)
+    output_dtype = operation.calculate_output_dtype(source.dtype)
+    whole_frame = operation._build_whole_frame_graph(
+        source,
+        (),
+        output_shape=output_shape,
+        output_dtype=output_dtype,
+    )
+
+    assert output_shape == (2, 1002)
+    assert channel_wise.shape == output_shape
+    assert channel_wise.dtype == np.dtype(np.float64)
+    assert channel_wise.chunks == ((1, 1), (1002,))
+
+    channel_values = channel_wise.compute(scheduler="synchronous")
+    assert kernel_shapes == [(1, 1001), (1, 1001)]
+    assert fallback_shapes == [(1, 1001), (1, 1001)]
+
+    kernel_shapes.clear()
+    fallback_shapes.clear()
+    whole_values = whole_frame.compute(scheduler="synchronous")
+    assert kernel_shapes == [(2, 1001)]
+    assert fallback_shapes == [(2, 1001)]
+    np.testing.assert_array_equal(channel_values, whole_values)

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -5,7 +5,7 @@ from typing import Any
 import numpy as np
 from scipy.signal import lfilter, resample, resample_poly
 
-from wandas.processing.base import AudioOperation, register_operation
+from wandas.processing.base import AudioOperation, ChannelIndependentAudioOperation, register_operation
 from wandas.processing.weighting import A_weight, frequency_weight
 from wandas.utils import validate_sampling_rate
 from wandas.utils.types import NDArrayReal
@@ -50,7 +50,7 @@ def _resampling_ratio(source_sr: float, target_sr: float) -> tuple[int, int]:
     return ratio.numerator, ratio.denominator
 
 
-class ReSampling(AudioOperation[NDArrayReal, NDArrayReal]):
+class ReSampling(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
     """Resampling operation"""
 
     name = "resampling"


### PR DESCRIPTION
## Summary

- apply the public `ChannelIndependentAudioOperation` contract introduced by #352 to `ReSampling`
- keep each resampling kernel on one complete channel time series
- preserve exact output-length rounding, dtype rules, sampling-rate metadata, Frame, Recipe, laziness, and lineage behavior
- add kernel-boundary, exact-parity, fallback, Frame/time-axis, and Recipe replay tests

## Public contract

Closes #346. `ReSampling` is channel-independent for every supported parameter configuration:

```python
op(all_channels) == concatenate(op(channel) for channel in each_channel)
```

It therefore subclasses the public `ChannelIndependentAudioOperation`. There is no new public symbol in this PR; it applies the contract published by #352 to `ReSampling`, adding that public type relationship. No private compatibility alias is added.

Task count, scheduler, chunks, and Dask graph topology remain implementation details rather than public guarantees. Whole-frame fallback for zero or unknown channel counts, runtime inputs, or channel-axis-changing output shapes preserves the same numerical channel independence.

## Preserved numerical and Frame behavior

- unchanged polyphase/exact-length numerical kernel and exact decimal ratio
- `ceil` output-length contract; 1001 samples at 44.1 kHz become 364 samples at 16 kHz
- unchanged dtype calculation and `target_sr` metadata update
- exact equality between channel-wise and forced whole-frame results for 1/2/4/8 channels
- each eligible kernel receives `(1, full_samples)`
- exact-length FFT fallback (`1000.0` Hz → `1000.0001` Hz) has exact channel-wise/whole-frame parity
- preserved shape, chunks, sampling rate, time coordinates, source offsets, metadata, calibration, immutability, laziness, lineage, and Recipe replay

## Validation

- rebased onto `origin/main` `e52db1ca1523252cefa27fb281b2d7f08b92d4a2` (includes #354 and #355)
- focused tests: `115 passed`
- full tests: `2610 passed, 3 skipped`
- `uv run ruff check wandas tests scripts`
- `uv run ruff format --check wandas tests scripts`
- `uv run ty check wandas tests`
- `uv run mkdocs build --strict -f docs/mkdocs.yml`

## Scope

Numerical processing, Recipe schema, Frame construction, scheduler control, and public execution-strategy parameters are unchanged. This PR is independent of #349 and is not merged by this update.

Closes #346
Related to #339, #343, #344, #345, #349, and #352