### PR TITLE
Run eligible normalization channel-wise

### DIFF
--- a/docs/src/explanation/audio-operation-execution.md
+++ b/docs/src/explanation/audio-operation-execution.md
@@ -57,7 +57,7 @@ channels depend on one another.
 | --- | --- | --- | --- |
 | `remove_dc` | Independent | Whole time series per channel for the mean | **Channel-wise** |
 | `abs`, `power` | Independent | Pointwise/time-local | Existing Dask-native graph override |
-| `normalize` | Parameter-dependent: `axis=-1` is independent; `axis=None` or a channel axis is cross-channel | Whole selected norm axis | Whole-frame |
+| `normalize` | Parameter-dependent: a non-`None` norm over the last axis is independent; `axis=None` or a channel axis is cross-channel | Whole selected norm axis | **Channel-wise when eligible** |
 | `trim`, `fix_length` | Independent | Indexed/padded time-local transform with output-shape change | Whole-frame |
 | `fade` | Independent | Needs the full signal length to define the envelope | Whole-frame |
 | high-pass, low-pass, band-pass | Independent | Stateful/whole continuous time series per channel | **Channel-wise** |
@@ -131,6 +131,22 @@ The issue #346 evaluation used 1,000,000 samples per channel at 48 kHz resampled
 from 0.0659 s to 0.0729 s, and same-environment median peak RSS decreased from about
 299.5 MiB to 278.9 MiB. Every paired numerical checksum was equal. These measurements
 describe the task/time/memory tradeoff and do not define a portable performance limit.
+
+## Parameter-dependent operation: Normalize
+
+`Normalize` is parameter-dependent, so it subclasses `AudioOperation`, not
+`ChannelIndependentAudioOperation`. It owns its eligibility semantics rather than
+extending the common graph builder with an operation-specific dependency language.
+A non-`None` norm over the last axis reuses private generic channel-wise graph
+mechanics. Global normalization (`axis=None`), a channel axis, `norm=None`, and invalid
+or inapplicable configurations retain conservative whole-frame execution. Threshold,
+fill, dtype, Frame metadata, lineage, and Recipe behavior remain unchanged.
+
+The issue #348 evaluation used L2 normalization over 1,000,000 samples per channel. At
+eight channels, tasks increased from 20 to 56, median compute time changed from about
+0.0441 s to 0.0373 s, and same-environment median peak RSS decreased from about
+393.4 MiB to 347.7 MiB. All paired arrays were exactly equal. These figures describe
+the observed tradeoff rather than define a portable threshold.
 
 ## Benchmark interpretation
 

--- a/tests/frames/test_channelwise_execution.py
+++ b/tests/frames/test_channelwise_execution.py
@@ -159,3 +159,40 @@ def test_resampling_channel_wise_execution_preserves_frame_contract() -> None:
             "params": {"target_sr": 16_000},
         }
     ]
+
+
+def test_normalize_channel_wise_execution_preserves_frame_contract() -> None:
+    source = _calibrated_frame()
+    source_values = source.data.copy()
+    source_metadata = source.metadata.copy()
+
+    result = source.normalize(norm=2, axis=-1, threshold=0.01, fill=False)
+
+    assert result is not source
+    assert isinstance(result._data, DaArray)
+    np.testing.assert_array_equal(source.data, source_values)
+    assert source.metadata == source_metadata
+    assert source.operation_history == []
+    assert result.shape == source.shape
+    assert result._data.dtype == np.dtype(np.float64)
+    assert result._data.chunks == ((1, 1), (4,))
+    assert result.sampling_rate == source.sampling_rate
+    assert result.metadata == source.metadata
+    assert [channel.id for channel in result.channels] == ["sensor-mic", "sensor-acc"]
+    assert result.labels == ["norm(microphone)", "norm(accelerometer)"]
+    assert [channel.calibration.factor for channel in result.channels] == [1.0, 1.0]
+    assert [channel.unit for channel in result.channels] == ["Pa", "m/s^2"]
+    assert [channel.ref for channel in result.channels] == [2e-5, 1.0]
+    np.testing.assert_array_equal(result.source_time_offset, np.array([0.25, 0.5]))
+    assert result.operation_history == [
+        {
+            "operation": "wandas.audio.normalize",
+            "version": 1,
+            "params": {
+                "axis": -1,
+                "fill": False,
+                "norm": 2,
+                "threshold": 0.01,
+            },
+        }
+    ]

