### PR TITLE
Remove legacy add_channel Recipe v1 compatibility

### DIFF
--- a/docs/src/api/frames.md
+++ b/docs/src/api/frames.md
@@ -35,6 +35,14 @@ channel metadata、calibration、source-time offsetとともに追加する場�
 サポートされないため、従来の`label=` prefixは
 `concat_frame(..., label_prefix=...)`へ移行してください。
 
+Recipe replay for `wandas.channel.add_channel` version 1 is no longer supported.
+Recreate saved workflows with `add_channel()` version 2 when the second input is a
+raw array, or with `concat_frame()` version 1 when it is a `ChannelFrame`.
+
+`wandas.channel.add_channel` version 1 Recipeの再生互換性は終了しました。
+第2入力がraw arrayなら`add_channel()` version 2、`ChannelFrame`なら
+`concat_frame()` version 1を使用して、保存済みworkflowを作り直してください。
+
 Use the <a href="../learning-path/07_per_channel_calibration.html">per-channel
 calibration learning app</a> to configure known conversion factors without
 modifying the source frame. Calibrated physical values are available from

--- a/docs/src/release-notes/v0.6.1.md
+++ b/docs/src/release-notes/v0.6.1.md
@@ -41,18 +41,18 @@ Wandas 0.6.1は、metadataの所有権の明確化と、復旧可能なrelease a
 `ChannelFrame.add_channel()` now accepts only one raw NumPy or Dask channel.
 To concatenate another `ChannelFrame`, replace
 `frame.add_channel(other, label="prefix")` with
-`frame.concat_frame(other, label_prefix="prefix")`. Existing valid
-`wandas.channel.add_channel` version 1 Recipes remain replayable, while new array
-calls emit version 2 and new Frame concatenations emit
-`wandas.channel.concat_frame` version 1.
+`frame.concat_frame(other, label_prefix="prefix")`. Replay compatibility for
+`wandas.channel.add_channel` version 1 Recipes has intentionally ended. Recreate
+saved raw-array workflows with `add_channel()` version 2 and saved `ChannelFrame`
+workflows with `concat_frame()` version 1.
 
 `ChannelFrame.add_channel()`はNumPyまたはDaskの生配列1チャンネルだけを受け取ります。
 別の`ChannelFrame`を連結する場合は、
 `frame.add_channel(other, label="prefix")`を
 `frame.concat_frame(other, label_prefix="prefix")`へ置き換えてください。
-既存の有効な`wandas.channel.add_channel` version 1 Recipeは引き続き再生でき、
-新しい配列呼び出しはversion 2、Frame連結は
-`wandas.channel.concat_frame` version 1を生成します。
+`wandas.channel.add_channel` version 1 Recipeの再生互換性は意図的に終了しました。
+保存済みのraw-array workflowは`add_channel()` version 2で、`ChannelFrame`
+workflowは`concat_frame()` version 1で作り直してください。
 
 This release does not change the public numerical-data boundary: use `frame.data`.
 WDF 0.4 and Recipe schema 2 remain unchanged. Cross-repository agent notification

--- a/tests/pipeline/test_channel_recipe_contract.py
+++ b/tests/pipeline/test_channel_recipe_contract.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from contextlib import nullcontext
-from copy import deepcopy
 from fractions import Fraction
 from typing import Any, overload
 
@@ -12,7 +11,8 @@ import pytest
 
 from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
-from wandas.pipeline import RecipeExecutionError, RecipePlan
+from wandas.pipeline import RecipePlan, default_recipe_registry
+from wandas.pipeline.errors import RecipeSerializationError
 from wandas.processing.semantic import freeze_value, semantic_lineage, value_to_json
 
 
@@ -275,46 +275,28 @@ def test_channel_public_parameter_validation_is_independent_of_runtime_condition
             base.concat_frame(other, **params)
 
 
