### PR TITLE
Run A-weighting channel-wise

### DIFF
--- a/docs/src/assets/benchmarks/a-weighting-channelwise/base-9d758ad8.json
+++ b/docs/src/assets/benchmarks/a-weighting-channelwise/base-9d758ad8.json
@@ -1,0 +1,334 @@
+{
+  "schema": "wandas.audio-operation-channelwise-benchmark",
+  "version": 1,
+  "role": "base",
+  "revision_sha": "9d758ad82cd7fbc4a814d37b0a6ff094ab0eb9f8",
+  "comparison_revision_sha": "100955fe3f7c693038bc54721f1cf5d00ea6211a",
+  "source_path": "/workspaces/wandas/.worktrees/channelwise-inventory-20260727",
+  "measured_at_utc": "2026-07-27T15:19:30Z",
+  "orchestration_command": "bash /tmp/run-wandas-a-weighting-formal-benchmark.sh",
+  "orchestration_script_sha256": "f6a59a06ba1c60ff0dcf0eb4b672275c97cf55fe3620283c39e2a0445e000906",
+  "worker_script_sha256": "1a15b7e706e1a0acaf29d02b6cb8d2de8f239d9dd0ac555f575ebcf0eaf39103",
+  "scheduler": "Dask default threaded scheduler; no scheduler, worker-count, or native-thread override",
+  "global_execution_order": [
+    "base-operation-run-1",
+    "candidate-operation-run-1",
+    "candidate-operation-run-2",
+    "base-operation-run-2",
+    "base-operation-run-3",
+    "candidate-operation-run-3",
+    "base-frame-run-1",
+    "candidate-frame-run-1",
+    "candidate-frame-run-2",
+    "base-frame-run-2",
+    "base-frame-run-3",
+    "candidate-frame-run-3"
+  ],
+  "exact_worker_commands": [
+    "PYTHONPATH=/workspaces/wandas/.worktrees/channelwise-inventory-20260727 uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation a_weighting --boundary operation --channels 8 --samples 1000000 --dtype float64 --label base-operation-run-1",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/channelwise-inventory-20260727 uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation a_weighting --boundary operation --channels 8 --samples 1000000 --dtype float64 --label base-operation-run-2",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/channelwise-inventory-20260727 uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation a_weighting --boundary operation --channels 8 --samples 1000000 --dtype float64 --label base-operation-run-3",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/channelwise-inventory-20260727 uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation a_weighting --boundary frame --channels 8 --samples 1000000 --dtype float64 --label base-frame-run-1",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/channelwise-inventory-20260727 uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation a_weighting --boundary frame --channels 8 --samples 1000000 --dtype float64 --label base-frame-run-2",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/channelwise-inventory-20260727 uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation a_weighting --boundary frame --channels 8 --samples 1000000 --dtype float64 --label base-frame-run-3"
+  ],
+  "runs": [
+    {
+      "boundary": "operation",
+      "channels": 8,
+      "chunks": [
+        [
+          8
+        ],
+        [
+          1000000
+        ]
+      ],
+      "executable": "/workspaces/wandas/.venv/bin/python3",
+      "execution_contract": "whole-frame",
+      "graph_build_seconds": 0.0009592389978934079,
+      "input_checksum": "7f3ca6a7112a9c4ff44594d6971936106f67066de22758d6c6f46a76c7dd5f9e",
+      "input_dtype": "float64",
+      "input_shape": [
+        8,
+        1000000
+      ],
+      "label": "base-operation-run-1",
+      "lock_sha256": "8f22e9d43bb9a4f1ec476219fb57464bd29929f8e7e30bc0d03c32f728414107",
+      "materialize_seconds": 0.06950144401344005,
+      "operation": "a_weighting",
+      "output_checksum": "829133cbe9536fefe7fd21e68b06dcc92d170cee17d1e404a413041917541504",
+      "output_dtype_actual": "float64",
+      "output_dtype_metadata": "float64",
+      "output_l2_squared": 190584.54874000614,
+      "output_shape_actual": [
+        8,
+        1000000
+      ],
+      "output_shape_metadata": [
+        8,
+        1000000
+      ],
+      "peak_rss_mib": 447.93359375,
+      "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+      "python": "3.10.20 (main, Jun 23 2026, 15:20:26) [Clang 22.1.3 ]",
+      "rss_before_compute_mib": 347.7421875,
+      "rss_peak_growth_mib": 100.19140625,
+      "samples": 1000000,
+      "sampling_rate": 48000,
+      "task_count": 20,
+      "thread_environment": {}
+    },
+    {
+      "boundary": "operation",
+      "channels": 8,
+      "chunks": [
+        [
+          8
+        ],
+        [
+          1000000
+        ]
+      ],
+      "executable": "/workspaces/wandas/.venv/bin/python3",
+      "execution_contract": "whole-frame",
+      "graph_build_seconds": 0.0009659560018917546,
+      "input_checksum": "7f3ca6a7112a9c4ff44594d6971936106f67066de22758d6c6f46a76c7dd5f9e",
+      "input_dtype": "float64",
+      "input_shape": [
+        8,
+        1000000
+      ],
+      "label": "base-operation-run-2",
+      "lock_sha256": "8f22e9d43bb9a4f1ec476219fb57464bd29929f8e7e30bc0d03c32f728414107",
+      "materialize_seconds": 0.06708651498774998,
+      "operation": "a_weighting",
+      "output_checksum": "829133cbe9536fefe7fd21e68b06dcc92d170cee17d1e404a413041917541504",
+      "output_dtype_actual": "float64",
+      "output_dtype_metadata": "float64",
+      "output_l2_squared": 190584.54874000614,
+      "output_shape_actual": [
+        8,
+        1000000
+      ],
+      "output_shape_metadata": [
+        8,
+        1000000
+      ],
+      "peak_rss_mib": 448.1875,
+      "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+      "python": "3.10.20 (main, Jun 23 2026, 15:20:26) [Clang 22.1.3 ]",
+      "rss_before_compute_mib": 347.8984375,
+      "rss_peak_growth_mib": 100.2890625,
+      "samples": 1000000,
+      "sampling_rate": 48000,
+      "task_count": 20,
+      "thread_environment": {}
+    },
+    {
+      "boundary": "operation",
+      "channels": 8,
+      "chunks": [
+        [
+          8
+        ],
+        [
+          1000000
+        ]
+      ],
+      "executable": "/workspaces/wandas/.venv/bin/python3",
+      "execution_contract": "whole-frame",
+      "graph_build_seconds": 0.00094957000692375,
+      "input_checksum": "7f3ca6a7112a9c4ff44594d6971936106f67066de22758d6c6f46a76c7dd5f9e",
+      "input_dtype": "float64",
+      "input_shape": [
+        8,
+        1000000
+      ],
+      "label": "base-operation-run-3",
+      "lock_sha256": "8f22e9d43bb9a4f1ec476219fb57464bd29929f8e7e30bc0d03c32f728414107",
+      "materialize_seconds": 0.06814757699612528,
+      "operation": "a_weighting",
+      "output_checksum": "829133cbe9536fefe7fd21e68b06dcc92d170cee17d1e404a413041917541504",
+      "output_dtype_actual": "float64",
+      "output_dtype_metadata": "float64",
+      "output_l2_squared": 190584.54874000614,
+      "output_shape_actual": [
+        8,
+        1000000
+      ],
+      "output_shape_metadata": [
+        8,
+        1000000
+      ],
+      "peak_rss_mib": 448.06640625,
+      "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+      "python": "3.10.20 (main, Jun 23 2026, 15:20:26) [Clang 22.1.3 ]",
+      "rss_before_compute_mib": 347.77734375,
+      "rss_peak_growth_mib": 100.2890625,
+      "samples": 1000000,
+      "sampling_rate": 48000,
+      "task_count": 20,
+      "thread_environment": {}
+    },
+    {
+      "boundary": "frame",
+      "channels": 8,
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          1000000
+        ]
+      ],
+      "executable": "/workspaces/wandas/.venv/bin/python3",
+      "execution_contract": "whole-frame",
+      "graph_build_seconds": 0.004206686993711628,
+      "input_checksum": "7f3ca6a7112a9c4ff44594d6971936106f67066de22758d6c6f46a76c7dd5f9e",
+      "input_dtype": "float64",
+      "input_shape": [
+        8,
+        1000000
+      ],
+      "label": "base-frame-run-1",
+      "lock_sha256": "8f22e9d43bb9a4f1ec476219fb57464bd29929f8e7e30bc0d03c32f728414107",
+      "materialize_seconds": 0.07491467699583154,
+      "operation": "a_weighting",
+      "output_checksum": "829133cbe9536fefe7fd21e68b06dcc92d170cee17d1e404a413041917541504",
+      "output_dtype_actual": "float64",
+      "output_dtype_metadata": "float64",
+      "output_l2_squared": 190584.54874000614,
+      "output_shape_actual": [
+        8,
+        1000000
+      ],
+      "output_shape_metadata": [
+        8,
+        1000000
+      ],
+      "peak_rss_mib": 448.57421875,
+      "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+      "python": "3.10.20 (main, Jun 23 2026, 15:20:26) [Clang 22.1.3 ]",
+      "rss_before_compute_mib": 347.6484375,
+      "rss_peak_growth_mib": 100.92578125,
+      "samples": 1000000,
+      "sampling_rate": 48000,
+      "task_count": 36,
+      "thread_environment": {}
+    },
+    {
+      "boundary": "frame",
+      "channels": 8,
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          1000000
+        ]
+      ],
+      "executable": "/workspaces/wandas/.venv/bin/python3",
+      "execution_contract": "whole-frame",
+      "graph_build_seconds": 0.004116466996492818,
+      "input_checksum": "7f3ca6a7112a9c4ff44594d6971936106f67066de22758d6c6f46a76c7dd5f9e",
+      "input_dtype": "float64",
+      "input_shape": [
+        8,
+        1000000
+      ],
+      "label": "base-frame-run-2",
+      "lock_sha256": "8f22e9d43bb9a4f1ec476219fb57464bd29929f8e7e30bc0d03c32f728414107",
+      "materialize_seconds": 0.08998317699297331,
+      "operation": "a_weighting",
+      "output_checksum": "829133cbe9536fefe7fd21e68b06dcc92d170cee17d1e404a413041917541504",
+      "output_dtype_actual": "float64",
+      "output_dtype_metadata": "float64",
+      "output_l2_squared": 190584.54874000614,
+      "output_shape_actual": [
+        8,
+        1000000
+      ],
+      "output_shape_metadata": [
+        8,
+        1000000
+      ],
+      "peak_rss_mib": 448.21484375,
+      "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+      "python": "3.10.20 (main, Jun 23 2026, 15:20:26) [Clang 22.1.3 ]",
+      "rss_before_compute_mib": 347.671875,
+      "rss_peak_growth_mib": 100.54296875,
+      "samples": 1000000,
+      "sampling_rate": 48000,
+      "task_count": 36,
+      "thread_environment": {}
+    },
+    {
+      "boundary": "frame",
+      "channels": 8,
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          1000000
+        ]
+      ],
+      "executable": "/workspaces/wandas/.venv/bin/python3",
+      "execution_contract": "whole-frame",
+      "graph_build_seconds": 0.004481818992644548,
+      "input_checksum": "7f3ca6a7112a9c4ff44594d6971936106f67066de22758d6c6f46a76c7dd5f9e",
+      "input_dtype": "float64",
+      "input_shape": [
+        8,
+        1000000
+      ],
+      "label": "base-frame-run-3",
+      "lock_sha256": "8f22e9d43bb9a4f1ec476219fb57464bd29929f8e7e30bc0d03c32f728414107",
+      "materialize_seconds": 0.07326447899686173,
+      "operation": "a_weighting",
+      "output_checksum": "829133cbe9536fefe7fd21e68b06dcc92d170cee17d1e404a413041917541504",
+      "output_dtype_actual": "float64",
+      "output_dtype_metadata": "float64",
+      "output_l2_squared": 190584.54874000614,
+      "output_shape_actual": [
+        8,
+        1000000
+      ],
+      "output_shape_metadata": [
+        8,
+        1000000
+      ],
+      "peak_rss_mib": 448.7265625,
+      "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+      "python": "3.10.20 (main, Jun 23 2026, 15:20:26) [Clang 22.1.3 ]",
+      "rss_before_compute_mib": 348.06640625,
+      "rss_peak_growth_mib": 100.66015625,
+      "samples": 1000000,
+      "sampling_rate": 48000,
+      "task_count": 36,
+      "thread_environment": {}
+    }
+  ]
+}

