### PR TITLE
fix(io): define read inference and CSV/WDF boundaries

### DIFF
--- a/docs/src/api/io.md
+++ b/docs/src/api/io.md
@@ -14,6 +14,71 @@ Wandas native WDF ファイルには `wd.load(...)` を使います。
 `read_wav()` and `read_csv()` remain available for compatibility, but new documentation and examples prefer `read()`.
 互換性のため `read_wav()` と `read_csv()` は残りますが、新しいドキュメントと例では `read()` を優先します。
 
+## `wd.read()` API
+
+::: wandas.read
+
+### Source and format selection / source と format の選択
+
+Local paths select a registered reader from the path suffix. HTTP/HTTPS URLs use
+the URL path suffix, or an explicit `file_type` when supplied. For `bytes`,
+`bytearray`, `memoryview`, and file-like objects, `wd.read()` uses the first
+available format hint in this order:
+
+1. explicit `file_type`;
+2. a file-like object's `.name` suffix;
+3. the `source_name` suffix;
+4. `.wav` for an otherwise anonymous in-memory source.
+
+local path は path suffix、HTTP/HTTPS URL は URL path suffix（または明示した
+`file_type`）から登録済みreaderを選びます。`bytes`、`bytearray`、`memoryview`、
+file-like object では、`file_type`、file-like `.name` の suffix、`source_name`
+の suffix、匿名入力の `.wav` の順で最初に利用できる hint を使います。
+
+The anonymous-WAV fallback is retained for compatibility with existing
+`wd.read(wav_bytes)` calls. It does not inspect or sniff the content. Anonymous
+CSV or other formats must provide `file_type`; alternatively, give
+`source_name` a registered suffix. `file_type` is case-insensitive and accepts
+both `"csv"` and `".csv"`.
+
+匿名入力を WAV とする fallback は既存の `wd.read(wav_bytes)` との互換性のため
+維持されます。content sniffing は行いません。匿名 CSV などは `file_type` を渡すか、
+登録済み suffix を持つ `source_name` を指定してください。`file_type` は大文字小文字を
+区別せず、`"csv"` と `".csv"` の両方を受け付けます。
+
+`source_name` has two roles for in-memory input: its suffix can select the
+reader, and its value supplies the Frame label and `_source_file` provenance
+metadata. It never opens or downloads that name. A file-like `.name` takes
+format precedence over an explicit `source_name`, while the explicit
+`source_name` remains the recorded provenance.
+
+in-memory input の `source_name` には、suffix による reader 選択と、Frame label／
+`_source_file` 由来metadataという2つの役割があります。その名前を別途open／download
+することはありません。file-like `.name` は明示した `source_name` より format 推論で
+優先されますが、記録される由来情報には明示した `source_name` を使います。
+
+```python
+import io
+import wandas as wd
+
+wav_frame = wd.read(wav_bytes)  # anonymous in-memory input defaults to WAV
+csv_frame = wd.read(csv_bytes, source_name="sensor.csv")
+
+stream = io.BytesIO(csv_bytes)
+stream.name = "upload.csv"
+csv_frame = wd.read(stream)
+```
+
+An unavailable suffix raises `ValueError` instead of trying another reader.
+Missing local paths raise `FileNotFoundError`; URL transport failures raise
+`OSError`. WDF is a separate persistence boundary: `wd.read("result.wdf")`
+raises with guidance to use `wd.load("result.wdf")`.
+
+未登録の suffix は別 reader を試さず `ValueError`、存在しない local path は
+`FileNotFoundError`、URL transport の失敗は `OSError` になります。WDF は別の
+永続化境界であり、`wd.read("result.wdf")` は `wd.load("result.wdf")` を使うよう
+案内して失敗します。
+
 ## Canonical numeric contract / 正規化数値契約
 
 Built-in readers always produce lazy, channel-first `float64` data. Equal file
@@ -67,7 +132,10 @@ WAVファイルの読み書き機能を提供します。
 
 ## WDF File IO / WDFファイル入出力
 
-Provides functions for reading and writing WDF (Wandas Data File) format, which enables complete preservation including metadata.
-WDF（Wandas Data File）形式の読み書き機能を提供します。このフォーマットはメタデータを含む完全な保存が可能です。
+WDF stores the concrete typed Frame state described in the
+[WDF 0.4 contract](wdf_io.md). It does not preserve every runtime object or an
+executable Recipe.
+WDF は [WDF 0.4 契約](wdf_io.md)に記載された具体的な型付き Frame state を保存します。
+すべての runtime object や実行可能 Recipe を保存するものではありません。
 
 ::: wandas.io.wdf_io

