### PR TITLE
Publish the channel-independent AudioOperation contract

### DIFF
--- a/docs/src/api/processing.md
+++ b/docs/src/api/processing.md
@@ -5,10 +5,20 @@ The `wandas.processing` module provides various processing capabilities for audi
 
 ## Base Processing / 基本処理
 
-Provides basic processing operations.
-基本的な処理操作を提供します。
+Provides the public operation extension contracts. Use `AudioOperation` for
+cross-channel algorithms and `ChannelIndependentAudioOperation` only when each output
+channel depends exclusively on its corresponding input channel.
+公開Operation拡張契約を提供します。cross-channel algorithmには`AudioOperation`を使い、
+各出力channelが対応入力channelだけに依存する場合だけ
+`ChannelIndependentAudioOperation`を使用します。
 
-::: wandas.processing.base
+::: wandas.processing.AudioOperation
+    options:
+      show_root_heading: true
+
+::: wandas.processing.ChannelIndependentAudioOperation
+    options:
+      show_root_heading: true
 
 ## Effects / エフェクト
 

--- a/docs/src/contributing/frame-operation-extensions.md
+++ b/docs/src/contributing/frame-operation-extensions.md
@@ -65,11 +65,20 @@ Frame metadataを変更してはいけません。
    `stats.py`, or `effects.py`.
    `filters.py`、`spectral.py`、`temporal.py`、`stats.py`、`effects.py`など、
    最も近いmoduleを選びます。
-2. Subclass `AudioOperation`, give it a stable registry `name`, and pass all
-   constructor configuration to `super().__init__`. The base class snapshots
-   caller-owned configuration.
-   `AudioOperation`を継承し、安定したregistry `name`を付け、constructor設定をすべて
-   `super().__init__`へ渡します。base classが呼出し側所有の設定値をsnapshotします。
+2. Decide channel dependency before choosing the base class. Subclass
+   `ChannelIndependentAudioOperation` only when every output channel depends on the
+   corresponding input channel and the kernel satisfies
+   `op(all_channels) == concatenate(op(channel) for channel in each_channel)`.
+   Subclasses inherit and must preserve that semantic contract. Use `AudioOperation`
+   for cross-channel or parameter-dependent operations that cannot make the
+   independence guarantee for every supported configuration. Give the operation a
+   stable registry `name` and pass all constructor configuration to
+   `super().__init__`; the base snapshots caller-owned configuration.
+   base classを選ぶ前にchannel依存性を判断します。各出力channelが対応入力channelだけに依存し、
+   上記の等価関係を全対応構成で保証できる場合だけ`ChannelIndependentAudioOperation`を継承します。
+   subclassもこの意味論を維持します。cross-channel処理や、全対応parameter構成では独立性を
+   保証できない処理は`AudioOperation`を使用します。安定したregistry `name`を付け、
+   constructor設定を`super().__init__`へ渡します。
 3. Validate operation parameters in `validate_params()` and implement the eager
    array kernel in `_process()`. `process()` is the shared lazy Dask boundary;
    do not replace it merely to implement the algorithm.
@@ -94,7 +103,7 @@ dtype appropriate for the real operation.
 次の例は必要な責務境界を示します。実際のOperationに適した検証とdtypeを使用してください。
 
 ```python
-class Gain(AudioOperation[NDArrayReal, NDArrayReal]):
+class Gain(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
     name = "gain"
     _display = "gain"
 
@@ -124,6 +133,22 @@ class Gain(AudioOperation[NDArrayReal, NDArrayReal]):
 
 register_operation(Gain)
 ```
+
+A cross-channel kernel must use the conservative base explicitly:
+
+```python
+class CommonModeRemoval(AudioOperation[NDArrayReal, NDArrayReal]):
+    name = "common_mode_removal"
+
+    def _process(self, data: NDArrayReal) -> NDArrayReal:
+        return data - data.mean(axis=0, keepdims=True)
+```
+
+`ChannelIndependentAudioOperation` expresses numerical meaning, not execution
+topology. Do not assume or document a fixed task count, per-channel scheduling, or
+public scheduler control. Its kernel must also accept multiple channels together
+because zero or unknown channel counts, runtime inputs, and channel-axis-changing
+outputs currently fall back to whole-frame execution.
 
 Never retain a user-supplied mutable list, mapping, or NumPy array on a separate
 public attribute that must stay synchronized with the base configuration. Read it

