### PR TITLE
Formalize `previous` as the immediate receiver

### DIFF
--- a/docs/src/contributing/frame-operation-extensions.md
+++ b/docs/src/contributing/frame-operation-extensions.md
@@ -234,12 +234,14 @@ Then implement the smallest `BaseFrame` subclass that satisfies them:
 `previous` is the immediate receiver Frame for runtime data comparison in notebooks.
 For binary or multi-input operations it follows only the left/base receiver. It is a
 process-local strong reference and is not persisted in WDF. Never derive history or
-Recipe structure from it: `lineage` remains the complete provenance authority and
-`RecipePlan` owns reusable execution intent.
+Recipe structure from it: `lineage` remains the complete provenance authority for
+Frame inputs, while `RecipePlan` owns reusable execution intent and external input
+slots. Concrete external arrays are supplied again at replay.
 `previous`はnotebookでruntime dataを比較するための、直前のreceiver Frameです。binaryまたは
 multi-input operationではleft/base receiverだけを辿ります。process-localなstrong referenceであり、
-WDFには永続化しません。historyやRecipe構造を`previous`から生成せず、完全なprovenanceは`lineage`、
-再利用可能な実行意図は`RecipePlan`を正本とします。
+WDFには永続化しません。historyやRecipe構造を`previous`から生成せず、Frame入力の完全なprovenanceは
+`lineage`、再利用可能な実行意図とexternal input slotは`RecipePlan`を正本とします。具体的なexternal
+arrayはreplay時に再度渡します。
 
 ## Make the operation Recipe-capable / Operation を Recipe 対応にする
 

--- a/docs/src/contributing/frame-operation-extensions.md
+++ b/docs/src/contributing/frame-operation-extensions.md
@@ -231,10 +231,15 @@ Then implement the smallest `BaseFrame` subclass that satisfies them:
    classを`wandas.frames`からexportします。top-level `wandas` exportは意図した公開UXの場合だけ
    追加し、Frame API referenceにも追加します。
 
-`previous` is a compatibility/debug pointer, not provenance. Never derive history or
-Recipe structure from it. `lineage` remains the only provenance state.
-`previous`は互換性・debug用pointerであり、provenanceではありません。historyやRecipe構造を
-`previous`から生成せず、`lineage`だけをprovenance stateにします。
+`previous` is the immediate receiver Frame for runtime data comparison in notebooks.
+For binary or multi-input operations it follows only the left/base receiver. It is a
+process-local strong reference and is not persisted in WDF. Never derive history or
+Recipe structure from it: `lineage` remains the complete provenance authority and
+`RecipePlan` owns reusable execution intent.
+`previous`はnotebookでruntime dataを比較するための、直前のreceiver Frameです。binaryまたは
+multi-input operationではleft/base receiverだけを辿ります。process-localなstrong referenceであり、
+WDFには永続化しません。historyやRecipe構造を`previous`から生成せず、完全なprovenanceは`lineage`、
+再利用可能な実行意図は`RecipePlan`を正本とします。
 
 ## Make the operation Recipe-capable / Operation を Recipe 対応にする
 

--- a/docs/src/explanation/pipeline-recipe-design.md
+++ b/docs/src/explanation/pipeline-recipe-design.md
@@ -31,6 +31,14 @@ results are deliberately outside the Recipe contract.
 WDF stores `operation_history` as a display-only source prefix. Loading a WDF starts a
 new executable lineage source; it does not restore Python callables or a Dask graph.
 
+`previous` serves a different, process-local purpose: it is a strong reference to the
+immediate receiver Frame so notebooks can compare concrete data before and after an
+operation. Unary operations and domain transforms point back to their receiver;
+binary and multi-input operations follow only the left/base receiver. Recipe replay
+naturally rebuilds that receiver-side chain by calling the public operations in order,
+but `previous` is not the complete input graph and is never serialized. Use `lineage`
+for complete multi-input provenance and `RecipePlan` for reusable execution intent.
+
 ## Why external arrays do not become temporary Frames
 
 NumPy and Dask operands do not carry a sampling rate, channel metadata, or source-time

--- a/docs/src/explanation/pipeline-recipe-design.md
+++ b/docs/src/explanation/pipeline-recipe-design.md
@@ -37,7 +37,9 @@ operation. Unary operations and domain transforms point back to their receiver;
 binary and multi-input operations follow only the left/base receiver. Recipe replay
 naturally rebuilds that receiver-side chain by calling the public operations in order,
 but `previous` is not the complete input graph and is never serialized. Use `lineage`
