### PR TITLE
Run Trim channel-wise with bounded metadata

### DIFF
--- a/docs/src/assets/benchmarks/trim-channelwise/base-9d758ad8-candidate-aabf090a.json
+++ b/docs/src/assets/benchmarks/trim-channelwise/base-9d758ad8-candidate-aabf090a.json
@@ -1,0 +1,431 @@
+{
+  "schema": "wandas.trim-channelwise-benchmark",
+  "version": 1,
+  "recorded_date": "2026-07-27",
+  "base_sha": "9d758ad82cd7fbc4a814d37b0a6ff094ab0eb9f8",
+  "candidate_sha": "aabf090a8a0d3cdf5efcda96d75d802808912eb9",
+  "environment": {
+    "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+    "python": "3.10.20 (main, Jun 23 2026, 15:20:26) [Clang 22.1.3 ]",
+    "executable": "/workspaces/wandas/.venv/bin/python3",
+    "uv_lock_sha256": "8f22e9d43bb9a4f1ec476219fb57464bd29929f8e7e30bc0d03c32f728414107",
+    "scheduler": "default threaded",
+    "native_thread_environment_overrides": {}
+  },
+  "case": {
+    "operation": "trim",
+    "channels": 8,
+    "samples_per_channel": 1000000,
+    "sampling_rate": 48000.0,
+    "input_dtype": "float64",
+    "start_seconds": 2.0833333333333335,
+    "end_seconds": 18.75,
+    "output_samples_per_channel": 800000,
+    "boundaries": [
+      "operation",
+      "frame"
+    ],
+    "runs_per_revision_per_boundary": 3,
+    "execution_order_per_boundary": [
+      "base-1",
+      "candidate-1",
+      "candidate-2",
+      "base-2",
+      "base-3",
+      "candidate-3"
+    ],
+    "process_isolation": "Each worker command ran in a separate process.",
+    "source_boundary": "Deterministic in-memory NumPy input converted to Dask; no file reader was involved.",
+    "rss_definition": "Absolute worker-lifetime ru_maxrss sampled after materialization, with Linux KiB converted to MiB."
+  },
+  "worker_script": "/tmp/wandas-channelwise-small-benchmark.py",
+  "worker_script_sha256": "1a15b7e706e1a0acaf29d02b6cb8d2de8f239d9dd0ac555f575ebcf0eaf39103",
+  "worker_commands": [
+    "PYTHONPATH=/workspaces/wandas/.worktrees/channelwise-inventory-20260727 uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation trim --boundary operation --channels 8 --samples 1000000 --dtype float64 --label base-operation-run-1",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/trim-channelwise uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation trim --boundary operation --channels 8 --samples 1000000 --dtype float64 --label candidate-operation-run-1",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/trim-channelwise uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation trim --boundary operation --channels 8 --samples 1000000 --dtype float64 --label candidate-operation-run-2",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/channelwise-inventory-20260727 uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation trim --boundary operation --channels 8 --samples 1000000 --dtype float64 --label base-operation-run-2",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/channelwise-inventory-20260727 uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation trim --boundary operation --channels 8 --samples 1000000 --dtype float64 --label base-operation-run-3",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/trim-channelwise uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation trim --boundary operation --channels 8 --samples 1000000 --dtype float64 --label candidate-operation-run-3",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/channelwise-inventory-20260727 uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation trim --boundary frame --channels 8 --samples 1000000 --dtype float64 --label base-frame-run-1",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/trim-channelwise uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation trim --boundary frame --channels 8 --samples 1000000 --dtype float64 --label candidate-frame-run-1",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/trim-channelwise uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation trim --boundary frame --channels 8 --samples 1000000 --dtype float64 --label candidate-frame-run-2",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/channelwise-inventory-20260727 uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation trim --boundary frame --channels 8 --samples 1000000 --dtype float64 --label base-frame-run-2",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/channelwise-inventory-20260727 uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation trim --boundary frame --channels 8 --samples 1000000 --dtype float64 --label base-frame-run-3",
+    "PYTHONPATH=/workspaces/wandas/.worktrees/trim-channelwise uv run --no-sync --project /workspaces/wandas python /tmp/wandas-channelwise-small-benchmark.py --operation trim --boundary frame --channels 8 --samples 1000000 --dtype float64 --label candidate-frame-run-3"
+  ],
+  "numerical_invariants": {
+    "input_shape": [
+      8,
+      1000000
+    ],
+    "output_shape_metadata": [
+      8,
+      800000
+    ],
+    "output_shape_actual": [
+      8,
+      800000
+    ],
+    "output_dtype_metadata": "float64",
+    "output_dtype_actual": "float64",
+    "input_checksum_sha256": "7f3ca6a7112a9c4ff44594d6971936106f67066de22758d6c6f46a76c7dd5f9e",
+    "output_checksum_sha256": "75d36e0a7f12251a70e3d3b6f8175901710cbb36e3daaa15e6dcca7a30bdf51c",
+    "output_l2_squared": 645004.6543670658,
+    "all_runs_exactly_equal": true
+  },
+  "median_summary": [
+    {
+      "boundary": "operation",
+      "revision": "base",
+      "execution_contract": "whole-frame",
+      "task_count": 20,
+      "graph_build_seconds": 0.0009839230042416602,
+      "materialize_seconds": 0.02187735699408222,
+      "peak_rss_mib": 374.55859375,
+      "rss_peak_growth_mib": 26.37890625
+    },
+    {
+      "boundary": "operation",
+      "revision": "candidate",
+      "execution_contract": "channel-independent",
+      "task_count": 56,
+      "graph_build_seconds": 0.005024026002502069,
+      "materialize_seconds": 0.01671078900108114,
+      "peak_rss_mib": 374.3046875,
+      "rss_peak_growth_mib": 26.17578125
+    },
+    {
+      "boundary": "frame",
+      "revision": "base",
+      "execution_contract": "whole-frame",
+      "task_count": 36,
+      "graph_build_seconds": 0.004151321991230361,
+      "materialize_seconds": 0.02513360900047701,
+      "peak_rss_mib": 374.84765625,
+      "rss_peak_growth_mib": 26.76171875
+    },
+    {
+      "boundary": "frame",
+      "revision": "candidate",
+      "execution_contract": "channel-independent",
+      "task_count": 56,
+      "graph_build_seconds": 0.007972977997269481,
+      "materialize_seconds": 0.01526624801044818,
+      "peak_rss_mib": 374.9609375,
+      "rss_peak_growth_mib": 26.8359375
+    }
+  ],
+  "observed_comparison": {
+    "operation_materialize_median_reduction_fraction": 0.23616051949961903,
+    "frame_data_median_reduction_fraction": 0.3925962638251258,
+    "operation_peak_rss_median_delta_mib": -0.25390625,
+    "frame_peak_rss_median_delta_mib": 0.11328125,
+    "conclusion": "The formal candidate reproducibly reduced normal Frame.data materialization time while absolute peak RSS remained effectively unchanged. Graph build time and task count increased as expected for per-channel task construction."
+  },
+  "runs": [
+    {
+      "boundary": "operation",
+      "revision": "base",
+      "run": 1,
+      "execution_contract": "whole-frame",
+      "chunks": [
+        [
+          8
+        ],
+        [
+          800000
+        ]
+      ],
+      "task_count": 20,
+      "graph_build_seconds": 0.0009839230042416602,
+      "materialize_seconds": 0.027133042996865697,
+      "rss_before_compute_mib": 348.15625,
+      "peak_rss_mib": 374.55859375,
+      "rss_peak_growth_mib": 26.40234375
+    },
+    {
+      "boundary": "operation",
+      "revision": "candidate",
+      "run": 1,
+      "execution_contract": "channel-independent",
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          800000
+        ]
+      ],
+      "task_count": 56,
+      "graph_build_seconds": 0.005024026002502069,
+      "materialize_seconds": 0.015850853989832103,
+      "rss_before_compute_mib": 347.359375,
+      "peak_rss_mib": 373.5,
+      "rss_peak_growth_mib": 26.140625
+    },
+    {
+      "boundary": "operation",
+      "revision": "candidate",
+      "run": 2,
+      "execution_contract": "channel-independent",
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          800000
+        ]
+      ],
+      "task_count": 56,
+      "graph_build_seconds": 0.00505194699508138,
+      "materialize_seconds": 0.01671078900108114,
+      "rss_before_compute_mib": 348.12890625,
+      "peak_rss_mib": 374.3046875,
+      "rss_peak_growth_mib": 26.17578125
+    },
+    {
+      "boundary": "operation",
+      "revision": "base",
+      "run": 2,
+      "execution_contract": "whole-frame",
+      "chunks": [
+        [
+          8
+        ],
+        [
+          800000
+        ]
+      ],
+      "task_count": 20,
+      "graph_build_seconds": 0.0009911490051308647,
+      "materialize_seconds": 0.02187735699408222,
+      "rss_before_compute_mib": 347.86328125,
+      "peak_rss_mib": 374.16015625,
+      "rss_peak_growth_mib": 26.296875
+    },
+    {
+      "boundary": "operation",
+      "revision": "base",
+      "run": 3,
+      "execution_contract": "whole-frame",
+      "chunks": [
+        [
+          8
+        ],
+        [
+          800000
+        ]
+      ],
+      "task_count": 20,
+      "graph_build_seconds": 0.0009626720129745081,
+      "materialize_seconds": 0.017460792005294934,
+      "rss_before_compute_mib": 349.01171875,
+      "peak_rss_mib": 375.390625,
+      "rss_peak_growth_mib": 26.37890625
+    },
+    {
+      "boundary": "operation",
+      "revision": "candidate",
+      "run": 3,
+      "execution_contract": "channel-independent",
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          800000
+        ]
+      ],
+      "task_count": 56,
+      "graph_build_seconds": 0.004914319986710325,
+      "materialize_seconds": 0.018221366000943817,
+      "rss_before_compute_mib": 348.48046875,
+      "peak_rss_mib": 374.72265625,
+      "rss_peak_growth_mib": 26.2421875
+    },
+    {
+      "boundary": "frame",
+      "revision": "base",
+      "run": 1,
+      "execution_contract": "whole-frame",
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          800000
+        ]
+      ],
+      "task_count": 36,
+      "graph_build_seconds": 0.004107608998310752,
+      "materialize_seconds": 0.027791044994955882,
+      "rss_before_compute_mib": 348.23046875,
+      "peak_rss_mib": 374.54296875,
+      "rss_peak_growth_mib": 26.3125
+    },
+    {
+      "boundary": "frame",
+      "revision": "candidate",
+      "run": 1,
+      "execution_contract": "channel-independent",
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          800000
+        ]
+      ],
+      "task_count": 56,
+      "graph_build_seconds": 0.0083306540036574,
+      "materialize_seconds": 0.01526624801044818,
+      "rss_before_compute_mib": 347.23046875,
+      "peak_rss_mib": 374.078125,
+      "rss_peak_growth_mib": 26.84765625
+    },
+    {
+      "boundary": "frame",
+      "revision": "candidate",
+      "run": 2,
+      "execution_contract": "channel-independent",
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          800000
+        ]
+      ],
+      "task_count": 56,
+      "graph_build_seconds": 0.007926624995889142,
+      "materialize_seconds": 0.017245562994503416,
+      "rss_before_compute_mib": 348.125,
+      "peak_rss_mib": 374.9609375,
+      "rss_peak_growth_mib": 26.8359375
+    },
+    {
+      "boundary": "frame",
+      "revision": "base",
+      "run": 2,
+      "execution_contract": "whole-frame",
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          800000
+        ]
+      ],
+      "task_count": 36,
+      "graph_build_seconds": 0.004151321991230361,
+      "materialize_seconds": 0.02360694299568422,
+      "rss_before_compute_mib": 348.0859375,
+      "peak_rss_mib": 374.84765625,
+      "rss_peak_growth_mib": 26.76171875
+    },
+    {
+      "boundary": "frame",
+      "revision": "base",
+      "run": 3,
+      "execution_contract": "whole-frame",
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          800000
+        ]
+      ],
+      "task_count": 36,
+      "graph_build_seconds": 0.00418663899472449,
+      "materialize_seconds": 0.02513360900047701,
+      "rss_before_compute_mib": 348.34765625,
+      "peak_rss_mib": 375.20703125,
+      "rss_peak_growth_mib": 26.859375
+    },
+    {
+      "boundary": "frame",
+      "revision": "candidate",
+      "run": 3,
+      "execution_contract": "channel-independent",
+      "chunks": [
+        [
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1
+        ],
+        [
+          800000
+        ]
+      ],
+      "task_count": 56,
+      "graph_build_seconds": 0.007972977997269481,
+      "materialize_seconds": 0.014371997996931896,
+      "rss_before_compute_mib": 348.73828125,
+      "peak_rss_mib": 375.1171875,
+      "rss_peak_growth_mib": 26.37890625
+    }
+  ]
+}