--- a/docs/src/api/io.md
+++ b/docs/src/api/io.md
@@ -37,6 +37,12 @@ file-like object では、`file_type`、file-like `.name` の suffix、`source_n
 の suffix（HTTP/HTTPS URL は query／fragment より前の URL path suffix）、匿名入力の
 `.wav` の順で最初に利用できる hint を使います。
 
+Only the URL path participates in inference. A filename hint found solely in a
+query or fragment, such as `?filename=data.csv`, is intentionally ignored; pass
+`file_type=".csv"` explicitly. URL 推論では URL path だけを使います。
+`?filename=data.csv` のように query／fragment だけにある filename hint は意図的に
+無視するため、`file_type=".csv"` を明示してください。
+
 The anonymous-WAV fallback is retained for compatibility with existing
 `wd.read(wav_bytes)` calls. It does not inspect or sniff the content. Anonymous
 CSV or other formats must provide `file_type`; alternatively, give
@@ -81,14 +87,20 @@ raises with guidance to use `wd.load("result.wdf")`.
 永続化境界であり、`wd.read("result.wdf")` は `wd.load("result.wdf")` を使うよう
 案内して失敗します。
 
-## Canonical numeric contract / 正規化数値契約
+## Canonical numeric and loading contract / 正規化数値・読込契約
 
-Built-in readers always produce lazy, channel-first `float64` data. Equal file
-content has equal values whether it comes from a local path, URL, bytes,
-`bytearray`, `memoryview`, or a file-like object.
+Built-in readers always return Dask-backed, channel-first `float64` data. Audio
+sample decoding is deferred until the Dask data is computed. CSV is different:
+its complete table is parsed synchronously once to determine exact shape and
+sampling rate before the Frame is returned, then parsed again when the Dask
+sample data is computed. Equal file content has equal values whether it comes
+from a local path, URL, bytes, `bytearray`, `memoryview`, or a file-like object.
 
-built-in readerは常に遅延実行のchannel-first `float64`を返します。同じファイル内容なら、
-local path、URL、bytes、`bytearray`、`memoryview`、file-like objectのどれから読んでも値は同じです。
+built-in readerは常にDask-backedのchannel-first `float64`を返します。audio sampleの
+decodeはDask dataをcomputeするまで遅延されます。CSVは異なり、正確なshapeと
+sampling rateを決めるため返却前に全tableを同期的に1回parseし、Dask sample dataの
+compute時に再度parseします。同じファイル内容なら、local path、URL、bytes、
+`bytearray`、`memoryview`、file-like objectのどれから読んでも値は同じです。
 
 | Input / 入力 | `wd.read()` numeric rule / 数値規則 |
 | --- | --- |

--- a/docs/src/api/io.md
+++ b/docs/src/api/io.md
@@ -27,13 +27,15 @@ available format hint in this order:
 
 1. explicit `file_type`;
 2. a file-like object's `.name` suffix;
-3. the `source_name` suffix;
+3. the `source_name` suffix (for HTTP/HTTPS URLs, the URL path suffix before
+   any query or fragment);
 4. `.wav` for an otherwise anonymous in-memory source.
 
 local path は path suffix、HTTP/HTTPS URL は URL path suffix（または明示した
 `file_type`）から登録済みreaderを選びます。`bytes`、`bytearray`、`memoryview`、
 file-like object では、`file_type`、file-like `.name` の suffix、`source_name`
-の suffix、匿名入力の `.wav` の順で最初に利用できる hint を使います。
+の suffix（HTTP/HTTPS URL は query／fragment より前の URL path suffix）、匿名入力の
+`.wav` の順で最初に利用できる hint を使います。
 
 The anonymous-WAV fallback is retained for compatibility with existing
 `wd.read(wav_bytes)` calls. It does not inspect or sniff the content. Anonymous

--- a/docs/src/api/wdf_io.md
+++ b/docs/src/api/wdf_io.md
@@ -15,6 +15,50 @@ Frameを型付きで往復する、xarray backedのHDF5 artifactです。
 - WDF 0.1 through 0.3 and future versions are explicitly unsupported. There is no
   fallback or migration layer.
 
+WDF 0.4 persists:
+
+- the exact built-in Frame type and its validated constructor state;
+- the raw tensor values, dtype, semantic dimension names, and stored
+  one-dimensional represented-axis coordinates (frequency and local time are
+  derived instead);
+- sampling rate, Frame label, strict-JSON user/recording metadata, stable channel
+  IDs, channel labels, calibration factors, units, references, channel extras,
+  and per-channel source-time offsets;
+- canonical operation history as a display-only compatibility view.
+
+WDF 0.4 が保存するものは次のとおりです。
+
+- exact built-in Frame type と検証済み constructor state
+- raw tensor の値と dtype、semantic dimension 名、および保存対象の1次元
+  represented-axis coordinate（frequency と local time は代わりに導出）
+- sampling rate、Frame label、strict-JSON の user／recording metadata、安定した
+  channel ID、channel label、校正係数、単位、基準値、channel extra、channel ごとの
+  source-time offset
+- display 専用の互換 view である canonical operation history
+
+WDF intentionally does **not** persist live lineage, `previous` Frame references,
+live operation objects or callables, executable `RecipePlan` intent, Dask graphs,
+task/chunk topology, scheduler state, or an open runtime storage backend. A loaded
+Frame reconstructs a new persistence-boundary lineage and uses the stored history
+only for display. Saving a processed result therefore does not make its workflow
+replayable.
+
+WDF は live lineage、`previous` Frame reference、live operation object／callable、
+実行可能な `RecipePlan` intent、Dask graph、task／chunk topology、scheduler state、
+open 中の runtime storage backend を意図的に保存しません。load 後の Frame は
+persistence boundary の新しい lineage を構築し、保存済み history は表示だけに使います。
+したがって、処理結果を保存しても workflow を再実行可能にはできません。
+
+Recipe JSON is the complementary boundary: schema 2 stores reusable operation
+intent and named input slots, but not Frame samples, live lineage, Dask graphs, or
+callables. Use WDF for one concrete typed result and Recipe JSON for a workflow to
+apply to runtime inputs.
+
+Recipe JSON は補完的な境界です。schema 2 は再利用可能な operation intent と名前付き
+input slot を保存しますが、Frame sample、live lineage、Dask graph、callable は保存しません。
+1つの具体的な型付き結果には WDF、runtime input に適用する workflow には Recipe JSON を
+使います。
+
 Root attributes are `version`, `frame_type`, `sampling_rate`, `label`,
 `constructor_json`, `metadata_json`, and `operation_history_json`. The xarray Dataset
 contains these data variables:
@@ -39,6 +83,16 @@ Raw tensor values and calibration are stored separately. This prevents calibrati
 from being applied twice after load. Runtime lineage, live operation objects, Recipe
 artifacts, and Dask graphs are outside WDF; `operation_history_json` is display
 history only.
+
+raw tensor value と calibration は別々に保存されるため、load 後に calibration が
+二重適用されません。runtime lineage、live operation object、Recipe artifact、
+Dask graph は WDF の対象外で、`operation_history_json` は表示専用 history です。
+
+Saving completes synchronously, but Wandas passes internal chunks to the writer
+without first materializing the complete tensor as a NumPy array. While a loaded
+Frame or a Frame derived from it remains in use, do not move, delete, or overwrite
+its source WDF file. Read NumPy values through `frame.data`; users do not manage
+the xarray/Dask backend directly.
 
 保存は同期的に完了しますが、Wandasは内部でchunkをwriterへ渡し、事前にtensor全体を
 NumPy化しません。WDFから読み込んだFrameと、そのFrameから派生したFrameを利用して

--- a/docs/src/explanation/public-api-stability.md
+++ b/docs/src/explanation/public-api-stability.md
@@ -41,12 +41,22 @@ fail with an actionable installation message; no optional operation may silently
 | Recipe JSON | `wandas.recipe` 2 | exact schema 2 | Reusable executable operation intent |
 
 WDF 0.1–0.3 and future format versions fail explicitly instead of being guessed or
-silently upgraded. A Frame loaded from WDF owns access to its source internally. Keep
-the source path unchanged while that Frame or Frames derived from it are in use, and
-read NumPy values through `frame.data` as with every other Frame. Users do not manage
-the xarray/Dask backend directly. Future Recipe schema versions also fail explicitly.
-Live lineage, Dask graphs, callables, and Frame samples are outside Recipe JSON. WDF
-history is display-only and is not executable Recipe intent.
+silently upgraded. WDF 0.4 stores one concrete built-in Frame's type, validated
+constructor state, raw tensor values and dtype, semantic dimensions and represented
+coordinates, sampling rate, labels, strict-JSON metadata, stable channel state,
+source-time offsets, and display history. It does not store live lineage, `previous`
+references, operation objects or callables, executable Recipe intent, Dask graphs,
+chunk/task topology, scheduler state, or an open runtime backend.
+
+A Frame loaded from WDF owns access to its source internally. Keep the source path
+unchanged while that Frame or Frames derived from it are in use, and read NumPy
+values through `frame.data` as with every other Frame. Users do not manage the
+xarray/Dask backend directly.
+
+Future Recipe schema versions also fail explicitly. Recipe JSON stores reusable
+operation intent and named runtime input slots, not Frame samples, live lineage,
+Dask graphs, or callables. WDF history is display-only and is not executable Recipe
+intent: use WDF for a concrete typed result and Recipe JSON for replay.
 
 ## Gate for new algorithms / 新規 algorithm の条件
 

--- a/docs/src/how-to/pyodide-browser.md
+++ b/docs/src/how-to/pyodide-browser.md
@@ -260,18 +260,21 @@ wav_bytes = await response.bytes()
 frame = wd.read(wav_bytes, source_name=url)
 ```
 