-for complete multi-input provenance and `RecipePlan` for reusable execution intent.
+for complete provenance of Frame inputs. External array values and identities are not
+lineage parents; `RecipePlan` preserves their named input slots, and callers supply the
+concrete arrays again at replay.
 
 ## Why external arrays do not become temporary Frames
 

--- a/docs/src/tutorial/index.md
+++ b/docs/src/tutorial/index.md
@@ -75,11 +75,13 @@ filtered.plot(title="filtered")
 
 `previous` is the immediate receiver Frame, retained in this process for before/after
 comparison. For operations with multiple inputs it follows only the left/base receiver;
-use `lineage` or `RecipePlan` when you need the complete input graph. WDF files do not
-persist this runtime reference.
+use `lineage` for the complete Frame-input graph. `RecipePlan` preserves reusable
+execution intent and external input slots, while concrete arrays are supplied again at
+replay. WDF files do not persist this runtime reference.
 
 `previous`はbefore/after比較のためにprocess内で保持される、直前のreceiver Frameです。複数入力の
-処理ではleft/base receiverだけを辿るため、完全な入力graphには`lineage`または`RecipePlan`を使用します。
+処理ではleft/base receiverだけを辿るため、Frame入力の完全なgraphには`lineage`を使用します。
+`RecipePlan`は再利用可能な実行意図とexternal input slotを保持し、具体的なarrayはreplay時に再度渡します。
 このruntime referenceはWDFには保存されません。
 
 ![Low-pass filter example](../assets/images/low_pass_filter.png)