--- a/docs/src/explanation/audio-operation-execution.md
+++ b/docs/src/explanation/audio-operation-execution.md
@@ -148,16 +148,18 @@ The 2026-07-27 evaluation used eight float64 channels with 1,000,000 samples eac
 selected the middle 800,000 samples. Whole-frame and channel-wise paths ran in
 interleaved, isolated processes for three runs per path with the default scheduler and
 no native-thread environment override. In the normal public `Frame.data` path, median
-materialization time decreased from 25.5 ms to 18.6 ms, while median process peak RSS
-was effectively unchanged at 374.4 MiB. Task count increased from 36 to 56 and median
-graph-build time increased from 4.4 ms to 8.2 ms. The direct operation boundary showed
-the same direction, from 22.0 ms to 17.5 ms, with tasks increasing from 20 to 56.
+materialization time decreased from 25.1 ms to 15.3 ms, while median process peak RSS
+was effectively unchanged at 374.85 MiB and 374.96 MiB. Task count increased from 36
+to 56 and median graph-build time increased from 4.15 ms to 7.97 ms. The direct
+operation boundary showed the same direction, from 21.9 ms to 16.7 ms, with tasks
+increasing from 20 to 56 and median peak RSS changing from 374.56 MiB to 374.30 MiB.
 Every run produced the same shape, dtype, checksum, and squared-L2 value.
 
