### PR TITLE
fix(signal): define canonical spectral numerical contracts

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
       - Overview: explanation/index.md
       - Scalability Contract: explanation/scalability-contract.md
       - AudioOperation Execution: explanation/audio-operation-execution.md
+      - Spectral Numerical Contracts: explanation/spectral-numerical-contracts.md
       - Public API Stability: explanation/public-api-stability.md
       - Pipeline Recipe Design: explanation/pipeline-recipe-design.md
       - Pipeline Recipe Developer Guide: explanation/pipeline-recipe-developer-guide.md

--- a/docs/src/api/frames.md
+++ b/docs/src/api/frames.md
@@ -98,6 +98,11 @@ API may be added separately in the future.
 SpectralFrame is a frame for handling frequency-domain data.
 SpectralFrameは周波数領域のデータを扱うためのフレームです。
 
+FFT, STFT, and Welch results use the canonical amplitude, unit, normalization,
+and decibel definitions in the
+[spectral numerical contracts](../explanation/spectral-numerical-contracts.md).
+In particular, `welch()` returns a Welch-averaged amplitude spectrum, not PSD.
+
 ::: wandas.frames.spectral.SpectralFrame
 
 ## CepstralFrame
@@ -134,6 +139,10 @@ SpectrogramFrameは時間-周波数領域（スペクトログラム）のデー
 
 NOctFrame is a frame class for octave-band analysis.
 NOctFrameはオクターブバンド解析のためのフレームクラスです。
+
+Its stored values are per-band RMS amplitudes in the input unit; see the
+[spectral numerical contracts](../explanation/spectral-numerical-contracts.md)
+for the level reference and `G` convention.
 
 ::: wandas.frames.noct.NOctFrame
 

--- a/docs/src/explanation/audio-operation-execution.md
+++ b/docs/src/explanation/audio-operation-execution.md
@@ -267,6 +267,12 @@ complete time axis. `NOctSynthesis` continues to use conservative whole-frame
 execution; the spectrum adoption does not change the shared `_NOctBase`, synthesis
 behavior, or the common graph helper.
 
+The numerical result is RMS amplitude in each band, in the calibrated input unit;
+its level uses `20 log10(band_rms / channel_ref)`. `G` selects MoSQITo's exact
+center-frequency ratio convention (base 10 or base 2) and is not a decibel gain.
+The complete quantity and reference definitions are in the
+[spectral numerical contracts](spectral-numerical-contracts.md).
+
 MoSQITo returns `float64` N-octave spectra for supported integer, `float32`, and
 `float64` inputs. `NOctSpectrum` now advertises that actual dtype directly instead of
 inheriting input dtype metadata. The correction is local to the spectrum operation.

--- a/docs/src/explanation/public-api-stability.md
+++ b/docs/src/explanation/public-api-stability.md
@@ -60,5 +60,10 @@ contract must cover the relevant items below:
 - notebook static visualization when the result is a new visual domain;
 - reference/theoretical numerical tests and serialization behavior where applicable.
 
+Existing FFT, STFT, Welch, fractional-octave, and spectral-level APIs follow the
+documented [spectral numerical contracts](spectral-numerical-contracts.md).
+Corrections to those contracts require reference-value and public round-trip tests;
+terminology alone must not silently change amplitude into power or PSD.
+
 This gate keeps Wandas focused on context-preserving analysis rather than matching the
 raw function count of SciPy or librosa.

--- a/docs/src/explanation/spectral-numerical-contracts.md
+++ b/docs/src/explanation/spectral-numerical-contracts.md
@@ -1,0 +1,43 @@
+# Spectral numerical contracts / スペクトル数値契約
+
+Wandas spectral Frames carry amplitude quantities unless an API explicitly says
+otherwise. Calibration is applied before analysis, so `unit` below means the
+physical unit of the input channel (or dimensionless full scale when no unit is
+set).
+
+| Result | Stored value and normalization | Unit | Level conversion |
+| --- | --- | --- | --- |
+| `ChannelFrame.fft()` | Complex one-sided peak-amplitude spectrum. The input is truncated or zero-padded to `n_fft`, multiplied by the selected window, divided by the window coherent gain (its sum), and non-DC/non-Nyquist positive bins are doubled. | Input unit | `20 log10(magnitude / channel_ref)` |
+| `ChannelFrame.stft()` | Complex one-sided peak-amplitude spectrum for each time frame. SciPy coherent-gain magnitude scaling is used and non-DC/non-Nyquist positive bins are doubled. | Input unit | `20 log10(magnitude / channel_ref)` |
+| `ChannelFrame.welch()` | Real one-sided peak-amplitude spectrum. Welch segment **power spectra** use `scaling="spectrum"`, are averaged, and are then converted to peak amplitude. This is not PSD and is not per hertz. | Input unit | `20 log10(amplitude / channel_ref)` |
+| `ChannelFrame.noct_spectrum()` | RMS amplitude in each fractional-octave band, as returned by MoSQITo. `G` selects the exact-center-frequency ratio convention (`10` for base `10**(3/10)`, `2` for base 2); it is not a gain. | Input unit | `20 log10(band_rms / channel_ref)` |
+
+`SpectralFrame.magnitude` is the absolute value of its stored complex amplitude.
+`SpectralFrame.power` is exactly `magnitude**2`, with squared input units; the
+name is a compatibility property and does not turn the result into power spectral
+density. The amplitude and power forms give the same level when their references
+are paired correctly:
+
+```text
+20 log10(amplitude / reference)
+  = 10 log10(amplitude**2 / reference**2)
+```
+
+Each channel's `channel_ref` comes from its calibration metadata. For example,
+`Pa` defaults to `20 µPa`, while uncalibrated full-scale data defaults to `1`.
+`dBA` adds the IEC 61672 A-weighting curve to that amplitude level; it does not
+change the underlying stored amplitude.
+
+## FFT inverse guarantee
+
+`SpectralFrame.ifft()` inverts Wandas' one-sided amplitude normalization. For a
+spectrum produced by `ChannelFrame.fft()` with its stored matching `n_fft` and
+`window`, the result is exactly the truncated-or-zero-padded analysis input
+multiplied by that window, within floating-point tolerance. A boxcar window
+therefore round-trips the prepared waveform. A tapered window such as Hann
+round-trips the **windowed** waveform: Wandas does not divide by the window and
+cannot reconstruct samples erased at its zeros.
+
+These transforms build Dask graphs lazily. Accessing a NumPy-value property such
+as `frame.data`, `magnitude`, `power`, `dB`, or plotting is the materialization
+boundary.

--- a/docs/src/explanation/spectral-numerical-contracts.md
+++ b/docs/src/explanation/spectral-numerical-contracts.md
@@ -12,11 +12,13 @@ set).
 | `ChannelFrame.welch()` | Real one-sided peak-amplitude spectrum. Welch segment **power spectra** use `scaling="spectrum"`, are averaged, and are then converted to peak amplitude. This is not PSD and is not per hertz. | Input unit | `20 log10(amplitude / channel_ref)` |
 | `ChannelFrame.noct_spectrum()` | RMS amplitude in each fractional-octave band, as returned by MoSQITo. `G` selects the exact-center-frequency ratio convention (`10` for base `10**(3/10)`, `2` for base 2); it is not a gain. | Input unit | `20 log10(band_rms / channel_ref)` |
 
