### PR TITLE
docs: align FrameDataset behavioral contracts

### DIFF
--- a/docs/src/api/index.md
+++ b/docs/src/api/index.md
@@ -76,7 +76,9 @@ The visualization module provides data visualization functions using Matplotlib.
 The utilities module provides auxiliary functions including dataset management and sample generation.
 ユーティリティモジュールは、データセット管理やサンプル生成などの補助機能を提供します。
 
-- Frame datasets / フレームデータセット - Batch processing of audio files / 音声ファイルのバッチ処理
+- Frame datasets / フレームデータセット - Lazy per-file loading and
+  subtype-preserving batch transforms; failed items are represented by `None` /
+  ファイル単位の遅延読み込みと subtype を保つ一括変換。失敗項目は `None` で表現
 - Sample generation / サンプル生成 - Generate test signals / テスト信号生成
 - Type definitions / 型定義
 

--- a/docs/src/api/utils.md
+++ b/docs/src/api/utils.md
@@ -19,8 +19,10 @@ The `FrameDataset` classes enable efficient batch processing of audio files in a
   **変換のチェーン**: 複数の処理操作を効率的に適用。
 - **Sampling**: Extract random subsets for testing or analysis.
   **サンプリング**: テストや分析のためにランダムなサブセットを抽出。
-- **Metadata Tracking**: Keep track of dataset properties and processing history.
-  **メタデータ追跡**: データセットのプロパティと処理履歴を記録。
+- **Summary Metadata**: Inspect dataset configuration, attempted-load counts, and
+  whether a lazy transform is present. Dataset processing history is not exposed.
+  **概要メタデータ**: Dataset 設定、読み込み試行済み件数、遅延 transform の有無を確認。
+  Dataset の処理履歴は公開されません。
 
 ### Main Classes / 主なクラス
 
