### PR TITLE
docs: bound scalability claims to execution contracts

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -39,14 +39,14 @@ Wandas は、音声・振動・センサーなどの波形データを `ChannelF
 
 5. **サイズを制御した多数の収録ファイルへ拡張できる**
 
-   `ChannelFrameDataset` はファイルを遅延探索するため、波形サンプルを読む前に path
-   または CSV metadata で対象を選べます。Frame のメソッドチェインが行うのは Dask の
-   遅延 graph 構築であり、実行境界は別です。数値 kernel は 1 チャンネルの連続した
-   時間軸全体を実体化することがあり、保守的な operation はマルチチャンネル Frame
-   全体を実体化することがあります。`frame.data` の取得、NumPy 変換、PyTorch /
-   TensorFlow への受け渡しでは最終結果が実体化されます。したがって Wandas が最も
-   得意なのは、単一の巨大な Frame を自由に分散することではなく、サイズを制御した
-   多数の収録ファイルを処理する workflow です。正確な実行保証と制約は
+   `ChannelFrameDataset` は構築時に file path と path／CSV metadata を探索・解決するため、
+   波形 sample を読む前に対象を選べます。選択した各収録ファイルの読み込みは遅延されます。
+   Frame のメソッドチェインが行うのは Dask の遅延 graph 構築であり、実行境界は別です。
+   数値 kernel は 1 チャンネルの連続した時間軸全体を実体化することがあり、保守的な
+   operation はマルチチャンネル Frame 全体を実体化することがあります。`frame.data`
+   の取得、NumPy 変換、PyTorch／TensorFlow への受け渡しでは最終結果が実体化されます。
+   したがって Wandas が最も得意なのは、単一の巨大な Frame を自由に分散することではなく、
+   サイズを制御した多数の収録ファイルを処理する workflow です。正確な実行保証と制約は
    [スケーラビリティ契約](docs/src/explanation/scalability-contract.md)を参照してください。
 
 ## インストール

--- a/README.ja.md
+++ b/README.ja.md
@@ -37,9 +37,17 @@ Wandas は、音声・振動・センサーなどの波形データを `ChannelF
 
    WAV、FLAC、OGG、AIFF、SND、CSV、URL、bytes、file-like object、NumPy 配列を共通の流れに載せられます。録音データもセンサーデータも、読み込んだ後は同じ frame API で扱えます。
 
-5. **大きなデータや ML 前処理へ伸ばせる**
+5. **サイズを制御した多数の収録ファイルへ拡張できる**
 
-   frame 内の処理は Dask による遅延評価を基本とし、フォルダ内の複数ファイルは `ChannelFrameDataset` で遅延読み込みできます。リサンプリング、トリミング、正規化、STFT をつなぎ、必要に応じて PyTorch / TensorFlow の tensor に変換できます。
+   `ChannelFrameDataset` はファイルを遅延探索するため、波形サンプルを読む前に path
+   または CSV metadata で対象を選べます。Frame のメソッドチェインが行うのは Dask の
+   遅延 graph 構築であり、実行境界は別です。数値 kernel は 1 チャンネルの連続した
+   時間軸全体を実体化することがあり、保守的な operation はマルチチャンネル Frame
+   全体を実体化することがあります。`frame.data` の取得、NumPy 変換、PyTorch /
+   TensorFlow への受け渡しでは最終結果が実体化されます。したがって Wandas が最も
+   得意なのは、単一の巨大な Frame を自由に分散することではなく、サイズを制御した
+   多数の収録ファイルを処理する workflow です。正確な実行保証と制約は
+   [スケーラビリティ契約](docs/src/explanation/scalability-contract.md)を参照してください。
 
 ## インストール
 
@@ -176,15 +184,23 @@ spectrum.plot(xlim=(20, fmax))
 
 物理量を扱う解析では、データの校正を保ってください。`normalize()` は振幅を変えるため、SPL、sound level、ラウドネス、粗さ、シャープネスなどを計算するときは、正しく Pa に換算された元データから解析します。心理音響指標には `wandas[psychoacoustic]`、WDF の保存・読み込みには `wandas[io]` が必要です。
 