-`source_name=url` provides both the `.wav` suffix used for decoding and the
-recorded provenance; it does not perform another download. An explicit
-`file_type=".wav"` would take precedence and is required when the logical source
-name has no registered suffix. Anonymous bytes keep the compatibility default
-of WAV, but CSV and other anonymous formats require `file_type`. Wandas does not
-inspect byte contents to choose a decoder.
+`source_name=url` provides both the `.wav` URL-path suffix used for decoding and
+the recorded provenance; it does not perform another download. Query and
+fragment components, including signed-URL tokens, are ignored when the URL-path
+suffix is inferred. An explicit `file_type=".wav"` would take precedence and is
+required when the logical source URL path has no registered suffix. Anonymous
+bytes keep the compatibility default of WAV, but CSV and other anonymous
+formats require `file_type`. Wandas does not inspect byte contents to choose a
+decoder.
 
-`source_name=url` は decode に使う `.wav` suffix と記録される由来情報の両方を
-提供し、再downloadは行いません。明示した `file_type=".wav"` はこれより優先され、
-logical source name に登録済み suffix がない場合に必要です。匿名 bytes は互換性のため
-WAV が既定値ですが、匿名 CSV などには `file_type` が必要です。Wandas は decoder
-選択のために byte content を検査しません。
+`source_name=url` は decode に使う URL path の `.wav` suffix と記録される由来情報の
+両方を提供し、再downloadは行いません。signed URL token を含む query／fragment は
+suffix 推論時に無視されます。明示した `file_type=".wav"` はこれより優先され、logical
+source URL path に登録済み suffix がない場合に必要です。匿名 bytes は互換性のため WAV が
+既定値ですが、匿名 CSV などには `file_type` が必要です。Wandas は decoder 選択のために
+byte content を検査しません。
 
 `pyfetch` is asynchronous, uses the browser Fetch API, supports HTTPS, and
 remains subject to the browser's CORS policy. Browser fetch and Wandas decoding
@@ -293,7 +296,7 @@ bytes を取得できるかを決め、`wd.read()` は受け取った bytes だ�
 
     Pyodideブラウザでは`wd.read("https://...")`を直接呼び出さないでください。
     現行の同期HTTP経路はこの環境で必要なTLS transportを提供できません。
-    `pyfetch/fetch → bytes → wd.read`を使ってください。
+    `pyfetch/fetch → bytes → wd.read(..., source_name=url)`を使ってください。
 
 JavaScript's native `fetch()` is an equivalent entry point. Convert its
 `ArrayBuffer` to `Uint8Array`, expose it with `pyodide.globals.set`, and call
@@ -311,7 +314,7 @@ JavaScript's native `fetch()` is an equivalent entry point. Convert its
 | Partial WAV reads | Supported / 対応 | Pass `start=` and/or `end=` to `wd.read()`. |
 | WAV writing and browser playback | Supported / 対応 | Write with `ChannelFrame.to_wav()`, make a `Blob`, and use an `<audio controls>` element. |
 | `soundfile` / libsndfile WAV backend | Supported / 対応 | It is the tested backend; no SciPy WAV fallback is needed. |