@@ -47,8 +49,11 @@ dataset = ChannelFrameDataset.from_folder(
 # Access individual files
 # 個別のファイルにアクセス
 first_file = dataset[0]
-print(f"File: {first_file.label}")
-print(f"Duration: {first_file.duration}s")
+if first_file is None:
+    print("The first file could not be loaded.")
+else:
+    print(f"File: {first_file.label}")
+    print(f"Duration: {first_file.duration}s")
 
 # Get dataset information
 # データセット情報を取得
@@ -71,10 +76,19 @@ sampled = dataset.sample(n=10, seed=42)
 # 比率でサンプリング
 sampled = dataset.sample(ratio=0.1, seed=42)
 
-# Default: 10% or minimum 1 file
-# デフォルト: 10% または最低1ファイル
+# Default for a non-empty dataset:
+# max(1, min(10, int(len(dataset) * 0.1))), capped at len(dataset)
+# 空でない Dataset のデフォルト:
+# max(1, min(10, int(len(dataset) * 0.1))) を len(dataset) 以下に制限
 sampled = dataset.sample(seed=42)
 ```
+
+For an empty dataset, `sample()` returns an empty dataset. An explicit `n` takes
+precedence when both `n` and `ratio` are supplied. All sampling modes preserve lazy
+Frame loading and cap the result at the number of discovered files.
+空の Dataset では `sample()` も空の Dataset を返します。`n` と `ratio` を両方指定した場合は
+`n` が優先されます。どの方法でも Frame の遅延読み込みは維持され、結果件数は探索済みファイル数を
+超えません。
 
 ### Metadata-driven file selection / メタデータ駆動のファイル選択
 
@@ -162,6 +176,15 @@ CSVにないWAVをDataset構築時のエラーにできるため、lookupの添�
 With `lazy_loading=False`, stage 2 runs for every file during construction, while stage 3 remains lazy.
 `lazy_loading=False` では構築時に全ファイルの段階2を実行しますが、段階3は引き続き遅延します。
 
+If stage 2 cannot load a file, or a lazy dataset transform raises or returns `None`,
+integer access returns `None`. The failed item is logged and cached as attempted, so
+later access does not retry it automatically. String lookup returns only successfully
+loaded matches. Check an integer result explicitly before accessing Frame properties.
+段階2でファイルを読み込めない場合、または遅延 Dataset transform が例外を送出するか `None` を
+返した場合、整数アクセスは `None` を返します。失敗はログに記録され、試行済みとしてキャッシュ
+されるため、以後のアクセスでは自動再試行しません。文字列検索は読み込みに成功した一致だけを
+返します。Frame のプロパティを使う前に整数アクセスの結果を明示的に確認してください。
+
 #### Resolver and selection contracts / resolverと選択の契約
 
 - The resolver receives a root-relative `Path` once per discovered file and must return a `Mapping[str, object]`. Wandas deep-copies the result. / resolverは探索した各ファイルにつき一度、ルート相対の`Path`を受け取り、`Mapping[str, object]`を返します。結果はディープコピーされます。
@@ -196,6 +219,18 @@ def custom_filter(frame):
 filtered = dataset.apply(custom_filter)
 ```
 
+`apply()`, `resample()`, `trim()`, and `normalize()` create lazy datasets of the
+same runtime dataset subtype and do not mutate the source dataset. `stft()` is the
+intentional domain transition: it returns `SpectrogramFrameDataset`. File metadata
+resolved during discovery is deep-copied into derived datasets and attached to each
+successful transformed Frame. Transform/load failures remain per-item `None` values;
+they do not abort other items.
+`apply()`、`resample()`、`trim()`、`normalize()` は元の Dataset を変更せず、同じ実行時
+Dataset subtype の遅延 Dataset を作ります。`stft()` は意図的な domain 遷移であり、
+`SpectrogramFrameDataset` を返します。探索時に解決したファイル metadata は派生 Dataset に
+ディープコピーされ、変換に成功した各 Frame に付与されます。transform/load の失敗は項目ごとの
+`None` として表され、他の項目の処理を中断しません。
+
 ### STFT - Spectrogram Generation / STFT - スペクトログラム生成
 
 Convert time-domain data to spectrograms:
@@ -213,7 +248,8 @@ spec_dataset = dataset.stft(
 # Access a spectrogram
 # スペクトログラムにアクセス
 spec_frame = spec_dataset[0]
-spec_frame.plot()
+if spec_frame is not None:
+    spec_frame.plot()
 ```
 
 ### Iteration / 反復処理
@@ -252,6 +288,22 @@ Trueの場合、相対親フォルダからAWS Glue形式のメタデータを�
 
 **metadata_resolver** (`Callable[[Path], Mapping[str, object]] | None`): Resolve file metadata from each root-relative path during discovery. Default: None.
 探索時に各ルート相対パスからファイルメタデータを解決します。デフォルト: None。
+
+### Unsupported and deprecated methods / 未対応・非推奨メソッド
+
+`FrameDataset.save()` is not a supported persistence API and always raises
+`NotImplementedError`. Save individual Frames with their supported Frame methods
+instead.
+`FrameDataset.save()` は対応済みの永続化 API ではなく、常に `NotImplementedError` を
+送出します。代わりに、個々の Frame が対応する保存メソッドを使用してください。
+
+`FrameDataset.get_by_label()` has been deprecated since 0.2.0 because duplicate
+filenames make a first-match result ambiguous. Use `get_all_by_label()` (or string
+indexing) to receive all successfully loaded matches. It is planned for removal no
+earlier than 0.7.0.
+重複ファイル名で最初の1件だけを返す動作が曖昧なため、`FrameDataset.get_by_label()` は
+0.2.0 から非推奨です。読み込みに成功した一致をすべて得るには `get_all_by_label()`（または
+文字列 indexing）を使ってください。削除は早くても 0.7.0 の予定です。
 
 ### Examples / 使用例
 

--- a/docs/src/api/utils.md
+++ b/docs/src/api/utils.md
@@ -177,13 +177,15 @@ With `lazy_loading=False`, stage 2 runs for every file during construction, whil
 `lazy_loading=False` では構築時に全ファイルの段階2を実行しますが、段階3は引き続き遅延します。
 
 If stage 2 cannot load a file, or a lazy dataset transform raises or returns `None`,
-integer access returns `None`. The failed item is logged and cached as attempted, so
-later access does not retry it automatically. String lookup returns only successfully
-loaded matches. Check an integer result explicitly before accessing Frame properties.
+integer access returns `None`. The result is cached as attempted, so later access does
+not retry it automatically; exceptions are also logged. String lookup returns only
+successfully loaded matches. Check an integer result explicitly before accessing Frame
+properties.
 段階2でファイルを読み込めない場合、または遅延 Dataset transform が例外を送出するか `None` を
-返した場合、整数アクセスは `None` を返します。失敗はログに記録され、試行済みとしてキャッシュ
-されるため、以後のアクセスでは自動再試行しません。文字列検索は読み込みに成功した一致だけを
-返します。Frame のプロパティを使う前に整数アクセスの結果を明示的に確認してください。
+返した場合、整数アクセスは `None` を返します。結果は試行済みとしてキャッシュされるため、
+以後のアクセスでは自動再試行しません。例外はログにも記録されます。文字列検索は読み込みに
+成功した一致だけを返します。Frame のプロパティを使う前に整数アクセスの結果を明示的に
+確認してください。
 
 #### Resolver and selection contracts / resolverと選択の契約
 

--- a/learning-path/00_why_wandas.py
+++ b/learning-path/00_why_wandas.py
@@ -369,8 +369,11 @@ def _(channel_frame_dataset, temp_dir):
 
     print("データセット情報:")
     print(f"  ファイル数: {len(dataset)}")
-    print(f"  サンプリングレート: {dataset[0].sampling_rate if dataset[0] else 'N/A'} Hz")
-    print(f"  長さ: {dataset[0].duration if dataset[0] else 'N/A'} 秒")
+    _source_frame = dataset[0]
+    if _source_frame is None:
+        raise RuntimeError("最初の音声ファイルを読み込めませんでした")
+    print(f"  サンプリングレート: {_source_frame.sampling_rate} Hz")
+    print(f"  長さ: {_source_frame.duration} 秒")
 
     dataset = (
         dataset.resample(target_sr=8000)  # 必要に応じてリサンプリング
@@ -379,19 +382,25 @@ def _(channel_frame_dataset, temp_dir):
     )
     print("リサンプリング後のデータセット情報:")
     print(f"  データセットサイズ: {len(dataset)}")
-    print(f"  サンプリングレート: {dataset[0].sampling_rate if dataset[0] else 'N/A'} Hz")
-    print(f"  長さ: {dataset[0].duration if dataset[0] else 'N/A'} 秒")
+    _processed_frame = dataset[0]
+    if _processed_frame is None:
+        raise RuntimeError("最初の音声ファイルを前処理できませんでした")
+    print(f"  サンプリングレート: {_processed_frame.sampling_rate} Hz")
+    print(f"  長さ: {_processed_frame.duration} 秒")
 
     # 全ファイルにSTFTを適用してスペクトログラムを作成
     spectrogram_dataset = dataset.stft(n_fft=512, hop_length=256)
 
     print("スペクトログラム作成完了:")
     print(f"  データセットサイズ: {len(spectrogram_dataset)}")
-    print(f"  周波数ビン数: {spectrogram_dataset[0].n_freq_bins if spectrogram_dataset[0] else 'N/A'}")
-    print(f"  時間フレーム数: {spectrogram_dataset[0].n_frames if spectrogram_dataset[0] else 'N/A'}")
+    _spectrogram_frame = spectrogram_dataset[0]
+    if _spectrogram_frame is None:
+        raise RuntimeError("最初の音声ファイルをスペクトログラムへ変換できませんでした")
+    print(f"  周波数ビン数: {_spectrogram_frame.n_freq_bins}")
+    print(f"  時間フレーム数: {_spectrogram_frame.n_frames}")
 
     # サンプルとして最初のスペクトログラムを表示
-    spectrogram_dataset[0][0].plot(title="Spectrogram Sample for ML Input")
+    _spectrogram_frame[0].plot(title="Spectrogram Sample for ML Input")
     return (spectrogram_dataset,)
 
 
@@ -448,8 +457,11 @@ def _(np, spectrogram_dataset):
         return ml_out
 
     ml_results = spectrogram_dataset.apply(process_ml)
-    ml_results[0].previous.plot(vmin=-60, vmax=0, title="Original Spectrogram")
-    ml_results[0].plot(vmin=-60, vmax=0, title="ML Spectrogram")
+    _ml_result = ml_results[0]
+    if _ml_result is None or _ml_result.previous is None:
+        raise RuntimeError("最初のスペクトログラムをML処理できませんでした")
+    _ml_result.previous.plot(vmin=-60, vmax=0, title="Original Spectrogram")
+    _ml_result.plot(vmin=-60, vmax=0, title="ML Spectrogram")
     return (ml_results,)
 
 

--- a/learning-path/08_metadata_driven_dataset_search.py
+++ b/learning-path/08_metadata_driven_dataset_search.py
@@ -120,8 +120,9 @@ def _(mo):
     2. `selected[0]`：選んだファイルの音声ヘッダーを読み、Frameを作る
     3. `frame.data`：選んだファイルの波形サンプルを実際に読み込む
 
-    `loaded_count` は、これまでにFrameとしてロードしたファイル数です。`select()` の直後は0件で、
-    `selected[0]` を実行すると1件になります。つまり、選択だけでは音声ヘッダーや波形を読みません。
+    `loaded_count` は、これまでにFrame作成を試みたファイル数です（失敗して `None` になった項目も
+    含みます）。`select()` の直後は0件で、ここで使う正常なサンプルでは `selected[0]` を実行すると
+    1件になります。つまり、選択だけでは音声ヘッダーや波形を読みません。
     """)
     return
 
@@ -129,10 +130,10 @@ def _(mo):
 @app.cell
 def _(selected):
     # selected[0]の前後でFrameの遅延読み込みを確認する
-    print("select()直後にFrameとしてロード済み:", selected.get_metadata()["loaded_count"], "件")
+    print("select()直後にFrame作成を試行済み:", selected.get_metadata()["loaded_count"], "件")
     selected_frame = selected[0]
-    assert selected_frame is not None
-    print("selected[0]後にFrameとしてロード済み:", selected.get_metadata()["loaded_count"], "件")
+    assert selected_frame is not None, "選択した音声ファイルを読み込めませんでした"
+    print("selected[0]後にFrame作成を試行済み:", selected.get_metadata()["loaded_count"], "件")
     return (selected_frame,)
 
 

--- a/tests/docs/test_frame_dataset_contracts.py
+++ b/tests/docs/test_frame_dataset_contracts.py
@@ -38,7 +38,7 @@ def test_documented_default_sample_formula_matches_runtime(
     sampled = dataset.sample(seed=7)
 
     assert len(sampled) == expected
-    assert all(not lazy_frame.is_loaded for lazy_frame in sampled._lazy_frames)
+    assert sampled.get_metadata()["loaded_count"] == 0
 
 
 def test_sample_formula_is_explicit_in_docstring_and_api_guide() -> None:

--- a/tests/docs/test_frame_dataset_contracts.py
+++ b/tests/docs/test_frame_dataset_contracts.py
@@ -1,0 +1,93 @@
+import inspect
+from pathlib import Path
+
+import pytest
+
+from wandas.utils.frame_dataset import ChannelFrameDataset, FrameDataset
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UTILS_DOC = REPO_ROOT / "docs" / "src" / "api" / "utils.md"
+
+
+@pytest.mark.parametrize(
+    ("total", "expected"),
+    [
+        (0, 0),
+        (1, 1),
+        (9, 1),
+        (10, 1),
+        (99, 9),
+        (100, 10),
+        (101, 10),
+        (250, 10),
+    ],
+)
+def test_documented_default_sample_formula_matches_runtime(
+    tmp_path: Path,
+    total: int,
+    expected: int,
+) -> None:
+    for index in range(total):
+        (tmp_path / f"{index:03}.wav").write_bytes(b"")
+    dataset = ChannelFrameDataset(
+        str(tmp_path),
+        file_extensions=[".wav"],
+        lazy_loading=True,
+    )
+
+    sampled = dataset.sample(seed=7)
+
+    assert len(sampled) == expected
+    assert all(not lazy_frame.is_loaded for lazy_frame in sampled._lazy_frames)
+
+
+def test_sample_formula_is_explicit_in_docstring_and_api_guide() -> None:
+    formula = "max(1, min(10, int(len(self) * 0.1)))"
+    docstring = inspect.getdoc(FrameDataset.sample)
+    api_guide = UTILS_DOC.read_text(encoding="utf-8")
+
+    assert docstring is not None
+    assert formula in docstring
+    assert "max(1, min(10, int(len(dataset) * 0.1)))" in api_guide
+    assert "For an empty dataset, `sample()` returns an empty dataset." in api_guide
+
+
+def test_unsupported_save_contract_is_visible() -> None:
+    docstring = inspect.getdoc(FrameDataset.save)
+    api_guide = UTILS_DOC.read_text(encoding="utf-8")
+
+    assert docstring is not None
+    assert docstring.startswith("Unsupported:")
+    assert "Always raised" in docstring
+    assert "`FrameDataset.save()` is not a supported persistence API" in api_guide
+
+
+def test_get_by_label_deprecation_names_replacement_and_support_window(
+    tmp_path: Path,
+) -> None:
+    docstring = inspect.getdoc(FrameDataset.get_by_label)
+    api_guide = UTILS_DOC.read_text(encoding="utf-8")
+    dataset = ChannelFrameDataset(
+        str(tmp_path),
+        file_extensions=[".wav"],
+        lazy_loading=True,
+    )
+
+    assert docstring is not None
+    assert "Deprecated:\n    Deprecated since version 0.2.0." in docstring
+    assert "get_all_by_label" in docstring
+    assert "no earlier than version 0.7.0" in " ".join(docstring.split())
+    assert "planned for removal no earlier than 0.7.0" in " ".join(api_guide.split())
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"deprecated since 0\.2\.0.*removal no earlier than 0\.7\.0",
+    ):
+        assert dataset.get_by_label("missing.wav") is None
+
+
+def test_api_examples_guard_optional_integer_access() -> None:
+    api_guide = UTILS_DOC.read_text(encoding="utf-8")
+
+    assert "first_file = dataset[0]\nif first_file is None:" in api_guide
+    assert "spec_frame = spec_dataset[0]\nif spec_frame is not None:" in api_guide
+    assert "processing history is not exposed" in api_guide

--- a/tests/utils/test_frame_dataset.py
+++ b/tests/utils/test_frame_dataset.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -1258,17 +1257,17 @@ class TestFrameDatasetGetByLabel:
         assert result.label == "test1"
 
     def test_get_by_label_no_match(self, create_test_files: Path) -> None:
-        """Get_by_label returns None when no match found."""
+        """Get_by_label warns and returns None when no match is found."""
         folder_path = create_test_files
         dataset = ChannelFrameDataset(str(folder_path), lazy_loading=True)
 
-        # No warning should be emitted when no matches
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with pytest.warns(
+            DeprecationWarning,
+            match=r"deprecated since 0\.2\.0.*removal no earlier than 0\.7\.0",
+        ):
             result = dataset.get_by_label("nonexistent.wav")
 
         assert result is None
-        assert len(w) == 0
 
 
 class TestFrameDatasetGetItemStringKey:

--- a/wandas/utils/frame_dataset.py
+++ b/wandas/utils/frame_dataset.py
@@ -87,9 +87,21 @@ class LazyFrame(Generic[F]):
 
 class FrameDataset(Generic[F], ABC):
     """
-    Abstract base dataset class for processing files in a folder.
-    Includes lazy loading capability to efficiently handle large datasets.
-    Subclasses handle specific frame types (ChannelFrame, SpectrogramFrame, etc.).
+    Abstract folder-backed collection of lazily loaded Frames.
+
+    File discovery does not create Frames. Integer access creates and caches the
+    requested Frame, while its Dask-backed sample data remains lazy until a Frame
+    materialization API such as ``frame.data`` is used. A load or transform failure
+    is logged, cached as an attempted item, and represented by ``None``.
+
+    Dataset transforms create a new dataset and leave the source dataset unchanged.
+    ``apply()``, ``resample()``, ``trim()``, and ``normalize()`` preserve the dataset
+    subtype; ``stft()`` intentionally returns ``SpectrogramFrameDataset``. Discovered
+    file metadata is deep-copied into derived datasets and attached to each
+    successfully loaded or transformed Frame.
+
+    ``get_metadata()`` returns current summary state. It does not expose a
+    processing-history or lineage API for the dataset.
     """
 
     def __init__(
@@ -268,7 +280,7 @@ class FrameDataset(Generic[F], ABC):
             return None
 
     def _ensure_loaded(self, index: int) -> F | None:
-        """Ensure the frame at the given index is loaded."""
+        """Load and cache one item, returning ``None`` after a load or transform failure."""
         if not (0 <= index < len(self._lazy_frames)):
             raise IndexError(f"Index {index} is out of range (0-{len(self._lazy_frames) - 1})")
 
@@ -312,6 +324,11 @@ class FrameDataset(Generic[F], ABC):
         """
         Get a frame by its label (filename).
 
+        Deprecated:
+            Deprecated since version 0.2.0. Use ``get_all_by_label()`` instead.
+            ``get_by_label()`` returns only the first matching filename and is
+            planned for removal no earlier than version 0.7.0.
+
         Parameters
         ----------
         label : str
@@ -328,16 +345,15 @@ class FrameDataset(Generic[F], ABC):
         >>> if frame:
         ...     print(frame.label)
         """
-        # Keep for backward compatibility: return the first match but emit
-        # a DeprecationWarning recommending `get_all_by_label`.
+        warnings.warn(
+            "FrameDataset.get_by_label() is deprecated since 0.2.0 and is planned "
+            "for removal no earlier than 0.7.0; use get_all_by_label() to obtain "
+            "all matches.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         all_matches = self.get_all_by_label(label)
         if len(all_matches) > 0:
-            warnings.warn(
-                "get_by_label() returns the first matching frame and is deprecated; "
-                "use get_all_by_label() to obtain all matches.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
             return all_matches[0]
         return None
 
@@ -387,8 +403,23 @@ class FrameDataset(Generic[F], ABC):
         Returns
         -------
         F | None or list[F]
-            If `key` is an int, returns the frame or None. If `key` is a str,
-            returns a list of matching frames (may be empty).
+            If ``key`` is an int, returns the cached Frame or ``None`` when loading
+            or transformation failed. If ``key`` is a str, returns all successfully
+            loaded matching Frames; the list is empty when no match loads.
+
+        Raises
+        ------
+        IndexError
+            If an integer index is outside ``0 <= key < len(dataset)``. Negative
+            indexing is not supported.
+        TypeError
+            If ``key`` is neither an integer nor a string.
+
+        Notes
+        -----
+        A failed integer access is logged and cached as an attempted item; it is not
+        retried automatically. Frame creation may inspect a file header, but sample
+        values remain Dask-lazy until a Frame materialization API is used.
 
         Examples
         --------
@@ -409,7 +440,17 @@ class FrameDataset(Generic[F], ABC):
     def apply(self, func: Callable[[F], Any | None]) -> "FrameDataset[Any]": ...
 
     def apply(self, func: Callable[[F], Any | None]) -> "FrameDataset[Any]":
-        """Apply a function to the entire dataset to create a new dataset."""
+        """Create a lazy transformed dataset without changing this dataset.
+
+        The returned dataset has the same runtime dataset subtype. The callable runs
+        once per item when that item is first accessed. Returning ``None`` or raising
+        an exception represents a failed/filtered item as ``None``; exceptions are
+        logged and do not abort access to other items.
+
+        Discovered file metadata is deep-copied to the derived dataset and attached
+        to every successfully transformed Frame. The metadata attached at discovery
+        takes precedence over same-named keys returned by ``func``.
+        """
         new_dataset = type(self)(
             folder_path=str(self.folder_path),
             lazy_loading=True,
@@ -423,7 +464,16 @@ class FrameDataset(Generic[F], ABC):
         return cast("FrameDataset[Any]", new_dataset)
 
     def save(self, output_folder: str, filename_prefix: str = "") -> None:
-        """Save processed frames to files."""
+        """Unsupported: dataset-level persistence is not implemented.
+
+        Saving individual Frames is supported through the Frame API. This method is
+        retained only to fail explicitly and must not be used as a persistence path.
+
+        Raises
+        ------
+        NotImplementedError
+            Always raised because ``FrameDataset.save()`` is unsupported.
+        """
         raise NotImplementedError("The save method is not currently implemented.")
 
     def sample(
@@ -432,7 +482,19 @@ class FrameDataset(Generic[F], ABC):
         ratio: float | None = None,
         seed: int | None = None,
     ) -> "FrameDataset[F]":
-        """Get a sample from the dataset."""
+        """Return a lazy random subset without loading Frames.
+
+        When both ``n`` and ``ratio`` are omitted, the requested size is
+        ``max(1, min(10, int(len(self) * 0.1)))`` and is then capped at
+        ``len(self)``. An empty dataset therefore returns an empty subset. When
+        ``ratio`` is provided, the requested size is
+        ``max(1, int(len(self) * ratio))``; an explicit ``n`` takes precedence over
+        ``ratio``. Explicit sizes are also clamped to the inclusive range from one
+        to the dataset length for non-empty datasets.
+
+        Sampling preserves file metadata and lazy Frame loading. ``seed`` makes the
+        selected file indices reproducible.
+        """
         if seed is not None:
             random.seed(seed)
 
@@ -486,7 +548,14 @@ class FrameDataset(Generic[F], ABC):
         )
 
     def get_metadata(self) -> dict[str, Any]:
-        """Get metadata for the dataset."""
+        """Return current dataset configuration and load-summary state.
+
+        This call does not load any Frames. ``loaded_count`` counts items whose Frame
+        load or transform has been attempted, including failed items cached as
+        ``None``. ``has_transform`` reports whether this dataset has one lazy
+        transform from a source dataset. The result is a summary, not a dataset
+        processing history or Frame lineage.
+        """
         actual_sr: int | float | None = self.sampling_rate
         frame_type_name = "Unknown"
 

--- a/wandas/utils/frame_dataset.py
+++ b/wandas/utils/frame_dataset.py
@@ -92,7 +92,8 @@ class FrameDataset(Generic[F], ABC):
     File discovery does not create Frames. Integer access creates and caches the
     requested Frame, while its Dask-backed sample data remains lazy until a Frame
     materialization API such as ``frame.data`` is used. A load or transform failure
-    is logged, cached as an attempted item, and represented by ``None``.
+    is cached as an attempted item and represented by ``None``; exceptions are also
+    logged.
 
     Dataset transforms create a new dataset and leave the source dataset unchanged.
     ``apply()``, ``resample()``, ``trim()``, and ``normalize()`` preserve the dataset
@@ -417,9 +418,10 @@ class FrameDataset(Generic[F], ABC):
 
         Notes
         -----
-        A failed integer access is logged and cached as an attempted item; it is not
-        retried automatically. Frame creation may inspect a file header, but sample
-        values remain Dask-lazy until a Frame materialization API is used.
+        A ``None`` result is cached as an attempted item and is not retried
+        automatically. Exceptions are also logged. Frame creation may inspect a file
+        header, but sample values remain Dask-lazy until a Frame materialization API
+        is used.
 
         Examples
         --------


### PR DESCRIPTION
Closes #370

## 修正内容

- `FrameDataset.sample()` の既定件数を `max(1, min(10, int(len(dataset) * 0.1)))`（空 Dataset は 0、最終的に Dataset 長以下）として正確に文書化
- 整数アクセスおよび lazy load/transform 失敗が、ログ記録・試行済みキャッシュ・`None` で表現される契約を docstring と API ガイドに明記
- `FrameDataset.save()` を未対応 API として明示し、`get_by_label()` に replacement、導入版、最短削除版を含む Deprecated セクションと warning message を追加
- Dataset summary metadata と処理履歴を区別し、transform の subtype/metadata 維持契約を明記
- API 例と対象 learning path で Optional な Dataset 要素を一度だけ評価し、`None` を明示処理

## 変更した主要ファイル

- `wandas/utils/frame_dataset.py`
- `docs/src/api/utils.md`
- `docs/src/api/index.md`
- `learning-path/00_why_wandas.py`
- `learning-path/08_metadata_driven_dataset_search.py`
- `tests/docs/test_frame_dataset_contracts.py`
- `tests/utils/test_frame_dataset.py`

## 追加・更新したテスト

- 0 / 1 / 9 / 10 / 99 / 100 / 101 / 250 件で既定 sample 式と最大 10 件を実動作確認
- sample 式、unsupported `save()`、Deprecated セクション、replacement/removal policy、Optional access 例を文書契約テストで固定
- match がない場合を含む全 `get_by_label()` 呼び出しで `DeprecationWarning` が一貫して出ることを確認

## 検証

- `uv run pytest tests/docs/test_frame_dataset_contracts.py tests/utils/test_frame_dataset.py tests/utils/test_frame_dataset_metadata.py tests/utils/test_frame_dataset_label.py -q` — 149 passed
- `uv run pytest tests/docs -q` — 57 passed
- `uv run pytest -q` — 2783 passed, 3 skipped
- `uv run ruff check wandas tests scripts learning-path --config=pyproject.toml` — passed
- `uv run ty check wandas tests` — passed
- `uv run marimo check learning-path/00_why_wandas.py learning-path/08_metadata_driven_dataset_search.py` — passed
- `uv run marimo export html ... --no-include-code -f`（両 learning path）— passed、セルエラーなし
- `uv run mkdocs build --strict -f docs/mkdocs.yml` — passed、Deprecated セクションと unsupported 表示を生成 HTML でも確認
- `git diff --check` — passed

## Codexレビューへの対応

- head `ac2bae1f` に対して `gh pr review --comment` で Codex self-review を review submission として記録
- 初回 review で、文書契約テストが private `_lazy_frames` に依存している点を検出
- `ac2bae1f` で公開 `get_metadata()["loaded_count"]` を使うよう修正し、focused 12 tests、Ruff、ty、`git diff --check` を再実行
- Copilot review で、明示的な `None` まで常にログされると読める表現を検出
- `a2365ccb` で「`None` 結果は試行済みキャッシュ、例外は追加でログ」と実装どおりに修正し、focused 123 tests、Ruff、ty、MkDocs strict、`git diff --check` を再実行
- head `a2365ccb` に対する Codex re-review submission を記録。最終差分に未解決の実行可能な指摘なし

## 残っているリスク・未実施検証

- scalability benchmark は未実施です。本変更は文書、warning timing、例、契約テストのみで、Dask graph、Frame materialization、数値処理、依存関係を変更しないため、benchmark の計測対象に影響しません。
- README / README.ja は変更していません。トップレベルの Dataset 記述は一般的な遅延読み込み・一括前処理の説明に留まり、今回修正した失敗時 `None` や Dataset history の誤った主張を含まないためです。
- PR はマージしていません。
