### PR TITLE
fix: make RoughnessFrame plot type contract explicit

### DIFF
--- a/tests/frames/test_roughness_frame.py
+++ b/tests/frames/test_roughness_frame.py
@@ -229,12 +229,27 @@ class TestRoughnessFrame:
             overlap=_OVERLAP,
         )
 
-        ax = frame.plot()
+        ax = frame.plot(plot_type="heatmap")
         assert ax is not None
         assert ax.get_xlabel() == "Time [s]"
         assert ax.get_ylabel() == "Frequency [Bark]"
 
         plt.close("all")
+
+    def test_plot_rejects_unsupported_plot_type(self) -> None:
+        """Unsupported plot strategies must not be silently ignored."""
+        frame = RoughnessFrame(
+            data=_DATA_MONO,
+            sampling_rate=_SAMPLING_RATE,
+            bark_axis=_BARK_AXIS,
+            overlap=_OVERLAP,
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="RoughnessFrame.plot supports only plot_type='heatmap'",
+        ):
+            frame.plot(plot_type="contour")  # ty: ignore[invalid-argument-type]
 
     def test_plot_stereo(self) -> None:
         """Test plot method with stereo data (should plot mean)."""

--- a/tests/frames/test_roughness_frame.py
+++ b/tests/frames/test_roughness_frame.py
@@ -236,14 +236,29 @@ class TestRoughnessFrame:
 
         plt.close("all")
 
-    def test_plot_rejects_unsupported_plot_type(self) -> None:
-        """Unsupported plot strategies must not be silently ignored."""
+    def test_plot_rejects_unsupported_plot_type(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Unsupported plot strategies fail before imports or computation."""
         frame = RoughnessFrame(
             data=_DATA_MONO,
             sampling_rate=_SAMPLING_RATE,
             bark_axis=_BARK_AXIS,
             overlap=_OVERLAP,
         )
+
+        def fail_matplotlib_import(*args: object, **kwargs: object) -> None:
+            pytest.fail("unsupported plot_type imported matplotlib")
+
+        def fail_compute(*args: object, **kwargs: object) -> None:
+            pytest.fail("unsupported plot_type computed Dask-backed data")
+
+        monkeypatch.setattr(
+            "wandas.frames.roughness.require_matplotlib_pyplot",
+            fail_matplotlib_import,
+        )
+        monkeypatch.setattr(RoughnessFrame, "_compute", fail_compute)
 
         with pytest.raises(
             ValueError,

--- a/wandas/frames/roughness.py
+++ b/wandas/frames/roughness.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections.abc import Mapping, Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 from dask.array.core import Array as DaArray
@@ -272,9 +272,10 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
             "RoughnessFrame is typically a terminal node in the processing chain."
         )
 
-    def plot(
+    # RoughnessFrame intentionally narrows BaseFrame's frame-specific plot vocabulary.
+    def plot(  # ty: ignore[invalid-method-override]
         self,
-        plot_type: str = "heatmap",
+        plot_type: Literal["heatmap"] = "heatmap",
         ax: "Axes | None" = None,
         title: str | None = None,
         cmap: str = "viridis",
@@ -292,6 +293,8 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
 
         Parameters
         ----------
+        plot_type : {"heatmap"}, default="heatmap"
+            Plot strategy. Only the Bark-time heatmap is supported.
         ax : Axes, optional
             Matplotlib axes to plot on. If None, a new figure is created.
         title : str, optional
@@ -314,6 +317,15 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
         Axes
             The matplotlib axes object containing the plot.
 
+        Raises
+        ------
+        ValueError
+            If ``plot_type`` is not ``"heatmap"``.
+
+        Notes
+        -----
+        Plotting is an explicit compute boundary.
+
         Examples
         --------
         >>> import wandas as wd
@@ -321,6 +333,9 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
         >>> roughness_spec = signal.roughness_dw_spec(overlap=0.5)
         >>> roughness_spec.plot(cmap="hot", title="Motor Roughness Analysis")
         """
+        if plot_type != "heatmap":
+            raise ValueError("RoughnessFrame.plot supports only plot_type='heatmap'.")
+
         plt = require_matplotlib_pyplot("roughness plot")
 
         if ax is None:


### PR DESCRIPTION
Closes #376

## Summary

- Narrow `RoughnessFrame.plot()` to the only supported strategy, `Literal["heatmap"]`, while preserving the existing default and explicit `plot_type="heatmap"` calls.
- Reject unsupported plot types with an actionable `ValueError` before importing matplotlib or computing the Dask-backed frame.
- Document the supported parameter, error behavior, and explicit compute boundary so generated API documentation reflects the real contract.

## Major files changed

- `wandas/frames/roughness.py`
- `tests/frames/test_roughness_frame.py`

## Tests added or updated

- Updated the mono plotting regression test to exercise explicit `plot_type="heatmap"`.
- Added coverage proving unsupported plot strategies are not silently ignored.
- Added failure sentinels proving unsupported values are rejected before both matplotlib loading and Dask-backed computation.

## Validation

- `uv run pytest tests/frames/test_roughness_frame.py -q` — 33 passed
- `uv run pytest tests/frames/test_channel_processing.py -k 'roughness_dw_spec_plot or roughness_dw_spec_basic' -q` — 2 passed, 77 deselected
- `uv run ruff check wandas tests scripts` — passed
- `uv run ty check wandas tests` — passed
- `uv run pytest -q` — 2772 passed, 3 skipped
- `uv run mkdocs build --strict -f docs/mkdocs.yml` — passed; generated API signature and parameter text verified
- `git diff --check` — passed
- GitHub CI for final head — all checks passed across lint/type, docs, core-only wheel smoke, Pyodide, Ubuntu Python 3.10–3.13, Windows Python 3.10–3.13, Codecov patch, and Release Drafter

## Codex review and review responses

- Initial Codex self-review covered API compatibility, type contract, validation order, Dask compute behavior, generated docs, and regression coverage.
- Copilot identified that the original rejection test did not lock validation ahead of matplotlib loading and Dask computation.
- Addressed that finding in `ab415ae6` with dedicated failure sentinels, replied in the inline thread, and resolved it after full validation.
- Completed a formal Codex re-review on final head `ab415ae66fc3baa3570411f0854a506b3b408efb`; no remaining actionable findings.
- Unresolved review threads: 0.

## Risks and unperformed validation

- `RoughnessFrame.plot` intentionally narrows the generic `BaseFrame.plot(str)` strategy vocabulary; the local type-check suppression documents that frame-specific contract.
- No public/export classification or Recipe/WDF behavior changed.
- No validation was skipped.