--- a/docs/src/explanation/audio-operation-execution.md
+++ b/docs/src/explanation/audio-operation-execution.md
@@ -35,7 +35,7 @@ then delegates graph construction through one polymorphic internal hook:
 - The base implementation is conservative whole-frame execution. One delayed kernel receives the complete
   channel-first tensor, preserving all existing operations and custom extensions.
 - `ChannelIndependentAudioOperation` can build one delayed kernel call for each
-  channel, where the kernel input retains shape `(1, ...)`, then concatenate the
+  channel, where the kernel input retains shape `(1, ...)`, then concatenates the
   outputs along the channel axis.
 
 The current optimization is deliberately narrow: channel-wise execution applies to

--- a/docs/src/explanation/audio-operation-execution.md
+++ b/docs/src/explanation/audio-operation-execution.md
@@ -10,6 +10,23 @@ be channel-independent while still requiring one complete, continuous time serie
 each channel. Channel-wise execution therefore reduces the number of channels that a
 kernel task materializes; it does not introduce time-axis distribution.
 
+## Public extension contracts
+
+Choose the base class from the numerical dependency, before considering the current
+graph implementation:
+
+- `AudioOperation` permits cross-channel dependencies and uses conservative
+  whole-frame execution by default.
+- `ChannelIndependentAudioOperation` declares that every output channel depends only
+  on the corresponding input channel. Subclasses must preserve
+  `op(all_channels) == concatenate(op(channel) for channel in each_channel)`.
+
+The second contract is semantic. It does not promise one task per channel, a scheduler,
+or a particular Dask graph. Its `_process()` implementation must remain correct when
+given either one channel or a complete multi-channel tensor. A gain operation is
+channel-independent; common-mode removal, which subtracts a mean across channels, is
+cross-channel and must use `AudioOperation`.
+
 ## Internal graph-builder contract
 
 `AudioOperation.process()` validates inputs and calculates output shape and dtype,
@@ -17,15 +34,15 @@ then delegates graph construction through one polymorphic internal hook:
 
 - The base implementation is conservative whole-frame execution. One delayed kernel receives the complete
   channel-first tensor, preserving all existing operations and custom extensions.
-- The channel-independent specialization builds one delayed kernel call for each
-  channel, where the kernel input retains shape `(1, ...)`, then concatenates the
+- `ChannelIndependentAudioOperation` can build one delayed kernel call for each
+  channel, where the kernel input retains shape `(1, ...)`, then concatenate the
   outputs along the channel axis.
 
-The prototype contract is deliberately narrow: channel-wise execution currently
-applies to unary operations with a known positive channel count that preserve the
-channel axis. Zero-channel, unknown-channel-count, multi-input, and channel-axis-changing
-inputs fall back to the base whole-frame graph. This makes channel-wise execution an
-opportunistic optimization without strengthening the `AudioOperation` input contract.
+The current optimization is deliberately narrow: channel-wise execution applies to
+unary operations with a known positive channel count that preserve the channel axis.
+Zero-channel, unknown-channel-count, multi-input, and channel-axis-changing inputs fall
+back to the base whole-frame graph. The fallback changes execution topology, not the
+public channel-independence contract.
 New execution forms override the graph-building hook instead of adding cases to a
 central dispatcher. The hook, Dask graph, chunks, scheduler, and xarray container
 remain private implementation details; the public Frame workflow is unchanged.
@@ -38,7 +55,7 @@ channels depend on one another.
 
 | Built-in family | Channel dependency | Time or analysis-axis dependency | Current execution |
 | --- | --- | --- | --- |
-| `remove_dc` | Independent | Whole time series per channel for the mean | **Channel-wise prototype** |
+| `remove_dc` | Independent | Whole time series per channel for the mean | **Channel-wise** |
 | `abs`, `power` | Independent | Pointwise/time-local | Existing Dask-native graph override |
 | `normalize` | Parameter-dependent: `axis=-1` is independent; `axis=None` or a channel axis is cross-channel | Whole selected norm axis | Whole-frame |
 | `trim`, `fix_length` | Independent | Indexed/padded time-local transform with output-shape change | Whole-frame |
@@ -60,14 +77,13 @@ STFT, Welch, psychoacoustic algorithms, or other continuity-sensitive transforms
 Those operations remain whole-signal per channel until they have an explicit state or
 overlap contract.
 
-## Prototype: RemoveDC
+## Adopted operation: RemoveDC
 
 `RemoveDC` is unary, shape-preserving, and numerically independent across channels. It