-@pytest.mark.parametrize("kind", ["array", "frame"])
-def test_legacy_add_channel_v1_recipes_load_and_replay(kind: str) -> None:
+def test_default_registry_contains_only_current_channel_recipe_versions() -> None:
+    registry = default_recipe_registry()
+
+    assert registry.require("wandas.channel.add_channel", 2).version == 2
+    assert registry.require("wandas.channel.concat_frame", 1).version == 1
+    with pytest.raises(
+        KeyError,
+        match=r"Recipe operation is not registered: 'wandas\.channel\.add_channel' version 1",
+    ):
+        registry.require("wandas.channel.add_channel", 1)
+
+
+def test_add_channel_v1_recipe_is_rejected_as_unknown_version() -> None:
     base = _frame(np.zeros((1, 8)), labels=["base"], offsets=[1.0])
-    if kind == "array":
-        external: Any = np.ones(8)
-        result = base.add_channel(external, label="legacy", source_time_offset=2.0)
-        payload = _payload(result, ("base", "data"))
-        payload["nodes"][0]["version"] = 1
-    else:
-        external = _frame(np.ones((1, 8)), labels=["other"], offsets=[2.0])
-        result = base.concat_frame(external, label_prefix="legacy")
-        payload = _payload(result, ("base", "data"))
-        payload["nodes"][0]["operation"] = "wandas.channel.add_channel"
-        payload["nodes"][0]["params"]["entries"] = [
-            ["label", "legacy"],
-            ["source_time_offset", None],
-        ]
+    payload = _payload(base.add_channel(np.ones(8)), ("base", "data"))
+    payload["nodes"][0]["version"] = 1
 
-    loaded = RecipePlan.from_dict(deepcopy(payload))
-    replayed = loaded.apply({"base": base, "data": external})
+    with pytest.raises(
+        RecipeSerializationError,
+        match="Invalid Recipe graph",
+    ) as exc_info:
+        RecipePlan.from_dict(payload)
 
-    assert loaded.nodes[0].version == 1
-    expected_labels = ["base", "legacy_other"] if kind == "frame" else ["base", "legacy"]
-    assert replayed.labels == expected_labels
-    np.testing.assert_array_equal(replayed.source_time_offset, [1.0, 2.0])
-
-
-def test_legacy_add_channel_v1_rejects_frame_offset_that_was_never_valid() -> None:
-    base = _frame(np.zeros((1, 8)), labels=["base"])
-    other = _frame(np.ones((1, 8)), labels=["other"])
-    payload = _payload(base.concat_frame(other), ("base", "data"))
-    payload["nodes"][0]["operation"] = "wandas.channel.add_channel"
-    payload["nodes"][0]["params"]["entries"] = [
-        [
-            "source_time_offset",
-            {"$type": "number", "kind": "python-float", "data": "3ff0000000000000"},
-        ]
-    ]
-
-    loaded = RecipePlan.from_dict(payload)
-
-    with pytest.raises(RecipeExecutionError, match="source_time_offset is only supported for array input"):
-        loaded.apply({"base": base, "data": other})
+    assert "Recipe node uses an unregistered operation" in str(exc_info.value)
+    assert "wandas.channel.add_channel" in str(exc_info.value)

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -14,7 +14,6 @@ from dask.array.core import Array as DaArray
 from dask.array.core import concatenate
 
 from wandas.pipeline.decorators import OperationCapture, recipe_operation
-from wandas.pipeline.registry import RecipeOperation
 from wandas.processing.calibration import _derive_absolute_calibration_factors
 from wandas.processing.semantic import InputBinding, thaw_params
 from wandas.utils.dask_helpers import da_from_array as _da_from_array
@@ -164,18 +163,6 @@ def _concat_frame_recipe(inputs: tuple[Any, ...], params: Mapping[str, Any]) -> 
     return inputs[0].concat_frame(inputs[1], **dict(params))
 
 