-`SpectralFrame.magnitude` is the absolute value of its stored complex amplitude.
-`SpectralFrame.power` is exactly `magnitude**2`, with squared input units; the
-name is a compatibility property and does not turn the result into power spectral
-density. The amplitude and power forms give the same level when their references
-are paired correctly:
+`SpectralFrame.magnitude` is the absolute value of its stored spectral quantity;
+for the FFT and Welch rows above, that quantity is amplitude.
+`SpectralFrame.power` is exactly `magnitude**2`; for an amplitude result it has
+squared input units. The name is a compatibility property and does not turn an
+arbitrary result into physical power or power spectral density. The amplitude and
+squared-amplitude forms give the same level when their references are paired
+correctly:
 
 ```text
 20 log10(amplitude / reference)
@@ -25,8 +27,8 @@ are paired correctly:
 
 Each channel's `channel_ref` comes from its calibration metadata. For example,
 `Pa` defaults to `20 µPa`, while uncalibrated full-scale data defaults to `1`.
-`dBA` adds the IEC 61672 A-weighting curve to that amplitude level; it does not
-change the underlying stored amplitude.
+For the amplitude results above, `dBA` adds the IEC 61672 A-weighting curve to
+that amplitude level; it does not change the underlying stored amplitude.
 
 ## FFT inverse guarantee
 

--- a/learning-path/03_signal_processing_basics.py
+++ b/learning-path/03_signal_processing_basics.py
@@ -167,7 +167,7 @@ def _(demo_signal):
     spectrum.info()
 
     # スペクトルをプロット
-    spectrum.plot(title="Frequency Domain (Magnitude Spectrum)")
+    spectrum.plot(title="Frequency Domain (Amplitude Level Spectrum)")
     return (spectrum,)
 
 
@@ -178,7 +178,7 @@ def _(mo):
 
     - **50Hz, 120Hz, 200Hz**のピークが見える
     - **ノイズ**は全周波数帯に広がっている
-    - **振幅**は元の信号の強さを表す
+    - 縦軸はチャンネル基準値に対する**振幅レベル**（dB）を表す
 
     ### 位相スペクトルも見てみましょう
     """)
@@ -189,7 +189,7 @@ def _(mo):
 def _(plt, spectrum):
     # 位相スペクトルも表示
     (_fig, (_ax1, _ax2)) = plt.subplots(2, 1, figsize=(12, 8))
-    spectrum.plot(ax=_ax1, title="Magnitude Spectrum", ylabel="Magnitude")
+    spectrum.plot(ax=_ax1, title="Amplitude Level Spectrum")
     # 振幅スペクトル
     _ax2.plot(spectrum.freqs, spectrum.unwrapped_phase, "b-", linewidth=1)
     _ax2.set_title("Phase Spectrum")
@@ -204,13 +204,16 @@ def _(plt, spectrum):
 @app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
-    ### Welch法によるパワースペクトル密度推定
+    ### Welch法による平均振幅スペクトル
 
-    **Welch法**は、信号をオーバーラップするセグメントに分割し、各セグメントのパワースペクトルを平均化することで、より滑らかで信頼性の高いパワースペクトル密度（PSD）を得る方法です。
+    Wandasの**Welch法**は、信号をオーバーラップするセグメントに分割し、
+    各セグメントのパワースペクトルを平均したあと、ピーク振幅へ変換します。
+    返り値は入力と同じ単位の**片側振幅スペクトル**であり、PSD（単位あたりHz）ではありません。
+    `dB`表示には振幅比の`20 log10(amplitude / channel_ref)`を使います。
 
     **FFT vs Welch法の違い:**
     - **FFT**: 単一のスペクトル（周波数分解能が高いが変動が大きい）
-    - **Welch法**: 平均化されたPSD（滑らかだが周波数分解能が低い）
+    - **Welch法**: 平均化された振幅スペクトル（滑らかだが周波数分解能が低い）
 
     **Welch法の利点:**
     - **分散の低減**: 平均化によりノイズの影響を軽減
@@ -222,7 +225,7 @@ def _(mo):
 
 @app.cell
 def _(demo_signal, spectrum):
-    # Welch法によるパワースペクトル推定
+    # Welch法による平均振幅スペクトル
     # demo_signal.welch()メソッドを使用
     welch_result = demo_signal.welch(win_length=1024, hop_length=512, n_fft=2048)
     print("🔄 Welch法によるスペクトル:")  # セグメント長
@@ -246,18 +249,18 @@ def _(mo):
     **📊 Welch法の特徴と利点**
 
     - **滑らかなスペクトル**: 平均化によりノイズの影響が軽減され、安定した推定結果が得られる
-    - **パワースペクトル**: 周波数帯域あたりのパワーを表す
+    - **振幅スペクトル**: 入力と同じ単位でピーク振幅を表す（PSDではない）
     - **50Hz, 120Hz, 200Hz**のピークがより明確に識別できる
     - **ノイズ床**: ノイズレベルが安定して推定される
 
     ### FFT vs Welch法の比較
 
-    **FFTパワースペクトル:**
+    **FFT振幅スペクトル:**
     - ✅ 高い周波数分解能
     - ❌ ノイズの影響で変動が大きい
     - 📈 単一の時間窓での計算
 
-    **Welch PSD:**
+    **Welch平均振幅スペクトル:**
     - ✅ 安定した推定値（平均化による）
     - ✅ ノイズと信号成分を区別しやすい
     - ❌ 周波数分解能が低い
@@ -267,14 +270,14 @@ def _(mo):
 
     Welch法のパラメータによって結果が大きく変わります：
 
-    - **`nperseg`**: セグメント長（大きいほど周波数分解能が高いが、時間分解能が低い）
-    - **`noverlap`**: オーバーラップ長（50-75%が一般的）
-    - **`nfft`**: FFTサイズ（nperseg以上にする）
+    - **`win_length`**: セグメント長（大きいほど周波数分解能が高いが、平均回数が減る）
+    - **`hop_length`**: セグメント開始間隔（省略時は`win_length // 4`）
+    - **`n_fft`**: FFTサイズ（`win_length`以上にする）
 
     **パラメータのトレードオフ:**
-    - **高周波数分解能**: npersegを大きく
-    - **高安定性**: noverlapを大きく（より多くの平均化）
-    - **高速処理**: npersegを小さく
+    - **高周波数分解能**: `win_length`と`n_fft`を大きく
+    - **高安定性**: `hop_length`を小さく（より多くの平均化）
+    - **高速処理**: `win_length`を小さく
     """)
     return
 

--- a/learning-path/04_advanced_processing.py
+++ b/learning-path/04_advanced_processing.py
@@ -263,7 +263,7 @@ def _(mo):
     **スペクトログラムの構成**:
     - **横軸**: 時間（秒） - 信号の時間進行
     - **縦軸**: 周波数（Hz） - 各時刻に含まれる周波数成分
-    - **色**: パワー（dB） - 明るい色ほど強い周波数成分
+    - **色**: 振幅レベル（dB、チャンネル基準値に対する値） - 明るい色ほど強い周波数成分
 
     **観察される結果**:
     - **0-1秒**: 10Hz付近に明るい水平線 → 低周波振動が支配的
@@ -362,7 +362,9 @@ def _(mo):
 
     ### なぜWelch法のパラメータ調整が重要か
 
-    **Welch法**は、信号を重複する区間に分割し、各区間のパワースペクトルを平均化することで、ノイズの影響を低減し、より安定したスペクトル推定を実現します。
+    **Welch法**は、信号を重複する区間に分割し、各区間のパワースペクトルを平均化することで、
+    ノイズの影響を低減します。Wandasはその平均をピーク振幅へ変換して返すため、
+    結果は入力と同じ単位の振幅スペクトルであり、PSD（単位あたりHz）ではありません。
 
     **02のmarimoアプリ**では、Welch法の基本的な使い方とFFTとの違いを学びました。このセクションでは、**パラメータ調整による推定精度の最適化**を実践します。
 
@@ -462,8 +464,8 @@ def _(noisy_data, plt, sampling_rate_1):
         _n_fft = config["n_fft"]
         _hop_length = config["hop_length"]
         label = config["label"]
-        psd = noisy_data.welch(n_fft=_n_fft, hop_length=_hop_length)
-        _welch_results[label] = psd
+        amplitude_spectrum = noisy_data.welch(n_fft=_n_fft, hop_length=_hop_length)
+        _welch_results[label] = amplitude_spectrum
         _freq_res = sampling_rate_1 / _n_fft
         n_segments = int((noisy_data.n_samples - _n_fft) / _hop_length) + 1
         print(f"\n{label}:")
@@ -471,8 +473,8 @@ def _(noisy_data, plt, sampling_rate_1):
         print(f"  周波数分解能: {_freq_res:.2f} Hz")
         print(f"  セグメント数: {n_segments} (平均化)")
     (_fig, _axes) = plt.subplots(1, 3, figsize=(18, 5))
-    for _ax, (label, psd) in zip(_axes, _welch_results.items()):
-        psd.plot(ax=_ax, title=label, xlim=(0, 300), ylim=(-30, 0))
+    for _ax, (label, amplitude_spectrum) in zip(_axes, _welch_results.items()):
+        amplitude_spectrum.plot(ax=_ax, title=label, xlim=(0, 300), ylim=(-30, 0))
         _ax.axvline(100, color="red", linestyle="--", alpha=0.7, linewidth=1, label="100Hz")
         _ax.axvline(150, color="orange", linestyle="--", alpha=0.7, linewidth=1, label="150Hz")
         _ax.legend()
@@ -542,7 +544,7 @@ def _(mo):
     - **1/3-octave**: 中程度の分解能（環境騒音の詳細分析、騒音対策の効果検証、機械の異音解析など精密な評価）
     - **1/12-octave**: 細かい分析（音楽の半音に対応）
 
-    このセクションでは、**1/3-octave分析**を実践し、音響エネルギーの周波数分布を視覚化します。
+    このセクションでは、**1/3-octave分析**を実践し、各帯域のRMS振幅レベルを視覚化します。
     """)
     return
 
@@ -599,7 +601,8 @@ def _(mo):
     それでは、作成した信号に対して1/3-octave分析を実行します。
 
     **パラメータ**:
-    - **`fraction=3`**: 1/3-octaveバンド（建築音響の標準）
+    - **`n=3`**: 1/3-octaveバンド（建築音響で一般的）
+    - **`G=10`**（既定値）: 中心周波数を定めるbase-10比率規約。dB gainではない
     - 各帯域の帯域幅は中心周波数に比例する
     """)
     return
@@ -632,7 +635,7 @@ def _(mo):
 
     **1/3-octaveスペクトルの特徴**:
     - **横軸**: 中心周波数（対数スケール）
-    - **縦軸**: 各帯域のエネルギーレベル（dB）
+    - **縦軸**: 各帯域のRMS振幅をチャンネル基準値で表したレベル（dB）
     - **帯域幅**: 低周波数では狭く、高周波数では広い
 
     **観察される結果**:
@@ -854,7 +857,7 @@ def _(
         welch_result.plot(ax=_ax1, alpha=0.8, label=welch_result.label)
     _ax1.set_title("Welch Method Comparison Across Conditions", fontsize=14)
     _ax1.set_xlim(20, 1000)
-    _ax1.set_ylabel("Spectrum level [dB re 1 FS]")
+    _ax1.set_ylabel("Amplitude level [dB re 1 FS]")
     _ax1.set_ylim(*audio_contract.COMPARISON_WELCH_YLIM)
     (fig2, _ax2) = plt.subplots(figsize=(12, 6))
     for _noct_result in noct_results:
@@ -862,7 +865,7 @@ def _(
     _ax2.set_title("N-Octave Analysis Comparison Across Conditions", fontsize=14)
     # N-octave分析の結果を1つの図にまとめてプロット
     _ax2.set_xlim(20, 10000)
-    _ax2.set_ylabel("Spectrum level [dB re 1 FS]")
+    _ax2.set_ylabel("Band RMS level [dB re 1 FS]")
     _ax2.set_ylim(*audio_contract.COMPARISON_NOCT_YLIM)
     _ax2.set_xscale("log")
     assert audio_contract.DB_REFERENCE_FS == 1.0
@@ -902,7 +905,7 @@ def _(mo):
     **N-octave分析の特徴**:
     - **対数間隔周波数帯域**: 低周波数で広い帯域、高周波数で狭い帯域
     - **人間聴覚特性対応**: 音響・振動の評価に適したスケール
-    - **広帯域特性評価**: 全体的なエネルギー分布を把握しやすい
+    - **広帯域特性評価**: 帯域ごとのRMS振幅分布を把握しやすい
     - **用途**: 騒音評価、建築音響、環境振動測定
 
     **実践的な使い分け**:

--- a/tests/docs/test_spectral_numerical_contracts.py
+++ b/tests/docs/test_spectral_numerical_contracts.py
@@ -1,0 +1,33 @@
+"""Keep duplicated spectral terminology aligned with the numerical contract."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[2]
+
+
+def test_canonical_contract_defines_value_unit_normalization_and_reference() -> None:
+    contract = (REPO_ROOT / "docs/src/explanation/spectral-numerical-contracts.md").read_text(encoding="utf-8")
+
+    assert "one-sided peak-amplitude spectrum" in contract
+    assert "window coherent gain" in contract
+    assert "This is not PSD and is not per hertz" in contract
+    assert "RMS amplitude in each fractional-octave band" in contract
+    assert "20 log10(amplitude / reference)" in contract
+    assert "windowed" in contract
+
+
+def test_learning_material_does_not_relabel_levels_as_raw_magnitude_or_psd() -> None:
+    lessons = "\n".join(
+        (REPO_ROOT / path).read_text(encoding="utf-8")
+        for path in (
+            "learning-path/03_signal_processing_basics.py",
+            "learning-path/04_advanced_processing.py",
+        )
+    )
+
+    assert "Magnitude Spectrum" not in lessons
+    assert "Welch PSD" not in lessons
+    assert "パワースペクトル密度" not in lessons
+    assert "Spectrum level [dB re 1 FS]" not in lessons
+    assert "Amplitude level Spectrum" not in lessons
+    assert "Band RMS level [dB re 1 FS]" in lessons

--- a/tests/frames/test_spectral_frame.py
+++ b/tests/frames/test_spectral_frame.py
@@ -680,24 +680,21 @@ class TestSpectralFrameCoverage:
 class TestSpectralFrameNumericalVerification:
     """Pillar 3 & 4: Numerical verification using known signals (non-mocked)."""
 
-    def test_fft_ifft_preserves_frequency_content(self, channel_frame: ChannelFrame) -> None:
-        """FFT->IFFT preserves frequency content (peak detection round-trip).
+    @pytest.mark.parametrize("window_name", ["boxcar", "hann"])
+    def test_fft_ifft_reconstructs_documented_windowed_input(
+        self,
+        channel_frame: ChannelFrame,
+        window_name: str,
+    ) -> None:
+        """The public round trip returns the prepared input times its window."""
+        from scipy.signal import get_window
 
-        Note: wandas FFT applies spectral-analysis scaling (window + normalization),
-        so FFT->IFFT is NOT an amplitude-preserving round-trip. Instead, verify
-        that frequency content is preserved through the transform pair.
-        Tolerance: ±1 FFT bin — spectral leakage at bin boundaries.
-        """
-        spectral = channel_frame.fft(n_fft=2048)
+        n_fft = 2048
+        spectral = channel_frame.fft(n_fft=n_fft, window=window_name)
         recovered = spectral.ifft()
 
-        # Verify the 440 Hz component is still the dominant frequency in channel 0
-        recovered_data = recovered.data
-        fft_of_recovered = np.fft.rfft(recovered_data[0])
-        freqs = np.fft.rfftfreq(len(recovered_data[0]), 1.0 / channel_frame.sampling_rate)
-        peak_freq = freqs[np.argmax(np.abs(fft_of_recovered))]
-        bin_resolution = freqs[1] - freqs[0]
-        assert abs(peak_freq - 440.0) <= bin_resolution, f"Expected 440 Hz peak after FFT->IFFT, got {peak_freq:.1f} Hz"
+        expected = channel_frame.data[..., :n_fft] * get_window(window_name, n_fft)
+        np.testing.assert_allclose(recovered.data, expected, rtol=1e-12, atol=1e-12)
 
     def test_spectral_data_is_complex(self, channel_frame: ChannelFrame) -> None:
         """SpectralFrame data must be complex-typed.

--- a/tests/pipeline/test_ifft_recipe_version.py
+++ b/tests/pipeline/test_ifft_recipe_version.py
@@ -1,0 +1,40 @@
+"""Recipe compatibility for versioned IFFT amplitude scaling."""
+
+import dask.array as da
+import numpy as np
+from dask.array.core import Array as DaArray
+
+from tests.frame_helpers import channel_first_values
+from wandas.frames.spectral import SpectralFrame
+from wandas.pipeline import RecipePlan
+
+
+def test_released_ifft_recipe_v1_replays_legacy_amplitude_scaling() -> None:
+    spectrum = SpectralFrame(
+        da.from_array(np.array([[1.0, 0.0, 0.0, 0.0, 0.0]], dtype=np.complex128), chunks=(1, 5)),
+        sampling_rate=8,
+        n_fft=8,
+        window="boxcar",
+    )
+    released_payload = {
+        "schema": "wandas.recipe",
+        "version": 2,
+        "inputs": [{"id": "input-0", "name": "signal", "kind": "frame"}],
+        "nodes": [
+            {
+                "id": "node-0",
+                "operation": "wandas.spectral.ifft",
+                "version": 1,
+                "inputs": ["input-0"],
+                "params": {"$type": "map", "entries": []},
+            }
+        ],
+        "output": "node-0",
+    }
+
+    plan = RecipePlan.from_dict(released_payload)
+    replayed = plan.apply({"signal": spectrum})
+
+    assert isinstance(replayed._data, DaArray)
+    np.testing.assert_allclose(channel_first_values(replayed), np.full((1, 8), 1.0 / 8.0))
+    assert replayed.operation_history == [{"operation": "wandas.spectral.ifft", "version": 1, "params": {}}]

--- a/tests/pipeline/test_recipe_execution.py
+++ b/tests/pipeline/test_recipe_execution.py
@@ -43,6 +43,7 @@ def test_fft_ifft_typed_transition_chain_replays() -> None:
     replayed = RecipePlan.from_dict(plan.to_dict()).apply({"signal": source})
 
     assert [node.operation for node in plan.nodes] == ["wandas.audio.fft", "wandas.spectral.ifft"]
+    assert [node.version for node in plan.nodes] == [1, 2]
     np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(processed))
 
 

--- a/tests/processing/test_cepstral_operations.py
+++ b/tests/processing/test_cepstral_operations.py
@@ -24,7 +24,12 @@ _LOG_FLOOR = 1e-12
 def _normalized_rfft_magnitude(signal: np.ndarray, n_fft: int, window: str) -> np.ndarray:
     """Return the independently calculated Wandas one-sided FFT magnitude."""
     analysis = signal[..., :n_fft]
-    window_values = get_window(window, analysis.shape[-1])
+    if analysis.shape[-1] < n_fft:
+        analysis = np.pad(
+            analysis,
+            [(0, 0)] * (analysis.ndim - 1) + [(0, n_fft - analysis.shape[-1])],
+        )
+    window_values = get_window(window, n_fft)
     spectrum = np.fft.rfft(analysis * window_values, n=n_fft, axis=-1)
     positive_frequency_stop = -1 if n_fft % 2 == 0 else None
     spectrum[..., 1:positive_frequency_stop] *= 2.0

--- a/tests/processing/test_spectral_operations.py
+++ b/tests/processing/test_spectral_operations.py
@@ -151,6 +151,20 @@ class TestFFTOperation:
         result = run_operation_eager(fft_op, np.array([long_signal]))
         assert result.shape == (1, 1024 // 2 + 1)
 
+    def test_fft_zero_padding_uses_the_declared_analysis_window(self) -> None:
+        """Short inputs are padded before the n_fft-length window is applied."""
+        signal = np.array([[1.0, 2.0, 3.0, 4.0]])
+        n_fft = 8
+        window = get_window("hann", n_fft)
+
+        result = FFT(_SR, n_fft=n_fft, window="hann")._process(signal)
+
+        prepared = np.pad(signal, ((0, 0), (0, n_fft - signal.shape[-1]))) * window
+        expected = np.fft.rfft(prepared, n=n_fft)
+        expected[..., 1:-1] *= 2
+        expected /= window.sum()
+        np.testing.assert_allclose(result, expected, rtol=1e-12, atol=1e-12)
+
     # -- Layer 3: Theoretical / numpy reference ----------------------------
 
     def test_fft_peak_at_correct_frequency_bin(self) -> None:
@@ -320,8 +334,9 @@ class TestIFFTOperation:
 
         result = IFFT(_SR, n_fft=5, window="boxcar")._process(spectrum)
 
-        # Undoing both doubled positive bins recovers the normalized impulse.
-        expected = np.array([[0.2, 0.0, 0.0, 0.0, 0.0]])
+        # Undoing both doubled positive bins and coherent-gain normalization
+        # recovers the boxcar-windowed impulse exactly.
+        expected = np.array([[1.0, 0.0, 0.0, 0.0, 0.0]])
         np.testing.assert_allclose(result, expected, rtol=1e-12, atol=1e-12)
 
     def test_ifft_without_n_fft_infers_length(self) -> None:
@@ -371,29 +386,19 @@ class TestIFFTOperation:
         # rtol=0.1: IFFT round-trip with windowing introduces spectral leakage
         np.testing.assert_allclose(detected_freq, f0, rtol=0.1)
 
-    def test_fft_ifft_roundtrip_preserves_frequency(self) -> None:
-        """FFT->IFFT round-trip preserves frequency content.
+    @pytest.mark.parametrize("window_name", ["boxcar", "hann"])
+    def test_fft_ifft_roundtrip_reconstructs_prepared_windowed_signal(self, window_name: str) -> None:
+        """FFT->IFFT reconstructs the documented prepared, windowed waveform."""
+        original = np.random.default_rng(20260730).standard_normal((2, self._N_FFT + 137))
 