-is the first operation to use the channel-independent specialization. For known,
-positive channel counts, each task still receives the complete time series for one
-channel, so subtracting that channel's mean is identical to the previous whole-frame
-kernel call. Indeterminate or inapplicable inputs retain the historical whole-frame
-behavior.
+uses `ChannelIndependentAudioOperation`. For known, positive channel counts, each task
+still receives the complete time series for one channel, so subtracting that channel's
+mean is identical to the whole-frame kernel call. Indeterminate or inapplicable inputs
+retain whole-frame execution.
 
 The Frame boundary is unchanged: calibration factors are applied lazily before the
 operation, consumed exactly once in output channel metadata, and channel IDs, labels,
@@ -75,18 +91,19 @@ units, references, extra metadata, source-time offsets, semantic lineage, and Re
 replay continue through the existing construction path. Shape and dtype are calculated
 before execution as before.
 
-Unsupported and cross-channel operations retain the default graph builder. This
-fail-safe default is also used by third-party `AudioOperation` subclasses, so the
-prototype does not silently reinterpret existing kernels as channel-independent.
+Unsupported and cross-channel operations retain the default graph builder. Third-party
+extensions remain whole-frame when they subclass `AudioOperation`; extensions that
+choose `ChannelIndependentAudioOperation` explicitly accept and pass its independence
+contract to their subclasses.
 
 ## Adopted family: Butterworth filters
 
 The shared `_ButterworthFilter` kernel used by the high-pass, low-pass, and band-pass
 operations applies `scipy.signal.filtfilt(..., axis=1)`. Each output row depends on one
-complete input row but not on any other channel, so the family uses the existing
-channel-independent specialization without a new graph-builder contract. Filter
-coefficients, output shape and `float64` dtype, Frame metadata, lineage, and Recipe
-declarations are unchanged.
+complete input row but not on any other channel, so the family uses the public
+`ChannelIndependentAudioOperation` contract without a new graph-builder mechanism.
+Filter coefficients, output shape and `float64` dtype, Frame metadata, lineage, and
+Recipe declarations are unchanged.
 
 The final LowPass comparison for issue #343 used the normal materialization path:
 `BaseFrame.data` calls `BaseFrame._compute()`, which calls Dask Array `compute()`

--- a/tests/processing/test_base_operations.py
+++ b/tests/processing/test_base_operations.py
@@ -11,12 +11,13 @@ from dask import delayed
 from dask.array.core import Array as DaArray
 from dask.base import tokenize
 