--- a/docs/src/tutorial/index.md
+++ b/docs/src/tutorial/index.md
@@ -73,6 +73,15 @@ filtered.previous.plot(title="Original")
 filtered.plot(title="filtered")
 ```
 
+`previous` is the immediate receiver Frame, retained in this process for before/after
+comparison. For operations with multiple inputs it follows only the left/base receiver;
+use `lineage` or `RecipePlan` when you need the complete input graph. WDF files do not
+persist this runtime reference.
+
+`previous`はbefore/after比較のためにprocess内で保持される、直前のreceiver Frameです。複数入力の
+処理ではleft/base receiverだけを辿るため、完全な入力graphには`lineage`または`RecipePlan`を使用します。
+このruntime referenceはWDFには保存されません。
+
 ![Low-pass filter example](../assets/images/low_pass_filter.png)
 
 ### Channel selection with `query` / チャンネル選択（`query` 引数）

--- a/tests/core/test_base_frame.py
+++ b/tests/core/test_base_frame.py
@@ -708,8 +708,8 @@ class TestBaseFrameUtilityMethods:
             result = self.channel_frame.visualize_graph()
             assert result is None  # Should return None on exception
 
-    def test_previous_property_keeps_debug_reference(self) -> None:
-        """Test previous remains a debug reference to the prior frame."""
+    def test_unary_operation_previous_is_immediate_receiver(self) -> None:
+        """Unary results retain their receiver for notebook data comparison."""
         assert self.channel_frame.previous is None
         result = self.channel_frame + 1
         assert result.previous is self.channel_frame

--- a/tests/core/test_base_frame.py
+++ b/tests/core/test_base_frame.py
@@ -708,8 +708,8 @@ class TestBaseFrameUtilityMethods:
             result = self.channel_frame.visualize_graph()
             assert result is None  # Should return None on exception
 
-    def test_unary_operation_previous_is_immediate_receiver(self) -> None:
-        """Unary results retain their receiver for notebook data comparison."""
+    def test_scalar_binary_operation_previous_is_immediate_receiver(self) -> None:
+        """Scalar binary results retain their receiver for data comparison."""
         assert self.channel_frame.previous is None
         result = self.channel_frame + 1
         assert result.previous is self.channel_frame

--- a/tests/core/test_base_frame_lineage.py
+++ b/tests/core/test_base_frame_lineage.py
@@ -71,7 +71,17 @@ def test_frame_binary_operation_preserves_operand_order_and_both_parents() -> No
         ("right", "frame"),
     ]
     assert result.lineage.inputs == (left.lineage, right.lineage)
+    assert result.previous is left
+    assert result.previous is not right
     np.testing.assert_allclose(channel_first_values(result), 3.0)
+
+
+def test_domain_transform_previous_is_immediate_receiver() -> None:
+    source = _frame()
+
+    result = source.fft(n_fft=16)
+
+    assert result.previous is source
 
 
 def test_external_array_binary_operation_has_no_array_lineage_parent() -> None:

--- a/tests/core/test_base_frame_lineage.py
+++ b/tests/core/test_base_frame_lineage.py
@@ -76,12 +76,26 @@ def test_frame_binary_operation_preserves_operand_order_and_both_parents() -> No
     np.testing.assert_allclose(channel_first_values(result), 3.0)
 
 
-def test_domain_transform_previous_is_immediate_receiver() -> None:
+def test_domain_transform_family_previous_is_immediate_receiver() -> None:
     source = _frame()
 
-    result = source.fft(n_fft=16)
+    spectrum = source.fft(n_fft=16)
+    assert spectrum.previous is source
 
-    assert result.previous is source
+    inverse_spectrum = spectrum.ifft()
+    assert inverse_spectrum.previous is spectrum
+
+    spectrogram = source.stft(n_fft=16, hop_length=4)
+    assert spectrogram.previous is source
+
+    spectral_frame = spectrogram.get_frame_at(0)
+    assert spectral_frame.previous is spectrogram
+
+    inverse_spectrogram = spectrogram.to_channel_frame()
+    assert inverse_spectrogram.previous is spectrogram
+
+    inverse_alias = spectrogram.istft()
+    assert inverse_alias.previous is spectrogram
 
 
 def test_external_array_binary_operation_has_no_array_lineage_parent() -> None:

--- a/tests/frames/test_spectral_frame.py
+++ b/tests/frames/test_spectral_frame.py
@@ -394,6 +394,7 @@ class TestSpectralFrame:
                 channel_ids=self.frame._channel_ids,
                 source_time_offset=mock.ANY,
                 lineage=mock.ANY,
+                previous=self.frame,
             )
             np.testing.assert_array_equal(
                 mock_channel_frame.call_args.kwargs["source_time_offset"],

--- a/tests/io/test_wdf_io.py
+++ b/tests/io/test_wdf_io.py
@@ -545,6 +545,7 @@ def test_operation_history_remains_display_history_not_recipe_lineage(tmp_path: 
     frame.save(path)
     loaded = wd.load(path)
     assert loaded.operation_history == frame.operation_history
+    # WDF preserves display history, not process-local receiver Frame references.
     assert loaded.previous is None
     json.loads(cast(str, xr.load_dataset(path, engine="h5netcdf").attrs["operation_history_json"]))
 

--- a/tests/pipeline/test_recipe_execution.py
+++ b/tests/pipeline/test_recipe_execution.py
@@ -100,6 +100,18 @@ def test_low_pass_channel_wise_execution_recipe_roundtrip_replays_lazily() -> No
     np.testing.assert_array_equal(channel_first_values(replayed), channel_first_values(processed))
 
 
+def test_recipe_replay_rebuilds_receiver_side_previous_chain() -> None:
+    source = _frame()
+    processed = source.normalize().fft(n_fft=32)
+    plan = RecipePlan.from_frame(processed, input_names=("signal",))
+
+    replay_source = _frame(2.0)
+    replayed = RecipePlan.from_dict(plan.to_dict()).apply({"signal": replay_source})
+
+    assert replayed.previous is not None
+    assert replayed.previous.previous is replay_source
+
+
 def test_typed_transition_after_true_frame_merge_replays() -> None:
     left = _frame(1.0)
     right = _frame(2.0)

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -421,8 +421,10 @@ class BaseFrame(ABC, Generic[T]):
         Metadata for each channel in the frame. Can be ChannelMetadata objects
         or dicts that will be converted to ChannelMetadata objects.
     previous : BaseFrame, optional
-        Compatibility/debug pointer to the immediate prior frame. This strong
-        reference is not the source of truth for processing history.
+        Immediate receiver frame used for runtime data comparison in notebooks.
+        For binary or multi-input operations, this strong reference follows only
+        the left/base receiver. Use ``lineage`` or ``RecipePlan`` for the complete
+        input graph. This process-local reference is not persisted in WDF.
 
     Attributes
     ----------
@@ -860,10 +862,13 @@ class BaseFrame(ABC, Generic[T]):
 
     @property
     def previous(self) -> "BaseFrame[Any] | None":
-        """Return the immediate prior frame for compatibility/debug inspection.
+        """Return the immediate receiver frame for runtime data comparison.
 
-        This strong reference is not the source of truth for processing
-        history. Runtime lineage drives ``operation_history`` and Recipe extraction.
+        Unary operations and domain transforms point to the frame on which the
+        operation was called. Binary and multi-input operations follow only the
+        left/base receiver, not every input. This is a process-local strong
+        reference and is not persisted in WDF. Use ``lineage`` for complete runtime
+        provenance and ``RecipePlan`` for reusable execution intent.
         """
         return self._previous
 

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -423,8 +423,10 @@ class BaseFrame(ABC, Generic[T]):
     previous : BaseFrame, optional
         Immediate receiver frame used for runtime data comparison in notebooks.
         For binary or multi-input operations, this strong reference follows only
-        the left/base receiver. Use ``lineage`` or ``RecipePlan`` for the complete
-        input graph. This process-local reference is not persisted in WDF.
+        the left/base receiver. Use ``lineage`` for complete Frame-input
+        provenance and ``RecipePlan`` for reusable execution intent and external
+        input slots. Concrete external arrays are supplied again at replay. This
+        process-local reference is not persisted in WDF.
 
     Attributes
     ----------
@@ -867,8 +869,9 @@ class BaseFrame(ABC, Generic[T]):
         Unary operations and domain transforms point to the frame on which the
         operation was called. Binary and multi-input operations follow only the
         left/base receiver, not every input. This is a process-local strong
-        reference and is not persisted in WDF. Use ``lineage`` for complete runtime
-        provenance and ``RecipePlan`` for reusable execution intent.
+        reference and is not persisted in WDF. Use ``lineage`` for complete
+        Frame-input provenance and ``RecipePlan`` for reusable execution intent
+        and external input slots; concrete external arrays are supplied at replay.
         """
         return self._previous
 

--- a/wandas/frames/cepstral.py
+++ b/wandas/frames/cepstral.py
@@ -58,7 +58,9 @@ class CepstralFrame(BaseFrame[NDArrayReal]):
     channel_ids : list[str], optional
         Stable identifiers aligned with the channel axis.
     previous : BaseFrame, optional
-        Compatibility/debug pointer to the immediate prior frame.
+        Immediate receiver Frame for process-local data comparison. For
+        multi-input operations, follows only the left/base receiver. Not
+        persisted in WDF.
     source_time_offset : float or sequence, default=0.0
         Per-channel source timeline offsets, preserved across domain changes.
     lineage : LineageNode, optional

--- a/wandas/frames/cepstrogram.py
+++ b/wandas/frames/cepstrogram.py
@@ -59,7 +59,9 @@ class CepstrogramFrame(BaseFrame[NDArrayReal]):
     channel_ids : list[str], optional
         Stable identifiers aligned with the channel axis.
     previous : BaseFrame, optional
-        Compatibility/debug pointer to the immediate prior frame.
+        Immediate receiver Frame for process-local data comparison. For
+        multi-input operations, follows only the left/base receiver. Not
+        persisted in WDF.
     source_time_offset : float or sequence, default=0.0
         Per-channel source timeline offsets.
     lineage : LineageNode, optional

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -413,8 +413,9 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
                 provenance source for executable replay and derived history
                 views.
             channel_metadata: Metadata for each channel.
-            previous: Compatibility/debug pointer to the immediate prior frame;
-                not the provenance source of truth.
+            previous: Immediate receiver Frame for process-local data comparison.
+                For multi-input operations, follows only the left/base receiver.
+                Not persisted in WDF.
             operation_history_prefix: Display history restored at a persistence boundary.
 
         Raises:

--- a/wandas/frames/noct.py
+++ b/wandas/frames/noct.py
@@ -67,8 +67,9 @@ class NOctFrame(BaseFrame[NDArrayReal]):
     channel_metadata : list[ChannelMetadata], optional
         Metadata for each channel in the frame.
     previous : BaseFrame, optional
-        Compatibility/debug pointer to the immediate prior frame; not the
-        provenance source of truth.
+        Immediate receiver Frame for process-local data comparison. For
+        multi-input operations, follows only the left/base receiver. Not
+        persisted in WDF.
 
     Attributes
     ----------

--- a/wandas/frames/roughness.py
+++ b/wandas/frames/roughness.py
@@ -55,8 +55,9 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
     channel_metadata : list[ChannelMetadata], optional
         Metadata for each channel.
     previous : BaseFrame, optional
-        Compatibility/debug pointer to the immediate prior frame; not the
-        provenance source of truth.
+        Immediate receiver Frame for process-local data comparison. For
+        multi-input operations, follows only the left/base receiver. Not
+        persisted in WDF.
 
     Attributes
     ----------

--- a/wandas/frames/spectral.py
+++ b/wandas/frames/spectral.py
@@ -62,8 +62,9 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
     channel_metadata : list[ChannelMetadata], optional
         Metadata for each channel in the frame.
     previous : BaseFrame, optional
-        Compatibility/debug pointer to the immediate prior frame; not the
-        provenance source of truth.
+        Immediate receiver Frame for process-local data comparison. For
+        multi-input operations, follows only the left/base receiver. Not
+        persisted in WDF.
 
     Attributes
     ----------
@@ -333,6 +334,7 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             channel_ids=self._channel_ids,
             source_time_offset=self.source_time_offset,
             lineage=lineage,
+            previous=self,
         )
 
     def _get_additional_init_kwargs(self) -> dict[str, Any]:

--- a/wandas/frames/spectrogram.py
+++ b/wandas/frames/spectrogram.py
@@ -61,8 +61,9 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
     channel_metadata : list[ChannelMetadata], optional
         Metadata for each channel in the frame.
     previous : BaseFrame, optional
-        Compatibility/debug pointer to the immediate prior frame; not the
-        provenance source of truth.
+        Immediate receiver Frame for process-local data comparison. For
+        multi-input operations, follows only the left/base receiver. Not
+        persisted in WDF.
 
     Attributes
     ----------
@@ -524,6 +525,7 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             channel_ids=self._channel_ids,
             source_time_offset=self.source_time_offset + float(self.times[time_idx]),
             lineage=lineage,
+            previous=self,
         )
 
     @recipe_operation("wandas.spectrogram.to_channel_frame")
@@ -574,6 +576,7 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             channel_ids=self._channel_ids,
             source_time_offset=self.source_time_offset,
             lineage=lineage,
+            previous=self,
         )
 
     def istft(self) -> "ChannelFrame":
@@ -738,7 +741,9 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             metadata: Optional metadata dictionary.
             lineage: Runtime operation lineage for this frame.
             channel_metadata: Metadata for each channel.
-            previous: Reference to the previous frame in the processing chain.
+            previous: Immediate receiver Frame for process-local data comparison.
+                For multi-input operations, follows only the left/base receiver.
+                Not persisted in WDF.
 
         Returns:
             A new SpectrogramFrame containing the NumPy data.


### PR DESCRIPTION
## Summary

- document `previous` as the process-local strong reference to the immediate receiver Frame across `BaseFrame` and all concrete Frame APIs
- clarify that binary and multi-input operations follow only the left/base receiver, while `lineage` owns Frame-input provenance and `RecipePlan` retains reusable execution intent and external input slots
- propagate `previous=self` through the previously inconsistent `ifft()`, `get_frame_at()`, and `to_channel_frame()` domain transitions
- cover scalar binary operations, the domain-transform family, binary lineage/receiver behavior, Recipe replay chains, and the WDF persistence boundary with contract tests

## Why

The runtime behavior already supported notebook before/after comparisons, but the public API still described `previous` as a compatibility/debug pointer. Review also identified three direct destination-Frame construction paths that bypassed the receiver contract. This makes the supported receiver-only contract explicit and applies it consistently across the bounded domain-transition family.

## User impact

Notebook users can rely on `result.previous` for immediate receiver data comparison, including inverse and spectrogram extraction transforms. The documentation distinguishes that convenience from complete Frame-input provenance and reusable execution intent; concrete external arrays remain replay-time inputs rather than lineage parents.

## Change-coherence review

- Outcome: `FIX_REQUIRED` with a stable contract and bounded implementation
- Sibling boundary: all Frame constructor calls under `wandas/frames`; source factories were excluded, and the three inconsistent receiver transforms were fixed
- Owners remain unchanged: Frame methods own destination construction, `lineage` owns Frame-input provenance, and `RecipePlan` owns replay intent/input slots
- No compatibility shim, duplicate state, Recipe branch, or deferred follow-up was introduced

## Validation

- `uv run pytest tests/core/test_base_frame.py tests/core/test_base_frame_lineage.py tests/frames/test_spectral_frame.py tests/frames/test_spectrogram_frame.py tests/pipeline/test_recipe_execution.py tests/io/test_wdf_io.py` (344 passed)
- `uv run pytest` (2602 passed, 3 skipped)
- `uv run ruff check wandas tests scripts`
- `uv run ty check wandas tests`
- `uv run mkdocs build --strict -f docs/mkdocs.yml`
- `git diff --check`

Closes #336