-def _legacy_add_channel_recipe(inputs: tuple[Any, ...], params: Mapping[str, Any]) -> Any:
-    """Replay a valid pre-split add_channel Recipe through its replacement API."""
-    if isinstance(inputs[1], ChannelFrame):
-        legacy_params = dict(params)
-        label = legacy_params.pop("label", None)
-        source_time_offset = legacy_params.pop("source_time_offset", None)
-        if source_time_offset is not None:
-            raise TypeError("source_time_offset is only supported for array input")
-        return inputs[0].concat_frame(inputs[1], label_prefix=label, **legacy_params)
-    return inputs[0].add_channel(inputs[1], **dict(params))
-
-
 def _capture_add_channel(args: tuple[Any, ...], params: Mapping[str, Any]) -> OperationCapture:
     """Capture the array-only add_channel v2 contract."""
     data = params["data"]
@@ -289,25 +276,6 @@ def _validate_concat_frame_recipe(params: Mapping[str, Any]) -> None:
     _normalize_channel_operation_params(params, label_name="label_prefix", allow_source_time_offset=False)
 
 
-LEGACY_ADD_CHANNEL_RECIPE_OPERATION = RecipeOperation(
-    "wandas.channel.add_channel",
-    1,
-    _channel_input_patterns("data"),
-    _legacy_add_channel_recipe,
-)
-
-
-def _legacy_add_channel_recipe_declaration() -> None:
-    """Expose the replay-only v1 definition to built-in declaration collection."""
-
-
-setattr(
-    _legacy_add_channel_recipe_declaration,
-    "__wandas_recipe_operation__",
-    LEGACY_ADD_CHANNEL_RECIPE_OPERATION,
-)
-
-
 def _resolve_channels(channel: int | list[int] | None, n_channels: int) -> list[int]:
     """Normalise a channel specification into a validated list of indices."""
     if channel is None:
@@ -416,8 +384,6 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
     This frame represents channel-based data such as audio signals and time series data,
     with each channel containing data samples in the time domain.
     """
-
-    _legacy_add_channel_recipe_declaration = _legacy_add_channel_recipe_declaration
 
     _xarray_dim_suffix = ("channel", "time")
 


### PR DESCRIPTION
## Summary

- remove the replay-only `wandas.channel.add_channel` version 1 `RecipeOperation`, declaration shim, handler, dispatch, and compatibility adapter from `ChannelFrame`
- keep `wandas.channel.add_channel` version 2 (`frame`, `array`) and `wandas.channel.concat_frame` version 1 (`frame`, `frame`) unchanged
- replace legacy replay tests with focused default-registry and load-time rejection coverage

## Compatibility and migration

Loading a `wandas.channel.add_channel` version 1 Recipe now fails through the normal unregistered-operation diagnostic used for unknown operation versions. This compatibility break is intentional.

Recreate saved workflows as follows:

- raw array input: call `add_channel()` and extract a version 2 Recipe
- `ChannelFrame` input: call `concat_frame()` and extract a version 1 Recipe

The API documentation and v0.6.1 compatibility notes now state this migration explicitly.

## Preserved contracts

- `add_channel()` version 2 still completes extract → serialize → load → apply
- `concat_frame()` version 1 still completes extract → serialize → load → apply
- public `add_channel()` and `concat_frame()` signatures and runtime behavior are unchanged
- shared current channel-parameter normalization and public execution paths are unchanged
- no operation-specific branch or other change was made to the central Recipe model, compiler, validator, executor, serializer, or registry contract

## Validation

- `uv run pytest -q tests/pipeline/test_channel_recipe_contract.py tests/pipeline/test_recipe_v2_characterization.py tests/frames/test_channel_collection.py` — 111 passed
- `uv run pytest -q` — 2600 passed, 3 skipped, 33 warnings
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed (167 files already formatted)
- `uv run ty check` — passed
- `uv run mkdocs build --strict -f docs/mkdocs.yml` — passed
- `git diff --check` — passed

The warnings are the existing non-interactive plotting, WAV metadata, psychoacoustic silence, and introspection warning categories. No validation was skipped.

## Intentionally unchanged

- WDF persistence and serialized WDF names
- numerical processing
- Frame metadata, lineage, IDs, and public channel behavior
- Dask laziness, scheduler behavior, and graph topology
- Recipe schema and central Recipe infrastructure
- historical design documents and past implementation records

Closes #353