-Both comparison worktrees were based on
-`9d758ad82cd7fbc4a814d37b0a6ff094ab0eb9f8`; the candidate added the inheritance-only
-channel-independent prototype. The runs used Linux `7.0.0-28-generic` x86-64 with
-glibc 2.36, CPython 3.10.20, and `uv.lock` SHA-256
+The base was `9d758ad82cd7fbc4a814d37b0a6ff094ab0eb9f8`; the formal candidate was
+`aabf090a8a0d3cdf5efcda96d75d802808912eb9`. Besides declaring the channel-independent
+contract, that candidate bounded its metadata correction to `Trim`: output shape and
+source time use the same normalized NumPy slice as the kernel. The runs used Linux
+`7.0.0-28-generic` x86-64 with glibc 2.36, CPython 3.10.20, and `uv.lock` SHA-256
 `8f22e9d43bb9a4f1ec476219fb57464bd29929f8e7e30bc0d03c32f728414107`. Each worker used
 the following command shape, varying source worktree, boundary, label, and run number:
 
@@ -166,11 +168,15 @@ PYTHONPATH=<base-or-candidate-worktree> \
   uv run --no-sync --project /workspaces/wandas python \
   /tmp/wandas-channelwise-small-benchmark.py \
   --operation trim --boundary <operation-or-frame> \
-  --samples 1000000 --label <base-or-candidate>-run-<N>
+  --channels 8 --samples 1000000 --dtype float64 \
+  --label <base-or-candidate>-<boundary>-run-<N>
 ```
 
-These figures record one same-environment observation. They are not a portable timing,
-task-count, or memory guarantee.
+The
+[revision-addressable benchmark asset](../assets/benchmarks/trim-channelwise/base-9d758ad8-candidate-aabf090a.json)
+records every worker command, raw run, median, environment field, checksum, shape, and
+dtype. These figures record one same-environment observation. They are not a portable
+timing, task-count, or memory guarantee.
 
 ## Parameter-dependent operation: Normalize
 

--- a/docs/src/explanation/audio-operation-execution.md
+++ b/docs/src/explanation/audio-operation-execution.md
@@ -58,7 +58,8 @@ channels depend on one another.
 | `remove_dc` | Independent | Whole time series per channel for the mean | **Channel-wise** |
 | `abs`, `power` | Independent | Pointwise/time-local | Existing Dask-native graph override |
 | `normalize` | Parameter-dependent: a non-`None` norm over the last axis is independent; `axis=None` or a channel axis is cross-channel | Whole selected norm axis | **Channel-wise when eligible** |
-| `trim`, `fix_length` | Independent | Indexed/padded time-local transform with output-shape change | Whole-frame |
+| `trim` | Independent | Indexed time slice with output-shape change | **Channel-wise** |
+| `fix_length` | Independent | Indexed/padded time-local transform with output-shape change | Whole-frame |
 | `fade` | Independent | Needs the full signal length to define the envelope | Whole-frame |
 | high-pass, low-pass, band-pass | Independent | Stateful/whole continuous time series per channel | **Channel-wise** |
 | A-weighting | Independent | Stateful/whole continuous time series per channel | Whole-frame |
@@ -131,6 +132,45 @@ The issue #346 evaluation used 1,000,000 samples per channel at 48 kHz resampled
 from 0.0659 s to 0.0729 s, and same-environment median peak RSS decreased from about
 299.5 MiB to 278.9 MiB. Every paired numerical checksum was equal. These measurements
 describe the task/time/memory tradeoff and do not define a portable performance limit.
+
+## Adopted operation: Trim
+
+`Trim` selects the same sample interval independently from every input channel. It
+preserves channel count and dtype while changing only the time-axis length, so its
+NumPy slice satisfies the direct channel-independence contract. Known positive channel
+counts use `ChannelIndependentAudioOperation`; zero or unknown channel counts retain
+whole-frame fallback. The existing sample-index rounding and NumPy slicing semantics
+are unchanged. Output-shape and source-time-offset metadata use those same normalized
+slice boundaries, including negative and out-of-range indices. Calibration consumption,
+metadata, lineage, and the Recipe declaration are unchanged.
+
+The 2026-07-27 evaluation used eight float64 channels with 1,000,000 samples each and
+selected the middle 800,000 samples. Whole-frame and channel-wise paths ran in
+interleaved, isolated processes for three runs per path with the default scheduler and
+no native-thread environment override. In the normal public `Frame.data` path, median
+materialization time decreased from 25.5 ms to 18.6 ms, while median process peak RSS
+was effectively unchanged at 374.4 MiB. Task count increased from 36 to 56 and median
+graph-build time increased from 4.4 ms to 8.2 ms. The direct operation boundary showed
+the same direction, from 22.0 ms to 17.5 ms, with tasks increasing from 20 to 56.
+Every run produced the same shape, dtype, checksum, and squared-L2 value.
+
+Both comparison worktrees were based on
+`9d758ad82cd7fbc4a814d37b0a6ff094ab0eb9f8`; the candidate added the inheritance-only
+channel-independent prototype. The runs used Linux `7.0.0-28-generic` x86-64 with
+glibc 2.36, CPython 3.10.20, and `uv.lock` SHA-256
+`8f22e9d43bb9a4f1ec476219fb57464bd29929f8e7e30bc0d03c32f728414107`. Each worker used
+the following command shape, varying source worktree, boundary, label, and run number:
+
+```bash
+PYTHONPATH=<base-or-candidate-worktree> \
+  uv run --no-sync --project /workspaces/wandas python \
+  /tmp/wandas-channelwise-small-benchmark.py \
+  --operation trim --boundary <operation-or-frame> \
+  --samples 1000000 --label <base-or-candidate>-run-<N>
+```
+
+These figures record one same-environment observation. They are not a portable timing,
+task-count, or memory guarantee.
 
 ## Parameter-dependent operation: Normalize
 

--- a/docs/src/explanation/audio-operation-execution.md
+++ b/docs/src/explanation/audio-operation-execution.md
@@ -139,9 +139,10 @@ describe the task/time/memory tradeoff and do not define a portable performance 
 preserves channel count and dtype while changing only the time-axis length, so its
 NumPy slice satisfies the direct channel-independence contract. Known positive channel
 counts use `ChannelIndependentAudioOperation`; zero or unknown channel counts retain
-whole-frame fallback. The existing sample-index rounding and NumPy slicing semantics
-are unchanged. Output-shape and source-time-offset metadata use those same normalized
-slice boundaries, including negative and out-of-range indices. Calibration consumption,
+whole-frame fallback. The existing sample-index rounding and positive-time NumPy
+slicing semantics are unchanged. Negative trim times are rejected. Output-shape and
+source-time-offset metadata use the same normalized boundaries for out-of-range
+positive indices. Calibration consumption,
 metadata, lineage, and the Recipe declaration are unchanged.
 
 The 2026-07-27 evaluation used eight float64 channels with 1,000,000 samples each and

--- a/docs/src/explanation/scalability-contract.md
+++ b/docs/src/explanation/scalability-contract.md
@@ -2,14 +2,15 @@
 
 Wandas scales primarily across collections of bounded recordings while preserving
 the continuous-time assumptions of signal processing. Stored and lazy Frame data
-retain a channel axis. `RemoveDC` is the first prototype operation that executes one
-complete channel per lazy kernel task; other delayed `AudioOperation` transforms keep
-the conservative whole-Frame boundary. Wandas therefore does not promise arbitrary
-channel-count or time-axis distribution for one enormous Frame.
+retain a channel axis. Operations that explicitly declare the channel-independent
+contract can execute one complete channel per lazy kernel task; other delayed
+`AudioOperation` transforms keep the conservative whole-Frame boundary. Wandas
+therefore does not promise arbitrary channel-count or time-axis distribution for one
+enormous Frame.
 
 Wandas は主に、サイズを制御した多数の収録ファイルを扱う方向へ拡張します。
-Frame の保存・遅延データはチャンネル軸を保持します。`RemoveDC` は、完全な
-1 チャンネルごとに遅延 kernel task を実行する最初の prototype operation です。
+Frame の保存・遅延データはチャンネル軸を保持します。channel-independent 契約を
+明示した operation は、完全な 1 チャンネルごとに遅延 kernel task を実行できます。
 その他の遅延 `AudioOperation` transform は、保守的な whole-Frame boundary を維持します。
 したがって Wandas は、単一の巨大な Frame をチャンネル数または時間方向へ自由に分散できるとは約束しません。
 
@@ -27,11 +28,14 @@ Frame の保存・遅延データはチャンネル軸を保持します。`Remo
 - Filters, FFT, STFT, and other continuity-sensitive operations normally require a
   single time chunk per channel.
 - Most delayed `AudioOperation` transforms wrap the complete channel-first Dask array