-複数ファイルでは、`wd.from_folder("recordings/", recursive=True)` から始められます。dataset に対して `.resample(16_000).trim(0, 5).normalize().stft(n_fft=512)` のように前処理をまとめて適用できます。ML へ渡すときは `frame.to_tensor(framework="torch")` または `frame.to_tensor(framework="tensorflow")` を使います（`wandas[ml]` が必要で、変換時に遅延データが実体化されます）。
+複数ファイルでは
+`dataset = wd.from_folder("recordings/", recursive=True, path_metadata=True)` から始め、
+目的に必要な、サイズを制御した収録ファイルを選択してから読み込み・処理します。その後で
+`selected.trim(0, 5).resample(16_000).normalize().stft(n_fft=512)` のような前処理を
+適用してください。corpus 全体を 1 つの Frame に連結することは避けます。ML へ渡すときは
+`frame.to_tensor(framework="torch")` または
+`frame.to_tensor(framework="tensorflow")` を使います（`wandas[ml]` が必要で、
+変換時に遅延データが実体化されます）。
 
 ### 波形を読む前にファイルを選ぶ
 
 グループや収録単位をフォルダで分けている場合は、Wandas にメタデータを推論させるのが最も手軽です。
 
-`dataset = wd.from_folder("recordings/", recursive=True, path_metadata=True)` で dataset を作り、`selected = dataset.select(partition_0="group_a")` でグループを選びます。
+上記のように dataset を作り、`selected = dataset.select(partition_0="group_a")`
+でグループを選びます。その後で、選択済みの収録ファイルだけを読み込み・処理します。
 
-通常のフォルダ名は `partition_0`、`partition_1` のようなキーになり、`group=group_a` のような Hive 形式では `group` がキーになります。選択時には音声ヘッダーや波形サンプルを読みません。独自のファイル名規則や外部テーブルからメタデータを得る場合だけ `metadata_resolver` を使います。実行可能な [メタデータ駆動のファイル検索 learning path](learning-path/08_metadata_driven_dataset_search.py) では、推奨するフォルダ経由の方法、CSV lookup、遅延読み込み、選択前の Dataset 一括処理を確認できます。
+通常のフォルダ名は `partition_0`、`partition_1` のようなキーになり、`group=group_a` のような Hive 形式では `group` がキーになります。選択時には音声ヘッダーや波形サンプルを読みません。独自のファイル名規則や外部テーブルからメタデータを得る場合だけ `metadata_resolver` を使います。実行可能な [メタデータ駆動のファイル検索 learning path](learning-path/08_metadata_driven_dataset_search.py) では、推奨するフォルダ経由の方法、CSV lookup、遅延読み込み、Dataset 一括処理の前に対象を選ぶ流れを確認できます。
 
 ## 小さな top-level API
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ Methods do not mutate their input; each one returns a new frame. The result reco
 
 5. **The workflow scales across collections of bounded recordings**
 
-   `ChannelFrameDataset` discovers files lazily, so you can select recordings from
-   path or CSV metadata before loading waveform samples. Frame method chains build
+   `ChannelFrameDataset` discovers file paths and their path or CSV metadata when the
+   dataset is constructed, so you can select recordings before loading waveform
+   samples. Loading each selected recording remains lazy. Frame method chains build
    lazy Dask graphs, but execution is a separate boundary: a numerical kernel may
    materialize one complete continuous channel, and conservative operations may
    materialize the whole multichannel Frame. Reading `frame.data`, converting to

--- a/README.md
+++ b/README.md
@@ -37,9 +37,18 @@ Methods do not mutate their input; each one returns a new frame. The result reco
 
    WAV, FLAC, OGG, AIFF, SND, CSV, URLs, bytes, file-like objects, and NumPy arrays all feed into the same frame-based API. Once loaded, recordings and sensor data follow the same analysis flow.
 
-5. **The workflow scales toward larger data and ML preprocessing**
+5. **The workflow scales across collections of bounded recordings**
 
-   Frame processing is Dask-backed and lazy by default, while `ChannelFrameDataset` lazily loads multiple files from a folder. You can chain resampling, trimming, normalization, and STFT before converting results to PyTorch or TensorFlow tensors when needed.
+   `ChannelFrameDataset` discovers files lazily, so you can select recordings from
+   path or CSV metadata before loading waveform samples. Frame method chains build
+   lazy Dask graphs, but execution is a separate boundary: a numerical kernel may
+   materialize one complete continuous channel, and conservative operations may
+   materialize the whole multichannel Frame. Reading `frame.data`, converting to
+   NumPy, or handing data to PyTorch or TensorFlow materializes the final result.
+   Wandas therefore scales best by processing many bounded recordings, not by
+   treating one enormous Frame as arbitrarily distributed. See the
+   [scalability contract](docs/src/explanation/scalability-contract.md) for the exact
+   execution guarantees and limits.
 
 ## Installation
 
