### PR TITLE
Make trim a structural Frame time slice

### DIFF
--- a/docs/src/explanation/audio-operation-execution.md
+++ b/docs/src/explanation/audio-operation-execution.md
@@ -73,15 +73,15 @@ channels depend on one another.
 | `add_with_snr` | Corresponding channels from two inputs | Whole time series for RMS scaling | Whole-frame; multi-input is outside the prototype |
 | `sum`, `mean`, `channel_difference` | Cross-channel | Pointwise after combining channels | Existing cross-channel Dask graph |
 | coherence, CSD, transfer function | Cross-channel | Window/overlap-sensitive cross-spectral analysis | Whole-frame |
+| `custom` | Unknown by construction | User-defined | Whole-frame |
 
 `Frame.trim()` does not execute through a registered numerical operation. It is a
-structural, Dask-native time-axis slice that shares the Frame indexing contract. It preserves
-channel calibration and descriptors, advances `source_time_offset` to the first
-selected sample, and records the stable `wandas.audio.trim` Recipe operation. The
-legacy `wandas.processing.Trim` class and `trim` registry key remain available with
-a deprecation warning for one feature-release compatibility period; Frame execution
-does not use them.
-| `custom` | Unknown by construction | User-defined | Whole-frame |
+structural, Dask-native time-axis slice that shares the Frame indexing contract. It
+preserves channel calibration and descriptors, advances `source_time_offset` to the
+first selected sample, and records the stable `wandas.audio.trim` Recipe operation.
+The legacy `wandas.processing.Trim` class and `trim` registry key remain available
+with a deprecation warning for one feature-release compatibility period; Frame
+execution does not use them.
 
 This classification does not authorize time chunking for filters, resampling, FFT,
 STFT, Welch, psychoacoustic algorithms, or other continuity-sensitive transforms.

--- a/docs/src/explanation/audio-operation-execution.md
+++ b/docs/src/explanation/audio-operation-execution.md
@@ -58,7 +58,7 @@ channels depend on one another.
 | `remove_dc` | Independent | Whole time series per channel for the mean | **Channel-wise** |
 | `abs`, `power` | Independent | Pointwise/time-local | Existing Dask-native graph override |
 | `normalize` | Parameter-dependent: a non-`None` norm over the last axis is independent; `axis=None` or a channel axis is cross-channel | Whole selected norm axis | **Channel-wise when eligible** |
-| `trim`, `fix_length` | Independent | Indexed/padded time-local transform with output-shape change | Whole-frame |
+| `trim` (deprecated direct processing API), `fix_length` | Independent | Indexed/padded time-local transform with output-shape change | Whole-frame |
 | `fade` | Independent | Needs the full signal length to define the envelope | Whole-frame |
 | high-pass, low-pass, band-pass | Independent | Stateful/whole continuous time series per channel | **Channel-wise** |
 | A-weighting | Independent | Stateful/whole continuous time series per channel | **Channel-wise** |
@@ -73,6 +73,14 @@ channels depend on one another.
 | `add_with_snr` | Corresponding channels from two inputs | Whole time series for RMS scaling | Whole-frame; multi-input is outside the prototype |
 | `sum`, `mean`, `channel_difference` | Cross-channel | Pointwise after combining channels | Existing cross-channel Dask graph |
 | coherence, CSD, transfer function | Cross-channel | Window/overlap-sensitive cross-spectral analysis | Whole-frame |
+
+`Frame.trim()` does not execute through a registered numerical operation. It is a
+structural, Dask-native time-axis slice that shares the Frame indexing contract. It preserves
+channel calibration and descriptors, advances `source_time_offset` to the first
+selected sample, and records the stable `wandas.audio.trim` Recipe operation. The
+legacy `wandas.processing.Trim` class and `trim` registry key remain available with
+a deprecation warning for one feature-release compatibility period; Frame execution
+does not use them.
 | `custom` | Unknown by construction | User-defined | Whole-frame |
 
 This classification does not authorize time chunking for filters, resampling, FFT,

--- a/docs/src/explanation/audio-operation-execution.md
+++ b/docs/src/explanation/audio-operation-execution.md
@@ -78,7 +78,9 @@ channels depend on one another.
 `Frame.trim()` does not execute through a registered numerical operation. It is a
 structural, Dask-native time-axis slice that shares the Frame indexing contract. It
 preserves channel calibration and descriptors, advances `source_time_offset` to the
-first selected sample, and records the stable `wandas.audio.trim` Recipe operation.
+first selected sample, and records the existing `wandas.frame.index` Recipe operation.
+Previously saved `wandas.audio.trim` version 1 plans retain their released
+array-operation replay contract.
 The legacy `wandas.processing.Trim` class and `trim` registry key remain available
 with a deprecation warning for one feature-release compatibility period; Frame
 execution does not use them.

--- a/docs/src/explanation/audio-operation-execution.md
+++ b/docs/src/explanation/audio-operation-execution.md
@@ -78,7 +78,8 @@ channels depend on one another.
 `Frame.trim()` does not execute through a registered numerical operation. It is a
 structural, Dask-native time-axis slice that shares the Frame indexing contract. It
 preserves channel calibration and descriptors, advances `source_time_offset` to the