-        Note: wandas FFT applies spectral-analysis scaling (window + normalization),
-        so FFT->IFFT is NOT an amplitude-preserving round-trip. Instead, verify
-        that the dominant frequency is preserved through the transform pair.
-        Tolerance: ±1 FFT bin — spectral leakage at bin boundaries.
-        """
-        t = np.linspace(0, 1, _SR, endpoint=False)
-        original = np.array([np.sin(2 * np.pi * 500 * t)])
-
-        fft = FFT(_SR, n_fft=self._N_FFT, window=self._WINDOW)
-        ifft = IFFT(_SR, n_fft=self._N_FFT, window=self._WINDOW)
+        fft = FFT(_SR, n_fft=self._N_FFT, window=window_name)
+        ifft = IFFT(_SR, n_fft=self._N_FFT, window=window_name)
 
         spectrum = run_operation_lazy(fft, original)
         recovered = run_operation_eager(ifft, spectrum)
 
-        # Verify frequency is preserved (not amplitude, due to analysis scaling)
-        fft_of_recovered = np.fft.rfft(recovered[0])
-        freq_bins = np.fft.rfftfreq(recovered.shape[1], 1.0 / _SR)
-        peak_freq = freq_bins[np.argmax(np.abs(fft_of_recovered))]
-        # ±1 bin tolerance for spectral leakage at bin boundaries
-        assert abs(peak_freq - 500.0) <= freq_bins[1], f"Expected 500 Hz peak after FFT->IFFT, got {peak_freq:.1f} Hz"
+        expected = original[..., : self._N_FFT] * get_window(window_name, self._N_FFT)
+        np.testing.assert_allclose(recovered, expected, rtol=1e-12, atol=1e-12)
 
 
 class TestSTFTOperation:
@@ -986,7 +991,7 @@ class TestNOctSynthesisOperation:
 
 
 class TestWelchOperation:
-    """Welch PSD operation: Layer 1 + Layer 2 + Layer 3 (scipy reference)."""
+    """Welch amplitude operation: Layer 1 + Layer 2 + Layer 3."""
 
     _N_FFT: int = 1024
     _HOP: int = 256
@@ -1158,7 +1163,7 @@ class TestWelchOperation:
     # -- Layer 3: Numerical verification (scipy reference) ------------------
 
     def test_peak_frequency_detected_correctly(self) -> None:
-        """Welch PSD peak at 1 kHz for a 1 kHz sine.
+        """Welch amplitude peak at 1 kHz for a 1 kHz sine.
 
         Tolerance: rtol=0.05 — frequency bin resolution.
         """
@@ -1169,7 +1174,7 @@ class TestWelchOperation:
         np.testing.assert_allclose(detected_freq, 1000.0, rtol=0.05)
 
     def test_stereo_second_channel_peak_at_2khz(self) -> None:
-        """Welch PSD peak at 2 kHz for stereo second channel.
+        """Welch amplitude peak at 2 kHz for stereo second channel.
 
         Tolerance: rtol=0.05 — frequency bin resolution.
         """
@@ -1221,6 +1226,22 @@ class TestWelchOperation:
         peak_idx = np.argmax(result[0])
         np.testing.assert_allclose(freq_bins[peak_idx], 1000.0, rtol=1e-10)
         np.testing.assert_allclose(result[0, peak_idx], amp, rtol=1e-10)
+
+    def test_odd_n_fft_scales_last_positive_bin_as_peak_amplitude(self) -> None:
+        """An odd FFT has no Nyquist bin, so its final positive bin is doubled."""
+        n_fft = 5
+        signal = np.cos(2 * np.pi * 2 * np.arange(25) / n_fft)[np.newaxis, :]
+        op = Welch(
+            _SR,
+            n_fft=n_fft,
+            win_length=n_fft,
+            hop_length=n_fft,
+            window="boxcar",
+        )
+
+        result = op._process(signal)
+
+        np.testing.assert_allclose(result[0, -1], 1.0, rtol=1e-12, atol=1e-12)
 
 
 _PAIRWISE_N_FFT = 1024

--- a/tests/visualization/test_plotting.py
+++ b/tests/visualization/test_plotting.py
@@ -423,12 +423,12 @@ class TestPlotting:
         result = strategy.plot(self.mock_spectral_frame, overlay=True)
         assert isinstance(result, Axes)
         assert result.get_xlabel() == "Frequency [Hz]"
-        assert result.get_ylabel() == "Spectrum level [dB]"
+        assert result.get_ylabel() == "Amplitude level [dB re channel ref]"
 
         # Test plot in dBA units
         result = strategy.plot(self.mock_spectral_frame, overlay=True, Aw=True)
         assert isinstance(result, Axes)
-        assert result.get_ylabel() == "Spectrum level [dBA]"
+        assert result.get_ylabel() == "A-weighted amplitude level [dB re channel ref]"
 
         # Test plot with multiple channels
         result = strategy.plot(self.mock_spectral_frame, overlay=False)
@@ -459,12 +459,12 @@ class TestPlotting:
         assert isinstance(result, Axes)
         assert result.get_title() == "Test Single Spectral"
         assert result.get_xlabel() == "Frequency [Hz]"
-        assert result.get_ylabel() == "Spectrum level [dB]"
+        assert result.get_ylabel() == "Amplitude level [dB re channel ref]"
 
         # Test single-channel plot in dBA (overlay=True, Aw=True)
         result = strategy.plot(self.mock_single_spectral_frame, overlay=True, Aw=True)
         assert isinstance(result, Axes)
-        assert result.get_ylabel() == "Spectrum level [dBA]"
+        assert result.get_ylabel() == "A-weighted amplitude level [dB re channel ref]"
 
         # Test single-channel plot (overlay=False)
         result = strategy.plot(self.mock_single_spectral_frame, overlay=False)
@@ -619,13 +619,13 @@ class TestPlotting:
         result = strategy.plot(self.mock_noct_frame, overlay=True)
         assert isinstance(result, Axes)
         assert result.get_xlabel() == "Center frequency [Hz]"
-        assert result.get_ylabel() == "Spectrum level [dBr]"
+        assert result.get_ylabel() == "Band RMS level [dB re channel ref]"
         assert result.get_title() == "Test NOct"
 
         # Test plot in dBA (overlay=True, Aw=True)
         result = strategy.plot(self.mock_noct_frame, overlay=True, Aw=True)
         assert isinstance(result, Axes)
-        assert result.get_ylabel() == "Spectrum level [dBrA]"
+        assert result.get_ylabel() == "A-weighted band RMS level [dB re channel ref]"
 
         # Test plot with multiple channels (overlay=False)
         result = strategy.plot(self.mock_noct_frame, overlay=False)
@@ -635,7 +635,7 @@ class TestPlotting:
 
         # Verify xlabel and ylabel on the last axis
         assert axes_list[-1].get_xlabel() == "Center frequency [Hz]"
-        assert axes_list[-1].get_ylabel() == "Spectrum level [dBr]"
+        assert axes_list[-1].get_ylabel() == "Band RMS level [dB re channel ref]"
 
     def test_single_channel_noct_plot_strategy(self) -> None:
         """Test single-channel NOctPlotStrategy."""
@@ -661,13 +661,13 @@ class TestPlotting:
         result = strategy.plot(self.mock_single_noct_frame, overlay=True)
         assert isinstance(result, Axes)
         assert result.get_xlabel() == "Center frequency [Hz]"
-        assert result.get_ylabel() == "Spectrum level [dBr]"
+        assert result.get_ylabel() == "Band RMS level [dB re channel ref]"
         assert result.get_title() == "Test Single NOct"
 
         # Test single-channel plot in dBA (overlay=True, Aw=True)
         result = strategy.plot(self.mock_single_noct_frame, overlay=True, Aw=True)
         assert isinstance(result, Axes)
-        assert result.get_ylabel() == "Spectrum level [dBrA]"
+        assert result.get_ylabel() == "A-weighted band RMS level [dB re channel ref]"
 
         # Test single-channel plot (overlay=False)
         result = strategy.plot(self.mock_single_noct_frame, overlay=False)
@@ -675,7 +675,7 @@ class TestPlotting:
         axes_list = list(result)
         assert len(axes_list) == 1  # single channel produces exactly 1 axis
         assert axes_list[0].get_xlabel() == "Center frequency [Hz]"
-        assert axes_list[0].get_ylabel() == "Spectrum level [dBr]"
+        assert axes_list[0].get_ylabel() == "Band RMS level [dB re channel ref]"
         assert axes_list[0].get_title() == "ch1"
         assert axes_list[0].figure.get_suptitle() == "Test Single NOct"
         # Test custom title

--- a/tests/visualization/test_plotting.py
+++ b/tests/visualization/test_plotting.py
@@ -118,6 +118,7 @@ class TestPlotting:
         self.mock_spectral_frame.freqs = _freqs
         self.mock_spectral_frame.dB = np.stack([_spec_ch0, _spec_ch1], axis=0)
         self.mock_spectral_frame.dBA = np.stack([_spec_ch0 * 0.8, _spec_ch1 * 0.8], axis=0)
+        self.mock_spectral_frame.operation_history = [{"operation": "wandas.audio.welch"}]
         self.mock_spectral_frame.labels = ["ch1", "ch2"]
         self.mock_spectral_frame.label = "Test Spectral"
         self.mock_spectral_frame.channels = [
@@ -131,6 +132,7 @@ class TestPlotting:
         self.mock_single_spectral_frame.freqs = _freqs
         self.mock_single_spectral_frame.dB = _spec_ch0
         self.mock_single_spectral_frame.dBA = _spec_ch0 * 0.8
+        self.mock_single_spectral_frame.operation_history = [{"operation": "wandas.audio.welch"}]
         self.mock_single_spectral_frame.labels = ["ch1"]
         self.mock_single_spectral_frame.label = "Test Single Spectral"
         self.mock_single_spectral_frame.channels = [

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -208,15 +208,21 @@ class ChannelTransformMixin:
 
     @recipe_operation("wandas.audio.fft")
     def fft(self: TransformFrameProtocol, n_fft: int | None = None, window: str = "hann") -> "SpectralFrame":
-        """Calculate Fast Fourier Transform (FFT).
+        """Calculate a one-sided peak-amplitude FFT spectrum.
+
+        The signal is truncated or zero-padded to ``n_fft``, windowed, and
+        normalized by the window's coherent gain. Values retain each channel's
+        physical unit. Positive-frequency bins other than Nyquist are doubled,
+        so an on-bin sinusoid's magnitude equals its peak amplitude. Graph
+        construction remains lazy.
 
         Args:
-            n_fft: Number of FFT points. Default is the next power of 2 of the data
-                length.
+            n_fft: Number of FFT points. By default, use the current sample
+                count exactly.
             window: Window type. Default is "hann".
 
         Returns:
-            SpectralFrame containing FFT results
+            A lazy SpectralFrame containing complex peak-amplitude values.
         """
         from wandas.frames.spectral import SpectralFrame
         from wandas.processing import FFT, create_operation