--- a/docs/src/assets/benchmarks/a-weighting-channelwise/candidate-100955fe.json
+++ b/docs/src/assets/benchmarks/a-weighting-channelwise/candidate-100955fe.json
@@ -1,0 +1,355 @@
+{
+  "schema": "wandas.audio-operation-channelwise-benchmark",
+  "version": 1,
+  "role": "candidate",
+  "revision_sha": "100955fe3f7c693038bc54721f1cf5d00ea6211a",
+  "comparison_revision_sha": "9d758ad82cd7fbc4a814d37b0a6ff094ab0eb9f8",
+  "source_path": "/workspaces/wandas/.worktrees/a-weighting-channelwise",
+  "measured_at_utc": "2026-07-27T15:19:30Z",
+  "orchestration_command": "bash /tmp/run-wandas-a-weighting-formal-benchmark.sh",
+  "orchestration_script_sha256": "f6a59a06ba1c60ff0dcf0eb4b672275c97cf55fe3620283c39e2a0445e000906",
+  "worker_script_sha256": "1a15b7e706e1a0acaf29d02b6cb8d2de8f239d9dd0ac555f575ebcf0eaf39103",
+  "scheduler": "Dask default threaded scheduler; no scheduler, worker-count, or native-thread override",
+  "global_execution_order": [
+    "base-operation-run-1",
+    "candidate-operation-run-1",
+    "candidate-operation-run-2",
+    "base-operation-run-2",
+    "base-operation-run-3",
+    "candidate-operation-run-3",
+    "base-frame-run-1",
+    "candidate-frame-run-1",
+    "candidate-frame-run-2",
+    "base-frame-run-2",
+    "base-frame-run-3",
+    "candidate-frame-run-3"
+  ],
+  "exact_worker_commands": [
+    "PYTHONPATH=/workspaces/wandas/.worktrees/a-weighting-channelwise uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation a_weighting --boundary operation --channels 8 --samples 1000000 --dtype float64 --label candidate-operation-run-1",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/a-weighting-channelwise uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation a_weighting --boundary operation --channels 8 --samples 1000000 --dtype float64 --label candidate-operation-run-2",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/a-weighting-channelwise uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation a_weighting --boundary operation --channels 8 --samples 1000000 --dtype float64 --label candidate-operation-run-3",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/a-weighting-channelwise uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation a_weighting --boundary frame --channels 8 --samples 1000000 --dtype float64 --label candidate-frame-run-1",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/a-weighting-channelwise uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation a_weighting --boundary frame --channels 8 --samples 1000000 --dtype float64 --label candidate-frame-run-2",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/a-weighting-channelwise uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation a_weighting --boundary frame --channels 8 --samples 1000000 --dtype float64 --label candidate-frame-run-3"
+  ],
+  "runs": [
+    {
+      "boundary": "operation",
+      "channels": 8,
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          1000000
+        ]
+      ],
+      "executable": "/workspaces/wandas/.venv/bin/python3",
+      "execution_contract": "channel-independent",
+      "graph_build_seconds": 0.005094418011140078,
+      "input_checksum": "7f3ca6a7112a9c4ff44594d6971936106f67066de22758d6c6f46a76c7dd5f9e",
+      "input_dtype": "float64",
+      "input_shape": [
+        8,
+        1000000
+      ],
+      "label": "candidate-operation-run-1",
+      "lock_sha256": "8f22e9d43bb9a4f1ec476219fb57464bd29929f8e7e30bc0d03c32f728414107",
+      "materialize_seconds": 0.0403595910029253,
+      "operation": "a_weighting",
+      "output_checksum": "829133cbe9536fefe7fd21e68b06dcc92d170cee17d1e404a413041917541504",
+      "output_dtype_actual": "float64",
+      "output_dtype_metadata": "float64",
+      "output_l2_squared": 190584.54874000614,
+      "output_shape_actual": [
+        8,
+        1000000
+      ],
+      "output_shape_metadata": [
+        8,
+        1000000
+      ],
+      "peak_rss_mib": 509.03125,
+      "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+      "python": "3.10.20 (main, Jun 23 2026, 15:20:26) [Clang 22.1.3 ]",
+      "rss_before_compute_mib": 347.8984375,
+      "rss_peak_growth_mib": 161.1328125,
+      "samples": 1000000,
+      "sampling_rate": 48000,
+      "task_count": 56,
+      "thread_environment": {}
+    },
+    {
+      "boundary": "operation",
+      "channels": 8,
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          1000000
+        ]
+      ],
+      "executable": "/workspaces/wandas/.venv/bin/python3",
+      "execution_contract": "channel-independent",
+      "graph_build_seconds": 0.0049837010010378435,
+      "input_checksum": "7f3ca6a7112a9c4ff44594d6971936106f67066de22758d6c6f46a76c7dd5f9e",
+      "input_dtype": "float64",
+      "input_shape": [
+        8,
+        1000000
+      ],
+      "label": "candidate-operation-run-2",
+      "lock_sha256": "8f22e9d43bb9a4f1ec476219fb57464bd29929f8e7e30bc0d03c32f728414107",
+      "materialize_seconds": 0.0374334100051783,
+      "operation": "a_weighting",
+      "output_checksum": "829133cbe9536fefe7fd21e68b06dcc92d170cee17d1e404a413041917541504",
+      "output_dtype_actual": "float64",
+      "output_dtype_metadata": "float64",
+      "output_l2_squared": 190584.54874000614,
+      "output_shape_actual": [
+        8,
+        1000000
+      ],
+      "output_shape_metadata": [
+        8,
+        1000000
+      ],
+      "peak_rss_mib": 508.99609375,
+      "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+      "python": "3.10.20 (main, Jun 23 2026, 15:20:26) [Clang 22.1.3 ]",
+      "rss_before_compute_mib": 347.9609375,
+      "rss_peak_growth_mib": 161.03515625,
+      "samples": 1000000,
+      "sampling_rate": 48000,
+      "task_count": 56,
+      "thread_environment": {}
+    },
+    {
+      "boundary": "operation",
+      "channels": 8,
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          1000000
+        ]
+      ],
+      "executable": "/workspaces/wandas/.venv/bin/python3",
+      "execution_contract": "channel-independent",
+      "graph_build_seconds": 0.005193611999857239,
+      "input_checksum": "7f3ca6a7112a9c4ff44594d6971936106f67066de22758d6c6f46a76c7dd5f9e",
+      "input_dtype": "float64",
+      "input_shape": [
+        8,
+        1000000
+      ],
+      "label": "candidate-operation-run-3",
+      "lock_sha256": "8f22e9d43bb9a4f1ec476219fb57464bd29929f8e7e30bc0d03c32f728414107",
+      "materialize_seconds": 0.03793645100085996,
+      "operation": "a_weighting",
+      "output_checksum": "829133cbe9536fefe7fd21e68b06dcc92d170cee17d1e404a413041917541504",
+      "output_dtype_actual": "float64",
+      "output_dtype_metadata": "float64",
+      "output_l2_squared": 190584.54874000614,
+      "output_shape_actual": [
+        8,
+        1000000
+      ],
+      "output_shape_metadata": [
+        8,
+        1000000
+      ],
+      "peak_rss_mib": 507.828125,
+      "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+      "python": "3.10.20 (main, Jun 23 2026, 15:20:26) [Clang 22.1.3 ]",
+      "rss_before_compute_mib": 347.5859375,
+      "rss_peak_growth_mib": 160.2421875,
+      "samples": 1000000,
+      "sampling_rate": 48000,
+      "task_count": 56,
+      "thread_environment": {}
+    },
+    {
+      "boundary": "frame",
+      "channels": 8,
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          1000000
+        ]
+      ],
+      "executable": "/workspaces/wandas/.venv/bin/python3",
+      "execution_contract": "channel-independent",
+      "graph_build_seconds": 0.008074596000369638,
+      "input_checksum": "7f3ca6a7112a9c4ff44594d6971936106f67066de22758d6c6f46a76c7dd5f9e",
+      "input_dtype": "float64",
+      "input_shape": [
+        8,
+        1000000
+      ],
+      "label": "candidate-frame-run-1",
+      "lock_sha256": "8f22e9d43bb9a4f1ec476219fb57464bd29929f8e7e30bc0d03c32f728414107",
+      "materialize_seconds": 0.04815556699759327,
+      "operation": "a_weighting",
+      "output_checksum": "829133cbe9536fefe7fd21e68b06dcc92d170cee17d1e404a413041917541504",
+      "output_dtype_actual": "float64",
+      "output_dtype_metadata": "float64",
+      "output_l2_squared": 190584.54874000614,
+      "output_shape_actual": [
+        8,
+        1000000
+      ],
+      "output_shape_metadata": [
+        8,
+        1000000
+      ],
+      "peak_rss_mib": 509.34765625,
+      "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+      "python": "3.10.20 (main, Jun 23 2026, 15:20:26) [Clang 22.1.3 ]",
+      "rss_before_compute_mib": 348.3671875,
+      "rss_peak_growth_mib": 160.98046875,
+      "samples": 1000000,
+      "sampling_rate": 48000,
+      "task_count": 56,
+      "thread_environment": {}
+    },
+    {
+      "boundary": "frame",
+      "channels": 8,
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          1000000
+        ]
+      ],
+      "executable": "/workspaces/wandas/.venv/bin/python3",
+      "execution_contract": "channel-independent",
+      "graph_build_seconds": 0.007947297999635339,
+      "input_checksum": "7f3ca6a7112a9c4ff44594d6971936106f67066de22758d6c6f46a76c7dd5f9e",
+      "input_dtype": "float64",
+      "input_shape": [
+        8,
+        1000000
+      ],
+      "label": "candidate-frame-run-2",
+      "lock_sha256": "8f22e9d43bb9a4f1ec476219fb57464bd29929f8e7e30bc0d03c32f728414107",
+      "materialize_seconds": 0.04128811899863649,
+      "operation": "a_weighting",
+      "output_checksum": "829133cbe9536fefe7fd21e68b06dcc92d170cee17d1e404a413041917541504",
+      "output_dtype_actual": "float64",
+      "output_dtype_metadata": "float64",
+      "output_l2_squared": 190584.54874000614,
+      "output_shape_actual": [
+        8,
+        1000000
+      ],
+      "output_shape_metadata": [
+        8,
+        1000000
+      ],
+      "peak_rss_mib": 509.0703125,
+      "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+      "python": "3.10.20 (main, Jun 23 2026, 15:20:26) [Clang 22.1.3 ]",
+      "rss_before_compute_mib": 347.83984375,
+      "rss_peak_growth_mib": 161.23046875,
+      "samples": 1000000,
+      "sampling_rate": 48000,
+      "task_count": 56,
+      "thread_environment": {}
+    },
+    {
+      "boundary": "frame",
+      "channels": 8,
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          1000000
+        ]
+      ],
+      "executable": "/workspaces/wandas/.venv/bin/python3",
+      "execution_contract": "channel-independent",
+      "graph_build_seconds": 0.007896370996604674,
+      "input_checksum": "7f3ca6a7112a9c4ff44594d6971936106f67066de22758d6c6f46a76c7dd5f9e",
+      "input_dtype": "float64",
+      "input_shape": [
+        8,
+        1000000
+      ],
+      "label": "candidate-frame-run-3",
+      "lock_sha256": "8f22e9d43bb9a4f1ec476219fb57464bd29929f8e7e30bc0d03c32f728414107",
+      "materialize_seconds": 0.038111486996058375,
+      "operation": "a_weighting",
+      "output_checksum": "829133cbe9536fefe7fd21e68b06dcc92d170cee17d1e404a413041917541504",
+      "output_dtype_actual": "float64",
+      "output_dtype_metadata": "float64",
+      "output_l2_squared": 190584.54874000614,
+      "output_shape_actual": [
+        8,
+        1000000
+      ],
+      "output_shape_metadata": [
+        8,
+        1000000
+      ],
+      "peak_rss_mib": 509.375,
+      "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+      "python": "3.10.20 (main, Jun 23 2026, 15:20:26) [Clang 22.1.3 ]",
+      "rss_before_compute_mib": 348.265625,
+      "rss_peak_growth_mib": 161.109375,
+      "samples": 1000000,
+      "sampling_rate": 48000,
+      "task_count": 56,
+      "thread_environment": {}
+    }
+  ]
+}