-| External HTTPS URL through `pyfetch` or JavaScript `fetch` | Supported when CORS permits / CORS許可時に対応 | Fetch bytes, then pass them to `wd.read(..., source_name=url)`; use `file_type` when the logical name lacks a suffix. |
+| External HTTPS URL through `pyfetch` or JavaScript `fetch` | Supported when CORS permits / CORS許可時に対応 | Fetch bytes, then pass them to `wd.read(..., source_name=url)`; signed query/fragment values are ignored for suffix inference, and `file_type` is needed when the URL path lacks a suffix. |
 | Direct `wd.read("https://...")` | Not supported in the browser / 非対応 | Use the fetch-to-bytes route. |
 | DOM access | Supported on the browser main thread / main threadで対応 | Import `document` from `js`; use worker messages when running Pyodide in a Web Worker. |
 | HPSS (`librosa`-backed effects) | Not supported by this target / 非対応 | The required `numba` Pyodide wheel is unavailable; do not install `wandas[effects]` for HPSS here. |

--- a/docs/src/how-to/pyodide-browser.md
+++ b/docs/src/how-to/pyodide-browser.md
@@ -257,25 +257,39 @@ url = "https://example.com/recording.wav"
 response = await pyfetch(url)
 response.raise_for_status()
 wav_bytes = await response.bytes()