-first selected sample, and records the existing `wandas.frame.index` Recipe operation.
+first selected sample, and records `wandas.frame.time_slice` version 1 so the
+time-valued bounds are recomputed for each Recipe runtime input.
 Previously saved `wandas.audio.trim` version 1 plans retain their released
 array-operation replay contract.
 The legacy `wandas.processing.Trim` class and `trim` registry key remain available

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -757,6 +757,75 @@ class TestChannelProcessing:
         np.testing.assert_array_equal(channel_first_values(trimmed_frame), data[:, 2:5])
         np.testing.assert_array_equal(channel_first_values(frame), data)
 
+    def test_trim_is_structural_time_slice_preserving_channel_state(self) -> None:
+        raw = np.arange(16, dtype=np.float32).reshape(2, 8)
+        frame = ChannelFrame(
+            _da_from_array(raw, chunks=(1, 4)),
+            sampling_rate=8,
+            channel_metadata=[
+                ChannelMetadata(
+                    label="left",
+                    calibration=ChannelCalibration(factor=2.0, unit="Pa", ref=2e-5),
+                    extra={"sensor": "mic-1"},
+                ),
+                ChannelMetadata(
+                    label="right",
+                    calibration=ChannelCalibration(factor=0.5, unit="V", ref=1.0),
+                    extra={"sensor": "mic-2"},
+                ),
+            ],
+            source_time_offset=[0.25, 0.5],
+        )
+
+        with (
+            mock.patch("wandas.processing.create_operation") as create_operation,
+            mock.patch.object(DaArray, "compute") as compute,
+        ):
+            result = frame.trim(start=0.25, end=0.75)
+            create_operation.assert_not_called()
+            compute.assert_not_called()
+
+        assert isinstance(result._data, DaArray)
+        assert result.labels == ["left", "right"]
+        assert [channel.calibration for channel in result.channels] == [
+            channel.calibration for channel in frame.channels
+        ]
+        assert [channel.extra for channel in result.channels] == [
+            {"sensor": "mic-1"},
+            {"sensor": "mic-2"},
+        ]
+        np.testing.assert_array_equal(result.source_time_offset, np.array([0.5, 0.75]))
+        expected = raw[:, 2:6] * np.array([[2.0], [0.5]])
+        np.testing.assert_array_equal(channel_first_values(result), expected)
+        np.testing.assert_array_equal(channel_first_values(frame), raw * np.array([[2.0], [0.5]]))
+
+    @pytest.mark.parametrize(
+        ("start", "end"),
+        [
+            pytest.param(-0.25, 0.75, id="negative-start"),
+            pytest.param(0.0, -0.25, id="negative-end"),
+        ],
+    )
+    def test_trim_negative_time_raises_value_error(self, start: float, end: float) -> None:
+        with pytest.raises(ValueError, match=r"Trim times must be non-negative"):
+            self.channel_frame.trim(start=start, end=end)
+
+    def test_trim_out_of_range_positive_times_follow_frame_slice_bounds(self) -> None:
+        raw = np.arange(8, dtype=np.float64).reshape(1, 8)
+        frame = ChannelFrame(
+            _da_from_array(raw, chunks=(1, 4)),
+            sampling_rate=8,
+            source_time_offset=0.25,
+        )
+
+        clipped_end = frame.trim(start=0.75, end=1.75)
+        after_end = frame.trim(start=1.25, end=1.75)
+
+        np.testing.assert_array_equal(channel_first_values(clipped_end), raw[:, 6:8])
+        np.testing.assert_array_equal(clipped_end.source_time_offset, np.array([1.0]))
+        assert after_end.n_samples == 0
+        np.testing.assert_array_equal(after_end.source_time_offset, np.array([1.25]))
+
     def test_hpss_operations(self) -> None:
         """Test HPSS (Harmonic-Percussive Source Separation) methods."""
         with mock.patch("wandas.processing.create_operation") as mock_create_op:

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -750,15 +750,9 @@ class TestChannelProcessing:
         trimmed_frame = frame.trim(start=0.2, end=0.5)
 
         assert trimmed_frame.operation_history[-1] == {
-            "operation": "wandas.frame.index",
+            "operation": "wandas.frame.time_slice",
             "version": 1,
-            "params": {
-                "selector": {
-                    "indexing": "multidimensional_slice",
-                    "channel": {"indexing": "channel_slice", "start": None, "stop": None, "step": None},
-                    "axis_slices": [{"start": 2, "stop": 5, "step": None}],
-                }
-            },
+            "params": {"start": 0.2, "end": 0.5},
         }
         np.testing.assert_array_equal(channel_first_values(trimmed_frame), data[:, 2:5])
         np.testing.assert_array_equal(channel_first_values(frame), data)

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -740,7 +740,7 @@ class TestChannelProcessing:
         assert trimmed_frame.n_samples == self.channel_frame.n_samples
 
         # Test trimming with invalid start and end times
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"start must be less than or equal to end"):
             self.channel_frame.trim(start=0.5, end=0.1)
 
     def test_trim_history_records_public_method_params(self) -> None:

--- a/tests/frames/test_channel_processing.py
+++ b/tests/frames/test_channel_processing.py
@@ -750,9 +750,15 @@ class TestChannelProcessing:
         trimmed_frame = frame.trim(start=0.2, end=0.5)
 
         assert trimmed_frame.operation_history[-1] == {
-            "operation": "wandas.audio.trim",
+            "operation": "wandas.frame.index",
             "version": 1,
-            "params": {"start": 0.2, "end": 0.5},
+            "params": {
+                "selector": {
+                    "indexing": "multidimensional_slice",
+                    "channel": {"indexing": "channel_slice", "start": None, "stop": None, "step": None},
+                    "axis_slices": [{"start": 2, "stop": 5, "step": None}],
+                }
+            },
         }
         np.testing.assert_array_equal(channel_first_values(trimmed_frame), data[:, 2:5])
         np.testing.assert_array_equal(channel_first_values(frame), data)
@@ -1243,7 +1249,6 @@ class TestChannelProcessing:
             pytest.param("a_weighting", {}, "a_weighting", {}, _SAMPLE_RATE, id="a-weighting"),
             pytest.param("abs", {}, "abs", {}, _SAMPLE_RATE, id="absolute"),
             pytest.param("power", {"exponent": 2.0}, "power", {}, _SAMPLE_RATE, id="power"),