--- a/tests/pipeline/test_recipe_execution.py
+++ b/tests/pipeline/test_recipe_execution.py
@@ -131,6 +131,30 @@ def test_resampling_channel_wise_execution_recipe_roundtrip_replays_lazily() -> 
     np.testing.assert_array_equal(channel_first_values(replayed), channel_first_values(processed))
 
 
+def test_normalize_channel_wise_execution_recipe_roundtrip_replays_lazily() -> None:
+    source = ChannelFrame(
+        da.from_array(np.arange(128, dtype=float).reshape(2, 64), chunks=(1, 16)),
+        sampling_rate=8_000,
+        source_time_offset=[0.25, 0.5],
+    )
+    processed = source.normalize(norm=2, axis=-1, threshold=0.01, fill=False)
+
+    plan = RecipePlan.from_frame(processed, input_names=("signal",))
+    replayed = RecipePlan.from_dict(plan.to_dict()).apply({"signal": source})
+
+    assert [node.operation for node in plan.nodes] == ["wandas.audio.normalize"]
+    assert replayed.operation_history[-1]["params"] == {
+        "axis": -1,
+        "fill": False,
+        "norm": 2,
+        "threshold": 0.01,
+    }
+    assert isinstance(replayed._data, DaArray)
+    assert replayed.shape == processed.shape
+    np.testing.assert_array_equal(replayed.source_time_offset, processed.source_time_offset)
+    np.testing.assert_array_equal(channel_first_values(replayed), channel_first_values(processed))
+
+
 def test_typed_transition_after_true_frame_merge_replays() -> None:
     left = _frame(1.0)
     right = _frame(2.0)