-  in one call. `RemoveDC` instead builds independent channel tasks, while every task
-  still materializes one complete continuous time series.
+  in one call. Explicitly adopted operations such as `RemoveDC`, Butterworth filters,
+  resampling, and `Trim` instead build independent channel tasks, while every task
+  still materializes one complete continuous time series. Eligible `Normalize`
+  configurations use the same private graph mechanics.
 - Whole-frame operations can therefore exceed memory as either channel count or
-  per-channel signal size grows. The `RemoveDC` prototype reduces its kernel boundary
-  across channels, but per-channel signal size remains bounded by available memory.
+  per-channel signal size grows. Independent channel-task execution reduces an
+  adopted operation's kernel boundary across channels, but per-channel signal size
+  remains bounded by available memory.
 - WDF 0.4 passes internal source chunks to the writer without first computing the
   complete tensor. This bounds the writer's upstream data access by source chunking,
   although backend and compression buffers still contribute to RSS.
@@ -92,6 +96,7 @@ uv run --no-dev --extra io python scripts/scalability_benchmark.py --samples 800
 These measurements characterize bounded upstream writer access, not a fixed RSS ceiling
 across platforms or HDF5 configurations. WDF preserves typed Frame state, axes,
 metadata, and deterministic failure behavior without precomputing the complete tensor.
-Independent channel-task execution is currently promised only for `RemoveDC`. See
-[AudioOperation execution dependencies](audio-operation-execution.md) for the internal
-prototype contract and the classification of operations that remain whole-frame.
+Independent channel-task execution applies only to operations explicitly classified
+under the channel-independent contract. See
+[AudioOperation execution dependencies](audio-operation-execution.md) for the
+internal contract and the classification of operations that remain whole-frame.

--- a/tests/frames/test_trim_channelwise_frame.py
+++ b/tests/frames/test_trim_channelwise_frame.py
@@ -95,21 +95,13 @@ def test_trim_public_frame_preserves_state_and_consumes_calibration_lazily() -> 
     assert source.lineage is source_lineage
 
 
-@pytest.mark.parametrize(
-    ("start", "end", "expected_slice", "expected_offset"),
-    [
-        pytest.param(-0.25, 1.0, slice(-2, 8), np.array([1.0, 1.25, 1.5]), id="negative-start"),
-        pytest.param(1.25, 1.75, slice(10, 14), np.array([1.25, 1.5, 1.75]), id="start-after-input"),
-    ],
-)
-def test_trim_public_frame_slice_boundaries_stay_lazy_and_match_metadata(
-    start: float,
-    end: float,
-    expected_slice: slice,
-    expected_offset: np.ndarray,
-) -> None:
+def test_trim_public_frame_slice_boundaries_stay_lazy_and_match_metadata() -> None:
     source = _source()
     raw = np.arange(24, dtype=np.float32).reshape(3, 8)
+    start = 1.25
+    end = 1.75
+    expected_slice = slice(10, 14)
+    expected_offset = np.array([1.25, 1.5, 1.75])
     expected = raw[:, expected_slice] * np.array([[2.0], [3.0], [0.5]], dtype=np.float64)
 
     with mock.patch.object(DaArray, "compute") as compute:
@@ -129,3 +121,23 @@ def test_trim_public_frame_slice_boundaries_stay_lazy_and_match_metadata(
         "version": 1,
         "params": {"start": start, "end": end},
     }
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "message"),
+    [
+        pytest.param(-0.25, 1.0, r"Trim start must be non-negative", id="negative-start"),
+        pytest.param(0.0, -0.25, r"Trim end must be non-negative", id="negative-end"),
+    ],
+)
+def test_trim_public_frame_negative_boundary_raises_value_error(
+    start: float,
+    end: float,
+    message: str,
+) -> None:
+    source = _source()
+
+    with pytest.raises(ValueError, match=message):
+        source.trim(start=start, end=end)
+
+    assert source.operation_history == []