+from wandas.processing import ChannelIndependentAudioOperation as PublicChannelIndependentAudioOperation
 from wandas.processing import base as base_module
 from wandas.processing.base import (
     _OPERATION_MODULES,
     _OPERATION_REGISTRY,
     AudioOperation,
-    _ChannelIndependentAudioOperation,
+    ChannelIndependentAudioOperation,
     _config_values_equal,
     _snapshot_config_value,
     _validate_channel_first_array,
@@ -126,6 +127,47 @@ def test_validate_channel_first_array_ignores_non_array_values() -> None:
     _validate_channel_first_array(object(), "data")
 
 
+def test_channel_independent_audio_operation_is_publicly_exported() -> None:
+    import wandas.processing as processing
+
+    assert PublicChannelIndependentAudioOperation is ChannelIndependentAudioOperation
+    assert processing.ChannelIndependentAudioOperation is ChannelIndependentAudioOperation
+    assert "ChannelIndependentAudioOperation" in processing.__all__
+
+
+def test_user_channel_independent_subclass_preserves_semantics_and_laziness() -> None:
+    class Gain(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
+        name = "public_channel_independent_gain"
+
+        def __init__(self, sampling_rate: float, factor: float) -> None:
+            super().__init__(sampling_rate, factor=factor)
+
+        @property
+        def factor(self) -> float:
+            return self._config_value("factor")
+
+        def _process(self, data: NDArrayReal) -> NDArrayReal:
+            return data * self.factor
+
+    values = np.arange(12, dtype=np.float64).reshape(3, 4)
+    operation = Gain(16_000, factor=2.5)
+    whole_values = operation._process(values)
+    per_channel_values = np.concatenate([operation._process(values[index : index + 1]) for index in range(3)])
+
+    np.testing.assert_array_equal(whole_values, per_channel_values)
+
+    lazy_values = da_from_array(values, chunks=(1, -1))
+    with mock.patch.object(DaArray, "compute") as compute:
+        result = operation.process(lazy_values)
+        compute.assert_not_called()
+
+    assert isinstance(result, DaArray)
+    assert result.shape == values.shape
+    assert result.dtype == values.dtype
+    assert result.chunks == ((1, 1, 1), (4,))
+    np.testing.assert_array_equal(result.compute(scheduler="synchronous"), whole_values)
+
+
 class TestAudioOperation:
     """Test AudioOperation base class."""
 
@@ -177,7 +219,7 @@ class TestAudioOperation:
         np.testing.assert_array_equal(result.compute(scheduler="synchronous"), data + 1.0)
 
     def test_channel_independent_execution_invokes_kernel_with_one_channel(self) -> None:
-        class ChannelWiseOperation(_ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
+        class ChannelWiseOperation(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
             name = "channel_wise_execution_op"
 
             def _process(self, x: NDArrayReal) -> NDArrayReal:
@@ -194,7 +236,7 @@ class TestAudioOperation:
         np.testing.assert_array_equal(result.compute(scheduler="synchronous"), data + 1.0)
 
     def test_channel_independent_execution_falls_back_for_multiple_inputs(self) -> None:
-        class MultiInputOperation(_ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
+        class MultiInputOperation(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
             name = "channel_independent_multi_input_op"
             _expected_input_count = 2
 
@@ -210,7 +252,7 @@ class TestAudioOperation:
         np.testing.assert_array_equal(result.compute(scheduler="synchronous"), 2 * data.compute())
 
     def test_channel_independent_execution_falls_back_for_unknown_channel_count(self) -> None:
-        class UnknownChannelOperation(_ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
+        class UnknownChannelOperation(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
             name = "unknown_channel_count_op"
 
             def _process(self, x: NDArrayReal) -> NDArrayReal:
@@ -229,7 +271,7 @@ class TestAudioOperation:
         np.testing.assert_array_equal(result.compute(scheduler="synchronous"), data + 1.0)
 
     def test_channel_independent_execution_falls_back_when_channel_axis_changes(self) -> None:
-        class ChannelReductionOperation(_ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
+        class ChannelReductionOperation(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
             name = "channel_reduction_op"
 
             def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:

--- a/wandas/processing/__init__.py
+++ b/wandas/processing/__init__.py
@@ -10,6 +10,7 @@ from wandas.processing.base import (
     _OPERATION_MODULES,
     _OPERATION_REGISTRY,
     AudioOperation,
+    ChannelIndependentAudioOperation,
     create_operation,
     get_operation,
     register_lazy_operation,
@@ -85,6 +86,7 @@ __all__ = [  # noqa: RUF022  # intentionally grouped by category
     "apply_channel_factors",
     # Base
     "AudioOperation",
+    "ChannelIndependentAudioOperation",
     "_OPERATION_MODULES",
     "_OPERATION_REGISTRY",
     "create_operation",

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -166,7 +166,15 @@ class _DefensiveParamsMapping(Mapping[str, Any]):
 
 
 class AudioOperation(Generic[InputArrayType, OutputArrayType]):
-    """Numerical Dask operation with an operation-owned config snapshot."""
+    """Base class for numerical audio operations.
+
+    Subclasses may depend on relationships between channels. The default lazy
+    execution graph therefore passes the complete channel-first tensor to the
+    eager :meth:`_process` kernel as one whole-frame operation.
+
+    Use :class:`ChannelIndependentAudioOperation` instead when every output
+    channel depends only on the corresponding input channel.
+    """
 
     # Class variable: operation name
     name: ClassVar[str]
@@ -397,12 +405,26 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
         )
 
 
-class _ChannelIndependentAudioOperation(AudioOperation[InputArrayType, OutputArrayType]):
-    """AudioOperation whose unary kernel is independent across channels.
+class ChannelIndependentAudioOperation(AudioOperation[InputArrayType, OutputArrayType]):
+    """Base class for operations whose channels are numerically independent.
 
-    Known, positive, channel-axis-preserving inputs use one lazy kernel task per
-    channel. Inputs outside that optimization boundary use the base whole-frame
-    graph, preserving the complete :class:`AudioOperation` input contract.
+    For every supported input, a conforming operation satisfies the semantic
+    equivalence
+
+    ``op(all_channels) == concatenate(op(channel) for channel in each_channel)``.
+
+    Subclasses must preserve this independence when overriding :meth:`_process`.
+    The kernel must also accept a complete multi-channel tensor because graph
+    construction can conservatively use whole-frame execution.
+
+    The class expresses numerical semantics, not a public scheduler, chunk, or
+    task-topology guarantee. The current implementation may evaluate eligible
+    unary, channel-axis-preserving inputs independently by channel. Unknown or
+    zero channel counts, runtime inputs, and channel-axis-changing outputs use
+    the whole-frame graph without changing the subclass contract.
+
+    Cross-channel algorithms, such as common-mode removal, must subclass
+    :class:`AudioOperation` instead.
     """
 
     def _build_execution_graph(

--- a/wandas/processing/effects.py
+++ b/wandas/processing/effects.py
@@ -4,7 +4,7 @@ from typing import Any
 import numpy as np
 from scipy.signal import windows as sp_windows
 
-from wandas.processing.base import AudioOperation, _ChannelIndependentAudioOperation, register_operation
+from wandas.processing.base import AudioOperation, ChannelIndependentAudioOperation, register_operation
 from wandas.utils import util
 from wandas.utils.optional_imports import require_librosa_effects
 from wandas.utils.types import NDArrayReal
@@ -226,7 +226,7 @@ class Normalize(AudioOperation[NDArrayReal, NDArrayReal]):
         return self._output_dtype(input_dtype, self.norm)
 
 
-class RemoveDC(_ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
+class RemoveDC(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
     """Remove DC component (DC offset) from the signal.
 
     This operation removes the DC component by subtracting the mean value

--- a/wandas/processing/filters.py
+++ b/wandas/processing/filters.py
@@ -6,7 +6,7 @@ from scipy import signal
 
 from wandas.processing.base import (
     AudioOperation,
-    _ChannelIndependentAudioOperation,
+    ChannelIndependentAudioOperation,
     register_operation,
 )
 from wandas.processing.weighting import A_weight
@@ -48,7 +48,7 @@ def _validate_cutoff(cutoff: float, sampling_rate: float, label: str = "Cutoff")
         )
 
 
-class _ButterworthFilter(_ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
+class _ButterworthFilter(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
     """Shared base for single-cutoff Butterworth filters (high-pass/low-pass)."""
 
     _btype: str  # "high" or "low" — set by subclasses


### PR DESCRIPTION
## Summary

- promote the private channel-independent specialization to the public
  `ChannelIndependentAudioOperation` extension contract
- export it from `wandas.processing` and migrate `RemoveDC` and the Butterworth
  family without changing their numerical kernels or graph construction
- document channel independence as a semantic subclass obligation, distinct
  from private Dask task topology
- add public-extension, semantic-equivalence, laziness, and existing fallback
  coverage

## Public contract

`ChannelIndependentAudioOperation` declares that each output channel depends
only on the corresponding input channel:

```text
op(all_channels) == concatenate(
    op(channel) for channel in each_channel
)
```

Subclasses must preserve that property. The contract does not promise one
kernel call per channel, a scheduler, or any particular Dask graph. `_process()`
must also remain correct for a multi-channel tensor because the current
implementation conservatively falls back to whole-frame execution for unknown
or zero channel counts, multi-input operations, and channel-axis-changing
outputs.

Cross-channel extensions continue to subclass `AudioOperation`.

## Compatibility

No alias is retained for `_ChannelIndependentAudioOperation`. It was a private
pre-alpha implementation symbol with no public compatibility basis, and keeping
both names would create two representations of one contract.

The graph builder, numerical kernels, Frame construction, Recipe schema, and
public materialization behavior are unchanged.

## Related work

- Follow-up to the contract discussion in #344:
  https://github.com/kasahart/wandas/pull/344#discussion_r3651404428
- #347 is intentionally not modified. Once this PR is integrated,
  `ReSampling` can migrate its import and base class to the public contract.
- #349 is intentionally not modified. `Normalize` has parameter-dependent
  channel eligibility, so it must not unconditionally inherit this semantic
  contract; its operation-owned eligibility should remain on its own branch.

## Validation

- `uv run pytest tests/processing/test_base_operations.py tests/processing/test_filter_channelwise_execution.py tests/processing/test_remove_dc.py tests/frames/test_channelwise_execution.py tests/pipeline/test_recipe_execution.py -q`
  - 129 passed
- `uv run ruff check wandas tests scripts`
- `uv run ruff format --check wandas tests scripts`
- `uv run ty check wandas tests`
- `uv run pytest -q`
  - 2523 passed, 3 skipped
- `uv run mkdocs build --strict -f docs/mkdocs.yml`

No new benchmark was run because this change publishes the existing semantic
contract without altering execution or numerical behavior.