@@ -258,18 +264,24 @@ class ChannelTransformMixin:
         window: str = "hann",
         average: str = "mean",
     ) -> "SpectralFrame":
-        """Calculate power spectral density using Welch's method.
+        """Calculate a Welch-averaged one-sided peak-amplitude spectrum.
+
+        Segment power spectra are averaged and converted to peak amplitude.
+        Values retain each channel's physical unit and are not power spectral
+        density or expressed per hertz. ``SpectralFrame.dB`` therefore uses the
+        amplitude rule ``20 * log10(amplitude / channel_ref)``. Graph
+        construction remains lazy.
 
         Args:
             n_fft: Number of FFT points. Default is 2048.
             hop_length: Number of samples between frames.
-                Default is n_fft//4.
+                Default is ``win_length // 4``.
             win_length: Window length. Default is n_fft.
             window: Window type. Default is "hann".
             average: Method for averaging segments. Default is "mean".
 
         Returns:
-            SpectralFrame containing power spectral density
+            A lazy SpectralFrame containing real peak-amplitude values.
         """
         from wandas.frames.spectral import SpectralFrame
         from wandas.processing import Welch, create_operation
@@ -318,15 +330,20 @@ class ChannelTransformMixin:
     ) -> "NOctFrame":
         """Calculate N-octave band spectrum.
 
+        Each output value is the RMS amplitude in one fractional-octave band
+        and retains the input channel's physical unit. ``NOctFrame.dB`` applies
+        ``20 * log10(band_rms / channel_ref)``.
+
         Args:
             fmin: Minimum center frequency (Hz). Default is 25 Hz.
             fmax: Maximum center frequency (Hz). Default is 20000 Hz.
             n: Band division (1: octave, 3: 1/3 octave). Default is 3.
-            G: Reference gain (dB). Default is 10 dB.
+            G: Exact center-frequency ratio convention. Use 10 for base
+                ``10**(3/10)`` or 2 for base 2. Default is 10.
             fr: Reference frequency (Hz). Default is 1000 Hz.
 
         Returns:
-            NOctFrame containing N-octave band spectrum
+            A lazy NOctFrame containing per-band RMS amplitudes.
         """
         from wandas.processing import NOctSpectrum, create_operation
 
@@ -370,12 +387,16 @@ class ChannelTransformMixin:
         win_length: int | None = None,
         window: str = "hann",
     ) -> "SpectrogramFrame":
-        """Calculate Short-Time Fourier Transform.
+        """Calculate a one-sided peak-amplitude Short-Time Fourier Transform.
+
+        Each time frame is normalized by its window's coherent gain. Complex
+        values retain the input physical unit; an on-bin sinusoid's magnitude
+        is its peak amplitude.
 
         Args:
             n_fft: Number of FFT points. Default is 2048.
             hop_length: Number of samples between frames.
-                Default is n_fft//4.
+                Default is ``n_fft // 4``.
             win_length: Window length. Default is n_fft.
             window: Window type. Default is "hann".
 

--- a/wandas/frames/mixins/spectral_properties_mixin.py
+++ b/wandas/frames/mixins/spectral_properties_mixin.py
@@ -56,7 +56,11 @@ class SpectralPropertiesMixin:
 
     @property
     def dBA(self: Any) -> NDArrayReal:  # noqa: N802
-        """A-weighted amplitude level relative to each channel reference."""
+        """A-weighted magnitude level relative to each channel reference.
+
+        For the canonical FFT, STFT, and Welch amplitude quantities, this is
+        an A-weighted amplitude level.
+        """
         weighted: NDArrayReal = a_weighting_db(frequencies=self.freqs, min_db=None)
         if self._data.ndim == 3:
             # SpectrogramFrame: broadcast over time axis

--- a/wandas/frames/mixins/spectral_properties_mixin.py
+++ b/wandas/frames/mixins/spectral_properties_mixin.py
@@ -16,17 +16,18 @@ from wandas.utils.util import ref_weighted_dB
 
 
 class SpectralPropertiesMixin:
-    """Shared magnitude / phase / power / dB / dBA properties.
+    """Shared amplitude, phase, squared-magnitude, and level properties.
 
     Host classes must provide ``data`` (computed array),
     ``_data`` (Dask array), ``_channel_metadata``, and ``freqs``.
+    Spectral values retain the input channel's physical unit.
     """
 
     # -- read-only properties reused by SpectralFrame & SpectrogramFrame --
 
     @property
     def magnitude(self: Any) -> NDArrayReal:
-        """Magnitude (absolute value) of the complex data."""
+        """Peak-amplitude magnitude in the input channel's physical unit."""
         result: NDArrayReal = np.abs(self.data)
         return result
 
@@ -38,20 +39,20 @@ class SpectralPropertiesMixin:
 
     @property
     def power(self: Any) -> NDArrayReal:
-        """Power (squared magnitude)."""
+        """Squared magnitude in the squared input unit, not a PSD."""
         mag: NDArrayReal = np.abs(self.data)
         result: NDArrayReal = mag**2
         return result
 
     @property
     def dB(self: Any) -> NDArrayReal:  # noqa: N802
-        """Decibel level relative to per-channel reference values."""
+        """Amplitude level: ``20 * log10(magnitude / channel_ref)``."""
         mag: NDArrayReal = np.abs(self.data)
         return ref_weighted_dB(mag, self._channel_metadata, self._data.ndim)
 
     @property
     def dBA(self: Any) -> NDArrayReal:  # noqa: N802
-        """A-weighted decibel level."""
+        """A-weighted amplitude level relative to each channel reference."""
         weighted: NDArrayReal = a_weighting_db(frequencies=self.freqs, min_db=None)
         if self._data.ndim == 3:
             # SpectrogramFrame: broadcast over time axis

--- a/wandas/frames/mixins/spectral_properties_mixin.py
+++ b/wandas/frames/mixins/spectral_properties_mixin.py
@@ -16,18 +16,18 @@ from wandas.utils.util import ref_weighted_dB
 
 
 class SpectralPropertiesMixin:
-    """Shared amplitude, phase, squared-magnitude, and level properties.
+    """Shared magnitude, phase, squared-magnitude, and level properties.
 
     Host classes must provide ``data`` (computed array),
     ``_data`` (Dask array), ``_channel_metadata``, and ``freqs``.