--- a/tests/frames/test_trim_channelwise_frame.py
+++ b/tests/frames/test_trim_channelwise_frame.py
@@ -1,0 +1,131 @@
+"""Public Frame contracts for channel-wise Trim execution."""
+
+from copy import deepcopy
+from unittest import mock
+
+import dask.array as da
+import numpy as np
+import pytest
+from dask.array.core import Array as DaArray
+
+from tests.frame_helpers import channel_first_values
+from wandas.core.metadata import ChannelCalibration
+from wandas.frames.channel import ChannelFrame, ChannelMetadata
+
+
+def _source() -> ChannelFrame:
+    values = np.arange(24, dtype=np.float32).reshape(3, 8)
+    return ChannelFrame(
+        da.from_array(values, chunks=(1, 4)),
+        sampling_rate=8,
+        label="measurement",
+        metadata={"session": {"id": "trim-contract"}},
+        channel_metadata=[
+            ChannelMetadata(
+                label="left",
+                calibration=ChannelCalibration(factor=2.0, unit="Pa", ref=2e-5),
+                extra={"sensor": "mic-1"},
+            ),
+            ChannelMetadata(
+                label="right",
+                calibration=ChannelCalibration(factor=3.0, unit="V", ref=1.0),
+                extra={"sensor": "mic-2"},
+            ),
+            ChannelMetadata(
+                label="aux",
+                calibration=ChannelCalibration(factor=0.5, unit="m/s^2", ref=1.0),
+                extra={"sensor": "accel"},
+            ),
+        ],
+        channel_ids=["left-id", "right-id", "aux-id"],
+        source_time_offset=[0.25, 0.5, 0.75],
+    )
+
+
+def test_trim_public_frame_preserves_state_and_consumes_calibration_lazily() -> None:
+    source = _source()
+    source_values = channel_first_values(source).copy()
+    source_metadata = deepcopy(source.metadata)
+    source_channels = source.channels.to_list()
+    source_history = deepcopy(source.operation_history)
+    source_lineage = source.lineage
+
+    with mock.patch.object(DaArray, "compute") as compute:
+        result = source.trim(start=0.25, end=0.75)
+        compute.assert_not_called()
+
+    assert isinstance(result, ChannelFrame)
+    assert result is not source
+    assert result.previous is source
+    assert isinstance(result._data, DaArray)
+    assert result.shape == (3, 4)
+    assert result._data.dtype == np.dtype(np.float64)
+    assert result._data.chunks == ((1, 1, 1), (4,))
+    assert result.sampling_rate == source.sampling_rate
+    assert result.label == source.label
+    assert result.metadata == source_metadata
+    assert [channel.id for channel in result.channels] == ["left-id", "right-id", "aux-id"]
+    assert result.labels == ["trim(left)", "trim(right)", "trim(aux)"]
+    assert [channel.unit for channel in result.channels] == ["Pa", "V", "m/s^2"]
+    assert [channel.ref for channel in result.channels] == [2e-5, 1.0, 1.0]
+    assert [channel.calibration.factor for channel in result.channels] == [1.0, 1.0, 1.0]
+    assert [channel.extra for channel in result.channels] == [
+        {"sensor": "mic-1"},
+        {"sensor": "mic-2"},
+        {"sensor": "accel"},
+    ]
+    np.testing.assert_array_equal(result.source_time_offset, np.array([0.5, 0.75, 1.0]))
+    assert result.operation_history == [
+        {
+            "operation": "wandas.audio.trim",
+            "version": 1,
+            "params": {"start": 0.25, "end": 0.75},
+        }
+    ]
+    assert result.lineage is not source.lineage
+
+    raw = np.arange(24, dtype=np.float32).reshape(3, 8)
+    expected = raw[:, 2:6] * np.array([[2.0], [3.0], [0.5]], dtype=np.float64)
+    np.testing.assert_array_equal(channel_first_values(result), expected)
+
+    np.testing.assert_array_equal(channel_first_values(source), source_values)
+    assert source.metadata == source_metadata
+    assert source.channels.to_list() == source_channels
+    assert source.operation_history == source_history
+    assert source.lineage is source_lineage
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "expected_slice", "expected_offset"),
+    [
+        pytest.param(-0.25, 1.0, slice(-2, 8), np.array([1.0, 1.25, 1.5]), id="negative-start"),
+        pytest.param(1.25, 1.75, slice(10, 14), np.array([1.25, 1.5, 1.75]), id="start-after-input"),
+    ],
+)
+def test_trim_public_frame_slice_boundaries_stay_lazy_and_match_metadata(
+    start: float,
+    end: float,
+    expected_slice: slice,
+    expected_offset: np.ndarray,
+) -> None:
+    source = _source()
+    raw = np.arange(24, dtype=np.float32).reshape(3, 8)
+    expected = raw[:, expected_slice] * np.array([[2.0], [3.0], [0.5]], dtype=np.float64)
+
+    with mock.patch.object(DaArray, "compute") as compute:
+        result = source.trim(start=start, end=end)
+        compute.assert_not_called()
+
+    assert isinstance(result._data, DaArray)
+    assert result.shape == expected.shape
+    assert result._data.chunks == ((1, 1, 1), (expected.shape[-1],))
+    np.testing.assert_array_equal(channel_first_values(result), expected)
+    np.testing.assert_array_equal(result.source_time_offset, expected_offset)
+    assert result.source_time.shape == expected.shape
+    if expected.shape[-1]:
+        np.testing.assert_array_equal(result.source_time[:, 0], expected_offset)
+    assert result.operation_history[-1] == {
+        "operation": "wandas.audio.trim",
+        "version": 1,
+        "params": {"start": start, "end": end},
+    }

