### PR TITLE
docs: update issue templates to current APIs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,7 @@ body:
       placeholder: |
         import wandas as wd
 
-        signal = wd.read_wav("audio.wav")
+        signal = wd.read("audio.wav")
         # ...
     validations:
       required: true
@@ -57,7 +57,7 @@ body:
       value: |
         - OS: [e.g. Ubuntu 22.04 / Windows 11 / macOS 14]
         - Python version: [e.g. 3.11]
-        - Wandas version: [e.g. 0.1.16]
+        - Wandas version: [installed version / インストール済みバージョン]
         - Installation method: [e.g. pip / uv / git]
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -30,7 +30,7 @@ body:
         # Example of how the new API might look:
         import wandas as wd
 
-        signal = wd.read_wav("audio.wav")
+        signal = wd.read("audio.wav")
         result = signal.new_method(...)
     validations:
       required: true
@@ -47,11 +47,12 @@ body:
       label: Affected Area / 対象領域
       description: Which part of the codebase does this feature relate to? / この機能はどのモジュールに関連しますか？
       options:
-        - "frames/ (ChannelFrame, SpectralFrame, SpectrogramFrame)"
-        - "processing/ (filters, spectral, psychoacoustics, stats, effects)"
-        - "io/ (WAV, WDF, CSV)"
-        - "visualization/ (plotting)"
-        - "datasets/ (sample data)"
+        - "frames/ (Frame types, metadata, channel views)"
+        - "processing/ (calibration, filters, transforms, statistics, psychoacoustics, effects)"
+        - "io/ (read, save, WAV, WDF, CSV)"
+        - "pipeline/ (RecipePlan, recipes, sklearn adapters)"
+        - "visualization/ (plotting, describe)"
+        - "datasets/ and utils/ (sample data, FrameDataset)"
         - "Other / その他"
     validations:
       required: true

--- a/tests/docs/test_issue_templates.py
+++ b/tests/docs/test_issue_templates.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPOSITORY_ROOT = Path(__file__).parents[2]
+TEMPLATE_DIRECTORY = REPOSITORY_ROOT / ".github" / "ISSUE_TEMPLATE"
+TEMPLATE_PATHS = (
+    TEMPLATE_DIRECTORY / "bug_report.yml",
+    TEMPLATE_DIRECTORY / "feature_request.yml",
+)
+
+
+def _load_template(path: Path) -> dict[str, Any]:
+    template = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(template, dict)
+    assert isinstance(template.get("body"), list)
+    return template
+
+
+def _body_item(template: dict[str, Any], item_id: str) -> dict[str, Any]:
+    for item in template["body"]:
+        if isinstance(item, dict) and item.get("id") == item_id:
+            return item
+    raise AssertionError(f"Missing issue template body item: {item_id}")
+
+
+def test_issue_template_examples_use_recommended_read_api() -> None:
+    bug_template = _load_template(TEMPLATE_PATHS[0])
+    feature_template = _load_template(TEMPLATE_PATHS[1])
+
+    reproduction = _body_item(bug_template, "reproduction")
+    solution = _body_item(feature_template, "solution")
+
+    assert 'wd.read("audio.wav")' in reproduction["attributes"]["placeholder"]
+    assert 'wd.read("audio.wav")' in solution["attributes"]["placeholder"]
+
+
+def test_issue_templates_reject_compatibility_helpers_and_pinned_versions() -> None:
+    template_text = "\n".join(path.read_text(encoding="utf-8") for path in TEMPLATE_PATHS)
+
+    for compatibility_helper in ("wd.read_wav(", "wd.read_csv(", "wd.from_ndarray("):
+        assert compatibility_helper not in template_text
+
+    bug_template = _load_template(TEMPLATE_PATHS[0])
+    environment = _body_item(bug_template, "environment")["attributes"]["value"]
+    wandas_version_line = next(line for line in environment.splitlines() if "Wandas version:" in line)
+    assert "installed version" in wandas_version_line
+    assert not any(character.isdigit() for character in wandas_version_line)
+
+
+def test_feature_template_areas_match_current_module_boundaries() -> None:
+    feature_template = _load_template(TEMPLATE_PATHS[1])
+    options = _body_item(feature_template, "area")["attributes"]["options"]
+
+    for module in ("frames/", "processing/", "io/", "pipeline/", "visualization/", "datasets/", "utils/"):
+        assert any(module in option for option in options)
+    assert any("Recipe" in option for option in options)
+    assert any("calibration" in option.lower() for option in options)


### PR DESCRIPTION
Closes #377

## Summary

- Replace compatibility-only `wd.read_wav()` examples in both issue forms with the recommended top-level `wd.read()` entry point.
- Ask reporters for their installed Wandas version without teaching an obsolete pinned release.
- Align the feature-area choices with the current repository boundaries, including `pipeline/` Recipe work and calibration.
- Add a focused YAML-backed regression test for the recommended API, neutral version prompt, and current area choices.

This follows the `wd.read()` direction established by #371 / PR #379 and the current stable API policy. It intentionally does not implement or pre-empt the broader API inventory work in #369 or documentation consistency tooling in #375; those follow-up issues can use this template regression as focused evidence.

## Major files

- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/feature_request.yml`
- `tests/docs/test_issue_templates.py`

## Tests added or updated

- Parse both issue forms as YAML and verify their expected body fields.
- Require `wd.read("audio.wav")` in both code examples.
- Reject `wd.read_wav()`, `wd.read_csv()`, and `wd.from_ndarray()` examples.
- Reject numeric Wandas versions in the environment prompt.
- Require current module choices plus Recipe and calibration coverage.

## Validation

- `uv run pytest tests/docs/test_issue_templates.py -q` — 3 passed
- `uv run pytest tests/docs -q` — 48 passed, 2 warnings
- `uv run pytest -q` — 2774 passed, 3 skipped, 33 warnings
- `uv run ruff check wandas tests` — passed
- `uv run ty check wandas tests` — passed
- YAML parse check for every `.github/ISSUE_TEMPLATE/*.yml` file — 3 files validated
- `git diff --check` — passed
- GitHub CI — all required jobs passed, including docs, lint/type, core-wheel smoke, Pyodide, Codecov patch, and Ubuntu/Windows on Python 3.10–3.13

## Codex review

- Codex formally reviewed fixed head `4229f8833fe008f742b25aa4ecc9ad91c48608c7` against Issue #377, the stable public API policy, and the `wd.read()` direction from #371 / PR #379.
- No actionable findings were identified, so no review-driven code changes or re-review were required.
- Copilot also reviewed all three changed files and generated no comments.
- There are no unresolved review threads.

## Risks and unrun checks

- No runtime, public API implementation, I/O behavior, or documentation page is changed.
- The issue-form UI was not manually previewed; all forms parse as YAML, focused regression coverage passed, and all required GitHub CI jobs passed.
- `mkdocs build` was not run locally because GitHub issue forms are outside the MkDocs source tree; the required GitHub documentation build passed.
- No remaining known risks or unperformed required checks.