--- a/tests/processing/test_normalize_channelwise_execution.py
+++ b/tests/processing/test_normalize_channelwise_execution.py
@@ -1,0 +1,211 @@
+"""Parameter-dependent channel-wise execution contracts for Normalize."""
+
+import dask.array as da
+import numpy as np
+import pytest
+from dask.array.core import Array as DaArray
+from dask.delayed import delayed
+
+from wandas.processing.base import AudioOperation, ChannelIndependentAudioOperation
+from wandas.processing.effects import Normalize
+from wandas.utils.dask_helpers import da_from_array
+
+
+def _source(channels: int, samples: int = 256) -> DaArray:
+    base = np.linspace(-1.0, 1.0, samples)
+    return da_from_array(
+        np.stack([(index + 1) * base for index in range(channels)]),
+        chunks=(1, 64),
+    )
+
+
+def test_normalize_keeps_parameter_dependent_base_contract() -> None:
+    assert issubclass(Normalize, AudioOperation)
+    assert not issubclass(Normalize, ChannelIndependentAudioOperation)
+
+
+@pytest.mark.parametrize("channels", [1, 2, 4, 8])
+@pytest.mark.parametrize("axis", [-1, 1])
+def test_normalize_last_axis_kernel_matches_whole_frame_exactly(
+    monkeypatch: pytest.MonkeyPatch,
+    channels: int,
+    axis: int,
+) -> None:
+    source = _source(channels)
+    operation = Normalize(8_000, norm=2, axis=axis)
+    original_process = operation._process
+    kernel_shapes: list[tuple[int, ...]] = []
+
+    def observed_process(values: np.ndarray) -> np.ndarray:
+        kernel_shapes.append(values.shape)
+        return original_process(values)
+
+    monkeypatch.setattr(operation, "_process", observed_process)
+    channel_wise = operation.process(source)
+    whole_frame = operation._build_whole_frame_graph(
+        source,
+        (),
+        output_shape=source.shape,
+        output_dtype=operation.calculate_output_dtype(source.dtype),
+    )
+
+    assert channel_wise.shape == source.shape
+    assert channel_wise.dtype == np.dtype(np.float64)
+    assert channel_wise.chunks == (channels * (1,), (256,))
+    channel_values = channel_wise.compute(scheduler="synchronous")
+    assert kernel_shapes == channels * [(1, 256)]
+
+    kernel_shapes.clear()
+    whole_values = whole_frame.compute(scheduler="synchronous")
+    assert kernel_shapes == [(channels, 256)]
+    np.testing.assert_array_equal(channel_values, whole_values)
+
+
+@pytest.mark.parametrize(
+    ("axis", "norm"),
+    [
+        (None, 2),
+        (0, 2),
+        (-2, 2),
+        (-1, None),
+    ],
+)
+def test_normalize_dependent_or_noop_configuration_uses_whole_frame(
+    monkeypatch: pytest.MonkeyPatch,
+    axis: int | None,
+    norm: float | None,
+) -> None:
+    source = _source(4)
+    operation = Normalize(8_000, norm=norm, axis=axis)
+    original_process = operation._process
+    kernel_shapes: list[tuple[int, ...]] = []
+
+    def observed_process(values: np.ndarray) -> np.ndarray:
+        kernel_shapes.append(values.shape)
+        return original_process(values)
+
+    monkeypatch.setattr(operation, "_process", observed_process)
+
+    result = operation.process(source)
+    result.compute(scheduler="synchronous")
+
+    assert kernel_shapes == [(4, 256)]
+    assert result.chunks == ((4,), (256,))
+
+
+def test_normalize_unhashable_axis_uses_whole_frame_before_kernel_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source(2)
+    operation = Normalize(8_000, norm=2, axis=[-1])  # ty: ignore[invalid-argument-type]
+    original_process = operation._process
+    kernel_shapes: list[tuple[int, ...]] = []
+
+    def observed_process(values: np.ndarray) -> np.ndarray:
+        kernel_shapes.append(values.shape)
+        return original_process(values)
+
+    monkeypatch.setattr(operation, "_process", observed_process)
+
+    result = operation.process(source)
+    with pytest.raises(TypeError):
+        result.compute(scheduler="synchronous")
+
+    assert kernel_shapes == [(2, 256)]
+
+
+def test_normalize_zero_channel_input_uses_whole_frame_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operation = Normalize(8_000, norm=np.inf, axis=-1)
+    original_process = operation._process
+    kernel_shapes: list[tuple[int, ...]] = []
+
+    def observed_process(values: np.ndarray) -> np.ndarray:
+        kernel_shapes.append(values.shape)
+        return original_process(values)
+
+    monkeypatch.setattr(operation, "_process", observed_process)
+    source = da.from_array(np.empty((0, 64)), chunks=(0, 64))
+
+    result = operation.process(source)
+
+    np.testing.assert_array_equal(result.compute(scheduler="synchronous"), np.empty((0, 64)))
+    assert kernel_shapes == [(0, 64)]
+
+
+def test_normalize_unknown_channel_count_uses_whole_frame_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    values = np.arange(8, dtype=float).reshape(2, 4)
+    source = da.from_delayed(
+        delayed(np.asarray)(values),
+        shape=(np.nan, 4),
+        dtype=float,
+    )
+    operation = Normalize(8_000, norm=np.inf, axis=-1)
+    original_process = operation._process
+    kernel_shapes: list[tuple[int, ...]] = []
+
+    def observed_process(array: np.ndarray) -> np.ndarray:
+        kernel_shapes.append(array.shape)
+        return original_process(array)
+
+    monkeypatch.setattr(operation, "_process", observed_process)
+
+    result = operation.process(source)
+    computed = result.compute(scheduler="synchronous")
+
+    expected = values / np.max(np.abs(values), axis=-1, keepdims=True)
+    np.testing.assert_array_equal(computed, expected)
+    assert np.isnan(result.shape[0])
+    assert result.shape[1:] == (4,)
+    assert result.dtype == np.dtype(np.float64)
+    assert kernel_shapes == [(2, 4)]
+
+
+@pytest.mark.parametrize(
+    ("dtype", "norm", "threshold", "fill"),
+    [
+        (np.dtype(np.int16), np.inf, None, None),
+        (np.dtype(np.float32), -np.inf, None, None),
+        (np.dtype(np.float64), 1, None, None),
+        (np.dtype(np.float32), 2, None, None),
+        (np.dtype(np.int16), 0, None, False),
+        (np.dtype(np.float64), 2, 1e6, True),
+    ],
+)
+def test_normalize_dtype_norm_threshold_fill_matches_whole_frame_exactly(
+    dtype: np.dtype[np.generic],
+    norm: float,
+    threshold: float | None,
+    fill: bool | None,
+) -> None:
+    source = da.from_array(
+        np.array([[1, -2, 3, -4], [2, -3, 4, -5]], dtype=dtype),
+        chunks=(1, 2),
+    )
+    operation = Normalize(
+        8_000,
+        norm=norm,
+        axis=-1,
+        threshold=threshold,
+        fill=fill,
+    )
+
+    channel_wise = operation.process(source)
+    whole_frame = operation._build_whole_frame_graph(
+        source,
+        (),
+        output_shape=source.shape,
+        output_dtype=operation.calculate_output_dtype(source.dtype),
+    )
+
+    assert channel_wise.shape == whole_frame.shape == source.shape
+    expected_dtype = operation.calculate_output_dtype(source.dtype)
+    assert channel_wise.dtype == whole_frame.dtype == expected_dtype
+    assert channel_wise.chunks == ((1, 1), (4,))
+    np.testing.assert_array_equal(
+        channel_wise.compute(scheduler="synchronous"),
+        whole_frame.compute(scheduler="synchronous"),
+    )

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -435,38 +435,59 @@ class ChannelIndependentAudioOperation(AudioOperation[InputArrayType, OutputArra
         output_shape: tuple[int, ...],
         output_dtype: np.dtype[Any],
     ) -> DaArray:
-        channel_count = data.shape[0]
-        if (
-            inputs
-            or not isinstance(channel_count, int | np.integer)
-            or channel_count <= 0
-            or not output_shape
-            or output_shape[0] != channel_count
-        ):
-            return super()._build_execution_graph(
-                data,
-                inputs,
-                output_shape=output_shape,
-                output_dtype=output_dtype,
-            )
+        result = _try_build_channelwise_graph(
+            self,
+            data,
+            inputs,
+            output_shape=output_shape,
+            output_dtype=output_dtype,
+        )
+        if result is not None:
+            return result
+        return super()._build_execution_graph(
+            data,
+            inputs,
+            output_shape=output_shape,
+            output_dtype=output_dtype,
+        )
 
-        per_channel_shape = (1, *output_shape[1:])
-        channel_results = []
-        for channel_index in range(int(channel_count)):
-            channel_data = data[channel_index : channel_index + 1]
-            delayed_result = delayed(
-                _execute_wandas_operation,
-                name=f"{self.name}-channel",
-                pure=self.pure,
-            )(self, channel_data)
-            channel_results.append(
-                _da_from_delayed(
-                    delayed_result,
-                    shape=per_channel_shape,
-                    dtype=output_dtype,
-                )
+
+def _try_build_channelwise_graph(
+    operation: AudioOperation[Any, Any],
+    data: DaArray,
+    inputs: tuple[DaArray, ...],
+    *,
+    output_shape: tuple[int, ...],
+    output_dtype: np.dtype[Any],
+) -> DaArray | None:
+    """Build generic unary channel-wise graph mechanics when shape permits."""
+    channel_count = data.shape[0]
+    if (
+        inputs
+        or not isinstance(channel_count, int | np.integer)
+        or channel_count <= 0
+        or not output_shape
+        or output_shape[0] != channel_count
+    ):
+        return None
+
+    per_channel_shape = (1, *output_shape[1:])
+    channel_results = []
+    for channel_index in range(int(channel_count)):
+        channel_data = data[channel_index : channel_index + 1]
+        delayed_result = delayed(
+            _execute_wandas_operation,
+            name=f"{operation.name}-channel",
+            pure=operation.pure,
+        )(operation, channel_data)
+        channel_results.append(
+            _da_from_delayed(
+                delayed_result,
+                shape=per_channel_shape,
+                dtype=output_dtype,
             )
-        return da.concatenate(channel_results, axis=0)
+        )
+    return da.concatenate(channel_results, axis=0)
 
 
 # Automatically collect operation types and corresponding classes

--- a/wandas/processing/effects.py
+++ b/wandas/processing/effects.py
@@ -2,9 +2,15 @@ import logging
 from typing import Any
 
 import numpy as np
+from dask.array.core import Array as DaArray
 from scipy.signal import windows as sp_windows
 
-from wandas.processing.base import AudioOperation, ChannelIndependentAudioOperation, register_operation
+from wandas.processing.base import (
+    AudioOperation,
+    ChannelIndependentAudioOperation,
+    _try_build_channelwise_graph,
+    register_operation,
+)
 from wandas.utils import util
 from wandas.utils.optional_imports import require_librosa_effects
 from wandas.utils.types import NDArrayReal
@@ -220,6 +226,38 @@ class Normalize(AudioOperation[NDArrayReal, NDArrayReal]):
 
         logger.debug(f"Normalization applied, returning result with shape: {result.shape}")
         return result
+
+    def _build_execution_graph(
+        self,
+        data: DaArray,
+        inputs: tuple[DaArray, ...],
+        *,
+        output_shape: tuple[int, ...],
+        output_dtype: np.dtype[Any],
+    ) -> DaArray:
+        axis = self.axis
+        if self.norm is None or not isinstance(axis, int | np.integer) or axis not in {-1, data.ndim - 1}:
+            return super()._build_execution_graph(
+                data,
+                inputs,
+                output_shape=output_shape,
+                output_dtype=output_dtype,
+            )
+        result = _try_build_channelwise_graph(
+            self,
+            data,
+            inputs,
+            output_shape=output_shape,
+            output_dtype=output_dtype,
+        )
+        if result is not None:
+            return result
+        return super()._build_execution_graph(
+            data,
+            inputs,
+            output_shape=output_shape,
+            output_dtype=output_dtype,
+        )
 
     def calculate_output_dtype(self, input_dtype: np.dtype[Any], *input_dtypes: np.dtype[Any]) -> np.dtype[Any]:
         """Return normalization output dtype metadata."""


### PR DESCRIPTION
## Summary

- rebase onto `main` `15f1d356628192c18b9ea985c8db979c5a8ff3f8`, which includes merged PR #347
- keep parameter-dependent `Normalize` as an `AudioOperation`, consistent with the public contract introduced by #352
- reuse only private generic channel-wise graph mechanics for eligible last-axis configurations
- keep `Normalize`-specific `axis` and `norm` eligibility owned by `Normalize`
- preserve both the merged ReSampling behavior and normalization mathematics, dtype, Frame, Recipe, laziness, and lineage behavior

## Public contract and ownership

Closes #348. `Normalize` is not channel-independent for every supported parameter configuration:

- channel-wise eligible: `norm is not None` and `axis` is `-1` or the equivalent positive last-axis index
- whole-frame: `axis=None`, a channel axis, `norm=None`, and generic fallback cases

Accordingly, `Normalize` subclasses `AudioOperation` and does **not** subclass `ChannelIndependentAudioOperation`. This preserves the #352 meaning that every subclass of the public channel-independent base must satisfy per-channel concatenation equivalence for all supported parameters. `ReSampling` remains a `ChannelIndependentAudioOperation` subclass.

The shared private `_try_build_channelwise_graph` helper owns only generic mechanics: unary input, known positive channel count, and channel-axis-preserving output. It returns `None` when ineligible. `Normalize` evaluates its own parameter semantics before using that helper. No eligibility DSL, strategy/DI layer, central operation dispatch, public `execution_strategy` argument, Normalize-specific base branch, unbound public-base call, or eager `.compute()` is introduced.

## Preserved numerical and Frame behavior

- exact equality between eligible channel-wise and forced whole-frame results for 1/2/4/8 channels
- each eligible kernel receives `(1, full_samples)`
- global, channel-axis, no-op, zero/unknown-channel, and other generic fallbacks stay whole-frame
- preserved dtype, shape, chunks, threshold, fill, metadata, calibration, source offsets, immutability, laziness, lineage, and Recipe replay
- regression coverage includes `AudioOperation`, `ChannelIndependentAudioOperation`, public consumer subclasses, RemoveDC, Butterworth filters, Normalize, ReSampling, and the exact-length FFT resampling fallback
- the previously temporary unknown-channel and dtype/norm/threshold/fill coverage is now part of this formal PR branch

## Validation

- current head: `dd28af3c505246f8c0dae1f32bcf4b84b65e753c`
- PR #347 is merged; this formal PR branch is rebased onto the resulting `main`
- focused tests: `461 passed`
- full tests: `2634 passed, 3 skipped`
- `uv run ruff check wandas tests scripts`
- `uv run ruff format --check wandas tests scripts`
- `uv run ty check wandas tests`
- `uv run mkdocs build --strict -f docs/mkdocs.yml`
- `git diff --check`

## Scope

Normalization mathematics, Recipe schema, Frame construction, scheduler control, and public APIs are unchanged. ReSampling and Normalize documentation, Frame contracts, and Recipe replay tests are both retained in the formal branch.

Closes #348
Related to #339, #343, #344, #345, #346, #347, and #352