--- a/tests/pipeline/test_trim_channelwise_recipe.py
+++ b/tests/pipeline/test_trim_channelwise_recipe.py
@@ -1,0 +1,109 @@
+"""Recipe round-trip contracts for channel-wise Trim execution."""
+
+import json
+
+import dask.array as da
+import numpy as np
+import pytest
+from dask.array.core import Array as DaArray
+
+from tests.frame_helpers import channel_first_values
+from wandas.core.metadata import ChannelCalibration
+from wandas.frames.channel import ChannelFrame, ChannelMetadata
+from wandas.pipeline import RecipePlan
+
+
+def _source() -> ChannelFrame:
+    return ChannelFrame(
+        da.from_array(np.arange(16, dtype=np.float64).reshape(2, 8), chunks=(1, 4)),
+        sampling_rate=8,
+        label="recipe-source",
+        metadata={"workflow": {"name": "trim"}},
+        channel_metadata=[
+            ChannelMetadata(
+                label="first",
+                calibration=ChannelCalibration(factor=2.0, unit="Pa", ref=2e-5),
+                extra={"position": 1},
+            ),
+            ChannelMetadata(
+                label="second",
+                calibration=ChannelCalibration(factor=0.25, unit="V", ref=1.0),
+                extra={"position": 2},
+            ),
+        ],
+        channel_ids=["first-id", "second-id"],
+        source_time_offset=[0.125, 0.375],
+    )
+
+
+def test_trim_recipe_extract_serialize_deserialize_and_replay_preserves_contract() -> None:
+    source = _source()
+    source_values = channel_first_values(source).copy()
+    processed = source.trim(start=0.25, end=0.75)
+
+    plan = RecipePlan.from_frame(processed, input_names=("signal",))
+    payload = json.loads(json.dumps(plan.to_dict(), allow_nan=False))
+    loaded = RecipePlan.from_dict(payload)
+    replayed = loaded.apply({"signal": source})
+
+    assert loaded.to_dict() == plan.to_dict()
+    assert [node.operation for node in loaded.nodes] == ["wandas.audio.trim"]
+    assert isinstance(replayed, ChannelFrame)
+    assert isinstance(replayed._data, DaArray)
+    assert replayed.previous is source
+    assert replayed.shape == processed.shape
+    assert replayed._data.dtype == processed._data.dtype
+    assert replayed._data.chunks == processed._data.chunks
+    assert replayed.sampling_rate == processed.sampling_rate
+    assert replayed.label == processed.label
+    assert replayed.metadata == processed.metadata
+    assert [channel.id for channel in replayed.channels] == ["first-id", "second-id"]
+    assert replayed.labels == processed.labels
+    assert [channel.calibration for channel in replayed.channels] == [
+        channel.calibration for channel in processed.channels
+    ]
+    assert [channel.extra for channel in replayed.channels] == [channel.extra for channel in processed.channels]
+    np.testing.assert_array_equal(replayed.source_time_offset, processed.source_time_offset)
+    assert replayed.operation_history == processed.operation_history
+    np.testing.assert_array_equal(channel_first_values(replayed), channel_first_values(processed))
+
+    np.testing.assert_array_equal(channel_first_values(source), source_values)
+    assert source.operation_history == []
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "expected_slice", "expected_offset"),
+    [
+        pytest.param(-0.25, 1.0, slice(-2, 8), np.array([0.875, 1.125]), id="negative-start"),
+        pytest.param(1.25, 1.75, slice(10, 14), np.array([1.125, 1.375]), id="start-after-input"),
+    ],
+)
+def test_trim_recipe_replays_slice_boundary_shape_and_metadata(
+    start: float,
+    end: float,
+    expected_slice: slice,
+    expected_offset: np.ndarray,
+) -> None:
+    source = _source()
+    raw = np.arange(16, dtype=np.float64).reshape(2, 8)
+    expected = raw[:, expected_slice] * np.array([[2.0], [0.25]], dtype=np.float64)
+    processed = source.trim(start=start, end=end)
+    plan = RecipePlan.from_frame(processed, input_names=("signal",))
+    loaded = RecipePlan.from_dict(json.loads(json.dumps(plan.to_dict(), allow_nan=False)))
+    replayed = loaded.apply({"signal": source})
+
+    assert isinstance(replayed._data, DaArray)
+    assert replayed.shape == expected.shape
+    assert replayed._data.chunks == ((1, 1), (expected.shape[-1],))
+    assert replayed.metadata == source.metadata
+    assert replayed.labels == ["trim(first)", "trim(second)"]
+    assert replayed.operation_history[-1] == {
+        "operation": "wandas.audio.trim",
+        "version": 1,
+        "params": {"start": start, "end": end},
+    }
+    np.testing.assert_array_equal(channel_first_values(replayed), expected)
+    np.testing.assert_array_equal(replayed.source_time_offset, expected_offset)
+    assert replayed.source_time.shape == expected.shape
+    if expected.shape[-1]:
+        np.testing.assert_array_equal(replayed.source_time[:, 0], expected_offset)

--- a/tests/pipeline/test_trim_channelwise_recipe.py
+++ b/tests/pipeline/test_trim_channelwise_recipe.py
@@ -4,7 +4,6 @@ import json
 
 import dask.array as da
 import numpy as np
-import pytest
 from dask.array.core import Array as DaArray
 
 from tests.frame_helpers import channel_first_values
@@ -71,21 +70,13 @@ def test_trim_recipe_extract_serialize_deserialize_and_replay_preserves_contract
     assert source.operation_history == []
 
 
-@pytest.mark.parametrize(
-    ("start", "end", "expected_slice", "expected_offset"),
-    [
-        pytest.param(-0.25, 1.0, slice(-2, 8), np.array([0.875, 1.125]), id="negative-start"),
-        pytest.param(1.25, 1.75, slice(10, 14), np.array([1.125, 1.375]), id="start-after-input"),
-    ],
-)
-def test_trim_recipe_replays_slice_boundary_shape_and_metadata(
-    start: float,
-    end: float,
-    expected_slice: slice,
-    expected_offset: np.ndarray,
-) -> None:
+def test_trim_recipe_replays_slice_boundary_shape_and_metadata() -> None:
     source = _source()
     raw = np.arange(16, dtype=np.float64).reshape(2, 8)
+    start = 1.25
+    end = 1.75
+    expected_slice = slice(10, 14)
+    expected_offset = np.array([1.125, 1.375])
     expected = raw[:, expected_slice] * np.array([[2.0], [0.25]], dtype=np.float64)
     processed = source.trim(start=start, end=end)
     plan = RecipePlan.from_frame(processed, input_names=("signal",))