--- a/docs/src/explanation/audio-operation-execution.md
+++ b/docs/src/explanation/audio-operation-execution.md
@@ -61,7 +61,7 @@ channels depend on one another.
 | `trim`, `fix_length` | Independent | Indexed/padded time-local transform with output-shape change | Whole-frame |
 | `fade` | Independent | Needs the full signal length to define the envelope | Whole-frame |
 | high-pass, low-pass, band-pass | Independent | Stateful/whole continuous time series per channel | **Channel-wise** |
-| A-weighting | Independent | Stateful/whole continuous time series per channel | Whole-frame |
+| A-weighting | Independent | Stateful/whole continuous time series per channel | **Channel-wise** |
 | resampling | Independent | Whole time series per channel for the resampling transform | **Channel-wise** |
 | RMS trend, sound level | Independent | Window/overlap-sensitive; weighting can add filter state | Whole-frame |
 | FFT, IFFT, cepstrum, lifter, spectral envelope, N-octave analysis/synthesis | Independent | Whole transform axis per channel | Whole-frame |
@@ -117,6 +117,36 @@ Recipe behavior, and fallback behavior were unchanged; focused tests require exa
 array equality with forced whole-frame execution for all three filters. These
 same-environment measurements explain the adoption decision, not a portable
 performance guarantee.