-            pytest.param("trim", {"start": 0.1, "end": 0.5}, "trim", {}, _SAMPLE_RATE, id="trim"),
             pytest.param("fix_length", {"length": 10_000}, "fix_length", {}, _SAMPLE_RATE, id="fix-length"),
             pytest.param(
                 "resampling",

--- a/tests/pipeline/test_trim_frame_slice_recipe.py
+++ b/tests/pipeline/test_trim_frame_slice_recipe.py
@@ -57,17 +57,31 @@ def test_trim_recipe_replay_preserves_structural_time_slice_contract() -> None:
     np.testing.assert_array_equal(channel_first_values(replayed), channel_first_values(processed))
     assert replayed.operation_history == [
         {
-            "operation": "wandas.frame.index",
+            "operation": "wandas.frame.time_slice",
             "version": 1,
-            "params": {
-                "selector": {
-                    "indexing": "multidimensional_slice",
-                    "channel": {"indexing": "channel_slice", "start": None, "stop": None, "step": None},
-                    "axis_slices": [{"start": 2, "stop": 6, "step": None}],
-                }
-            },
+            "params": {"start": 0.25, "end": 0.75},
         }
     ]
+
+
+@pytest.mark.parametrize(
+    ("end", "expected"),
+    [
+        pytest.param(2.0, np.arange(20, 40), id="explicit-end"),
+        pytest.param(None, np.arange(20, 60), id="runtime-input-end"),
+    ],
+)
+def test_structural_time_slice_recipe_recomputes_samples_for_runtime_input(
+    end: float | None,
+    expected: np.ndarray,
+) -> None:
+    planned_source = ChannelFrame.from_numpy(np.arange(30).reshape(1, 30), sampling_rate=10)
+    runtime_source = ChannelFrame.from_numpy(np.arange(60).reshape(1, 60), sampling_rate=20)
+    plan = RecipePlan.from_frame(planned_source.trim(start=1.0, end=end), input_names=("signal",))
+
+    replayed = plan.apply({"signal": runtime_source})
+
+    np.testing.assert_array_equal(channel_first_values(replayed), expected.reshape(1, -1))
 
 
 def test_released_trim_recipe_v1_replays_legacy_array_operation_contract() -> None:

--- a/tests/pipeline/test_trim_frame_slice_recipe.py
+++ b/tests/pipeline/test_trim_frame_slice_recipe.py
@@ -56,8 +56,48 @@ def test_trim_recipe_replay_preserves_structural_time_slice_contract() -> None:
     np.testing.assert_array_equal(channel_first_values(replayed), channel_first_values(processed))
     assert replayed.operation_history == [
         {
-            "operation": "wandas.audio.trim",
+            "operation": "wandas.frame.index",
             "version": 1,
-            "params": {"start": 0.25, "end": 0.75},
+            "params": {
+                "selector": {
+                    "indexing": "multidimensional_slice",
+                    "channel": {"indexing": "channel_slice", "start": None, "stop": None, "step": None},
+                    "axis_slices": [{"start": 2, "stop": 6, "step": None}],
+                }
+            },
         }
     ]
+
+
+def test_released_trim_recipe_v1_replays_legacy_array_operation_contract() -> None:
+    raw = np.arange(16, dtype=np.float32).reshape(2, 8)
+    source = ChannelFrame(
+        da.from_array(raw, chunks=(1, 4)),
+        sampling_rate=8,
+        channel_metadata=[
+            ChannelMetadata(
+                label="left",
+                calibration=ChannelCalibration(factor=2.0, unit="Pa", ref=2e-5),
+            ),
+            ChannelMetadata(
+                label="right",
+                calibration=ChannelCalibration(factor=0.5, unit="V", ref=1.0),
+            ),
+        ],
+        source_time_offset=[0.25, 0.5],
+    )
+
+    legacy = source._trim_recipe_v1(start=0.25, end=0.75).with_calibration([3.0, 4.0])
+    plan = RecipePlan.from_dict(
+        json.loads(json.dumps(RecipePlan.from_frame(legacy, input_names=("signal",)).to_dict(), allow_nan=False))
+    )
+    replayed = plan.apply({"signal": source})
+
+    assert [(node.operation, node.version) for node in plan.nodes] == [
+        ("wandas.audio.trim", 1),
+        ("wandas.channel.with_calibration", 1),
+    ]
+    expected = raw[:, 2:6] * np.array([[2.0 * 3.0], [0.5 * 4.0]])
+    np.testing.assert_array_equal(channel_first_values(legacy), expected)
+    np.testing.assert_array_equal(channel_first_values(replayed), expected)
+    np.testing.assert_array_equal(replayed.source_time_offset, np.array([0.5, 0.75]))

--- a/tests/pipeline/test_trim_frame_slice_recipe.py
+++ b/tests/pipeline/test_trim_frame_slice_recipe.py
@@ -1,0 +1,63 @@
+"""Recipe contract for structural Frame trimming."""
+
+import json
+
+import dask.array as da
+import numpy as np
+from dask.array.core import Array as DaArray
+
+from tests.frame_helpers import channel_first_values
+from wandas.core.metadata import ChannelCalibration
+from wandas.frames.channel import ChannelFrame, ChannelMetadata
+from wandas.pipeline import RecipePlan
+
+
+def test_trim_recipe_replay_preserves_structural_time_slice_contract() -> None:
+    raw = np.arange(16, dtype=np.float32).reshape(2, 8)
+    source = ChannelFrame(
+        da.from_array(raw, chunks=(1, 4)),
+        sampling_rate=8,
+        label="recipe-source",
+        metadata={"workflow": "trim"},
+        channel_metadata=[
+            ChannelMetadata(
+                label="left",
+                calibration=ChannelCalibration(factor=2.0, unit="Pa", ref=2e-5),
+                extra={"sensor": "mic-1"},
+            ),
+            ChannelMetadata(
+                label="right",
+                calibration=ChannelCalibration(factor=0.5, unit="V", ref=1.0),
+                extra={"sensor": "mic-2"},
+            ),
+        ],
+        channel_ids=["left-id", "right-id"],
+        source_time_offset=[0.25, 0.5],
+    )
+
+    processed = source.trim(start=0.25, end=0.75)
+    plan = RecipePlan.from_frame(processed, input_names=("signal",))
+    loaded = RecipePlan.from_dict(json.loads(json.dumps(plan.to_dict(), allow_nan=False)))
+    replayed = loaded.apply({"signal": source})
+
+    assert isinstance(replayed._data, DaArray)
+    assert replayed.shape == (2, 4)
+    assert replayed.labels == source.labels
+    assert replayed.metadata == source.metadata
+    assert [channel.id for channel in replayed.channels] == ["left-id", "right-id"]
+    assert [channel.calibration for channel in replayed.channels] == [
+        channel.calibration for channel in source.channels
+    ]
+    assert [channel.extra for channel in replayed.channels] == [
+        {"sensor": "mic-1"},
+        {"sensor": "mic-2"},
+    ]
+    np.testing.assert_array_equal(replayed.source_time_offset, np.array([0.5, 0.75]))
+    np.testing.assert_array_equal(channel_first_values(replayed), channel_first_values(processed))
+    assert replayed.operation_history == [
+        {
+            "operation": "wandas.audio.trim",
+            "version": 1,
+            "params": {"start": 0.25, "end": 0.75},
+        }
+    ]

--- a/tests/pipeline/test_trim_frame_slice_recipe.py
+++ b/tests/pipeline/test_trim_frame_slice_recipe.py
@@ -4,6 +4,7 @@ import json
 
 import dask.array as da
 import numpy as np
+import pytest
 from dask.array.core import Array as DaArray
 
 from tests.frame_helpers import channel_first_values
@@ -101,3 +102,14 @@ def test_released_trim_recipe_v1_replays_legacy_array_operation_contract() -> No
     np.testing.assert_array_equal(channel_first_values(legacy), expected)
     np.testing.assert_array_equal(channel_first_values(replayed), expected)
     np.testing.assert_array_equal(replayed.source_time_offset, np.array([0.5, 0.75]))
+
+
+def test_released_trim_recipe_v1_preserves_default_end_and_order_validation() -> None:
+    raw = np.arange(8, dtype=np.float32).reshape(1, 8)
+    source = ChannelFrame.from_numpy(raw, sampling_rate=8)
+
+    legacy = source._trim_recipe_v1(start=0.25)
+
+    np.testing.assert_array_equal(channel_first_values(legacy), raw[:, 2:])
+    with pytest.raises(ValueError, match="start must be less than end"):
+        source._trim_recipe_v1(start=0.75, end=0.25)

--- a/tests/processing/test_display_names.py
+++ b/tests/processing/test_display_names.py
@@ -29,6 +29,8 @@ from wandas.processing.spectral import (
 from wandas.processing.stats import ABS, ChannelDifference, Mean, Power, Sum
 from wandas.processing.temporal import FixLength, ReSampling, RmsTrend, SoundLevel, Trim
 
+pytestmark = pytest.mark.filterwarnings("ignore:wandas.processing.Trim is deprecated:DeprecationWarning")
+
 _SAMPLE_RATE = 44_100
 _PAIRWISE_SPECTRAL_PARAMS: dict[str, Any] = {
     "n_fft": 2_048,
@@ -70,7 +72,7 @@ _DISPLAY_NAME_CASES = (
     pytest.param(AddWithSNR, {"snr": 10.0}, "+SNR", id="add-with-snr"),
     pytest.param(Fade, {"fade_ms": 50}, "fade", id="fade"),
     pytest.param(ReSampling, {"target_sr": 16_000}, "rs", id="resampling"),
-    pytest.param(Trim, {"start": 0.0, "end": 1.0}, "trim", id="trim"),
+    pytest.param(Trim, {"start": 0.0, "end": 1.0}, "trim", id="trim-deprecated"),
     pytest.param(FixLength, {"length": _SAMPLE_RATE}, "fix", id="fix-length"),
     pytest.param(RmsTrend, {}, "RMS", id="rms-trend"),
     pytest.param(

--- a/tests/processing/test_operation_lazy_metadata_contract.py
+++ b/tests/processing/test_operation_lazy_metadata_contract.py
@@ -48,6 +48,8 @@ from wandas.processing.spectral import (
 from wandas.processing.stats import ABS, ChannelDifference, Mean, Power, Sum
 from wandas.processing.temporal import FixLength, ReSampling, RmsTrend, SoundLevel, Trim
 
+pytestmark = pytest.mark.filterwarnings("ignore:wandas.processing.Trim is deprecated:DeprecationWarning")
+
 SR = 16000
 
 

--- a/tests/processing/test_temporal_operations.py
+++ b/tests/processing/test_temporal_operations.py
@@ -34,6 +34,26 @@ def test_trim_processing_operation_is_deprecated_compatibility_surface() -> None
     )
 
 
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [
+        pytest.param(1.25, 1.75, id="start-after-input"),
+        pytest.param(0.75, 0.25, id="reverse-range"),
+    ],
+)
+def test_trim_deprecated_compatibility_surface_reports_empty_slice_shape(
+    start: float,
+    end: float,
+) -> None:
+    with pytest.warns(DeprecationWarning, match=r"wandas.processing.Trim is deprecated"):
+        operation = Trim(8, start=start, end=end)
+    values = da_from_array(np.arange(8).reshape(1, 8), chunks=(1, -1))
+
+    assert operation.calculate_output_shape(values.shape) == (1, 0)
+    assert operation.process(values).shape == (1, 0)
+    np.testing.assert_array_equal(operation.process(values).compute(), np.empty((1, 0), dtype=int))
+
+
 class TestAWeightingDb:
     """A-weighting dB reference checks."""
 

--- a/tests/processing/test_temporal_operations.py
+++ b/tests/processing/test_temporal_operations.py
@@ -21,6 +21,19 @@ from wandas.utils.types import NDArrayReal
 _SR: int = 16000
 
 
+def test_trim_processing_operation_is_deprecated_compatibility_surface() -> None:
+    """Direct processing use warns while preserving one-release compatibility."""
+    with pytest.warns(DeprecationWarning, match=r"wandas.processing.Trim is deprecated"):
+        operation = create_operation("trim", 8, start=0.25, end=0.75)
+
+    assert isinstance(operation, Trim)
+    values = da_from_array(np.arange(16).reshape(2, 8), chunks=(1, -1))
+    np.testing.assert_array_equal(
+        operation.process(values).compute(),
+        np.arange(16).reshape(2, 8)[:, 2:6],
+    )
+
+
 class TestAWeightingDb:
     """A-weighting dB reference checks."""
 
@@ -232,83 +245,6 @@ class TestReSampling:
         fft_result = np.abs(np.fft.rfft(signal))
         freqs = np.fft.rfftfreq(len(signal), 1 / sr)
         return float(freqs[np.argmax(fft_result)])
-
-
-class TestTrim:
-    """Trim operation: Layer 1 + Layer 2 + Layer 3 (slice equivalence)."""
-
-    _START: float = 0.1
-    _END: float = 0.5
-
-    # -- Layer 1: Unit tests -----------------------------------------------
-
-    def test_trim_init_stores_params(self) -> None:
-        """Test Trim stores start/end times and derived sample indices."""
-        trim = Trim(_SR, self._START, self._END)
-        assert trim.sampling_rate == _SR
-        assert trim.start == self._START
-        assert trim.end == self._END
-        assert trim.start_sample == int(self._START * _SR)
-        assert trim.end_sample == int(self._END * _SR)
-        with pytest.raises(AttributeError):
-            setattr(trim, "start_sample", 0)
-
-    def test_trim_registry_returns_correct_class(self) -> None:
-        """Test that Trim is registered as 'trim'."""
-        assert get_operation("trim") == Trim
-        t = create_operation("trim", 16000, start=0.2, end=0.8)
-        assert isinstance(t, Trim)
-        assert t.start == 0.2
-        assert t.end == 0.8
-
-    # -- Layer 2: Domain (shape + immutability) ----------------------------
-
-    def test_trim_preserves_immutability_and_dask_type(self, pure_sine_440hz_dask: tuple[DaArray, int]) -> None:
-        """Input unchanged after trimming; result is DaArray."""
-        dask_input, sr = pure_sine_440hz_dask
-        trim = Trim(sr, self._START, self._END)
-        input_copy = dask_input.compute().copy()
-
-        result_da = trim.process(dask_input)
-
-        assert result_da is not dask_input
-        np.testing.assert_array_equal(dask_input.compute(), input_copy)
-        assert isinstance(result_da, DaArray)
-
-    def test_trim_shape_mono(self, pure_sine_440hz_dask: tuple[DaArray, int]) -> None:
-        """Trimmed mono shape matches expected sample range."""
-        dask_input, sr = pure_sine_440hz_dask
-        trim = Trim(sr, self._START, self._END)
-
-        result = trim.process(dask_input).compute()
-        expected_samples = int(self._END * sr) - int(self._START * sr)
-        assert result.shape == (1, expected_samples)
-
-    def test_trim_shape_stereo(self, stereo_sine_440_880hz_dask: tuple[DaArray, int]) -> None:
-        """Trimmed stereo preserves channel count."""
-        dask_input, sr = stereo_sine_440_880hz_dask
-        trim = Trim(sr, self._START, self._END)
-
-        result = trim.process(dask_input).compute()
-        expected_samples = int(self._END * sr) - int(self._START * sr)
-        assert result.shape == (2, expected_samples)
-
-    # -- Layer 3: Slice equivalence ----------------------------------------
-
-    def test_trim_content_matches_numpy_slice(self, pure_sine_440hz_dask: tuple[DaArray, int]) -> None:
-        """Trimmed result equals direct numpy slice (exact, no tolerance).
-
-        Tolerance: none — slicing is exact, no numerical transformation.
-        """
-        dask_input, sr = pure_sine_440hz_dask
-        trim = Trim(sr, self._START, self._END)
-
-        result = trim.process(dask_input).compute()
-
-        start_idx = int(self._START * sr)
-        end_idx = int(self._END * sr)
-        expected = dask_input.compute()[:, start_idx:end_idx]
-        np.testing.assert_array_equal(result, expected)
 
 
 class TestRmsTrend:
@@ -958,13 +894,6 @@ class TestTemporalHelperMethods:
         assert operation.get_metadata_updates() == {"sampling_rate": 22050}
         assert operation.calculate_output_shape((2, 441)) == (2, 221)
         assert operation.get_display_name() == "rs"
-
-    def test_trim_helper_methods_cap_output_length_to_input(self) -> None:
-        """Trim should cap the output length when end exceeds the input length."""
-        operation = Trim(1000, start=0.1, end=2.0)
-
-        assert operation.calculate_output_shape((2, 500)) == (2, 400)
-        assert operation.get_display_name() == "trim"
 
     def test_fix_length_helper_methods(self) -> None:
         """FixLength helper methods should expose target length metadata."""

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -2130,9 +2130,6 @@ class BaseFrame(ABC, Generic[T]):
         lineage = self._required_semantic_lineage()
 
         metadata_updates = operation.get_metadata_updates()
-        if operation_name == "trim":
-            start_sample = int(float(params.get("start", 0.0)) * self.sampling_rate)
-            metadata_updates["source_time_offset"] = self.source_time_offset + start_sample / self.sampling_rate
 
         display = operation.get_display_name() or operation_name
         new_channel_metadata = self._metadata_after_analysis()

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -2067,6 +2067,7 @@ class BaseFrame(ABC, Generic[T]):
         operation_name: str | None = None,
         output_frame_class: None = None,
         output_frame_kwargs: dict[str, Any] | None = None,
+        frame_metadata_updates: Mapping[str, Any] | None = None,
     ) -> S: ...
 
     @overload
@@ -2076,6 +2077,7 @@ class BaseFrame(ABC, Generic[T]):
         operation_name: str | None = None,
         output_frame_class: type[S_Out] = ...,
         output_frame_kwargs: dict[str, Any] | None = None,
+        frame_metadata_updates: Mapping[str, Any] | None = None,
     ) -> S_Out: ...
 
     def _apply_operation_instance(
@@ -2084,6 +2086,7 @@ class BaseFrame(ABC, Generic[T]):
         operation_name: str | None = None,
         output_frame_class: type[S_Out] | None = None,
         output_frame_kwargs: dict[str, Any] | None = None,
+        frame_metadata_updates: Mapping[str, Any] | None = None,
     ) -> S | S_Out:
         """Apply an already-instantiated operation to the frame.
 
@@ -2106,6 +2109,9 @@ class BaseFrame(ABC, Generic[T]):
         output_frame_kwargs : dict, optional
             Extra constructor keyword arguments required by *output_frame_class*
             (e.g. ``{"n_fft": 1024, "window": "hann"}``).
+        frame_metadata_updates : Mapping, optional
+            Explicit Frame-owned state updates supplied by the public method.
+            These take precedence over updates declared by the numerical operation.
         """
         if operation_name is None:
             operation_name = getattr(operation, "name", "unknown_operation")
@@ -2129,7 +2135,9 @@ class BaseFrame(ABC, Generic[T]):
         new_metadata = self._updated_metadata(operation_name, params)
         lineage = self._required_semantic_lineage()
 
-        metadata_updates = operation.get_metadata_updates()
+        metadata_updates = dict(operation.get_metadata_updates())
+        if frame_metadata_updates is not None:
+            metadata_updates.update(frame_metadata_updates)
 
         display = operation.get_display_name() or operation_name
         new_channel_metadata = self._metadata_after_analysis()

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -448,7 +448,7 @@ class ChannelProcessingMixin:
         if start < 0 or (end is not None and end < 0):
             raise ValueError("Trim times must be non-negative")
         if end is not None and start > end:
-            raise ValueError("start must be less than end")
+            raise ValueError("start must be less than or equal to end")
         start_sample = int(start * self.sampling_rate)
         end_sample = self.n_samples if end is None else int(end * self.sampling_rate)
         result = cast(Any, self)._handle_multidim_indexing((slice(None), slice(start_sample, end_sample)))

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -437,16 +437,21 @@ class ChannelProcessingMixin:
             end: End time (seconds)
 
         Returns:
-            New ChannelFrame containing the trimmed signal
+            New ChannelFrame containing the trimmed signal. The operation is a
+            lazy structural time slice: channel labels, calibration, metadata,
+            and channel IDs are preserved, while source-time offsets advance
+            to the first selected sample.
 
         Raises:
-            ValueError: If end time is earlier than start time
+            ValueError: If either time is negative or end is earlier than start
         """
-        if end is None:
-            end = self.duration
-        if start > end:
+        if start < 0 or (end is not None and end < 0):
+            raise ValueError("Trim times must be non-negative")
+        if end is not None and start > end:
             raise ValueError("start must be less than end")
-        result = self._apply_named_operation("trim", start=start, end=end)
+        start_sample = int(start * self.sampling_rate)
+        end_sample = self.n_samples if end is None else int(end * self.sampling_rate)
+        result = cast(Any, self)._handle_multidim_indexing((slice(None), slice(start_sample, end_sample)))
         return cast(T_Processing, result)
 
     @recipe_operation("wandas.audio.fix_length")

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -451,6 +451,7 @@ class ChannelProcessingMixin:
             ),
         )
 
+    @recipe_operation("wandas.frame.time_slice")
     def trim(
         self: T_Processing,
         start: float = 0,

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -1,6 +1,7 @@
 """Module providing mixins related to signal processing."""
 
 import logging
+import warnings
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, SupportsFloat, SupportsIndex, TypeAlias, TypeVar, cast, overload
 
@@ -424,7 +425,32 @@ class ChannelProcessingMixin:
         """
         return cast(T_Processing, cast(Any, self)._reduce_channels("mean"))
 
-    @recipe_operation("wandas.audio.trim")
+    @recipe_operation("wandas.audio.trim", version=1)
+    def _trim_recipe_v1(
+        self: T_Processing,
+        start: float = 0,
+        end: float | None = None,
+    ) -> T_Processing:
+        """Replay the released array-operation contract for saved Recipe plans."""
+        if end is None:
+            end = self.duration
+        if start > end:
+            raise ValueError("start must be less than end")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            operation = create_operation("trim", self.sampling_rate, start=start, end=end)
+        start_sample = int(start * self.sampling_rate)
+        return cast(
+            T_Processing,
+            cast(Any, self)._apply_operation_instance(
+                operation,
+                operation_name="trim",
+                frame_metadata_updates={
+                    "source_time_offset": cast(Any, self).source_time_offset + start_sample / self.sampling_rate,
+                },
+            ),
+        )
+
     def trim(
         self: T_Processing,
         start: float = 0,
@@ -451,7 +477,7 @@ class ChannelProcessingMixin:
             raise ValueError("start must be less than or equal to end")
         start_sample = int(start * self.sampling_rate)
         end_sample = self.n_samples if end is None else int(end * self.sampling_rate)
-        result = cast(Any, self)._handle_multidim_indexing((slice(None), slice(start_sample, end_sample)))
+        result = cast(Any, self)[slice(None), slice(start_sample, end_sample)]
         return cast(T_Processing, result)
 
     @recipe_operation("wandas.audio.fix_length")

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -187,8 +187,8 @@ class Trim(AudioOperation[NDArrayReal, NDArrayReal]):
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
         """Return the legacy array-slice output shape."""
-        end_sample = min(self.end_sample, input_shape[-1])
-        n_samples = end_sample - self.start_sample
+        start_sample, end_sample, _ = slice(self.start_sample, self.end_sample).indices(input_shape[-1])
+        n_samples = max(0, end_sample - start_sample)
         return (*input_shape[:-1], n_samples)
 
     def _process(self, x: NDArrayReal) -> NDArrayReal:

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from fractions import Fraction
 from typing import Any
 
@@ -142,7 +143,11 @@ class ReSampling(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
 
 
 class Trim(AudioOperation[NDArrayReal, NDArrayReal]):
-    """Trimming operation"""
+    """Deprecated array-level trimming operation.
+
+    Use :meth:`wandas.frames.channel.ChannelFrame.trim` for structural
+    time-range selection.
+    """
 
     name = "trim"
     _display = "trim"
@@ -152,21 +157,13 @@ class Trim(AudioOperation[NDArrayReal, NDArrayReal]):
         sampling_rate: float,
         start: float,
         end: float,
-    ):
-        """
-        Initialize trimming operation
-
-        Parameters
-        ----------
-        sampling_rate : float
-            Sampling rate (Hz)
-        start : float
-            Start time for trimming (seconds)
-        end : float
-            End time for trimming (seconds)
-        """
+    ) -> None:
+        warnings.warn(
+            "wandas.processing.Trim is deprecated; use Frame.trim() for structural time-range selection",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(sampling_rate, start=start, end=end)
-        logger.debug(f"Initialized Trim operation with start: {start}, end: {end}")
 
     @property
     def start(self) -> float:
@@ -189,32 +186,14 @@ class Trim(AudioOperation[NDArrayReal, NDArrayReal]):
         return int(self.end * self.sampling_rate)
 
     def calculate_output_shape(self, input_shape: tuple[int, ...]) -> tuple[int, ...]:
-        """
-        Calculate output data shape after operation
-
-        Parameters
-        ----------
-        input_shape : tuple
-            Input data shape
-
-        Returns
-        -------
-        tuple
-            Output data shape
-        """
-        # Calculate length after trimming
-        # Exclude parts where there is no signal
+        """Return the legacy array-slice output shape."""
         end_sample = min(self.end_sample, input_shape[-1])
         n_samples = end_sample - self.start_sample
         return (*input_shape[:-1], n_samples)
 
     def _process(self, x: NDArrayReal) -> NDArrayReal:
-        """Create processor function for trimming operation"""
-        logger.debug(f"Applying trim to array with shape: {x.shape}")
-        # Apply trimming
-        result = x[..., self.start_sample : self.end_sample]
-        logger.debug(f"Trim applied, returning result with shape: {result.shape}")
-        return result
+        """Apply the legacy array-level slice."""
+        return x[..., self.start_sample : self.end_sample]
 
 
 class FixLength(AudioOperation[NDArrayReal, NDArrayReal]):


### PR DESCRIPTION
## Summary

- redesign `Frame.trim()` as a structural, Dask-native time-axis slice instead of an `AudioOperation`
- delegate data selection and source-time normalization through multidimensional Frame indexing
- preserve time-valued Recipe intent as the new structural `wandas.frame.time_slice` version 1 contract
- preserve released `wandas.audio.trim` version 1 plans with a private legacy replay handler
- reject negative trim times explicitly
- preserve channel labels, calibration, IDs, extras, user metadata, laziness, and source-time placement
- remove the `operation_name == "trim"` conditional from `BaseFrame`
- retain direct `wandas.processing.Trim` and the `trim` registry key with `DeprecationWarning` for one feature-release compatibility period

This supersedes and replaces the closed #357. The earlier approach classified Trim as channel-independent numerical processing, but review showed that time-range selection is structural Frame behavior. Moving source-time ownership into the numerical operation would cross the Frame/processing boundary.

## Contract revision

Supported:

- `Frame.trim(start, end)` selects samples relative to the current Frame
- positive out-of-range bounds follow existing Frame/Python slice normalization
- the result remains lazy and immutable
- `source_time_offset` advances to the actual first selected sample
- channel calibration and descriptors remain attached rather than being consumed by a numerical operation
- new trim lineage and Recipe extraction use `wandas.frame.time_slice` version 1 and retain seconds, including `end=None`, for each runtime input
- previously serialized `wandas.audio.trim` version 1 plans replay their released array-operation semantics, including calibration consumption and source-time updates

Invalid:

- negative `start` or `end`
- `start > end`

Deprecated compatibility surface:

- direct construction/import of `wandas.processing.Trim`
- `create_operation("trim", ...)`

These remain functional with `DeprecationWarning`; the public `Frame.trim()` path no longer calls them.

## Ownership and bounded sibling search

- numerical algorithms remain owned by `wandas/processing`
- structural time selection and source-time placement remain owned by Frame indexing
- time-valued portable intent is owned by the structural `wandas.frame.time_slice` Recipe contract
- legacy `wandas.audio.trim` version 1 replay is isolated in `ChannelProcessingMixin`; `BaseFrame` exposes only a generic explicit Frame-state update input and contains no trim-name branch
- the sibling search covered Frame indexing, sampling-rate and runtime-length replay, `source_time_offset`, registry/export, dataset delegation, Recipe extraction/serialization/replay, calibration and label preservation, and execution documentation

## Representative scalability evidence

Same environment and lock, three runs per revision, 8 float64 channels × 1,000,000 samples, chunks `(1, 250000)`, trimming 2.0–18.0 seconds at 48 kHz:

- base: `03ec19684eb29fcfd0f3e3a31413ce434f87d356`
- candidate: `8b8f07a44221ebf34c01aed45be5f0f813cc8827`
- output shape: `(8, 768000)` for every run
- output checksum: `293f13fba0b345654df18df155cce3bc2f8d44793b3ca7a2c2704b7ac68eef94` for every run
- task count: `100 → 56`
- median graph build: `6.242 → 3.653 ms`
- median materialization: `45.652 → 23.442 ms`

The repository benchmark does not exercise Trim, so a revision-addressable path-specific comparison was used. Timing is observational, not a repository-wide performance budget.

## Validation

Current head `8b8f07a44221ebf34c01aed45be5f0f813cc8827`:

- focused trim/time-slice Recipe suite: 11 passed
- full suite: 2767 passed, 3 skipped
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run mkdocs build --strict` from `docs/`
- `git diff --check`

All gates passed.