--- a/tests/processing/test_trim_channelwise.py
+++ b/tests/processing/test_trim_channelwise.py
@@ -146,11 +146,26 @@ def test_trim_rejects_extra_runtime_input_before_graph_construction() -> None:
 
 
 @pytest.mark.parametrize(
+    ("start", "end", "message"),
+    [
+        pytest.param(-0.001, _END, r"Trim start must be non-negative", id="negative-start"),
+        pytest.param(_START, -0.001, r"Trim end must be non-negative", id="negative-end"),
+        pytest.param(_END, _START, r"Trim start must not be later than end", id="start-after-end"),
+    ],
+)
+def test_trim_invalid_boundary_raises_value_error(
+    start: float,
+    end: float,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        Trim(_SAMPLING_RATE, start=start, end=end)
+
+
+@pytest.mark.parametrize(
     ("start_sample", "end_sample"),
     [
-        pytest.param(-2, 8, id="negative-start"),
         pytest.param(10, 14, id="start-after-input"),
-        pytest.param(6, 2, id="reverse-range-direct"),
         pytest.param(4, 4, id="empty-range"),
         pytest.param(2, 12, id="end-clipped-to-input"),
     ],

--- a/tests/processing/test_trim_channelwise.py
+++ b/tests/processing/test_trim_channelwise.py
@@ -1,0 +1,185 @@
+"""Channel-wise execution contracts for the Trim operation."""
+
+from typing import Any
+from unittest import mock
+
+import dask.array as da
+import numpy as np
+import pytest
+from dask import delayed
+from dask.array.core import Array as DaArray
+
+from wandas.processing.temporal import Trim
+from wandas.utils.dask_helpers import da_from_array
+
+_SAMPLING_RATE = 1_000
+_N_SAMPLES = 16
+_START = 0.003
+_END = 0.011
+_EXPECTED_SLICE = slice(3, 11)
+
+
+def _values(channels: int, dtype: np.dtype[Any]) -> np.ndarray:
+    return np.arange(channels * _N_SAMPLES, dtype=dtype).reshape(channels, _N_SAMPLES)
+
+
+def _wandas_operation_task_keys(result: DaArray) -> tuple[str, ...]:
+    return tuple(
+        sorted(key for key in result.dask if isinstance(key, str) and key.startswith("_execute_wandas_operation-"))
+    )
+
+
+@pytest.mark.parametrize("channels", [1, 2, 4, 8])
+@pytest.mark.parametrize("dtype", [np.dtype(np.int16), np.dtype(np.float32), np.dtype(np.float64)])
+def test_trim_channel_wise_kernel_matches_numpy_and_whole_frame_exactly(
+    monkeypatch: pytest.MonkeyPatch,
+    channels: int,
+    dtype: np.dtype[Any],
+) -> None:
+    values = _values(channels, dtype)
+    values_before = values.copy()
+    source = da_from_array(values, chunks=(1, -1))
+    operation = Trim(_SAMPLING_RATE, start=_START, end=_END)
+    original_process = operation._process
+    kernel_shapes: list[tuple[int, ...]] = []
+
+    def observed_process(channel_values: np.ndarray) -> np.ndarray:
+        kernel_shapes.append(channel_values.shape)
+        return original_process(channel_values)
+
+    monkeypatch.setattr(operation, "_process", observed_process)
+    with mock.patch.object(DaArray, "compute") as compute:
+        channel_wise = operation.process(source)
+        compute.assert_not_called()
+
+    whole_frame = operation._build_whole_frame_graph(
+        source,
+        (),
+        output_shape=(channels, 8),
+        output_dtype=dtype,
+    )
+
+    assert isinstance(channel_wise, DaArray)
+    assert channel_wise.shape == (channels, 8)
+    assert channel_wise.dtype == dtype
+    assert channel_wise.chunks == (channels * (1,), (8,))
+
+    channel_values = channel_wise.compute(scheduler="synchronous")
+    assert kernel_shapes == channels * [(1, _N_SAMPLES)]
+
+    kernel_shapes.clear()
+    whole_values = whole_frame.compute(scheduler="synchronous")
+    assert kernel_shapes == [(channels, _N_SAMPLES)]
+
+    np.testing.assert_array_equal(channel_values, values[:, _EXPECTED_SLICE])
+    np.testing.assert_array_equal(channel_values, whole_values)
+    np.testing.assert_array_equal(values, values_before)
+
+
+def test_trim_repeated_graph_builds_use_stable_wandas_task_keys() -> None:
+    source = da_from_array(_values(4, np.dtype(np.float64)), chunks=(1, -1))
+    operation = Trim(_SAMPLING_RATE, start=_START, end=_END)
+
+    first = operation.process(source)
+    second = operation.process(source)
+
+    first_keys = _wandas_operation_task_keys(first)
+    assert len(first_keys) == 4
+    assert first_keys == _wandas_operation_task_keys(second)
+
+
+def test_trim_zero_channel_input_uses_whole_frame_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = da.from_array(np.empty((0, _N_SAMPLES), dtype=np.float64), chunks=(0, _N_SAMPLES))
+    operation = Trim(_SAMPLING_RATE, start=_START, end=_END)
+    original_process = operation._process
+    kernel_shapes: list[tuple[int, ...]] = []
+
+    def observed_process(values: np.ndarray) -> np.ndarray:
+        kernel_shapes.append(values.shape)
+        return original_process(values)
+
+    monkeypatch.setattr(operation, "_process", observed_process)
+    result = operation.process(source)
+
+    np.testing.assert_array_equal(
+        result.compute(scheduler="synchronous"),
+        np.empty((0, 8), dtype=np.float64),
+    )
+    assert kernel_shapes == [(0, _N_SAMPLES)]
+    assert result.chunks == ((0,), (8,))
+
+
+def test_trim_unknown_channel_count_uses_whole_frame_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    values = _values(3, np.dtype(np.float64))
+    source = da.from_delayed(
+        delayed(np.asarray)(values),
+        shape=(np.nan, _N_SAMPLES),
+        dtype=values.dtype,
+    )
+    operation = Trim(_SAMPLING_RATE, start=_START, end=_END)
+    original_process = operation._process
+    kernel_shapes: list[tuple[int, ...]] = []
+
+    def observed_process(input_values: np.ndarray) -> np.ndarray:
+        kernel_shapes.append(input_values.shape)
+        return original_process(input_values)
+
+    monkeypatch.setattr(operation, "_process", observed_process)
+    result = operation.process(source)
+
+    np.testing.assert_array_equal(
+        result.compute(scheduler="synchronous"),
+        values[:, _EXPECTED_SLICE],
+    )
+    assert kernel_shapes == [(3, _N_SAMPLES)]
+
+
+def test_trim_rejects_extra_runtime_input_before_graph_construction() -> None:
+    source = da_from_array(_values(2, np.dtype(np.float64)), chunks=(1, -1))
+
+    with pytest.raises(ValueError, match=r"Expected exactly one input for Trim"):
+        Trim(_SAMPLING_RATE, start=_START, end=_END).process(source, source)
+
+
+@pytest.mark.parametrize(
+    ("start_sample", "end_sample"),
+    [
+        pytest.param(-2, 8, id="negative-start"),
+        pytest.param(10, 14, id="start-after-input"),
+        pytest.param(6, 2, id="reverse-range-direct"),
+        pytest.param(4, 4, id="empty-range"),
+        pytest.param(2, 12, id="end-clipped-to-input"),
+    ],
+)
+def test_trim_slice_boundaries_advertise_and_compute_numpy_shape_exactly(
+    start_sample: int,
+    end_sample: int,
+) -> None:
+    values = np.arange(16, dtype=np.float64).reshape(2, 8)
+    source = da_from_array(values, chunks=(1, -1))
+    operation = Trim(
+        sampling_rate=8,
+        start=start_sample / 8,
+        end=end_sample / 8,
+    )
+    expected = values[..., start_sample:end_sample]
+    advertised_shape = operation.calculate_output_shape(values.shape)
+
+    assert advertised_shape == expected.shape
+
+    channel_wise = operation.process(source)
+    whole_frame = operation._build_whole_frame_graph(
+        source,
+        (),
+        output_shape=advertised_shape,
+        output_dtype=values.dtype,
+    )
+
+    assert channel_wise.shape == expected.shape
+    assert whole_frame.shape == expected.shape
+    np.testing.assert_array_equal(channel_wise.compute(scheduler="synchronous"), expected)
+    np.testing.assert_array_equal(whole_frame.compute(scheduler="synchronous"), expected)

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -2132,7 +2132,11 @@ class BaseFrame(ABC, Generic[T]):
         metadata_updates = operation.get_metadata_updates()
         if operation_name == "trim":
             start_sample = int(float(params.get("start", 0.0)) * self.sampling_rate)
-            metadata_updates["source_time_offset"] = self.source_time_offset + start_sample / self.sampling_rate
+            end = params.get("end")
+            n_samples: int = self._data.shape[-1]
+            end_sample = n_samples if end is None else int(float(end) * self.sampling_rate)
+            effective_start = slice(start_sample, end_sample).indices(n_samples)[0]
+            metadata_updates["source_time_offset"] = self.source_time_offset + effective_start / self.sampling_rate
 
         display = operation.get_display_name() or operation_name
         new_channel_metadata = self._metadata_after_analysis()

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -440,12 +440,10 @@ class ChannelProcessingMixin:
             New ChannelFrame containing the trimmed signal
 
         Raises:
-            ValueError: If end time is earlier than start time
+            ValueError: If either time is negative or end is earlier than start
         """
         if end is None:
             end = self.duration
-        if start > end:
-            raise ValueError("start must be less than end")
         result = self._apply_named_operation("trim", start=start, end=end)
         return cast(T_Processing, result)
 

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -141,7 +141,7 @@ class ReSampling(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
         return self._output_dtype(input_dtype)
 
 
-class Trim(AudioOperation[NDArrayReal, NDArrayReal]):
+class Trim(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
     """Trimming operation"""
 
     name = "trim"
@@ -202,10 +202,10 @@ class Trim(AudioOperation[NDArrayReal, NDArrayReal]):
         tuple
             Output data shape
         """
-        # Calculate length after trimming
-        # Exclude parts where there is no signal
-        end_sample = min(self.end_sample, input_shape[-1])
-        n_samples = end_sample - self.start_sample
+        # Match the NumPy slice used by _process, including negative and
+        # out-of-bounds indices, without changing the public validation policy.
+        start_sample, end_sample, _ = slice(self.start_sample, self.end_sample).indices(input_shape[-1])
+        n_samples = max(0, end_sample - start_sample)
         return (*input_shape[:-1], n_samples)
 
     def _process(self, x: NDArrayReal) -> NDArrayReal:

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -188,6 +188,30 @@ class Trim(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
         """End sample index derived from the captured end time."""
         return int(self.end * self.sampling_rate)
 
+    def validate_params(self) -> None:
+        """Validate that trim boundaries use non-negative source times."""
+        if self.start < 0:
+            raise ValueError(
+                "Trim start must be non-negative\n"
+                f"  Got: start={self.start}\n"
+                "  Expected: start >= 0 seconds\n"
+                "Pass a time measured from the beginning of the signal."
+            )
+        if self.end < 0:
+            raise ValueError(
+                "Trim end must be non-negative\n"
+                f"  Got: end={self.end}\n"
+                "  Expected: end >= 0 seconds\n"
+                "Pass a time measured from the beginning of the signal."
+            )
+        if self.start > self.end:
+            raise ValueError(
+                "Trim start must not be later than end\n"
+                f"  Got: start={self.start}, end={self.end}\n"
+                "  Expected: start <= end\n"
+                "Pass an end time at or after the start time."
+            )
+
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
         """
         Calculate output data shape after operation
@@ -202,8 +226,7 @@ class Trim(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
         tuple
             Output data shape
         """
-        # Match the NumPy slice used by _process, including negative and
-        # out-of-bounds indices, without changing the public validation policy.
+        # Match the NumPy slice used by _process for out-of-bounds indices.
         start_sample, end_sample, _ = slice(self.start_sample, self.end_sample).indices(input_shape[-1])
         n_samples = max(0, end_sample - start_sample)
         return (*input_shape[:-1], n_samples)


### PR DESCRIPTION
## Summary

- declare `Trim` as a `ChannelIndependentAudioOperation`
- reject negative trim times and centralize boundary-order validation in `Trim`
- align declared output shape with the NumPy slice used by the unchanged kernel for permitted boundaries
- align the existing Frame trim `source_time_offset` update with the same normalized slice boundary
- add processing, public Frame, and Recipe regression coverage plus formal benchmark evidence

## Contract and bounded correctness fix

`Trim` slices only the final time axis and preserves the leading channel count, so corresponding output channels depend only on their matching input channels. Each eligible task receives one complete time axis.

The existing shape estimator clipped only `end` while NumPy normalized out-of-range slice bounds. Out-of-range starts could therefore produce declared shapes and source-time provenance that disagreed with the actual slice. This PR uses `slice(start, end).indices(n_samples)` in the operation’s shape calculation and in the existing Frame trim metadata branch. Negative `start` and `end` values are explicitly rejected rather than interpreted as NumPy negative indices. The existing `start <= end` rule is now enforced by `Trim` itself, so direct Operation calls, public Frame calls, and Recipe replay share one validation contract. The numerical kernel, Recipe schema, and existing whole-frame fallbacks remain unchanged. No new dispatcher, abstraction, scheduler API, or time-axis chunking is introduced.

## Numerical and performance evidence

- Base SHA: `9d758ad82cd7fbc4a814d37b0a6ff094ab0eb9f8`
- Benchmarked candidate SHA: `aabf090a8a0d3cdf5efcda96d75d802808912eb9`
- PR head SHA: `b01327d854736c123b7e90c1a25acff54803321d` (candidate-to-head changes are contract validation, tests, documentation, and benchmark evidence only)
- 1/2/4/8 channels × int16/float32/float64: channel-wise, forced whole-frame, and independent NumPy slice results are exactly equal
- negative boundaries and reversed ranges are rejected; after-end starts, zero length, and end clipping have matching shape metadata and actual output
- public Frame and Recipe replay preserve normalized source-time provenance for permitted boundaries

Eight-channel, 1,000,000-sample float64 input trimmed to 800,000 samples; three isolated interleaved reruns per boundary with the default threaded scheduler:

| Boundary | Tasks | Build | Materialize | Peak RSS |
|---|---:|---:|---:|---:|
| operation | 20 → 56 | 0.984 → 5.024 ms | 21.877 → 16.711 ms | 374.559 → 374.305 MiB |
| `Frame.data` | 36 → 56 | 4.151 → 7.973 ms | 25.134 → 15.266 ms | 374.848 → 374.961 MiB |

All 12 runs matched shape `(8, 800000)`, dtype `float64`, checksum `75d36e0a7f12251a70e3d3b6f8175901710cbb36e3daaa15e6dcca7a30bdf51c`, and L2² exactly. The committed JSON asset records every worker command, run order, environment, lock identity, task/build/materialization metrics, and RSS. RSS is worker-lifetime process peak with the full in-memory source; it is not a one-channel memory claim.

## Validation

- TDD RED for initial channel-wise topology: 10 failed, 8 passed
- TDD RED for shape boundary correction: 7 failed, 20 passed
- TDD RED for source-time correction: 4 failed, 23 passed
- dedicated focused tests: 28 passed
- broader focused tests: 183 passed
- `uv run pytest -q` — 2662 passed, 3 skipped
- `uv run ruff check wandas tests scripts`
- `uv run ruff format --check wandas tests scripts`
- `uv run ty check wandas tests`
- `uv run mkdocs build --strict -f docs/mkdocs.yml`
- `git diff --check`

All gates passed.