+
+## Adopted operation: AWeighting
+
+`AWeighting` applies the same second-order-section filter independently along the
+complete time axis of each channel. Its output preserves the leading channel count
+and always has `float64` dtype. The operation therefore uses
+`ChannelIndependentAudioOperation`; each eligible kernel receives one complete
+channel. Zero or unknown channel counts retain the conservative whole-frame fallback,
+while an extra runtime input is rejected. The numerical kernel, public Frame method,
+calibration consumption, metadata, lineage, and Recipe declaration are unchanged.
+
+The adoption evaluation used eight channels with 1,000,000 float64 samples per
+channel at 48 kHz, interleaved whole-frame and inheritance-only candidate runs
+across three isolated processes per path. Normal `Frame.data` materialization used
+the default threaded scheduler. Median end-to-end materialization time decreased
+from 78.9 ms to 42.5 ms, while graph construction increased from 4.36 ms to
+8.10 ms and task count increased from 36 to 56. Median process peak RSS increased
+from 448.6 MiB to 509.3 MiB (13.5%). At the operation boundary, median compute time
+decreased from 71.9 ms to 43.2 ms, graph construction increased from 0.93 ms to
+5.25 ms, task count increased from 20 to 56, and median process peak RSS increased
+from 448.137 MiB to 508.297 MiB. Every paired output checksum, shape, and dtype
+matched exactly.
+
+The RSS observation includes the resident in-memory source, concurrent filter
+temporaries, and final NumPy output; it is not a one-channel memory claim. The
+reproducible normal-materialization speedup justified adoption despite that measured
+memory tradeoff. These observations were made on Linux 7.0.0-28-generic x86-64 with
+CPython 3.10.20 and `uv.lock` SHA-256
+`8f22e9d43bb9a4f1ec476219fb57464bd29929f8e7e30bc0d03c32f728414107`; they are not
+portable performance guarantees.
 
 ## Adopted operation: ReSampling
 