@@ -176,15 +185,25 @@ spectrum.plot(xlim=(20, fmax))
 
 Preserve calibration when analyzing physical quantities. Because `normalize()` changes amplitude, calculate SPL, sound level, loudness, roughness, sharpness, and similar metrics from the original data after correctly converting it to Pa. Read the calibrated NumPy values from `frame.data`; the internal array backend does not need to be managed directly. The executable [per-channel calibration learning path](learning-path/07_per_channel_calibration.py) covers certificate and CSV-managed factors, acceleration, 100-channel configuration, and WDF round-trips. Psychoacoustic metrics require `wandas[psychoacoustic]`, while WDF save and load require `wandas[io]`.
 
-For multiple files, start with `wd.from_folder("recordings/", recursive=True)`. Apply preprocessing to the dataset with a chain such as `.resample(16_000).trim(0, 5).normalize().stft(n_fft=512)`. To pass a frame to ML code, use `frame.to_tensor(framework="torch")` or `frame.to_tensor(framework="tensorflow")` (`wandas[ml]` is required, and conversion materializes the lazy data).
+For multiple files, start with
+`dataset = wd.from_folder("recordings/", recursive=True, path_metadata=True)`.
+Select the bounded recordings needed for the task before loading and processing them,
+then apply a chain such as
+`selected.trim(0, 5).resample(16_000).normalize().stft(n_fft=512)`. Avoid
+concatenating an entire corpus into one Frame. To pass a frame to ML code, use
+`frame.to_tensor(framework="torch")` or
+`frame.to_tensor(framework="tensorflow")` (`wandas[ml]` is required, and
+conversion materializes the lazy data).
 
 ### Select files before reading waveforms
 
 When folders describe groups or recording batches, let Wandas infer that metadata during discovery and select only the files you need:
 
-Create the dataset with `dataset = wd.from_folder("recordings/", recursive=True, path_metadata=True)`, then select a group with `selected = dataset.select(partition_0="group_a")`.
+Create the dataset as above, then select a group with
+`selected = dataset.select(partition_0="group_a")`. Only then load or process the
+selected recordings.
 
-Plain folders become `partition_0`, `partition_1`, and so on; Hive-style folders such as `group=group_a` use `group` as the key. File selection does not read audio headers or waveform samples. Use `metadata_resolver` only when metadata must come from custom filename rules or an external table. The executable [metadata-driven dataset search learning path](learning-path/08_metadata_driven_dataset_search.py) covers the recommended folder workflow, CSV lookup, lazy loading, and dataset-wide processing before selection.
+Plain folders become `partition_0`, `partition_1`, and so on; Hive-style folders such as `group=group_a` use `group` as the key. File selection does not read audio headers or waveform samples. Use `metadata_resolver` only when metadata must come from custom filename rules or an external table. The executable [metadata-driven dataset search learning path](learning-path/08_metadata_driven_dataset_search.py) covers the recommended folder workflow, CSV lookup, lazy loading, and selection before dataset-wide processing.
 
 ## Small top-level API
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,8 +12,19 @@
 - **Integration with Visualization Libraries**: Seamlessly integrate with Matplotlib for easy data visualization.
   **可視化ライブラリとの統合**: Matplotlibとシームレスに統合してデータを簡単に可視化可能。
 