-    Spectral values retain the input channel's physical unit.
+    The operation that created the host defines the stored quantity and unit.
     """
 
     # -- read-only properties reused by SpectralFrame & SpectrogramFrame --
 
     @property
     def magnitude(self: Any) -> NDArrayReal:
-        """Peak-amplitude magnitude in the input channel's physical unit."""
+        """Absolute magnitude of the stored spectral quantity."""
         result: NDArrayReal = np.abs(self.data)
         return result
 
@@ -39,14 +39,18 @@ class SpectralPropertiesMixin:
 
     @property
     def power(self: Any) -> NDArrayReal:
-        """Squared magnitude in the squared input unit, not a PSD."""
+        """Squared magnitude, a compatibility property that is not a PSD."""
         mag: NDArrayReal = np.abs(self.data)
         result: NDArrayReal = mag**2
         return result
 
     @property
     def dB(self: Any) -> NDArrayReal:  # noqa: N802
-        """Amplitude level: ``20 * log10(magnitude / channel_ref)``."""
+        """Magnitude level: ``20 * log10(magnitude / channel_ref)``.
+
+        For the canonical FFT, STFT, and Welch amplitude quantities, this is
+        an amplitude level.
+        """
         mag: NDArrayReal = np.abs(self.data)
         return ref_weighted_dB(mag, self._channel_metadata, self._data.ndim)
 

--- a/wandas/frames/noct.py
+++ b/wandas/frames/noct.py
@@ -35,8 +35,8 @@ class NOctFrame(BaseFrame[NDArrayReal]):
 
     This class represents frequency data analyzed in fractional octave bands,
     typically used in acoustic and vibration analysis. It handles real-valued
-    data representing energy or power in each frequency band, following standard
-    acoustical band definitions.
+    data representing RMS amplitude in each frequency band, following standard
+    acoustical band definitions. Values retain the input channel's physical unit.
 
     Parameters
     ----------
@@ -54,7 +54,8 @@ class NOctFrame(BaseFrame[NDArrayReal]):
     n : int, default=3
         Number of bands per octave (e.g., 3 for third-octave bands).
     G : int, default=10
-        Reference band number according to IEC 61260-1:2014.
+        Exact center-frequency ratio convention: 10 selects base
+        ``10**(3/10)`` and 2 selects base 2.
     fr : int, default=1000
         Reference frequency in Hz, typically 1000 Hz for acoustic analysis.
     label : str, optional
@@ -77,7 +78,8 @@ class NOctFrame(BaseFrame[NDArrayReal]):
         The center frequencies of each band in Hz, calculated according to
         the standard fractional octave band definitions.
     dB : NDArrayReal
-        The spectrum in decibels relative to channel reference values.
+        Band RMS amplitude level,
+        ``20 * log10(band_rms / channel_ref)``.
     dBA : NDArrayReal
         The A-weighted spectrum in decibels, applying frequency weighting
         for better correlation with perceived loudness.
@@ -88,7 +90,7 @@ class NOctFrame(BaseFrame[NDArrayReal]):
     n : int
         Number of bands per octave.
     G : int
-        Reference band number.
+        Exact center-frequency ratio convention.
     fr : int
         Reference frequency in Hz.
 
@@ -183,10 +185,12 @@ class NOctFrame(BaseFrame[NDArrayReal]):
     @property
     def dB(self) -> NDArrayReal:  # noqa: N802
         """
-        Get the spectrum in decibels relative to each channel's reference value.
+        Get band RMS amplitude levels relative to each channel reference.
 
-        The reference value for each channel is specified in its metadata.
-        A minimum value of -120 dB is enforced to avoid numerical issues.
+        The conversion is
+        ``20 * log10(max(band_rms / channel_ref, 1e-12))``. The reference has
+        the same physical unit as the band RMS value and is specified by each
+        channel's calibration metadata.
 
         Returns
         -------
@@ -369,7 +373,7 @@ class NOctFrame(BaseFrame[NDArrayReal]):
         dict[str, Any]
             Additional initialization arguments specific to NOctFrame:
             - n: Number of bands per octave
-            - G: Reference band number
+            - G: Exact center-frequency ratio convention
             - fr: Reference frequency
             - fmin: Lower frequency bound
             - fmax: Upper frequency bound

--- a/wandas/frames/spectral.py
+++ b/wandas/frames/spectral.py
@@ -69,15 +69,17 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
     Attributes
     ----------
     magnitude : NDArrayReal
-        The magnitude spectrum of the data.
+        Absolute value of the complex amplitude spectrum, in the input channel
+        unit.
     phase : NDArrayReal
         The phase spectrum in radians.
     unwrapped_phase : NDArrayReal
         The unwrapped phase spectrum in radians.
     power : NDArrayReal
-        The power spectrum (magnitude squared).
+        Squared magnitude, in the squared input unit. This is not a power
+        spectral density.
     dB : NDArrayReal
-        The spectrum in decibels relative to channel reference values.
+        Amplitude level, ``20 * log10(magnitude / channel_ref)``.
     dBA : NDArrayReal
         The A-weighted spectrum in decibels.
     freqs : NDArrayReal
@@ -89,7 +91,7 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
     >>> signal = ChannelFrame.from_numpy(data, sampling_rate=44100)
     >>> spectrum = signal.fft(n_fft=2048)
 
-    Plot the magnitude spectrum:
+    Plot the amplitude level spectrum:
     >>> spectrum.plot()
 
     Perform binary operations:
@@ -296,16 +298,20 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
     @recipe_operation("wandas.spectral.ifft")
     def ifft(self) -> ChannelFrame:
         """
-        Compute the Inverse Fast Fourier Transform (IFFT) to return to time domain.
+        Invert Wandas FFT normalization to a windowed time-domain signal.
 
-        This method transforms the frequency-domain data back to the time domain using
-        the inverse FFT operation. The window function used in the forward FFT is
-        taken into account to ensure proper reconstruction.
+        For a spectrum returned by ``ChannelFrame.fft()`` with matching stored
+        ``n_fft`` and ``window``, this returns the truncated-or-zero-padded
+        analysis input multiplied by the FFT window. With ``window="boxcar"``,
+        that prepared input is reconstructed exactly. A tapered window such as
+        the default Hann window is not divided out because its zero-valued
+        samples cannot be recovered. Graph construction remains lazy.
 
         Returns
         -------
         ChannelFrame
-            A new ChannelFrame containing the time-domain signal.
+            A new ChannelFrame containing the windowed time-domain signal in
+            the original channel unit.
 
         """
         from ..processing import IFFT, create_operation
@@ -381,7 +387,8 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         n : int, default=3
             Number of bands per octave (e.g., 3 for third-octave bands).
         G : int, default=10
-            Reference band number.
+            Exact center-frequency ratio convention. Use 10 for base
+            ``10**(3/10)`` or 2 for base 2.
         fr : int, default=1000
             Reference frequency in Hz.
 

--- a/wandas/frames/spectral.py
+++ b/wandas/frames/spectral.py
@@ -82,7 +82,8 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         Magnitude level, ``20 * log10(magnitude / channel_ref)``. For FFT and
         Welch results this is an amplitude level.
     dBA : NDArrayReal
-        The A-weighted spectrum in decibels.
+        A-weighted magnitude level. For FFT and Welch results this is an
+        A-weighted amplitude level.
     freqs : NDArrayReal
         The frequency axis values in Hz.
 

--- a/wandas/frames/spectral.py
+++ b/wandas/frames/spectral.py
@@ -69,17 +69,18 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
     Attributes
     ----------
     magnitude : NDArrayReal
-        Absolute value of the complex amplitude spectrum, in the input channel
-        unit.
+        Absolute value of the stored spectral quantity. FFT and Welch results
+        are amplitudes in the input channel unit.
     phase : NDArrayReal
         The phase spectrum in radians.
     unwrapped_phase : NDArrayReal
         The unwrapped phase spectrum in radians.
     power : NDArrayReal
-        Squared magnitude, in the squared input unit. This is not a power
-        spectral density.
+        Squared magnitude. This compatibility property is not necessarily
+        physical power or power spectral density.
     dB : NDArrayReal
-        Amplitude level, ``20 * log10(magnitude / channel_ref)``.
+        Magnitude level, ``20 * log10(magnitude / channel_ref)``. For FFT and
+        Welch results this is an amplitude level.
     dBA : NDArrayReal
         The A-weighted spectrum in decibels.
     freqs : NDArrayReal

--- a/wandas/frames/spectral.py
+++ b/wandas/frames/spectral.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     import pandas as pd
     from matplotlib.axes import Axes
 
+    from ..processing.spectral import IFFT
     from ..visualization.plotting import PlotStrategy
     from .channel import ChannelFrame
     from .noct import NOctFrame
@@ -297,7 +298,7 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
 
         return _ax
 
-    @recipe_operation("wandas.spectral.ifft")
+    @recipe_operation("wandas.spectral.ifft", version=2)
     def ifft(self) -> ChannelFrame:
         """
         Invert Wandas FFT normalization to a windowed time-domain signal.