--- a/docs/src/explanation/audio-operation-execution.md
+++ b/docs/src/explanation/audio-operation-execution.md
@@ -128,23 +128,38 @@ channel. Zero or unknown channel counts retain the conservative whole-frame fall
 while an extra runtime input is rejected. The numerical kernel, public Frame method,
 calibration consumption, metadata, lineage, and Recipe declaration are unchanged.
 
-The adoption evaluation used eight channels with 1,000,000 float64 samples per
-channel at 48 kHz, interleaved whole-frame and inheritance-only candidate runs
-across three isolated processes per path. Normal `Frame.data` materialization used
-the default threaded scheduler. Median end-to-end materialization time decreased
-from 78.9 ms to 42.5 ms, while graph construction increased from 4.36 ms to
-8.10 ms and task count increased from 36 to 56. Median process peak RSS increased
-from 448.6 MiB to 509.3 MiB (13.5%). At the operation boundary, median compute time
-decreased from 71.9 ms to 43.2 ms, graph construction increased from 0.93 ms to
-5.25 ms, task count increased from 20 to 56, and median process peak RSS increased
-from 448.137 MiB to 508.297 MiB. Every paired output checksum, shape, and dtype
-matched exactly.
+The revision-addressable adoption evaluation compared base
+`9d758ad82cd7fbc4a814d37b0a6ff094ab0eb9f8` with candidate
+`100955fe3f7c693038bc54721f1cf5d00ea6211a`. It used eight channels with
+1,000,000 float64 samples per channel at 48 kHz. For each boundary, separate
+processes ran in the interleaved order `base1`, `candidate1`, `candidate2`, `base2`,
+`base3`, `candidate3`. No scheduler, worker-count, or native-thread override was
+set, so normal `Frame.data` materialization used the default threaded scheduler.
+
+| Boundary | Tasks, base → candidate | Median build, ms | Median materialization, ms | Median peak RSS, MiB |
+| --- | ---: | ---: | ---: | ---: |
+| Operation | 20 → 56 | 0.959 → 5.094 | 68.148 → 37.936 | 448.066 → 508.996 |
+| `Frame.data` | 36 → 56 | 4.207 → 7.947 | 74.915 → 41.288 | 448.574 → 509.348 |
+
+All 12 outputs had shape `(8, 1000000)`, `float64` dtype, and exact SHA-256
+checksum
+`829133cbe9536fefe7fd21e68b06dcc92d170cee17d1e404a413041917541504`.
+The exact expanded worker commands and every raw observation are recorded in the
+[base report](../assets/benchmarks/a-weighting-channelwise/base-9d758ad8.json)
+and
+[candidate report](../assets/benchmarks/a-weighting-channelwise/candidate-100955fe.json).
+The orchestration command was:
+
+```bash
+bash /tmp/run-wandas-a-weighting-formal-benchmark.sh
+```
 
 The RSS observation includes the resident in-memory source, concurrent filter
 temporaries, and final NumPy output; it is not a one-channel memory claim. The
 reproducible normal-materialization speedup justified adoption despite that measured
 memory tradeoff. These observations were made on Linux 7.0.0-28-generic x86-64 with
-CPython 3.10.20 and `uv.lock` SHA-256
+glibc 2.36, CPython 3.10.20 from `/workspaces/wandas/.venv/bin/python3`, and
+`uv.lock` SHA-256
 `8f22e9d43bb9a4f1ec476219fb57464bd29929f8e7e30bc0d03c32f728414107`; they are not
 portable performance guarantees.
 

--- a/docs/src/explanation/scalability-contract.md
+++ b/docs/src/explanation/scalability-contract.md
@@ -2,16 +2,20 @@
 
 Wandas scales primarily across collections of bounded recordings while preserving
 the continuous-time assumptions of signal processing. Stored and lazy Frame data
-retain a channel axis. `RemoveDC` is the first prototype operation that executes one
-complete channel per lazy kernel task; other delayed `AudioOperation` transforms keep
-the conservative whole-Frame boundary. Wandas therefore does not promise arbitrary
-channel-count or time-axis distribution for one enormous Frame.
+retain a channel axis. Numerically independent operations can declare the
+`ChannelIndependentAudioOperation` contract, allowing eligible lazy graphs to pass
+one complete channel to each kernel task. Conservative `AudioOperation` subclasses
+keep the whole-Frame boundary unless the operation itself owns a narrower eligibility
+rule, as `Normalize` does. Wandas therefore does not promise arbitrary channel-count
+or time-axis distribution for one enormous Frame.
 
 Wandas は主に、サイズを制御した多数の収録ファイルを扱う方向へ拡張します。