-- **Lazy Evaluation**: Efficiently process large data using dask.
-  **遅延評価**: daskを活用した効率的な大規模データ処理。
+- **Bounded-recording scalability**: Discover and select recordings before loading
+  samples, then build lazy Dask graphs across a collection of bounded recordings.
+  Graph construction does not compute samples, but kernel execution can materialize a
+  complete continuous channel or a whole multichannel Frame, and NumPy/tensor
+  conversion materializes the final result. Wandas does not promise arbitrary
+  distribution of one enormous Frame. See the
+  [scalability contract](explanation/scalability-contract.md).
+  **サイズを制御した収録ファイルへの拡張**: sampleを読む前に収録ファイルを探索・選択し、
+  サイズを制御した多数の収録ファイルに対して遅延 Dask graph を構築します。graph 構築は
+  sample を計算しませんが、kernel 実行時には連続した 1 チャンネル全体または
+  マルチチャンネル Frame 全体が実体化されることがあり、NumPy／tensor 変換では最終結果が
+  実体化されます。単一の巨大な Frame を自由に分散できるという保証ではありません。
+  詳細は[スケーラビリティ契約](explanation/scalability-contract.md)を参照してください。
 
 - **Various Analysis Tools**: Frequency analysis, octave band analysis, time-frequency analysis, and more.
   **多様な分析ツール**: 周波数分析、オクターブバンド分析、時間-周波数分析など。

--- a/learning-path/00_why_wandas.py
+++ b/learning-path/00_why_wandas.py
@@ -343,12 +343,15 @@ def _(np, wd):
     _duration = 10.0
     n_files = 10
     for i in range(n_files):
+        _split = "train" if i < 8 else "validation"
+        _split_dir = os.path.join(temp_dir, f"split={_split}")
+        os.makedirs(_split_dir, exist_ok=True)
         _freqs = [440 + i * 100, 880 + i * 50]
         audio = wd.generate_sin(freqs=_freqs, duration=_duration, sampling_rate=_sampling_rate)
         audio = audio + np.random.randn(audio.n_samples) * 0.1
-        filename = os.path.join(temp_dir, f"audio_sample_{i + 1:03d}.wav")
+        filename = os.path.join(_split_dir, f"audio_sample_{i + 1:03d}.wav")
         audio.to_wav(filename)
-    print(f"{n_files}個のサンプル音声ファイルを作成しました")
+    print(f"{n_files}個のサンプル音声ファイルをsplit metadata付きで作成しました")
     return channel_frame_dataset, temp_dir
 
 
@@ -357,12 +360,14 @@ def _(mo):
     mo.md(r"""
     #### ステップ2: データセットの読み込みと前処理
 
-    作成したデータセットをFrameDatasetで読み込み、MLモデルへの入力に適した形式に前処理します。
+    作成したデータセットから `split="train"` を先に選び、選択した収録ファイルだけを
+    MLモデルへの入力に適した形式へ前処理します。
 
     **前処理の内容:**
+    - **select()**: path metadata だけを使い、sample を読む前に対象を選ぶ
     - **遅延読み込み**: データを必要になるまで各録音の sample を読み込まない
-    - **resample()**: サンプリングレートを統一（MLモデルは固定レートを期待）
     - **trim()**: 音声の長さを統一（バッチ処理のため）
+    - **resample()**: サンプリングレートを統一（MLモデルは固定レートを期待）
 
     **なぜ前処理が必要か:**
     - MLモデルは入力データの形式が統一されていることを前提としている
@@ -373,20 +378,24 @@ def _(mo):
 
 @app.cell
 def _(channel_frame_dataset, temp_dir):
-    # FrameDatasetでフォルダからデータを読み込み
+    # path metadata を解決してから、sample を読む前に train split を選択
     dataset = channel_frame_dataset.from_folder(
         folder_path=temp_dir,
         lazy_loading=True,  # 各録音のsampleは必要になるまで読み込まない
+        recursive=True,
+        path_metadata=True,
     )
+    selected_dataset = dataset.select(split="train")
 
     print("データセット情報:")
-    print(f"  ファイル数: {len(dataset)}")
-    print(f"  サンプリングレート: {dataset[0].sampling_rate if dataset[0] else 'N/A'} Hz")
-    print(f"  長さ: {dataset[0].duration if dataset[0] else 'N/A'} 秒")
+    print(f"  探索したファイル数: {len(dataset)}")
+    print(f"  trainとして選択したファイル数: {len(selected_dataset)}")
+    print(f"  サンプリングレート: {selected_dataset[0].sampling_rate if selected_dataset[0] else 'N/A'} Hz")
+    print(f"  長さ: {selected_dataset[0].duration if selected_dataset[0] else 'N/A'} 秒")
 
     dataset = (
-        dataset.resample(target_sr=8000)  # 必要に応じてリサンプリング
-        .trim(start=0, end=5)  # 長さを指定
+        selected_dataset.trim(start=0, end=5)  # 各録音の長さを先に制限
+        .resample(target_sr=8000)  # 必要に応じてリサンプリング
         .normalize()  # 正規化
     )
     print("リサンプリング後のデータセット情報:")

--- a/learning-path/00_why_wandas.py
+++ b/learning-path/00_why_wandas.py
@@ -63,7 +63,7 @@ def _(mo):
     #### 2. **データ管理の複雑さ**
 
     - **多次元データの扱い**: チャンネル数、サンプリングレート、時間軸の管理
-    - **メモリ効率**: 大規模データの処理
+    - **実行境界**: 遅延 graph 構築と、kernel・最終結果の実体化を区別
     - **メタデータ**: 単位、チャンネル名、処理履歴の管理
     - **型安全性**: NumPy配列のdtype管理
     """)