@@ -316,8 +317,7 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             the original channel unit.
 
         """
-        from ..processing import IFFT, create_operation
-        from .channel import ChannelFrame
+        from ..processing import create_operation
 
         params = {"n_fft": self.n_fft, "window": self.window}
         operation_name = "ifft"
@@ -326,10 +326,28 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         # Create operation instance
         operation = create_operation(operation_name, self.sampling_rate, **params)
         operation = cast("IFFT", operation)
+        return self._ifft_with_operation(operation)
+
+    @recipe_operation("wandas.spectral.ifft", version=1)
+    def _ifft_recipe_v1(self) -> ChannelFrame:
+        """Replay the released Recipe v1 IFFT amplitude-scaling contract."""
+        from ..processing.spectral import _RecipeIFFTV1
+
+        operation = _RecipeIFFTV1(
+            self.sampling_rate,
+            n_fft=self.n_fft,
+            window=self.window,
+        )
+        return self._ifft_with_operation(operation)
+
+    def _ifft_with_operation(self, operation: IFFT) -> ChannelFrame:
+        """Build an inverse transform while preserving Frame orchestration."""
+        from .channel import ChannelFrame
+
         # Apply processing to data
         time_series = operation.process(self._data)
 
-        logger.debug(f"Created new SpectralFrame with operation {operation_name} added to graph")
+        logger.debug("Created new ChannelFrame with IFFT operation added to graph")
 
         # Create new instance
         lineage = self._required_semantic_lineage()

--- a/wandas/processing/cepstral.py
+++ b/wandas/processing/cepstral.py
@@ -183,7 +183,12 @@ class Cepstrum(AudioOperation[NDArrayReal, NDArrayReal]):
             )
         n_fft = _resolve_fft_size(self.n_fft, int(data.shape[-1]))
         analysis = np.asarray(data[..., :n_fft], dtype=np.float64)
-        window_values = get_window(self.window, analysis.shape[-1])
+        if analysis.shape[-1] < n_fft:
+            analysis = np.pad(
+                analysis,
+                [(0, 0)] * (analysis.ndim - 1) + [(0, n_fft - analysis.shape[-1])],
+            )
+        window_values = get_window(self.window, n_fft)
         window_gain = float(np.sum(window_values))
         if not np.isfinite(window_gain) or window_gain == 0:
             raise ValueError(

--- a/wandas/processing/spectral.py
+++ b/wandas/processing/spectral.py
@@ -352,6 +352,27 @@ class IFFT(AudioOperation[NDArrayComplex, NDArrayReal]):
         return result
 
 
+class _RecipeIFFTV1(IFFT):
+    """Released Recipe v1 IFFT scaling retained for deterministic replay."""
+
+    name = "_recipe_ifft_v1"
+    _display = "iFFT Recipe v1"
+
+    def _process(self, x: NDArrayComplex) -> NDArrayReal:
+        """Apply the legacy normalization exactly as released."""
+        logger.debug(f"Applying Recipe v1 IFFT to array with shape: {x.shape}")
+
+        fft_size = 2 * (int(x.shape[-1]) - 1) if self.n_fft is None else self.n_fft
+        _x = _denormalize_rfft_amplitude(x, n_fft=fft_size, window_gain=1.0)
+        result: NDArrayReal = np.fft.irfft(_x, n=self.n_fft, axis=-1)
+        win = get_window(self.window, result.shape[-1])
+        scaling_factor = np.sum(win) / result.shape[-1]
+        result = result / scaling_factor
+
+        logger.debug(f"Recipe v1 IFFT applied, returning result with shape: {result.shape}")
+        return result
+
+
 class STFT(AudioOperation[NDArrayReal, NDArrayComplex]):
     """One-sided peak-amplitude Short-Time Fourier Transform.
 

--- a/wandas/processing/spectral.py
+++ b/wandas/processing/spectral.py
@@ -258,8 +258,6 @@ class FFT(AudioOperation[NDArrayReal, NDArrayComplex]):
 
     def _process(self, x: NDArrayReal) -> NDArrayComplex:
         """Apply FFT to the input array."""
-        from scipy.signal import get_window
-
         fft_size = int(x.shape[-1]) if self.n_fft is None else self.n_fft
         if x.shape[-1] >= fft_size:
             x = x[..., :fft_size]
@@ -828,7 +826,7 @@ class Welch(AudioOperation[NDArrayReal, NDArrayReal]):
         result = np.sqrt(result)
         result[_rfft_positive_frequency_bins(result.ndim, n_fft=self.n_fft, axis=-1)] *= np.sqrt(2)
 
-        return np.array(result)
+        return result
 
 
 class _NOctBase(AudioOperation[NDArrayReal, NDArrayReal]):