-Frame の保存・遅延データはチャンネル軸を保持します。`RemoveDC` は、完全な
-1 チャンネルごとに遅延 kernel task を実行する最初の prototype operation です。
-その他の遅延 `AudioOperation` transform は、保守的な whole-Frame boundary を維持します。
-したがって Wandas は、単一の巨大な Frame をチャンネル数または時間方向へ自由に分散できるとは約束しません。
+Frame の保存・遅延データはチャンネル軸を保持します。数値的に独立な operation は
+`ChannelIndependentAudioOperation` 契約を宣言でき、適格な遅延 graph では完全な
+1 チャンネルを各 kernel task へ渡せます。保守的な `AudioOperation` subclass は、
+`Normalize` のように operation 自身が限定的な適格性を所有する場合を除き、
+whole-Frame boundary を維持します。したがって Wandas は、単一の巨大な Frame を
+チャンネル数または時間方向へ自由に分散できるとは約束しません。
 
 ## What scales well / 得意な処理
 
@@ -26,12 +30,15 @@ Frame の保存・遅延データはチャンネル軸を保持します。`Remo
 
 - Filters, FFT, STFT, and other continuity-sensitive operations normally require a
   single time chunk per channel.
-- Most delayed `AudioOperation` transforms wrap the complete channel-first Dask array
-  in one call. `RemoveDC` instead builds independent channel tasks, while every task
-  still materializes one complete continuous time series.
+- Conservative `AudioOperation` transforms wrap the complete channel-first Dask array
+  in one call. Eligible `ChannelIndependentAudioOperation` transforms, including
+  `RemoveDC`, the Butterworth filters, resampling, and A-weighting, can build
+  independent channel tasks while every task still materializes one complete
+  continuous time series.
 - Whole-frame operations can therefore exceed memory as either channel count or
-  per-channel signal size grows. The `RemoveDC` prototype reduces its kernel boundary
-  across channels, but per-channel signal size remains bounded by available memory.
+  per-channel signal size grows. Channel-wise execution reduces the number of
+  channels at one kernel boundary, but per-channel signal size remains bounded by
+  available memory and scheduler concurrency can still increase process peak RSS.
 - WDF 0.4 passes internal source chunks to the writer without first computing the
   complete tensor. This bounds the writer's upstream data access by source chunking,
   although backend and compression buffers still contribute to RSS.
@@ -92,6 +99,9 @@ uv run --no-dev --extra io python scripts/scalability_benchmark.py --samples 800
 These measurements characterize bounded upstream writer access, not a fixed RSS ceiling
 across platforms or HDF5 configurations. WDF preserves typed Frame state, axes,
 metadata, and deterministic failure behavior without precomputing the complete tensor.
-Independent channel-task execution is currently promised only for `RemoveDC`. See
-[AudioOperation execution dependencies](audio-operation-execution.md) for the internal
-prototype contract and the classification of operations that remain whole-frame.
+Channel independence is a numerical contract; task topology, chunk layout, and
+scheduler choice remain private. Eligible inputs currently use channel tasks for
+`RemoveDC`, the Butterworth filters, resampling, and A-weighting, while `Normalize`
+owns a parameter-dependent channel-wise path. See
+[AudioOperation execution dependencies](audio-operation-execution.md) for the
+execution contract and the classification of operations that remain whole-frame.

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -6,11 +6,14 @@ import dask.array as da
 import numpy as np
 import pytest
 from dask.array.core import Array as DaArray
+from scipy import signal
 
 from tests.frame_helpers import channel_first_values
+from wandas.core.metadata import ChannelCalibration
 from wandas.frames.channel import ChannelFrame, ChannelMetadata
 from wandas.frames.spectral import SpectralFrame
 from wandas.processing.semantic import source_lineage, thaw_params
+from wandas.processing.weighting import A_weighting
 from wandas.utils.types import NDArrayReal
 from wandas.utils.util import calculate_rms
 
@@ -402,6 +405,85 @@ class TestChannelProcessing:
             result = self.channel_frame.a_weighting()
             mock_create_op.assert_called_with("a_weighting", self.sample_rate)
             assert isinstance(result, ChannelFrame)
+
+    def test_a_weighting_preserves_public_frame_contract(self) -> None:
+        sampling_rate = 48_000
+        time = np.arange(2_048) / sampling_rate
+        caller_values = np.stack(
+            [
+                np.sin(2 * np.pi * 440 * time),
+                0.5 * np.cos(2 * np.pi * 1_200 * time),
+            ]
+        ).astype(np.float32)
+        caller_values_before = caller_values.copy()
+        source = ChannelFrame(
+            data=da.from_array(caller_values, chunks=(1, 256)),
+            sampling_rate=sampling_rate,
+            label="measurement",
+            metadata={"site": {"name": "lab-a"}, "take": 7},
+            channel_metadata=[
+                ChannelMetadata(
+                    label="left",
+                    calibration=ChannelCalibration(2.0, "Pa", 2e-5),
+                    extra={"sensor": "mic-a"},
+                ),
+                ChannelMetadata(
+                    label="right",
+                    calibration=ChannelCalibration(0.5, "Pa", 1e-5),
+                    extra={"sensor": "mic-b"},
+                ),
+            ],
+            channel_ids=["mic-left", "mic-right"],
+            source_time_offset=[0.25, 1.5],
+        )
+        source_values_before = source._data.compute(scheduler="synchronous").copy()
+        source_metadata_before = source.metadata
+        source_history_before = source.operation_history
+        source_lineage_before = source.lineage
+
+        result = source.a_weighting()
+
+        assert result is not source
+        assert isinstance(result._data, DaArray)
+        assert result.shape == source.shape
+        assert result._data.dtype == np.dtype(np.float64)
+        assert result.sampling_rate == source.sampling_rate
+        assert result._channel_ids == source._channel_ids == ["mic-left", "mic-right"]
+        assert result.labels == ["Aw(left)", "Aw(right)"]
+        assert [channel.unit for channel in result.channels] == ["Pa", "Pa"]
+        assert [channel.ref for channel in result.channels] == [2e-5, 1e-5]
+        assert [channel.calibration.factor for channel in result.channels] == [1.0, 1.0]
+        assert [channel.extra for channel in result.channels] == [
+            {"sensor": "mic-a"},
+            {"sensor": "mic-b"},
+        ]
+        assert result.metadata == source.metadata == source_metadata_before
+        np.testing.assert_array_equal(result.source_time_offset, source.source_time_offset)
+        assert result.previous is source
+        assert result.lineage is not None
+        assert result.lineage.operation is not None
+        assert result.lineage.operation.operation_id == "wandas.audio.a_weighting"
+        assert result.lineage.inputs == (source.lineage,)
+        assert result.operation_history == [
+            {
+                "operation": "wandas.audio.a_weighting",
+                "version": 1,
+                "params": {},
+            }
+        ]
+
+        effective_values = caller_values.astype(np.float64) * np.array([[2.0], [0.5]])
+        sos = A_weighting(sampling_rate, output="sos")
+        expected = signal.sosfilt(sos, effective_values, axis=-1)
+        np.testing.assert_array_equal(channel_first_values(result), expected)
+
+        np.testing.assert_array_equal(caller_values, caller_values_before)
+        np.testing.assert_array_equal(source._data.compute(scheduler="synchronous"), source_values_before)
+        assert source.metadata == source_metadata_before
+        assert source.labels == ["left", "right"]
+        assert [channel.calibration.factor for channel in source.channels] == [2.0, 0.5]
+        assert source.operation_history == source_history_before
+        assert source.lineage is source_lineage_before
 
     def test_sound_level(self) -> None:
         """Test sound_level operation."""

--- a/tests/pipeline/test_recipe_behavior_parity.py
+++ b/tests/pipeline/test_recipe_behavior_parity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
@@ -56,6 +57,37 @@ def test_supported_unary_audio_operations_replay(build: Callable[[ChannelFrame],
     replayed = _assert_replay(source, processed)
 
     assert replayed.metadata == processed.metadata
+
+
+def test_a_weighting_recipe_roundtrip_preserves_lazy_frame_contract() -> None:
+    source = _frame()
+    processed = source.a_weighting()
+    plan = RecipePlan.from_frame(processed, input_names=("signal",))
+
+    payload = plan.to_dict()
+    json.dumps(payload)
+    loaded = RecipePlan.from_dict(payload)
+    replayed = loaded.apply({"signal": source})
+
+    assert loaded.to_dict() == payload
+    assert [node.operation for node in plan.nodes] == ["wandas.audio.a_weighting"]
+    assert isinstance(replayed._data, da.Array)
+    assert type(replayed) is type(processed)
+    assert replayed.shape == processed.shape
+    assert replayed.sampling_rate == processed.sampling_rate
+    assert replayed._channel_ids == processed._channel_ids
+    assert replayed.labels == processed.labels
+    assert replayed.metadata == processed.metadata
+    np.testing.assert_array_equal(replayed.source_time_offset, processed.source_time_offset)
+    np.testing.assert_array_equal(
+        channel_first_values(replayed),
+        channel_first_values(processed),
+    )
+    assert replayed.previous is source
+    assert replayed.lineage is not None
+    assert replayed.lineage.operation is not None
+    assert replayed.lineage.operation.operation_id == "wandas.audio.a_weighting"
+    assert replayed.operation_history == processed.operation_history
 
 
 @pytest.mark.parametrize("method", ["hpss_harmonic", "hpss_percussive"])

--- a/tests/processing/test_a_weighting_channelwise_execution.py
+++ b/tests/processing/test_a_weighting_channelwise_execution.py
@@ -1,0 +1,169 @@
+"""Channel-wise execution contracts for A-weighting."""
+
+from unittest import mock
+
+import dask.array as da
+import numpy as np
+import pytest
+from dask.array.core import Array as DaArray
+from dask.delayed import delayed
+
+from wandas.processing.base import ChannelIndependentAudioOperation
+from wandas.processing.filters import AWeighting
+from wandas.utils.dask_helpers import da_from_array
+
+_SAMPLING_RATE = 48_000
+_SAMPLES = 1_024
+
+
+def _values(channels: int, dtype: np.dtype[np.generic]) -> np.ndarray:
+    time = np.arange(_SAMPLES) / _SAMPLING_RATE
+    values = np.stack(
+        [
+            (index + 1)
+            * (1_000 * np.sin(2 * np.pi * (200 + 100 * index) * time) + 300 * np.cos(2 * np.pi * 2_000 * time))
+            for index in range(channels)
+        ]
+    )
+    return values.astype(dtype)
+
+
+def _source(channels: int, dtype: np.dtype[np.generic]) -> DaArray:
+    return da_from_array(_values(channels, dtype), chunks=(1, 128))
+
+
+def _kernel_keys(array: DaArray) -> tuple[str, ...]:
+    return tuple(sorted(repr(key) for key in array.dask if "_execute_wandas_operation" in repr(key)))
+
+
+def test_a_weighting_declares_channel_independent_contract() -> None:
+    assert issubclass(AWeighting, ChannelIndependentAudioOperation)
+
+
+@pytest.mark.parametrize("channels", [1, 2, 4, 8])
+@pytest.mark.parametrize(
+    "dtype",
+    [np.dtype(np.float32), np.dtype(np.float64), np.dtype(np.int16)],
+    ids=["float32", "float64", "int16"],
+)
+def test_a_weighting_channel_wise_kernel_matches_whole_frame_exactly(
+    monkeypatch: pytest.MonkeyPatch,
+    channels: int,
+    dtype: np.dtype[np.generic],
+) -> None:
+    source = _source(channels, dtype)
+    source_before = source.compute(scheduler="synchronous").copy()
+    operation = AWeighting(_SAMPLING_RATE)
+    original_process = operation._process
+    kernel_shapes: list[tuple[int, ...]] = []
+
+    def observed_process(values: np.ndarray) -> np.ndarray:
+        kernel_shapes.append(values.shape)
+        return original_process(values)
+
+    monkeypatch.setattr(operation, "_process", observed_process)
+    channel_wise = operation.process(source)
+    whole_frame = operation._build_whole_frame_graph(
+        source,
+        (),
+        output_shape=source.shape,
+        output_dtype=np.dtype(np.float64),
+    )
+
+    assert isinstance(channel_wise, DaArray)
+    assert channel_wise.shape == whole_frame.shape == source.shape
+    assert channel_wise.dtype == whole_frame.dtype == np.dtype(np.float64)
+    assert channel_wise.chunks == (channels * (1,), (_SAMPLES,))
+    assert kernel_shapes == []
+
+    channel_values = channel_wise.compute(scheduler="synchronous")
+    assert kernel_shapes == channels * [(1, _SAMPLES)]
+
+    kernel_shapes.clear()
+    whole_values = whole_frame.compute(scheduler="synchronous")
+    assert kernel_shapes == [(channels, _SAMPLES)]
+    np.testing.assert_array_equal(channel_values, whole_values)
+    np.testing.assert_array_equal(source.compute(scheduler="synchronous"), source_before)
+
+
+def test_a_weighting_repeated_graphs_have_stable_pure_output_and_kernel_keys() -> None:
+    source = _source(4, np.dtype(np.float64))
+    operation = AWeighting(_SAMPLING_RATE)
+
+    with mock.patch("wandas.processing.base.delayed", wraps=delayed) as delayed_builder:
+        first = operation.process(source)
+        second = operation.process(source)
+
+    assert operation.pure is True
+    assert first.name == second.name
+    assert first.__dask_keys__() == second.__dask_keys__()
+    assert _kernel_keys(first) == _kernel_keys(second)
+    assert len(_kernel_keys(first)) == 4
+    assert len(delayed_builder.call_args_list) == 8
+    assert all(call.kwargs["pure"] is True for call in delayed_builder.call_args_list)
+
+
+def test_a_weighting_zero_channel_input_uses_whole_frame_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operation = AWeighting(_SAMPLING_RATE)
+    original_process = operation._process
+    kernel_shapes: list[tuple[int, ...]] = []
+
+    def observed_process(values: np.ndarray) -> np.ndarray:
+        kernel_shapes.append(values.shape)
+        return original_process(values)
+
+    monkeypatch.setattr(operation, "_process", observed_process)
+    source = da.from_array(np.empty((0, _SAMPLES)), chunks=(0, _SAMPLES))
+
+    result = operation.process(source)
+
+    assert result.dtype == np.dtype(np.float64)
+    assert result.chunks == ((0,), (_SAMPLES,))
+    np.testing.assert_array_equal(
+        result.compute(scheduler="synchronous"),
+        np.empty((0, _SAMPLES)),
+    )
+    assert kernel_shapes == [(0, _SAMPLES)]
+
+
+def test_a_weighting_unknown_channel_count_uses_whole_frame_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    values = _values(2, np.dtype(np.float64))
+    source = da.from_delayed(
+        delayed(np.asarray)(values),
+        shape=(np.nan, _SAMPLES),
+        dtype=values.dtype,
+    )
+    operation = AWeighting(_SAMPLING_RATE)
+    original_process = operation._process
+    kernel_shapes: list[tuple[int, ...]] = []
+
+    def observed_process(array: np.ndarray) -> np.ndarray:
+        kernel_shapes.append(array.shape)
+        return original_process(array)
+
+    monkeypatch.setattr(operation, "_process", observed_process)
+    result = operation.process(source)
+    expected = original_process(values)
+
+    assert np.isnan(result.shape[0])
+    assert result.shape[1:] == (_SAMPLES,)
+    assert result.dtype == np.dtype(np.float64)
+    np.testing.assert_array_equal(
+        result.compute(scheduler="synchronous"),
+        expected,
+    )
+    assert kernel_shapes == [(2, _SAMPLES)]
+
+
+def test_a_weighting_extra_runtime_input_keeps_existing_error() -> None:
+    source = _source(2, np.dtype(np.float64))
+
+    with pytest.raises(
+        ValueError,
+        match=r"Expected exactly one input for AWeighting; got 2",
+    ):
+        AWeighting(_SAMPLING_RATE).process(source, source)

--- a/wandas/processing/filters.py
+++ b/wandas/processing/filters.py
@@ -194,7 +194,7 @@ class BandPassFilter(_ButterworthFilter):
         logger.debug(f"Bandpass filter coefficients calculated: b={self._b}, a={self._a}")
 
 
-class AWeighting(AudioOperation[NDArrayReal, NDArrayReal]):
+class AWeighting(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
     """A-weighting filter operation"""
 
     name = "a_weighting"


### PR DESCRIPTION
## Summary

- declare `AWeighting` as a `ChannelIndependentAudioOperation`
- preserve the existing SOS kernel, public Frame API, metadata/calibration behavior, lineage, and Recipe schema
- add exact whole-frame parity, fallback, stable-key, public Frame, and Recipe regression coverage
- update the execution/scalability documentation and commit revision-addressable benchmark evidence

## Contract

A-weighting applies the same `sosfilt(..., axis=-1)` kernel to each channel with independent zero initial state and a complete time axis. The output preserves channel count and is always `float64`. Zero or unknown channel counts keep the conservative whole-frame fallback; extra runtime inputs remain rejected by the unary contract.

The production change is one inheritance line. No public API, Recipe schema, scheduler control, central dispatch, dependency, or time-axis chunking change is included.

## Numerical and performance evidence

- Base SHA: `9d758ad82cd7fbc4a814d37b0a6ff094ab0eb9f8`
- Benchmarked candidate SHA: `100955fe3f7c693038bc54721f1cf5d00ea6211a`
- PR head SHA: `a8929f14607414a079c3cee4a66b61dad8683b53` (candidate-to-head changes are documentation and benchmark assets only)
- 1/2/4/8 channels × float32/float64/int16: forced whole-frame and channel-wise results are exactly equal
- every channel kernel receives `(1, full_time_axis)`
- all 12 isolated formal benchmark runs matched shape `(8, 1000000)`, dtype `float64`, and checksum `829133cbe9536fefe7fd21e68b06dcc92d170cee17d1e404a413041917541504`

Eight-channel, 1,000,000-sample float64 medians with normal default-threaded materialization:

| Boundary | Tasks | Build | Materialize | Peak RSS |
|---|---:|---:|---:|---:|
| operation | 20 → 56 | 0.959 → 5.094 ms | 68.148 → 37.936 ms | 448.066 → 508.996 MiB |
| `Frame.data` | 36 → 56 | 4.207 → 7.947 ms | 74.915 → 41.288 ms | 448.574 → 509.348 MiB |

The RSS increase is an accepted, documented concurrency trade-off; it is not described as a one-channel end-to-end memory bound. Raw base/candidate JSON in `docs/src/assets/benchmarks/a-weighting-channelwise/` records the exact worker commands, execution order, environment, lock identity, checksums, timings, tasks, and RSS.

## Validation

- `PYTHONPATH=/workspaces/wandas/.worktrees/a-weighting-channelwise uv run --no-sync --project /workspaces/wandas pytest -q` — 2653 passed, 3 skipped
- focused channel-wise/public/Recipe tests — 19 passed
- existing IEC/SciPy authority selection — 14 passed
- `uv run ruff check wandas tests scripts`
- `uv run ruff format --check wandas tests scripts`
- `uv run ty check wandas tests`
- `uv run mkdocs build --strict -f docs/mkdocs.yml`
- `git diff --check`

All validation passed. Three review tracks covered numerical/signal-processing correctness, architecture/Frame/Recipe contracts, and tests/performance/documentation. The two low documentation findings and one benchmark-evidence finding were fixed and independently rechecked; no actionable finding or contract-replan requirement remains.