-frame = wd.read(wav_bytes, file_type=".wav", source_name=url)
+frame = wd.read(wav_bytes, source_name=url)
 ```
 
-`file_type=".wav"` is explicit because a byte sequence has no filename from
-which to infer a format. `source_name=url` is optional provenance; it does not
-perform another download. `pyfetch` is asynchronous, uses the browser Fetch
-API, supports HTTPS, and remains subject to the browser's CORS policy. Its
-current response contract is documented in
+`source_name=url` provides both the `.wav` suffix used for decoding and the
+recorded provenance; it does not perform another download. An explicit
+`file_type=".wav"` would take precedence and is required when the logical source
+name has no registered suffix. Anonymous bytes keep the compatibility default
+of WAV, but CSV and other anonymous formats require `file_type`. Wandas does not
+inspect byte contents to choose a decoder.
+
+`source_name=url` は decode に使う `.wav` suffix と記録される由来情報の両方を
+提供し、再downloadは行いません。明示した `file_type=".wav"` はこれより優先され、
+logical source name に登録済み suffix がない場合に必要です。匿名 bytes は互換性のため
+WAV が既定値ですが、匿名 CSV などには `file_type` が必要です。Wandas は decoder
+選択のために byte content を検査しません。
+
+`pyfetch` is asynchronous, uses the browser Fetch API, supports HTTPS, and
+remains subject to the browser's CORS policy. Browser fetch and Wandas decoding
+are separate steps: CORS and HTTP status determine whether bytes are obtained;
+`wd.read()` only decodes the bytes it receives. The current response contract
+is documented in
 [`pyodide.http`](https://pyodide.org/en/stable/usage/api/python-api/http.html).
 
-byte列からは拡張子を推定できないため、`file_type=".wav"`を明示します。
-`source_name=url`は任意の由来情報であり、再ダウンロードは行いません。
+`pyfetch` は非同期の browser Fetch API で HTTPS に対応し、browser の CORS policy に
+従います。browser fetch と Wandas decode は別の段階です。CORS と HTTP status は
+bytes を取得できるかを決め、`wd.read()` は受け取った bytes だけをdecodeします。
 
 !!! warning "`wd.read(URL)` is not the browser URL API"
 
     Do **not** call `wd.read("https://...")` in a Pyodide browser. Wandas's
     current direct-URL path uses synchronous Python HTTP behavior that does not
     provide the required TLS transport in this environment. Use
-    `pyfetch/fetch → bytes → wd.read(..., file_type=".wav")` instead.
+    `pyfetch/fetch → bytes → wd.read(..., source_name=url)` instead.
 
     Pyodideブラウザでは`wd.read("https://...")`を直接呼び出さないでください。
     現行の同期HTTP経路はこの環境で必要なTLS transportを提供できません。
@@ -297,7 +311,7 @@ JavaScript's native `fetch()` is an equivalent entry point. Convert its
 | Partial WAV reads | Supported / 対応 | Pass `start=` and/or `end=` to `wd.read()`. |
 | WAV writing and browser playback | Supported / 対応 | Write with `ChannelFrame.to_wav()`, make a `Blob`, and use an `<audio controls>` element. |
 | `soundfile` / libsndfile WAV backend | Supported / 対応 | It is the tested backend; no SciPy WAV fallback is needed. |
-| External HTTPS URL through `pyfetch` or JavaScript `fetch` | Supported when CORS permits / CORS許可時に対応 | Fetch bytes, then pass them to `wd.read(..., file_type=".wav")`. |
+| External HTTPS URL through `pyfetch` or JavaScript `fetch` | Supported when CORS permits / CORS許可時に対応 | Fetch bytes, then pass them to `wd.read(..., source_name=url)`; use `file_type` when the logical name lacks a suffix. |
 | Direct `wd.read("https://...")` | Not supported in the browser / 非対応 | Use the fetch-to-bytes route. |
 | DOM access | Supported on the browser main thread / main threadで対応 | Import `document` from `js`; use worker messages when running Pyodide in a Web Worker. |
 | HPSS (`librosa`-backed effects) | Not supported by this target / 非対応 | The required `numba` Pyodide wheel is unavailable; do not install `wandas[effects]` for HPSS here. |

--- a/tests/frames/test_channel_frame_edge_contracts.py
+++ b/tests/frames/test_channel_frame_edge_contracts.py
@@ -78,8 +78,8 @@ def test_from_file_in_memory_and_source_name_and_ch_labels_and_header_and_csv_kw
     assert cf.labels == ["L", "R"]
     assert cap.get("time_column") == 1
     assert cap.get("delimiter") == ";"
-    # header=None should not be inserted into kwargs
-    assert "header" not in cap
+    # header=None is semantic CSV input and must override pandas' header=0 default.
+    assert cap["header"] is None
 
 
 def test_from_file_get_data_not_ndarray_raises(monkeypatch):

--- a/tests/frames/test_channel_frame_edge_contracts.py
+++ b/tests/frames/test_channel_frame_edge_contracts.py
@@ -391,6 +391,17 @@ def test_from_file_source_name_path_failure(monkeypatch):
     monkeypatch.setattr(channel_mod, "Path", original_path_cls)
 
 
+def test_from_file_signed_url_source_name_uses_url_path_for_label(monkeypatch):
+    fake = FakeReader(sr=100, channels=1, frames=4)
+    monkeypatch.setattr(channel_mod, "get_file_reader", lambda *args, **kwargs: fake)
+    source_name = "https://example.com/audio/recording.wav?token=a.b#download.c"
+
+    cf = ChannelFrame.from_file(b"data", file_type=".wav", source_name=source_name)
+
+    assert cf.label == "recording"
+    assert cf.metadata["_source_file"] == source_name
+
+
 def test_rename_channels_capture_rejects_non_mapping_and_non_string_or_integer_keys() -> None:
     frame = make_cf(np.arange(6).reshape(2, 3))
 

--- a/tests/io/test_file_readers.py
+++ b/tests/io/test_file_readers.py
@@ -253,6 +253,19 @@ class TestCSVFileReader:
         assert info["samplerate"] == 100, f"Expected 100Hz, got {info['samplerate']}"
         assert info["channels"] == 2, f"Expected 2 channels, got {info['channels']}"
 
+    def test_headerless_csv_preserves_first_sample_and_uses_string_labels(self, tmp_path: Path) -> None:
+        """header=None keeps every row and exposes stable string channel labels."""
+        path = tmp_path / "headerless.csv"
+        path.write_text("0.0,1.0,2.0\n0.1,3.0,4.0\n", encoding="utf-8")
+
+        info = self.reader.get_file_info(path, header=None)
+        data = self.reader.get_data(path, channels=[], start_idx=0, frames=2, header=None)
+
+        assert info["frames"] == 2
+        assert info["samplerate"] == 10
+        assert info["ch_labels"] == ["1", "2"]
+        np.testing.assert_array_equal(data, [[1.0, 3.0], [2.0, 4.0]])
+
     def test_time_column_in_middle_aligns_info_and_data(self, tmp_path: Path) -> None:
         """A named time column is excluded regardless of its physical position."""
         path = tmp_path / "middle_time.csv"

--- a/tests/io/test_read.py
+++ b/tests/io/test_read.py
@@ -112,6 +112,29 @@ def test_read_keeps_explicit_file_type_over_source_name(monkeypatch: pytest.Monk
     assert captured["source_name"] == "sensor.csv"
 
 
+def test_read_keeps_explicit_file_type_over_named_stream_and_source_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = object()
+    captured: dict[str, object] = {}
+
+    def fake_from_file(cls: type[ChannelFrame], path: object, **kwargs: object) -> object:
+        captured["path"] = path
+        captured.update(kwargs)
+        return sentinel
+
+    buffer = io.BytesIO(b"not real audio")
+    buffer.name = "named.csv"
+    monkeypatch.setattr(ChannelFrame, "from_file", classmethod(fake_from_file))
+
+    result = read(buffer, file_type="wav", source_name="logical.flac")
+
+    assert result is sentinel
+    assert captured["path"] is buffer
+    assert captured["file_type"] == "wav"
+    assert captured["source_name"] == "logical.flac"
+
+
 def test_read_defaults_unnamed_file_like_source_to_wav(monkeypatch: pytest.MonkeyPatch) -> None:
     sentinel = object()
     captured: dict[str, object] = {}
@@ -163,7 +186,10 @@ def test_read_rejects_wdf_file_type_with_load_guidance(file_type: str) -> None:
         read(b"not a real wdf", file_type=file_type)
 
 
-def test_read_preserves_explicit_source_name_for_named_stream(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_read_named_stream_suffix_precedes_explicit_source_name(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     expected = object()
     path = tmp_path / "sensor.csv"
     path.write_text("time,left\n0.0,1.0\n", encoding="utf-8")

--- a/tests/io/test_read.py
+++ b/tests/io/test_read.py
@@ -73,6 +73,26 @@ def test_read_infers_bytes_type_from_source_name(monkeypatch: pytest.MonkeyPatch
     assert captured["source_name"] == "sensor.csv"
 
 
+def test_read_infers_bytes_type_from_signed_url_source_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    sentinel = object()
+    captured: dict[str, object] = {}
+
+    def fake_from_file(cls: type[ChannelFrame], path: object, **kwargs: object) -> object:
+        captured["path"] = path
+        captured.update(kwargs)
+        return sentinel
+
+    source_name = "https://example.com/audio/recording.wav?token=signed#download"
+    monkeypatch.setattr(ChannelFrame, "from_file", classmethod(fake_from_file))
+
+    result = read(b"not real wav", source_name=source_name)
+
+    assert result is sentinel
+    assert captured["path"] == b"not real wav"
+    assert captured["file_type"] == ".wav"
+    assert captured["source_name"] == source_name
+
+
 def test_read_infers_unnamed_file_like_type_from_source_name(monkeypatch: pytest.MonkeyPatch) -> None:
     sentinel = object()
     captured: dict[str, object] = {}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -290,6 +290,18 @@ def test_read_loads_csv_like_read_csv(tmp_path: Path) -> None:
     assert signal.labels == ["left", "right"]
 
 
+def test_read_loads_headerless_csv_without_dropping_first_sample(tmp_path: Path) -> None:
+    path = tmp_path / "headerless.csv"
+    path.write_text("0.0,1.0,2.0\n0.1,3.0,4.0\n", encoding="utf-8")
+
+    signal = wandas.read(path, header=None)
+
+    assert signal.sampling_rate == 10
+    assert signal.n_channels == 2
+    assert signal.labels == ["1", "2"]
+    np.testing.assert_array_equal(channel_first_values(signal), [[1.0, 3.0], [2.0, 4.0]])
+
+
 def test_read_rejects_wdf_with_load_guidance(tmp_path: Path) -> None:
     path = tmp_path / "analysis.wdf"
     path.write_bytes(b"not a real wdf")

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -1284,6 +1284,11 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             channel-wise chunking by default (chunks=(1, -1)). Use `.rechunk(...)`
             on the returned frame for custom sample-axis chunking.
 
+            Audio sample decoding is deferred through the returned Dask array.
+            CSV metadata inspection synchronously parses the complete table to
+            determine shape and sampling rate; the sample table is parsed again
+            when the Dask data is computed.
+
         Args:
             path: Path to the audio file, in-memory bytes/stream, or an HTTP/HTTPS
                 URL. When a URL is given it is streamed into a temporary file
@@ -1360,8 +1365,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         if (path_obj is not None and path_obj.suffix.lower() == ".csv") or (normalized_file_type == ".csv"):
             reader_kwargs["time_column"] = time_column
             reader_kwargs["delimiter"] = delimiter
-            if header is not None:
-                reader_kwargs["header"] = header
+            reader_kwargs["header"] = header
 
         try:
             info = reader.get_file_info(source_obj, **reader_kwargs)
@@ -1534,7 +1538,8 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             header: Row number to use as header.
 
         Returns:
-            A new ChannelFrame containing the data (lazy loading).
+            A new ChannelFrame containing Dask-backed sample data. CSV metadata
+            inspection occurs synchronously before the Frame is returned.
 
         Examples:
             >>> # Read CSV with default settings

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -1455,7 +1455,13 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
 
         if source_name is not None:
             try:
-                frame_label = Path(source_name).stem
+                if source_name.lower().startswith(("http://", "https://")):
+                    from pathlib import PurePosixPath
+                    from urllib.parse import urlparse
+
+                    frame_label = PurePosixPath(urlparse(source_name).path).stem
+                else:
+                    frame_label = Path(source_name).stem
             except (TypeError, ValueError, OSError):
                 logger.debug(
                     "Using raw source_name as frame label because Path(source_name) failed; source_name=%r",

--- a/wandas/io/read.py
+++ b/wandas/io/read.py
@@ -44,6 +44,14 @@ def _named_in_memory_source(path: object) -> str | None:
     return source_name or None
 
 
+def _source_name_suffix(source_name: str) -> str:
+    """Return a filesystem or HTTP(S) URL path suffix."""
+    source_path = source_name
+    if source_name.lower().startswith(("http://", "https://")):
+        source_path = urlparse(source_name).path
+    return Path(source_path).suffix
+
+
 def _infer_in_memory_file_type(
     path: str | Path | bytes | bytearray | memoryview | BinaryIO,
     file_type: str | None,
@@ -56,7 +64,7 @@ def _infer_in_memory_file_type(
     for candidate_source_name in (named_source_name, source_name):
         if candidate_source_name is None:
             continue
-        suffix = Path(candidate_source_name).suffix
+        suffix = _source_name_suffix(candidate_source_name)
         if suffix:
             return suffix
     return ".wav"
@@ -105,10 +113,11 @@ def read(
     3. the suffix of ``source_name``;
     4. ``".wav"`` for an otherwise anonymous in-memory source.
 
-    Filesystem paths use their path suffix. URL paths use their suffix unless
+    Filesystem paths use their path suffix. URL paths, including URL values used
+    as ``source_name``, use the suffix before any query or fragment unless
     ``file_type`` is supplied. ``file_type`` is case-insensitive and accepts
-    values with or without a leading dot. Use :func:`wd.load` rather than this
-    function for Wandas native WDF files.
+    values with or without a leading dot. Use :func:`wandas.load` rather than
+    this function for Wandas native WDF files.
 
     Args:
         path: Local path, HTTP/HTTPS URL, bytes-like value, or readable binary

--- a/wandas/io/read.py
+++ b/wandas/io/read.py
@@ -140,8 +140,10 @@ def read(
             in-memory name inference.
         source_name: Optional logical source name for in-memory data. Its suffix
             participates in format inference after a file-like ``.name``. It is
-            also used for the Frame label and ``_source_file`` metadata; it does
-            not read or download another resource.
+            also used for the Frame label and ``_source_file`` metadata. For an
+            HTTP(S) URL, the label comes from the URL path while ``_source_file``
+            retains the complete URL. It does not read or download another
+            resource.
         timeout: HTTP/HTTPS download timeout in seconds. It has no effect for
             local or in-memory sources.
 

--- a/wandas/io/read.py
+++ b/wandas/io/read.py
@@ -102,8 +102,11 @@ def read(
 
     Use this entry point for WAV, CSV, other registered audio formats, local
     paths, HTTP/HTTPS URLs, bytes, and binary file-like objects. The returned
-    Frame is channel-first and Dask-backed; source metadata is inspected while
-    this function runs, but sample decoding remains lazy.
+    Frame is channel-first and Dask-backed. Source metadata is inspected
+    synchronously. Audio sample decoding is deferred until the Dask data is
+    computed. CSV metadata inspection parses the complete table synchronously
+    to determine shape and sampling rate, and the table is parsed again when
+    the Dask sample data is computed.
 
     For bytes and file-like sources, format selection uses the first available
     value in this order:
@@ -116,8 +119,10 @@ def read(
     Filesystem paths use their path suffix. URL paths, including URL values used
     as ``source_name``, use the suffix before any query or fragment unless
     ``file_type`` is supplied. ``file_type`` is case-insensitive and accepts
-    values with or without a leading dot. Use :func:`wandas.load` rather than
-    this function for Wandas native WDF files.
+    values with or without a leading dot. A filename hint that appears only in
+    a URL query or fragment is not inferred; pass ``file_type`` explicitly.
+    Use :func:`wandas.load` rather than this function for Wandas native WDF
+    files.
 
     Args:
         path: Local path, HTTP/HTTPS URL, bytes-like value, or readable binary
@@ -141,8 +146,9 @@ def read(
             local or in-memory sources.
 
     Returns:
-        A lazy :class:`~wandas.frames.channel.ChannelFrame` with channel-first
-        ``float64`` decoded data.
+        A Dask-backed :class:`~wandas.frames.channel.ChannelFrame` with
+        channel-first ``float64`` data. Audio decoding is deferred; CSV has the
+        synchronous metadata pass described above.
 
     Raises:
         FileNotFoundError: If a local source path does not exist.

--- a/wandas/io/read.py
+++ b/wandas/io/read.py
@@ -49,6 +49,7 @@ def _infer_in_memory_file_type(
     file_type: str | None,
     source_name: str | None,
 ) -> str | None:
+    """Apply the stable in-memory format-inference precedence."""
     if file_type is not None or not _is_in_memory_source(path):
         return file_type
     named_source_name = _named_in_memory_source(path)
@@ -91,8 +92,70 @@ def read(
 ) -> "ChannelFrame":
     """Read external source data into a ChannelFrame.
 
-    Use this for WAV, CSV, supported audio files, URLs, bytes, and file-like
-    objects. Use ``wd.load()`` for Wandas native WDF files.
+    Use this entry point for WAV, CSV, other registered audio formats, local
+    paths, HTTP/HTTPS URLs, bytes, and binary file-like objects. The returned
+    Frame is channel-first and Dask-backed; source metadata is inspected while
+    this function runs, but sample decoding remains lazy.
+
+    For bytes and file-like sources, format selection uses the first available
+    value in this order:
+
+    1. explicit ``file_type``;
+    2. the suffix of a file-like object's ``.name``;
+    3. the suffix of ``source_name``;
+    4. ``".wav"`` for an otherwise anonymous in-memory source.
+
+    Filesystem paths use their path suffix. URL paths use their suffix unless
+    ``file_type`` is supplied. ``file_type`` is case-insensitive and accepts
+    values with or without a leading dot. Use :func:`wd.load` rather than this
+    function for Wandas native WDF files.
+
+    Args:
+        path: Local path, HTTP/HTTPS URL, bytes-like value, or readable binary
+            file-like object.
+        channel: Zero-based channel index or indices to load. ``None`` loads
+            every channel.
+        start: Optional start time in seconds.
+        end: Optional end time in seconds.
+        ch_labels: Optional replacement labels for the selected channels.
+        time_column: CSV time-column index or unique column name.
+        delimiter: CSV field delimiter.
+        header: CSV header row, or ``None`` for a headerless file.
+        file_type: Explicit registered extension for in-memory data or a URL,
+            for example ``".wav"`` or ``"csv"``. It takes precedence over
+            in-memory name inference.
+        source_name: Optional logical source name for in-memory data. Its suffix
+            participates in format inference after a file-like ``.name``. It is
+            also used for the Frame label and ``_source_file`` metadata; it does
+            not read or download another resource.
+        timeout: HTTP/HTTPS download timeout in seconds. It has no effect for
+            local or in-memory sources.
+
+    Returns:
+        A lazy :class:`~wandas.frames.channel.ChannelFrame` with channel-first
+        ``float64`` decoded data.
+
+    Raises:
+        FileNotFoundError: If a local source path does not exist.
+        OSError: If an HTTP/HTTPS download fails or exceeds its size limit.
+        ValueError: If no registered reader matches the selected format, a WDF
+            source is passed, or CSV options or channel indices are invalid.
+
+    Examples:
+        Read a local file using its suffix:
+
+        >>> import wandas as wd
+        >>> frame = wd.read("recording.wav", channel=0, start=0.25, end=1.25)
+
+        Infer CSV from a logical name attached to bytes:
+
+        >>> csv_bytes = b"time,left\\n0.0,1.0\\n0.1,2.0\\n"
+        >>> frame = wd.read(csv_bytes, source_name="sensor.csv")
+
+        Anonymous bytes retain the compatibility default of WAV; pass
+        ``file_type`` when the bytes contain another format:
+
+        >>> frame = wd.read(csv_bytes, file_type="csv")
     """
     from wandas.frames.channel import ChannelFrame
 

--- a/wandas/io/readers.py
+++ b/wandas/io/readers.py
@@ -229,7 +229,12 @@ def _resolve_csv_time_column(columns: list[Any], time_column: int | str) -> int:
 
 
 class CSVFileReader(FileReader):
-    """CSV file reader for time series data."""
+    """CSV file reader for time series data.
+
+    Metadata inspection eagerly parses the complete table to determine its exact
+    shape and sampling rate. Sample values in the public Frame remain Dask-backed,
+    and ``get_data()`` parses the table again when that graph is computed.
+    """
 
     # CSV supported formats
     supported_extensions: ClassVar[list[str]] = [".csv"]
@@ -277,7 +282,8 @@ class CSVFileReader(FileReader):
         header: int | None = kwargs.get("header", 0)
         time_column: int | str = kwargs.get("time_column", 0)
 
-        # Read first few lines to determine structure
+        # Parse the complete table because exact frame count and sampling rate are
+        # required before the public Dask array can be constructed.
         pd = require_pandas("CSV file reading")
         df = pd.read_csv(_prepare_file_source(path), delimiter=delimiter, header=header)
         time_index = _resolve_csv_time_column(df.columns.tolist(), time_column)
@@ -296,7 +302,7 @@ class CSVFileReader(FileReader):
             estimated_sr = 0  # Default if can't calculate
             time_start = 0.0
 
-        channel_labels = [column for index, column in enumerate(df.columns) if index != time_index]
+        channel_labels = [str(column) for index, column in enumerate(df.columns) if index != time_index]
         frames = df.shape[0]
         duration = frames / estimated_sr if estimated_sr else None
 

--- a/wandas/io/readers.py
+++ b/wandas/io/readers.py
@@ -569,7 +569,17 @@ def get_file_reader(
     *,
     file_type: str | None = None,
 ) -> FileReader:
-    """Get an appropriate file reader for the given path or file type."""
+    """Return the registered reader selected by an explicit type or path suffix.
+
+    ``file_type`` is case-insensitive and may include or omit the leading dot.
+    This lower-level registry boundary does not guess a format from file
+    contents. The public :func:`wandas.read` entry point owns the additional
+    name-based inference and anonymous-WAV compatibility default.
+
+    Raises:
+        ValueError: If neither a type nor suffix is available, or if the
+            normalized extension has no registered reader.
+    """
     path_str = str(path)
     ext = _normalize_extension(file_type)
     if ext is None and isinstance(path, (str, Path)):


### PR DESCRIPTION
Closes #371

## Summary

- Add a first-class `wd.read()` API reference covering parameters, Dask-backed return behavior, examples, and common errors.
- Document and regression-test in-memory format precedence: explicit `file_type`, file-like `.name`, `source_name`, then the anonymous-WAV compatibility fallback.
- Infer HTTP/HTTPS `source_name` formats and Frame labels from the parsed URL path so signed query and fragment values do not corrupt either value, while retaining the complete URL in `_source_file` provenance.
- Preserve every row of headerless CSV input by forwarding `header=None` through both metadata and sample reads, with stable string channel labels.
- State the real loading boundary: audio decoding is deferred, while CSV performs a synchronous full-table metadata pass before its Dask-backed sample task runs.
- Align the Pyodide guide with native inference and separate browser fetch/CORS responsibility from Wandas decoding.
- Replace the inaccurate complete-preservation claim with the exact WDF 0.4 persisted state and an explicit WDF-versus-Recipe boundary.

## Major files

- `wandas/io/read.py`
- `wandas/io/readers.py`
- `wandas/frames/channel.py`
- `docs/src/api/io.md`
- `docs/src/api/wdf_io.md`
- `docs/src/how-to/pyodide-browser.md`
- `docs/src/explanation/public-api-stability.md`
- `tests/io/test_read.py`
- `tests/io/test_file_readers.py`
- `tests/frames/test_channel_frame_edge_contracts.py`
- `tests/test_init.py`

## Tests added or updated

- Cover explicit `file_type` precedence over both a named stream and `source_name`.
- Cover signed HTTP/HTTPS `source_name` inference and Frame-label derivation from the URL path while preserving the complete provenance value.
- Cover `header=None` forwarding at the Frame/reader boundary.
- Cover headerless CSV metadata, string labels, and top-level `wd.read()` without dropping the first sample row.
- Existing integration coverage continues to prove anonymous WAV bytes and named CSV streams through top-level `wandas.read`.

## Validation

- `uv run pytest tests/io/test_file_readers.py tests/io/test_canonical_float64_read.py tests/io/test_wdf_io.py tests/io/test_wav_io.py tests/io/test_read.py tests/frames/test_channel_frame_edge_contracts.py tests/test_init.py tests/docs/test_issue_templates.py -q` — 274 passed, 1 warning after merging the latest `main`
- `uv run pytest -q` — 2772 passed, 3 skipped, 33 warnings on the initial reviewed head; the final-head GitHub Actions matrix passed on Ubuntu and Windows for Python 3.10–3.13
- `uv run ruff check wandas tests scripts` — passed after merging the latest `main`
- `uv run ty check wandas tests` — passed after merging the latest `main`
- `uv run mkdocs build --strict -f docs/mkdocs.yml` — passed after the final documentation change; final-head documentation CI passed
- Pyodide was not run locally because Node.js is unavailable; final-head `Pyodide 314.0.3` CI passed
- Final-head CI run `30642228356` — all required jobs passed, including docs, core-wheel smoke, lint/type, Pyodide, Ubuntu 3.10–3.13, Windows 3.10–3.13, and Codecov

Representative scalability evidence was not run because the changes do not affect WDF save/load execution, materialization, graph, chunk, or benchmark paths.

## Codex review

- Earlier rounds fixed the public-symbol cross-reference and signed URL path inference.
- Review of `9d6619afe2` found three issues: `header=None` forwarding, the inaccurate blanket lazy-decoding statement, and query-only filename-hint compatibility. The first two were fixed with regression coverage and precise public contracts. Query-only hints are intentionally unsupported per user decision; explicit `file_type` is documented as the workaround.
- Review of `1c0f174c53` found that signed-URL Frame labels still used the complete URL. Fixed in `e852f28a67` by deriving labels from the parsed path while preserving complete provenance, with regression coverage.
- Every actionable thread has an evidence-backed reply and is resolved.
- Final Codex review of exact current head `26ae62e6ce` found no major issues: https://github.com/kasahart/wandas/pull/379#issuecomment-5144516219

## Risks and unrun checks

- Anonymous-byte WAV compatibility and inference precedence remain unchanged.
- Signed HTTP/HTTPS logical names use their URL path suffix and stem. A filename hint only in a query or fragment, such as `?filename=data.csv`, is intentionally ignored; pass `file_type=".csv"` explicitly.
- CSV returns Dask-backed sample data but currently parses the complete table once for metadata and again when samples compute.
- The local Pyodide/browser harness was not run without Node.js; final-head CI supplies this evidence.
- No known unresolved review findings or failing checks remain. The branch contains the latest `main` (`1a68d37143296e6b904751cf2da2e395f44df993`).