--- a/wandas/processing/spectral.py
+++ b/wandas/processing/spectral.py
@@ -182,7 +182,14 @@ def _validate_spectral_params(
 
 
 class FFT(AudioOperation[NDArrayReal, NDArrayComplex]):
-    """FFT (Fast Fourier Transform) operation"""
+    """One-sided, coherent-gain-normalized peak-amplitude FFT.
+
+    The input is truncated or zero-padded to ``n_fft`` before the selected
+    window is applied. DC and Nyquist bins retain their real-FFT scaling; every
+    other positive-frequency bin is doubled. The complex result therefore has
+    the same physical unit as the input, and an on-bin sinusoid's magnitude is
+    its peak amplitude.
+    """
 
     name = "fft"
     _display = "FFT"
@@ -253,16 +260,15 @@ class FFT(AudioOperation[NDArrayReal, NDArrayComplex]):
         """Apply FFT to the input array."""
         from scipy.signal import get_window
 
-        n_fft = self.n_fft
-        if n_fft is not None and x.shape[-1] > n_fft:
-            # If n_fft is specified and input length exceeds it, truncate
-            x = x[..., :n_fft]
+        fft_size = int(x.shape[-1]) if self.n_fft is None else self.n_fft
+        if x.shape[-1] >= fft_size:
+            x = x[..., :fft_size]
+        else:
+            x = np.pad(x, [(0, 0)] * (x.ndim - 1) + [(0, fft_size - x.shape[-1])])
 
-        win = get_window(self.window, x.shape[-1])
+        win = get_window(self.window, fft_size)
         x = x * win
-        fft_size = int(x.shape[-1]) if n_fft is None else n_fft
         result: NDArrayComplex = np.fft.rfft(x, n=fft_size, axis=-1)
-        # Window function scaling correction
         scaling_factor = np.sum(win)
         return _normalize_rfft_amplitude(
             result,
@@ -272,7 +278,14 @@ class FFT(AudioOperation[NDArrayReal, NDArrayComplex]):
 
 
 class IFFT(AudioOperation[NDArrayComplex, NDArrayReal]):
-    """IFFT (Inverse Fast Fourier Transform) operation"""
+    """Inverse of Wandas' one-sided peak-amplitude FFT normalization.
+
+    For a spectrum produced by :class:`FFT` with matching ``n_fft`` and
+    ``window``, the result is the truncated-or-zero-padded input multiplied by
+    that analysis window. A boxcar window therefore reconstructs the prepared
+    input exactly; tapered windows intentionally reconstruct the windowed
+    waveform rather than guessing samples discarded by the analysis window.
+    """
 
     name = "ifft"
     _display = "iFFT"
@@ -324,35 +337,30 @@ class IFFT(AudioOperation[NDArrayComplex, NDArrayReal]):
         return np.dtype(np.float64)
 
     def _process(self, x: NDArrayComplex) -> NDArrayReal:
-        """Create processor function for IFFT operation"""
+        """Invert Wandas peak-amplitude scaling to a windowed waveform."""
         logger.debug(f"Applying IFFT to array with shape: {x.shape}")
 
-        # Restore frequency component scaling (remove the 2.0 multiplier applied in FFT)
         fft_size = 2 * (int(x.shape[-1]) - 1) if self.n_fft is None else self.n_fft
+        win = get_window(self.window, fft_size)
         _x = _denormalize_rfft_amplitude(
             x,
             n_fft=fft_size,
-            window_gain=1.0,
+            window_gain=float(np.sum(win)),
         )
 
-        # Execute IFFT
-        result: NDArrayReal = np.fft.irfft(_x, n=self.n_fft, axis=-1)
-
-        # Window function correction (inverse of FFT operation)
-        from scipy.signal import get_window
-
-        win = get_window(self.window, result.shape[-1])
-
-        # Correct the FFT window function scaling
-        scaling_factor = np.sum(win) / result.shape[-1]
-        result = result / scaling_factor
+        result: NDArrayReal = np.fft.irfft(_x, n=fft_size, axis=-1)
 
         logger.debug(f"IFFT applied, returning result with shape: {result.shape}")
         return result
 
 
 class STFT(AudioOperation[NDArrayReal, NDArrayComplex]):
-    """Short-Time Fourier Transform operation"""
+    """One-sided peak-amplitude Short-Time Fourier Transform.
+
+    Each frame uses SciPy's coherent-gain magnitude scaling, with non-DC and
+    non-Nyquist positive-frequency bins doubled. Values retain the input
+    physical unit.
+    """
 
     name = "stft"
     _display = "STFT"
@@ -665,18 +673,20 @@ class ISTFT(AudioOperation[NDArrayComplex, NDArrayReal]):
 
 
 class Welch(AudioOperation[NDArrayReal, NDArrayReal]):
-    """Welch method for power spectral density estimation.
+    """Welch-averaged one-sided peak-amplitude spectrum.
 
-    Computes the one-sided amplitude spectrum using Welch's method for
-    consistency with FFT and STFT methods. For a sine wave with amplitude A,
-    the peak value at its frequency will be approximately A.
+    Segment power spectra are averaged with ``scaling="spectrum"`` and then
+    converted to peak amplitude. Values retain the input physical unit; they
+    are neither power spectral density nor expressed per hertz. For an on-bin
+    sine wave with peak amplitude ``A``, the corresponding bin is approximately
+    ``A``.
 
     Notes
     -----
     Internally uses scipy.signal.welch with scaling='spectrum' and converts
     the power spectrum to amplitude spectrum:
     - DC component (f=0): A = sqrt(P)
-    - AC components (f>0): A = sqrt(2*P)
+    - positive non-Nyquist components: A = sqrt(2*P)
     """
 
     name = "welch"
@@ -786,10 +796,10 @@ class Welch(AudioOperation[NDArrayReal, NDArrayReal]):
         return _spectral_real_dtype(input_dtype)
 
     def _process(self, x: NDArrayReal) -> NDArrayReal:
-        """Create processor function for Welch operation.
+        """Return a Welch-averaged one-sided peak-amplitude spectrum.
 
-        Converts power spectrum from scipy.signal.welch to one-sided
-        amplitude spectrum for consistency with FFT/STFT.
+        Converts ``scipy.signal.welch(..., scaling="spectrum")`` power to
+        peak amplitude for consistency with FFT/STFT.
         """
         from scipy import signal as ss
 
@@ -815,8 +825,8 @@ class Welch(AudioOperation[NDArrayReal, NDArrayReal]):
         # To recover amplitude A:
         #   - DC: A = sqrt(P)
         #   - AC: A = sqrt(2*P) = sqrt(2) * sqrt(P)
-        result = np.sqrt(result)  # Convert to amplitude
-        result[..., 1:-1] *= np.sqrt(2)  # Apply factor of sqrt(2) for AC components
+        result = np.sqrt(result)
+        result[_rfft_positive_frequency_bins(result.ndim, n_fft=self.n_fft, axis=-1)] *= np.sqrt(2)
 
         return np.array(result)
 

--- a/wandas/visualization/plotting.py
+++ b/wandas/visualization/plotting.py
@@ -373,16 +373,22 @@ class FrequencyPlotStrategy(PlotStrategy["SpectralFrame"]):
         axes_cls = _matplotlib_axes_type("frequency plot")
         line2d_cls = _matplotlib_line2d_type("frequency plot")
         is_aw = kwargs.pop("Aw", False)
-        if len(bf.operation_history) > 0 and bf.operation_history[-1]["operation"] == "coherence":
+        last_operation = ""
+        if len(bf.operation_history) > 0:
+            last_operation = str(bf.operation_history[-1]["operation"]).rsplit(".", maxsplit=1)[-1]
+        if last_operation == "coherence":
             data = bf.magnitude
             ylabel = kwargs.pop("ylabel", "coherence")
         else:
+            is_amplitude = last_operation in {"fft", "stft", "welch", "to_spectral_envelope"}
             if is_aw:
                 data = bf.dBA
-                default_ylabel = "A-weighted amplitude level [dB re channel ref]"
+                quantity = "amplitude" if is_amplitude else "spectrum magnitude"
+                default_ylabel = f"A-weighted {quantity} level [dB re channel ref]"
             else:
                 data = bf.dB
-                default_ylabel = "Amplitude level [dB re channel ref]"
+                quantity = "Amplitude" if is_amplitude else "Spectrum magnitude"
+                default_ylabel = f"{quantity} level [dB re channel ref]"
             ylabel = kwargs.pop("ylabel", default_ylabel)
         data = _reshape_to_2d(data)
         xlabel = kwargs.pop("xlabel", "Frequency [Hz]")

--- a/wandas/visualization/plotting.py
+++ b/wandas/visualization/plotting.py
@@ -378,12 +378,12 @@ class FrequencyPlotStrategy(PlotStrategy["SpectralFrame"]):
             ylabel = kwargs.pop("ylabel", "coherence")
         else:
             if is_aw:
-                unit = "dBA"
                 data = bf.dBA
+                default_ylabel = "A-weighted amplitude level [dB re channel ref]"
             else:
-                unit = "dB"
                 data = bf.dB
-            ylabel = kwargs.pop("ylabel", f"Spectrum level [{unit}]")
+                default_ylabel = "Amplitude level [dB re channel ref]"
+            ylabel = kwargs.pop("ylabel", default_ylabel)
         data = _reshape_to_2d(data)
         xlabel = kwargs.pop("xlabel", "Frequency [Hz]")
         alpha = kwargs.pop("alpha", 1)
@@ -448,13 +448,13 @@ class NOctPlotStrategy(PlotStrategy["NOctFrame"]):
         is_aw = kwargs.pop("Aw", False)
 
         if is_aw:
-            unit = "dBrA"
             data = bf.dBA
+            default_ylabel = "A-weighted band RMS level [dB re channel ref]"
         else:
-            unit = "dBr"
             data = bf.dB
+            default_ylabel = "Band RMS level [dB re channel ref]"
         data = _reshape_to_2d(data)
-        ylabel = kwargs.pop("ylabel", f"Spectrum level [{unit}]")
+        ylabel = kwargs.pop("ylabel", default_ylabel)
         xlabel = kwargs.pop("xlabel", "Center frequency [Hz]")
         alpha = kwargs.pop("alpha", 1)
         label = kwargs.pop("label", None)


### PR DESCRIPTION
Closes #365

## Summary

- Define one canonical contract for FFT, STFT, Welch, fractional-octave, magnitude/power, and dB quantities.
- Keep FFT/STFT/Welch as one-sided peak-amplitude results in the calibrated input unit; document that Welch is not PSD.
- Correct FFT zero-padding so padding precedes the declared analysis window, correct IFFT normalization so boxcar reconstructs the prepared waveform and tapered windows reconstruct the exact windowed waveform, and align cepstral zero-padding with the same FFT contract.
- Correct odd-size Welch positive-bin scaling.
- Label spectral plots as amplitude level and N-octave plots as band RMS level, with the per-channel dB reference explicit.
- Align public docstrings, API/theory documentation, and executable learning material.

## Root cause and impact

The implementation mixed a coherent-gain peak-amplitude FFT/STFT convention with documentation that called some results magnitude, power, or PSD. IFFT then undid only part of the forward normalization, and FFT zero-padding applied a shorter window than the declared transform. Users can now reason consistently about value, unit, normalization, dB reference, and the precise inverse guarantee.

## Major files

- `wandas/processing/spectral.py`, `wandas/processing/cepstral.py`
- `wandas/frames/mixins/channel_transform_mixin.py`
- `wandas/frames/spectral.py`, `wandas/frames/noct.py`
- `wandas/frames/mixins/spectral_properties_mixin.py`
- `wandas/visualization/plotting.py`
- `docs/src/explanation/spectral-numerical-contracts.md`
- `learning-path/03_signal_processing_basics.py`, `learning-path/04_advanced_processing.py`

## Tests added or updated

- Added independent FFT zero-padding and exact FFT/IFFT windowed round-trip tests.
- Added odd-`n_fft` Welch peak-amplitude coverage.
- Updated public Frame round-trip and plot-label contracts.
- Aligned cepstral analytical references with canonical pad-before-window FFT behavior.
- Added `tests/docs/test_spectral_numerical_contracts.py` to prevent terminology drift.

## Validation

- Focused spectral/frame/plot/docs tests — 260 passed
- Pipeline, WDF I/O, and docs tests — 490 passed, 2 warnings
- Cepstral/frame/recipe tests — 54 passed
- `uv run pytest -q` — 2777 passed, 3 skipped, 33 warnings
- Review-follow-up spectral tests — 163 passed
- `uv run ruff check wandas tests scripts` — passed
- `uv run ty check wandas tests` — passed
- `uv run mkdocs build --strict -f docs/mkdocs.yml` — passed
- `uv run marimo check learning-path/03_signal_processing_basics.py learning-path/04_advanced_processing.py` — passed
- Both notebooks exported to HTML with `--no-include-code`; execution completed without cell errors. Only existing missing-CJK-font warnings were emitted.
- `git diff --check` — passed
- GitHub CI at head `753390c77336aae66d38ea083f6e74a90662265a` — 14/14 successful (Linux/Windows Python matrix, lint/type, docs, core-only wheel, Pyodide, Codecov, Release Drafter)

Representative scalability comparison was not run because the repository benchmark exclusively measures `RemoveDC`; none of the changed FFT/IFFT/Welch/Cepstrum/plot/docs paths are imported or executed by that benchmark, so it cannot produce relevant before/after evidence. The full suite includes the benchmark schema/smoke tests.

## Codex review

- Formal Codex review completed on `d1b1e3276f97fdca235590b1854ded5b03a169bf`; self-review findings for cepstral padding and generic spectral quantity terminology were fixed before submission.
- Copilot reviewed all 19 changed files and raised two actionable comments.
- Both comments were fixed in `753390c77336aae66d38ea083f6e74a90662265a`: the redundant local `get_window` import and an unnecessary Welch ndarray copy were removed.
- Both inline threads were answered and resolved.
- Codex re-review is anchored to the final head and reports no remaining actionable findings.

## Risks and unrun checks

- FFT zero-padding and IFFT amplitude reconstruction intentionally correct observable numerical values. The exact behavior is now specified and covered by independent reference tests.
- The `RemoveDC`-only scalability benchmark was skipped for the reason above.
- No required checks remain pending or omitted.