@@ -176,7 +176,15 @@ def _(mo):
     - **多次元データ**: チャンネル × サンプルの2D配列
     - **メタデータ**: サンプリングレート、チャンネル名、単位、処理履歴
     - **型安全性**: ty対応の厳格な型付け
-    - **遅延評価**: Daskによるメモリ効率的な処理
+    - **遅延評価**: Dask graph の構築時には sample を計算しない
+
+    遅延 graph の構築と実行時のメモリ使用は同じではありません。数値 kernel は連続した
+    1 チャンネル全体を必要とすることがあり、operation によってはマルチチャンネル Frame
+    全体を必要とします。`frame.data`、NumPy、tensor への変換では最終結果を実体化します。
+    Wandas は単一の巨大な Frame を自由に分散するのではなく、サイズを制御した多数の
+    収録ファイルを扱う workflow に適しています。正確な保証は
+    [スケーラビリティ契約](https://kasahart.github.io/wandas/explanation/scalability-contract/)
+    を参照してください。
     """)
     return
 
@@ -278,17 +286,18 @@ def _(mo):
     mo.md(r"""
     ### ユースケース2: 機械学習向けデータ前処理
 
-    **課題:** フォルダに格納された大量のwavファイルを、
+    **課題:** フォルダに格納された多数の、サイズを制御したwavファイルを、
     MLモデルに入力するためにスペクトログラムを作成し、前処理を行う必要がある
 
     **Wandasを使った実装:**
     ```python
-    # FrameDatasetで大量のwavファイルをバッチ処理
-    dataset = wd.ChannelFrameDataset.from_folder('audio_dataset/', lazy_loading=True)
+    # metadataで対象を選んでから、サイズを制御した録音単位で処理
+    dataset = wd.from_folder('audio_dataset/', recursive=True, path_metadata=True)
+    selected = dataset.select(split='train')
     # 前処理パイプライン（リサンプリング、トリミング、正規化）
-    dataset = (dataset
+    dataset = (selected
+        .trim(start=0, end=5)      # 各録音の長さを制限
         .resample(target_sr=8000)  # サンプリングレート統一
-        .trim(start=0, end=5)      # 長さ統一
         .normalize())              # 振幅正規化
     # 全ファイルにSTFTを適用してスペクトログラムを作成
     spectrograms = dataset.stft(n_fft=512, hop_length=256)
@@ -299,7 +308,7 @@ def _(mo):
     ```
 
     **このユースケースで学ぶこと:**
-    - 大規模データセットの効率的な処理方法
+    - metadataで先に選択し、サイズを制御した録音単位で処理する方法
     - ML向けのデータ前処理パイプライン
     - スペクトログラムベースの特徴抽出
     - 処理結果の検証
@@ -312,7 +321,10 @@ def _(mo):
     mo.md(r"""
     #### ステップ1: MLデータセットの準備
 
-    機械学習モデルをトレーニングするためには、大量のデータが必要です。ここでは、実際のwavファイルの代わりに、プログラムで様々な周波数特性を持つ音声ファイルを生成してデータセットを作成します。
+    機械学習モデルをトレーニングするためには、多数のデータが必要です。corpus 全体を
+    1 つの Frame に連結せず、必要なファイルを metadata で選択し、サイズを制御した録音単位で
+    処理します。ここでは、実際のwavファイルの代わりに、プログラムで様々な周波数特性を持つ
+    小さな音声ファイルを生成してデータセットを作成します。
     """)
     return
 
@@ -348,7 +360,7 @@ def _(mo):
     作成したデータセットをFrameDatasetで読み込み、MLモデルへの入力に適した形式に前処理します。
 
     **前処理の内容:**
-    - **lazy_loading=True**: メモリ効率のため、データを必要になるまで読み込まない
+    - **遅延読み込み**: データを必要になるまで各録音の sample を読み込まない
     - **resample()**: サンプリングレートを統一（MLモデルは固定レートを期待）
     - **trim()**: 音声の長さを統一（バッチ処理のため）
 
@@ -364,7 +376,7 @@ def _(channel_frame_dataset, temp_dir):
     # FrameDatasetでフォルダからデータを読み込み
     dataset = channel_frame_dataset.from_folder(
         folder_path=temp_dir,
-        lazy_loading=True,  # メモリ効率のため遅延読み込み
+        lazy_loading=True,  # 各録音のsampleは必要になるまで読み込まない
     )
 
     print("データセット情報:")
@@ -662,7 +674,7 @@ def _(mo):
     - 包括的なテストで品質を保証
 
     ### 3. **拡張性の高さ**
-    - Dask統合で大規模データ対応
+    - Dask graphを遅延構築し、サイズを制御した多数の収録ファイルを処理
     - モジュール化でカスタム処理を追加
     - エコシステム統合（pandas, NumPy, Matplotlib）
 
@@ -688,7 +700,7 @@ def _(mo):
     ### すぐに始められる
     - **Python経験者**: pandasやNumPyを知っていればOK
     - **信号処理初心者**: 専門知識がなくても使える
-    - **大規模データユーザー**: Daskでメモリ効率的に処理
+    - **多数ファイルの利用者**: metadataで選択してから、収録単位で処理
     """)
     return
 

--- a/tests/docs/test_scalability_claims.py
+++ b/tests/docs/test_scalability_claims.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+README_EN = REPO_ROOT / "README.md"
+README_JA = REPO_ROOT / "README.ja.md"
+DOCS_HOME = REPO_ROOT / "docs" / "src" / "index.md"
+LEARNING_INTRO = REPO_ROOT / "learning-path" / "00_why_wandas.py"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_top_level_scalability_claims_link_to_canonical_contract() -> None:
+    """Every broad entry point should lead readers to the exact execution contract."""
+    assert "(docs/src/explanation/scalability-contract.md)" in _read(README_EN)
+    assert "(docs/src/explanation/scalability-contract.md)" in _read(README_JA)
+    assert "(explanation/scalability-contract.md)" in _read(DOCS_HOME)
+    assert "https://kasahart.github.io/wandas/explanation/scalability-contract/" in _read(LEARNING_INTRO)
+
+
+def test_top_level_claims_distinguish_all_materialization_boundaries() -> None:
+    """Lazy construction must not be presented as an unbounded-memory guarantee."""
+    english_surfaces = (_read(README_EN), _read(DOCS_HOME))
+    japanese_surfaces = (_read(README_JA), _read(LEARNING_INTRO))
+
+    for text in english_surfaces:
+        assert "lazy Dask graph" in text
+        assert "kernel" in text
+        assert "materialize" in text
+        assert "NumPy" in text
+        assert "tensor" in text
+
+    for text in japanese_surfaces:
+        assert "遅延" in text
+        assert "graph" in text
+        assert "kernel" in text
+        assert "実体化" in text
+        assert "NumPy" in text
+        assert "tensor" in text
+
+
+def test_top_level_guidance_is_select_first_and_recording_bounded() -> None:
+    """Examples should select files before processing bounded recordings."""
+    english = _read(README_EN)
+    japanese = _read(README_JA)
+    learning = _read(LEARNING_INTRO)
+
+    assert english.index("selected = dataset.select") < english.index("Only then load or process")
+    assert japanese.index("selected = dataset.select") < japanese.index("その後で、選択済み")
+    assert learning.index("selected = dataset.select") < learning.index("dataset = (selected")
+    assert "processing before selection" not in english
+    assert "選択前の Dataset 一括処理" not in japanese
+
+    for text in (english, japanese, learning):
+        assert "サイズを制御" in text or "bounded recording" in text
+
+
+def test_top_level_docs_do_not_claim_unbounded_single_frame_distribution() -> None:
+    """The former broad Dask claims must not return without the single-Frame limit."""
+    all_surfaces = " ".join(
+        "\n".join(_read(path) for path in (README_EN, README_JA, DOCS_HOME, LEARNING_INTRO)).split()
+    )
+
+    prohibited_claims = (
+        "Efficiently process large data using dask",
+        "daskを活用した効率的な大規模データ処理",
+        "Dask統合で大規模データ対応",
+        "Daskでメモリ効率的に処理",
+    )
+    for claim in prohibited_claims:
+        assert claim not in all_surfaces
+
+    assert "not by treating one enormous Frame as arbitrarily distributed" in all_surfaces
+    assert "単一の巨大な Frame を自由に分散" in all_surfaces

--- a/tests/docs/test_scalability_claims.py
+++ b/tests/docs/test_scalability_claims.py
@@ -48,7 +48,13 @@ def test_top_level_guidance_is_select_first_and_recording_bounded() -> None:
 
     assert english.index("selected = dataset.select") < english.index("Only then load or process")
     assert japanese.index("selected = dataset.select") < japanese.index("その後で、選択済み")
-    assert learning.index("selected = dataset.select") < learning.index("dataset = (selected")
+    assert 'f"split={_split}"' in learning
+    selection = learning.index('selected_dataset = dataset.select(split="train")')
+    first_load = learning.index("selected_dataset[0]")
+    trim = learning.index("selected_dataset.trim(start=0, end=5)")
+    resample = learning.index(".resample(target_sr=8000)", trim)
+    assert selection < first_load
+    assert selection < trim < resample
     assert "processing before selection" not in english
     assert "選択前の Dataset 一括処理" not in japanese
 


### PR DESCRIPTION
Closes #374

## 修正内容

- README（英語・日本語）と documentation home の大規模データ表現を、実際の Dask 実行契約に合わせて bounded-recording scalability として定義しました
- lazy graph construction、kernel execution 時の channel/whole-Frame materialization、最終 NumPy/tensor materializationを区別しました
- metadataで対象を先に選び、サイズを制御した収録単位で処理するworkflowを推奨し、corpus全体を単一の巨大なFrameに連結しない制約を明記しました
- top-level entry pointからcanonical scalability contractへ直接リンクしました
- learning introのbroad memory-efficiency claimとML preprocessing exampleを同じ契約へ揃えました
- 最新のmainを統合し、learning exampleではmain側のOptional access契約とPR側のselect-first順序を両立させました

## 主要ファイル

- `README.md`
- `README.ja.md`
- `docs/src/index.md`
- `learning-path/00_why_wandas.py`
- `tests/docs/test_scalability_claims.py`

## テスト対象

- canonical contract link
- 3つのmaterialization boundary
- metadata fixtureとselect-first ordering
- bounded-recording wording
- 旧unbounded claimの不在
- READMEのPython block、リンク、説明契約
- learning introのmarimo checkとHTML export

## 検証

最終head `f4559a87`:

- `uv run pytest tests/docs -q` — 64 passed（README実行時の既知のnoninteractive backend warning 2件）
- `uv run ruff check wandas tests scripts learning-path --config=pyproject.toml` — passed
- `uv run ty check wandas tests learning-path` — passed
- `uv run marimo check learning-path/00_why_wandas.py` — passed
- `uv run marimo export html learning-path/00_why_wandas.py ...` — passed、cell errorなし
- 実行結果: 10件探索 → train 8件選択 → 選択済み8件だけをtrim/resample
- `uv run mkdocs build --strict -f docs/mkdocs.yml` — passed
- `git diff --check` — passed
- 全pytestは競合解消後には再実行していません。競合はlearning notebookの1セルだけで、現行mainとの差分は本PRの5ファイルに限定されています

## Codex review

- 初回headのreviewで、eager discoveryの表現とselect-first実証不足を修正しました
- 旧head `4cea0ac2` のre-reviewはno findingsでした
- main統合後のheadは `f4559a87` です

## リスク・未実施

- production implementation、Dask graph、benchmark schema/metrics、materialization boundaryは変更していません。このためrepresentative scalability benchmarkは実施していません
- mainへマージ済みの#380・#383のAPI/FrameDataset契約を保持して競合解消しました
- PRはマージしません
