### PR TITLE
Release Wandas 0.6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wandas"
-version = "0.6.1"
+version = "0.6.2"
 description = "Wandas is an open source library for efficient signal analysis in Python"
 authors = [{name = "kasahart", email="kasahart66@gmail.com"}]
 maintainers = [

--- a/uv.lock
+++ b/uv.lock
@@ -3938,7 +3938,7 @@ wheels = [
 
 [[package]]
 name = "wandas"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "cattrs" },


### PR DESCRIPTION
## Summary

- bump the package version from 0.6.1 to 0.6.2
- keep the uv lockfile package metadata in sync

## Validation

- `uv lock --check`
- `uv run ruff check wandas tests --config=pyproject.toml`
- `uv run ty check wandas tests`
- `uv run pytest -n auto` (2771 passed, 3 skipped)
- `uv build`