### PR TITLE
docs: validate deployed site links and metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             for file in 0{0..8}_*.py; do
               uv run --no-sync marimo export html "$file" \
                 -o "../docs/site/learning-path/$(basename "${file%.py}.html")" \
-                --no-include-code -f
+                -f
             done
             uv run --no-sync python ../scripts/finalize_learning_html.py ../docs/site \
               --site-url https://kasahart.github.io/wandas/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,14 +70,15 @@ jobs:
 
         - name: Learning applicationsをHTMLへexport
           shell: bash
+          working-directory: learning-path
           run: |
-            mkdir -p docs/site/learning-path
-            for file in learning-path/0{0..8}_*.py; do
+            mkdir -p ../docs/site/learning-path
+            for file in 0{0..8}_*.py; do
               uv run --no-sync marimo export html "$file" \
-                -o "docs/site/learning-path/$(basename "${file%.py}.html")" \
+                -o "../docs/site/learning-path/$(basename "${file%.py}.html")" \
                 --no-include-code -f
             done
-            uv run --no-sync python scripts/finalize_learning_html.py docs/site \
+            uv run --no-sync python ../scripts/finalize_learning_html.py ../docs/site \
               --site-url https://kasahart.github.io/wandas/
 
         - name: 生成サイトのURLとmetadataを検証

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
   docs:
       name: Build Documentation
       runs-on: ubuntu-latest
-      timeout-minutes: 5
+      timeout-minutes: 30
       steps:
         - name: チェックアウト
           uses: actions/checkout@v4
@@ -61,9 +61,30 @@ jobs:
           # ドキュメント構築に必要なパッケージ群と非ML extrasのみをインストール
           run: uv sync --no-dev --extra io --extra effects --extra marimo --extra psychoacoustic --group docs
 
+        - name: Learning applicationsを検証
+          run: uv run --no-sync marimo check learning-path/0{0..8}_*.py
+
         - name: ドキュメントのビルドテスト (MkDocs)
           # --strictフラグにより、警告（リンク切れやパースエラー）をエラーとして扱いCIを落とす
           run: uv run --no-sync mkdocs build -f docs/mkdocs.yml --strict
+
+        - name: Learning applicationsをHTMLへexport
+          shell: bash
+          run: |
+            mkdir -p docs/site/learning-path
+            for file in learning-path/0{0..8}_*.py; do
+              uv run --no-sync marimo export html "$file" \
+                -o "docs/site/learning-path/$(basename "${file%.py}.html")" \
+                --no-include-code -f
+            done
+            uv run --no-sync python scripts/finalize_learning_html.py docs/site \
+              --site-url https://kasahart.github.io/wandas/
+
+        - name: 生成サイトのURLとmetadataを検証
+          run: >-
+            uv run --no-sync python scripts/check_docs_site.py docs/site
+            --source-dir docs/src
+            --site-url https://kasahart.github.io/wandas/
 
   core-install-smoke:
     name: Core-only wheel install smoke

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -36,14 +36,15 @@ jobs:
 
       - name: Export and finalize learning applications
         # Export after MkDocs so its clean build cannot remove the applications.
+        working-directory: learning-path
         run: |
-          mkdir -p docs/site/learning-path
-          for file in learning-path/0{0..8}_*.py; do
+          mkdir -p ../docs/site/learning-path
+          for file in 0{0..8}_*.py; do
             uv run marimo export html "$file" \
-              -o "docs/site/learning-path/$(basename "${file%.py}.html")" \
+              -o "../docs/site/learning-path/$(basename "${file%.py}.html")" \
               --no-include-code -f
           done
-          uv run python scripts/finalize_learning_html.py docs/site \
+          uv run python ../scripts/finalize_learning_html.py ../docs/site \
             --site-url https://kasahart.github.io/wandas/
 
       - name: Validate generated site

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,24 +27,30 @@ jobs:
         # docsグループでドキュメント生成に必要なパッケージのみインストール
         run: uv sync --all-extras --group docs
 
-      - name: Convert marimo notebooks to HTML
-        # learning-path の Python ファイルを marimo export html で HTML に変換
-        run: |
-          mkdir -p docs/src/learning-path
-          for file in learning-path/0{0..8}_*.py; do
-            if [ -f "$file" ]; then
-              echo "Converting $file to HTML..."
-              uv run marimo export html "$file" -o "docs/src/learning-path/$(basename ${file%.py}.html)"
-            fi
-          done
+      - name: Validate learning applications
+        run: uv run marimo check learning-path/0{0..8}_*.py
 
       - name: Build MkDocs documentation
         # uv run を使って uv の環境で mkdocs を実行
-        run: uv run mkdocs build -f docs/mkdocs.yml
+        run: uv run mkdocs build -f docs/mkdocs.yml --strict
 
-      - name: Copy learning-path HTML to site directory
-        # MkDocs ビルド後、learning-path フォルダを site にコピー
-        run: cp -r docs/src/learning-path docs/site/
+      - name: Export and finalize learning applications
+        # Export after MkDocs so its clean build cannot remove the applications.
+        run: |
+          mkdir -p docs/site/learning-path
+          for file in learning-path/0{0..8}_*.py; do
+            uv run marimo export html "$file" \
+              -o "docs/site/learning-path/$(basename "${file%.py}.html")" \
+              --no-include-code -f
+          done
+          uv run python scripts/finalize_learning_html.py docs/site \
+            --site-url https://kasahart.github.io/wandas/
+
+      - name: Validate generated site
+        run: >-
+          uv run python scripts/check_docs_site.py docs/site
+          --source-dir docs/src
+          --site-url https://kasahart.github.io/wandas/
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -42,7 +42,7 @@ jobs:
           for file in 0{0..8}_*.py; do
             uv run marimo export html "$file" \
               -o "../docs/site/learning-path/$(basename "${file%.py}.html")" \
-              --no-include-code -f
+              -f
           done
           uv run python ../scripts/finalize_learning_html.py ../docs/site \
             --site-url https://kasahart.github.io/wandas/

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -2,15 +2,17 @@
 site_name: Wandas
 site_description: Wandas ライブラリのドキュメント
 site_author: Wandas Team
-site_url: https://wandas.github.io/
-copyright: © 2025 Wandas Team
+site_url: https://kasahart.github.io/wandas/
+# Keep the first-publication year stable and advance the ending year for each
+# production documentation release.
+copyright: © 2025–2026 Wandas Team
 
 docs_dir: src
 site_dir: site
 
 repo_name: kasahart/wandas
 repo_url: https://github.com/kasahart/wandas
-edit_uri: edit/main/src/
+edit_uri: edit/main/docs/src/
 
 # ─── テーマ (Material) ─────────────────────
 theme:
@@ -36,6 +38,7 @@ theme:
     - navigation.top
     - search.highlight
     - search.share
+    - content.action.edit
 
 # ─── Markdown 拡張 ─────────────────────────
 markdown_extensions:
@@ -124,6 +127,7 @@ nav:
 
 # ─── 追加設定 ──────────────────────────────
 extra:
-  analytics: { provider: google, property: G-MEASUREMENT-ID }
+  # Analytics is intentionally disabled. Production analytics may only be
+  # enabled from a real repository secret; never commit a placeholder ID.
   social:
     - { icon: fontawesome/brands/github, link: https://github.com/kasahart/wandas, name: Wandas on GitHub }

--- a/docs/src/api/core.md
+++ b/docs/src/api/core.md
@@ -21,7 +21,7 @@ ChannelMetadataクラスはオーディオデータのチャンネルに関連�
 
 `ChannelCalibration` stores the immutable recorded-to-physical factor, unit, and
 level reference for one channel. See the
-<a href="../learning-path/07_per_channel_calibration.html">per-channel calibration
+<a href="/wandas/learning-path/07_per_channel_calibration.html">per-channel calibration
 learning app</a> for list, mapping, CSV, and 100-channel examples.
 
 ::: wandas.core.metadata.ChannelCalibration

--- a/docs/src/api/frames.md
+++ b/docs/src/api/frames.md
@@ -43,7 +43,7 @@ raw array, or with `concat_frame()` version 1 when it is a `ChannelFrame`.
 第2入力がraw arrayなら`add_channel()` version 2、`ChannelFrame`なら
 `concat_frame()` version 1を使用して、保存済みworkflowを作り直してください。
 
-Use the <a href="../learning-path/07_per_channel_calibration.html">per-channel
+Use the <a href="/wandas/learning-path/07_per_channel_calibration.html">per-channel
 calibration learning app</a> to configure known conversion factors without
 modifying the source frame. Calibrated physical values are available from
 `frame.data` as a NumPy array; users do not need to manage the internal array

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -129,6 +129,35 @@ Documentation is built with MkDocs.
   uv run mkdocs serve -f docs/mkdocs.yml
   ```
 
+### Production metadata / 本番メタデータ
+
+The canonical documentation origin is `https://kasahart.github.io/wandas/`.
+The copyright starts with the first publication year, 2025, and its ending year
+is advanced whenever a production documentation release is prepared.
+Analytics remains disabled unless a repository maintainer wires a real property
+ID from a GitHub Actions secret at deployment time. Never commit an analytics
+placeholder or a production property ID.
+
+ドキュメントのcanonical originは`https://kasahart.github.io/wandas/`です。
+copyrightは初回公開年の2025を保持し、本番ドキュメントをリリースするたびに終了年を
+更新します。Analyticsは、repository maintainerがdeploy時にGitHub Actions secretから
+実在するproperty IDを注入する構成を追加するまで無効です。placeholderや本番property
+IDをcommitしてはいけません。
+
+CI and deployment run `scripts/check_docs_site.py` only after MkDocs output and
+all exported learning applications are in `docs/site`. The checker treats
+`site_url` as a project-site boundary and validates every generated HTML
+reference and fragment, local asset, canonical URL, MkDocs edit target, and
+sitemap location. Run the same final-site check when another documentation gate
+changes generated output; source-only link checks are not a substitute.
+
+CIとdeployは、MkDocs出力とexport済みlearning applicationがすべて`docs/site`へ
+配置された後にだけ`scripts/check_docs_site.py`を実行します。このcheckerは
+`site_url`をproject site境界として、生成HTMLの全参照とfragment、local asset、
+canonical URL、MkDocs edit target、sitemap locationを検証します。別の
+documentation gateが生成物を変える場合も、sourceだけのlink checkで代用せず、
+同じ完成site checkを実行してください。
+
 ## Release-to-Agent Notification / リリースからAgentへの通知
 
 When `WANDAS_AGENT_TOKEN` is configured, every strict `vX.Y.Z` tag dispatches

--- a/docs/src/tutorial/index.md
+++ b/docs/src/tutorial/index.md
@@ -116,19 +116,19 @@ Note: Keys specified in dict are only allowed for dataclass fields of `ChannelMe
 
 ## Next Steps / 次のステップ
 
-- <a href="../learning-path/07_per_channel_calibration.html">Per-Channel Calibration (marimo)</a>
+- <a href="/wandas/learning-path/07_per_channel_calibration.html">Per-Channel Calibration (marimo)</a>
   - Apply certificate or CSV-managed factors to audio, acceleration, and 100-channel signals, then read physical values from `frame.data`.
   - 証明書やCSVで管理された係数を音・加速度・100ch信号へ適用し、物理値を`frame.data`から取得する。
 - [Cepstral Analysis / ケプストラム解析](../how-to/cepstral-analysis.md)
   - Separate a smooth spectral envelope from fine harmonic structure with a typed lazy workflow.
   - 型付き遅延ワークフローで、滑らかなスペクトル包絡と細かな調波構造を分離する。
-- <a href="../learning-path/08_metadata_driven_dataset_search.html">Metadata-Driven Dataset Search (marimo)</a>
+- <a href="/wandas/learning-path/08_metadata_driven_dataset_search.html">Metadata-Driven Dataset Search (marimo)</a>
   - Use this when you have many recordings and want to select files before reading waveforms.
   - 多数の録音から、波形を読む前に対象ファイルを選びたい場合に使う。
 - [Pipeline Recipes Examples / Recipe例](pipeline-recipes.md)
   - Use this to extract a RecipePlan from frame operations and replay it on another input.
   - frame操作からRecipePlanを抽出し、別の入力で再実行する方法を確認する。
-- <a href="../learning-path/06_reusable_pipeline_recipes.html">Reusable Pipeline Recipes (marimo)</a>
+- <a href="/wandas/learning-path/06_reusable_pipeline_recipes.html">Reusable Pipeline Recipes (marimo)</a>
   - Build, serialize, load, and replay a RecipePlan with observable checks.
   - RecipePlanの作成、保存、読込、再実行を実行可能な例で確認する。
 - [API Reference / APIリファレンス](../api/index.md)
@@ -143,12 +143,12 @@ Note: Keys specified in dict are only allowed for dataclass fields of `ChannelMe
 This section provides links to tutorial marimo apps that demonstrate more detailed features and application examples of the Wandas library.
 このセクションでは、Wandasライブラリのより詳細な機能や応用例を、以下のチュートリアル marimo アプリを通じて学ぶことができます。
 
-- <a href="../learning-path/00_why_wandas.html">Learning Path — 00_Why Wandas (marimo)</a>: Overview and motivation / 概要と動機付け
-- <a href="../learning-path/01_getting_started.html">Learning Path — 01_Getting Started (marimo)</a>: Setup and basic configuration / セットアップと基本的な設定
-- <a href="../learning-path/02_working_with_data.html">Learning Path — 02_Working With Data (marimo)</a>: Reading, inspecting, and simple transformations / 読み込み、検査、基本的な変換
-- <a href="../learning-path/03_signal_processing_basics.html">Learning Path — 03_Signal Processing Basics (marimo)</a>: Filtering and frequency analysis / フィルタリングと周波数分析
-- <a href="../learning-path/04_advanced_processing.html">Learning Path — 04_Advanced Processing (marimo)</a>: Spectrograms and time-frequency analysis / スペクトログラムと時間周波数解析
-- <a href="../learning-path/05_custom_functions.html">Learning Path — 05_Custom Functions (marimo)</a>: Custom frame operations / custom frame操作
-- <a href="../learning-path/06_reusable_pipeline_recipes.html">Learning Path — 06_Reusable Pipeline Recipes (marimo)</a>: Reuse public Frame workflows / 公開Frame処理の再利用
-- <a href="../learning-path/07_per_channel_calibration.html">Learning Path — 07_Per-Channel Calibration (marimo)</a>: Apply known coefficients from certificates and CSV / 証明書・CSVの既知係数をチャンネルへ適用
-- <a href="../learning-path/08_metadata_driven_dataset_search.html">Learning Path — 08_Metadata-Driven Dataset Search (marimo)</a>: Select files from path or CSV metadata before loading waveforms / パス・CSVメタデータで波形ロード前にファイルを選択
+- <a href="/wandas/learning-path/00_why_wandas.html">Learning Path — 00_Why Wandas (marimo)</a>: Overview and motivation / 概要と動機付け
+- <a href="/wandas/learning-path/01_getting_started.html">Learning Path — 01_Getting Started (marimo)</a>: Setup and basic configuration / セットアップと基本的な設定
+- <a href="/wandas/learning-path/02_working_with_data.html">Learning Path — 02_Working With Data (marimo)</a>: Reading, inspecting, and simple transformations / 読み込み、検査、基本的な変換
+- <a href="/wandas/learning-path/03_signal_processing_basics.html">Learning Path — 03_Signal Processing Basics (marimo)</a>: Filtering and frequency analysis / フィルタリングと周波数分析
+- <a href="/wandas/learning-path/04_advanced_processing.html">Learning Path — 04_Advanced Processing (marimo)</a>: Spectrograms and time-frequency analysis / スペクトログラムと時間周波数解析
+- <a href="/wandas/learning-path/05_custom_functions.html">Learning Path — 05_Custom Functions (marimo)</a>: Custom frame operations / custom frame操作
+- <a href="/wandas/learning-path/06_reusable_pipeline_recipes.html">Learning Path — 06_Reusable Pipeline Recipes (marimo)</a>: Reuse public Frame workflows / 公開Frame処理の再利用
+- <a href="/wandas/learning-path/07_per_channel_calibration.html">Learning Path — 07_Per-Channel Calibration (marimo)</a>: Apply known coefficients from certificates and CSV / 証明書・CSVの既知係数をチャンネルへ適用
+- <a href="/wandas/learning-path/08_metadata_driven_dataset_search.html">Learning Path — 08_Metadata-Driven Dataset Search (marimo)</a>: Select files from path or CSV metadata before loading waveforms / パス・CSVメタデータで波形ロード前にファイルを選択

--- a/learning-path/00_why_wandas.py
+++ b/learning-path/00_why_wandas.py
@@ -733,7 +733,7 @@ def _(mo):
 
     Wandasの可能性を感じていただけましたか？
 
-    **次のmarimoアプリ**: [01_getting_started](01_getting_started.html)
+    **次のmarimoアプリ**: [01_getting_started](01_getting_started.py)
 
     ここでは実際にWandasをインストールし、環境を設定して、最初の信号処理を行ってみましょう。
 

--- a/learning-path/00_why_wandas.py
+++ b/learning-path/00_why_wandas.py
@@ -700,7 +700,7 @@ def _(mo):
 
     Wandasの可能性を感じていただけましたか？
 
-    **次のmarimoアプリ**: [01_getting_started.py](01_getting_started.py)
+    **次のmarimoアプリ**: [01_getting_started](01_getting_started.html)
 
     ここでは実際にWandasをインストールし、環境を設定して、最初の信号処理を行ってみましょう。
 

--- a/learning-path/01_getting_started.py
+++ b/learning-path/01_getting_started.py
@@ -477,7 +477,9 @@ def _(mo):
 
     環境構築と基本操作が完了しました！
 
-    **次のmarimoアプリ**: [02_working_with_data.py](02_working_with_data.py)
+    **前のmarimoアプリ**: [00_why_wandas](00_why_wandas.html)
+
+    **次のmarimoアプリ**: [02_working_with_data](02_working_with_data.html)
 
     ここでは、実際のデータファイル（WAV, CSVなど）を読み込んで、Wandasのデータ構造について紹介します。
 

--- a/learning-path/01_getting_started.py
+++ b/learning-path/01_getting_started.py
@@ -473,9 +473,9 @@ def _(mo):
 
     環境構築と基本操作が完了しました！
 
-    **前のmarimoアプリ**: [00_why_wandas](00_why_wandas.html)
+    **前のmarimoアプリ**: [00_why_wandas](00_why_wandas.py)
 
-    **次のmarimoアプリ**: [02_working_with_data](02_working_with_data.html)
+    **次のmarimoアプリ**: [02_working_with_data](02_working_with_data.py)
 
     ここでは、実際のデータファイル（WAV, CSVなど）を読み込んで、Wandasのデータ構造について紹介します。
 

--- a/learning-path/02_working_with_data.py
+++ b/learning-path/02_working_with_data.py
@@ -661,9 +661,9 @@ def _(mo):
 
     データの読み込みと基本操作をマスターしました！
 
-    **前のmarimoアプリ**: [01_getting_started](01_getting_started.html)
+    **前のmarimoアプリ**: [01_getting_started](01_getting_started.py)
 
-    **次のmarimoアプリ**: [03_signal_processing_basics](03_signal_processing_basics.html)
+    **次のmarimoアプリ**: [03_signal_processing_basics](03_signal_processing_basics.py)
 
     ここでは、読み込んだデータを**フィルタリング**や**周波数分析**などの信号処理テクニックで加工する方法を紹介します。
 

--- a/learning-path/02_working_with_data.py
+++ b/learning-path/02_working_with_data.py
@@ -661,7 +661,9 @@ def _(mo):
 
     データの読み込みと基本操作をマスターしました！
 
-    **次のmarimoアプリ**: [03_signal_processing_basics.py](03_signal_processing_basics.py)
+    **前のmarimoアプリ**: [01_getting_started](01_getting_started.html)
+
+    **次のmarimoアプリ**: [03_signal_processing_basics](03_signal_processing_basics.html)
 
     ここでは、読み込んだデータを**フィルタリング**や**周波数分析**などの信号処理テクニックで加工する方法を紹介します。
 

--- a/learning-path/03_signal_processing_basics.py
+++ b/learning-path/03_signal_processing_basics.py
@@ -770,9 +770,9 @@ def _(mo):
 
     信号処理の基礎をマスターしました！
 
-    **前のmarimoアプリ**: [02_working_with_data](02_working_with_data.html)
+    **前のmarimoアプリ**: [02_working_with_data](02_working_with_data.py)
 
-    **次のmarimoアプリ**: [04_advanced_processing](04_advanced_processing.html)
+    **次のmarimoアプリ**: [04_advanced_processing](04_advanced_processing.py)
 
     ここでは、**スペクトル分析**や**ウェーブレット変換**などの高度な信号処理手法を紹介します。
 

--- a/learning-path/03_signal_processing_basics.py
+++ b/learning-path/03_signal_processing_basics.py
@@ -767,7 +767,9 @@ def _(mo):
 
     信号処理の基礎をマスターしました！
 
-    **次のmarimoアプリ**: [04_advanced_processing.py](04_advanced_processing.py)
+    **前のmarimoアプリ**: [02_working_with_data](02_working_with_data.html)
+
+    **次のmarimoアプリ**: [04_advanced_processing](04_advanced_processing.html)
 
     ここでは、**スペクトル分析**や**ウェーブレット変換**などの高度な信号処理手法を紹介します。
 

--- a/learning-path/04_advanced_processing.py
+++ b/learning-path/04_advanced_processing.py
@@ -1040,9 +1040,9 @@ def _(mo):
 
     高度な信号処理手法を実践的に習得しました。
 
-    **前のmarimoアプリ**: [03_signal_processing_basics](03_signal_processing_basics.html)
+    **前のmarimoアプリ**: [03_signal_processing_basics](03_signal_processing_basics.py)
 
-    **次のmarimoアプリ**: [05_custom_functions](05_custom_functions.html)
+    **次のmarimoアプリ**: [05_custom_functions](05_custom_functions.py)
 
     ここでは、Wandasの処理チェーンに**独自関数を組み込む方法**を学び、
     現場課題に合わせた分析パイプラインを設計する実践に進みます。

--- a/learning-path/04_advanced_processing.py
+++ b/learning-path/04_advanced_processing.py
@@ -1037,7 +1037,9 @@ def _(mo):
 
     高度な信号処理手法を実践的に習得しました。
 
-    **次のmarimoアプリ**: [05_custom_functions.py](05_custom_functions.py)
+    **前のmarimoアプリ**: [03_signal_processing_basics](03_signal_processing_basics.html)
+
+    **次のmarimoアプリ**: [05_custom_functions](05_custom_functions.html)
 
     ここでは、Wandasの処理チェーンに**独自関数を組み込む方法**を学び、
     現場課題に合わせた分析パイプラインを設計する実践に進みます。

--- a/learning-path/05_custom_functions.py
+++ b/learning-path/05_custom_functions.py
@@ -563,9 +563,9 @@ def _(mo):
 
     カスタム関数を活用することで、Wandasの機能を自由に拡張できます！
 
-    **前のmarimoアプリ**: [04_advanced_processing](04_advanced_processing.html)
+    **前のmarimoアプリ**: [04_advanced_processing](04_advanced_processing.py)
 
-    **次のmarimoアプリ**: [06_reusable_pipeline_recipes](06_reusable_pipeline_recipes.html)
+    **次のmarimoアプリ**: [06_reusable_pipeline_recipes](06_reusable_pipeline_recipes.py)
     """)
     return
 

--- a/learning-path/05_custom_functions.py
+++ b/learning-path/05_custom_functions.py
@@ -562,6 +562,10 @@ def _(mo):
     - ベストプラクティスと注意点
 
     カスタム関数を活用することで、Wandasの機能を自由に拡張できます！
+
+    **前のmarimoアプリ**: [04_advanced_processing](04_advanced_processing.html)
+
+    **次のmarimoアプリ**: [06_reusable_pipeline_recipes](06_reusable_pipeline_recipes.html)
     """)
     return
 

--- a/learning-path/06_reusable_pipeline_recipes.py
+++ b/learning-path/06_reusable_pipeline_recipes.py
@@ -196,6 +196,10 @@ def _(mo):
     詳細な入力形状と制約は
     [RecipePlan how-to](../how-to/pipeline-recipes/) を、API signatureは
     [Pipeline API reference](../api/pipeline/) を参照してください。
+
+    **前のmarimoアプリ**: [05_custom_functions](05_custom_functions.html)
+
+    **次のmarimoアプリ**: [07_per_channel_calibration](07_per_channel_calibration.html)
     """)
     return
 

--- a/learning-path/06_reusable_pipeline_recipes.py
+++ b/learning-path/06_reusable_pipeline_recipes.py
@@ -197,9 +197,9 @@ def _(mo):
     [RecipePlan how-to](../how-to/pipeline-recipes/) を、API signatureは
     [Pipeline API reference](../api/pipeline/) を参照してください。
 
-    **前のmarimoアプリ**: [05_custom_functions](05_custom_functions.html)
+    **前のmarimoアプリ**: [05_custom_functions](05_custom_functions.py)
 
-    **次のmarimoアプリ**: [07_per_channel_calibration](07_per_channel_calibration.html)
+    **次のmarimoアプリ**: [07_per_channel_calibration](07_per_channel_calibration.py)
     """)
     return
 

--- a/learning-path/07_per_channel_calibration.py
+++ b/learning-path/07_per_channel_calibration.py
@@ -421,6 +421,10 @@ def _(mo):
 
     API signatureは[Frames API reference](../api/frames/)を、WDFの詳細は
     [WDF File I/O](../api/wdf_io/)を参照してください。
+
+    **前のmarimoアプリ**: [06_reusable_pipeline_recipes](06_reusable_pipeline_recipes.html)
+
+    **次のmarimoアプリ**: [08_metadata_driven_dataset_search](08_metadata_driven_dataset_search.html)
     """)
     return
 

--- a/learning-path/07_per_channel_calibration.py
+++ b/learning-path/07_per_channel_calibration.py
@@ -422,9 +422,9 @@ def _(mo):
     API signatureは[Frames API reference](../api/frames/)を、WDFの詳細は
     [WDF File I/O](../api/wdf_io/)を参照してください。
 
-    **前のmarimoアプリ**: [06_reusable_pipeline_recipes](06_reusable_pipeline_recipes.html)
+    **前のmarimoアプリ**: [06_reusable_pipeline_recipes](06_reusable_pipeline_recipes.py)
 
-    **次のmarimoアプリ**: [08_metadata_driven_dataset_search](08_metadata_driven_dataset_search.html)
+    **次のmarimoアプリ**: [08_metadata_driven_dataset_search](08_metadata_driven_dataset_search.py)
     """)
     return
 

--- a/learning-path/08_metadata_driven_dataset_search.py
+++ b/learning-path/08_metadata_driven_dataset_search.py
@@ -237,10 +237,10 @@ def _(mo):
     - 外部属性が必要な場合だけ、CSVをlookupへ変換してresolver契約へ接続する
 
     APIの詳細とエラー契約は
-    [Frame Dataset utility reference](../api/utils/#metadata-driven-file-selection--メタデータ駆動のファイル選択)
+    [Frame Dataset utility reference](../api/utils/#metadata-driven-file-selection)
     を参照してください。
 
-    **前のmarimoアプリ**: [07_per_channel_calibration](07_per_channel_calibration.html)
+    **前のmarimoアプリ**: [07_per_channel_calibration](07_per_channel_calibration.py)
     """)
     return
 

--- a/learning-path/08_metadata_driven_dataset_search.py
+++ b/learning-path/08_metadata_driven_dataset_search.py
@@ -236,8 +236,10 @@ def _(mo):
     - 外部属性が必要な場合だけ、CSVをlookupへ変換してresolver契約へ接続する
 
     APIの詳細とエラー契約は
-    [Frame Dataset utility reference](../api/utils.md#metadata-driven-file-selection--メタデータ駆動のファイル選択)
+    [Frame Dataset utility reference](../api/utils/#metadata-driven-file-selection--メタデータ駆動のファイル選択)
     を参照してください。
+
+    **前のmarimoアプリ**: [07_per_channel_calibration](07_per_channel_calibration.html)
     """)
     return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ test = [
     "ruff>=0.9.9",
     "ty>=0.0.26",
     "pandas-stubs",
+    "tinycss2>=1.4.0",
 ]
 
 # ドキュメント生成
@@ -92,6 +93,7 @@ docs = [
     "mkdocs-git-revision-date-localized-plugin>=1.4.5",
     "markdown-exec>=1.10.3",
     "marimo>=0.23.3",
+    "tinycss2>=1.4.0",
 ]
 
 # 開発補助ツール（ローカル開発用）

--- a/scripts/check_docs_site.py
+++ b/scripts/check_docs_site.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import posixpath
 import re
 from dataclasses import dataclass, field
 from html.parser import HTMLParser
@@ -61,6 +62,42 @@ def _css_string(content: str, position: int) -> tuple[str, int]:
     raise ValueError("unterminated CSS string")
 
 
+def _decode_css_escapes(value: str) -> str:
+    """Decode CSS escapes in one URL or import token."""
+    decoded: list[str] = []
+    position = 0
+    while position < len(value):
+        if value[position] != "\\":
+            decoded.append(value[position])
+            position += 1
+            continue
+        position += 1
+        if position >= len(value):
+            raise ValueError("unterminated CSS escape")
+        if value[position] in "\r\n\f":
+            if value[position] == "\r" and position + 1 < len(value) and value[position + 1] == "\n":
+                position += 1
+            position += 1
+            continue
+        hex_start = position
+        while position < len(value) and position - hex_start < 6 and value[position].lower() in "0123456789abcdef":
+            position += 1
+        if position > hex_start:
+            codepoint = int(value[hex_start:position], 16)
+            if codepoint == 0 or codepoint > 0x10FFFF or 0xD800 <= codepoint <= 0xDFFF:
+                decoded.append("\N{REPLACEMENT CHARACTER}")
+            else:
+                decoded.append(chr(codepoint))
+            if position < len(value) and value[position].isspace():
+                if value[position] == "\r" and position + 1 < len(value) and value[position + 1] == "\n":
+                    position += 1
+                position += 1
+            continue
+        decoded.append(value[position])
+        position += 1
+    return "".join(decoded)
+
+
 def _css_trivia_end(content: str, position: int) -> int:
     while position < len(content):
         if content[position].isspace():
@@ -87,11 +124,17 @@ def _css_url(content: str, position: int) -> tuple[str, int] | None:
         position = _css_trivia_end(content, position)
         if position >= len(content) or content[position] != ")":
             raise ValueError("unterminated CSS url()")
-        return value, position + 1
-    position = content.find(")", value_start)
-    if position < 0:
-        raise ValueError("unterminated CSS url()")
-    return content[value_start:position].strip(), position + 1
+        return _decode_css_escapes(value), position + 1
+    position = value_start
+    while position < len(content):
+        if content[position] == "\\":
+            position += 2
+            continue
+        if content[position] == ")":
+            raw_value = content[value_start:position].strip()
+            return _decode_css_escapes(raw_value), position + 1
+        position += 1
+    raise ValueError("unterminated CSS url()")
 
 
 def _parse_css_content(content: str, *, line_offset: int = 0) -> list[Reference]:
@@ -116,6 +159,7 @@ def _parse_css_content(content: str, *, line_offset: int = 0) -> list[Reference]
                 target, position = parsed_url
             elif value_start < len(content) and content[value_start] in {'"', "'"}:
                 target, position = _css_string(content, value_start)
+                target = _decode_css_escapes(target)
             else:
                 position = value_start + 1
                 continue
@@ -359,10 +403,25 @@ def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
         if document.base_hrefs:
             base_href = document.base_hrefs[0]
             candidate = urlparse(urljoin(document_url, base_href))
-            if candidate.scheme in {"http", "https"} and candidate.netloc:
+            candidate_host = (candidate.hostname or "").lower()
+            try:
+                candidate_port = candidate.port or (443 if candidate.scheme == "https" else 80)
+            except ValueError:
+                candidate_port = -1
+            candidate_path = unquote(candidate.path)
+            normalized_candidate_path = posixpath.normpath(candidate_path)
+            if (
+                candidate.scheme == base.scheme
+                and candidate_host == base_host
+                and candidate_port == base_port
+                and (
+                    normalized_candidate_path == project_prefix.rstrip("/")
+                    or normalized_candidate_path.startswith(project_prefix)
+                )
+            ):
                 reference_url = candidate.geturl()
             else:
-                errors.append(f"{relative}: base href {base_href!r} is not a deployable HTTP(S) URL")
+                errors.append(f"{relative}: base href {base_href!r} is outside the deployment origin or project prefix")
         expected_canonical = document_url
         if relative.as_posix() != "404.html":
             if len(document.canonicals) != 1:

--- a/scripts/check_docs_site.py
+++ b/scripts/check_docs_site.py
@@ -7,6 +7,7 @@ import re
 from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from pathlib import Path, PurePosixPath
+from typing import Literal
 from urllib.parse import unquote, urljoin, urlparse
 from xml.etree import ElementTree
 
@@ -17,8 +18,7 @@ else:
 
 IGNORED_SCHEMES = {"data", "javascript", "mailto", "tel", "blob"}
 EDIT_PREFIX = "https://github.com/kasahart/wandas/edit/main/docs/src/"
-_CSS_URL = re.compile(r"url\(\s*(['\"]?)(.*?)\1\s*\)", flags=re.IGNORECASE)
-_CSS_IMPORT = re.compile(r"@import\s+(['\"])(.*?)\1", flags=re.IGNORECASE)
+_LEARNING_EXPORT = re.compile(r"learning-path/0[0-8]_[^/]+\.html\Z")
 
 
 @dataclass(frozen=True)
@@ -26,6 +26,7 @@ class Reference:
     attribute: str
     target: str
     line: int
+    kind: Literal["resource", "stylesheet"] = "resource"
 
 
 @dataclass
@@ -39,18 +40,111 @@ class HtmlDocument:
     parse_errors: list[str] = field(default_factory=list)
 
 
+def _css_comment_end(content: str, position: int) -> int:
+    end = content.find("*/", position + 2)
+    if end < 0:
+        raise ValueError("unterminated CSS comment")
+    return end + 2
+
+
+def _css_string(content: str, position: int) -> tuple[str, int]:
+    quote = content[position]
+    start = position + 1
+    position = start
+    while position < len(content):
+        if content[position] == "\\":
+            position += 2
+            continue
+        if content[position] == quote:
+            return content[start:position], position + 1
+        position += 1
+    raise ValueError("unterminated CSS string")
+
+
+def _css_trivia_end(content: str, position: int) -> int:
+    while position < len(content):
+        if content[position].isspace():
+            position += 1
+        elif content.startswith("/*", position):
+            position = _css_comment_end(content, position)
+        else:
+            break
+    return position
+
+
+def _css_url(content: str, position: int) -> tuple[str, int] | None:
+    after_name = position + 3
+    if position and (content[position - 1].isalnum() or content[position - 1] in "_-"):
+        return None
+    after_name = _css_trivia_end(content, after_name)
+    if after_name >= len(content) or content[after_name] != "(":
+        return None
+    value_start = _css_trivia_end(content, after_name + 1)
+    if value_start >= len(content):
+        raise ValueError("unterminated CSS url()")
+    if content[value_start] in {'"', "'"}:
+        value, position = _css_string(content, value_start)
+        position = _css_trivia_end(content, position)
+        if position >= len(content) or content[position] != ")":
+            raise ValueError("unterminated CSS url()")
+        return value, position + 1
+    position = content.find(")", value_start)
+    if position < 0:
+        raise ValueError("unterminated CSS url()")
+    return content[value_start:position].strip(), position + 1
+
+
 def _parse_css_content(content: str, *, line_offset: int = 0) -> list[Reference]:
     """Return dependency candidates declared by CSS source text."""
     references: list[Reference] = []
-    for attribute, pattern in (("css-url", _CSS_URL), ("css-import", _CSS_IMPORT)):
-        for match in pattern.finditer(content):
+    lowered = content.lower()
+    position = 0
+    while position < len(content):
+        if content.startswith("/*", position):
+            position = _css_comment_end(content, position)
+            continue
+        if content[position] in {'"', "'"}:
+            _, position = _css_string(content, position)
+            continue
+        if lowered.startswith("@import", position) and (
+            position + 7 == len(content) or not (content[position + 7].isalnum() or content[position + 7] in "_-")
+        ):
+            start = position
+            value_start = _css_trivia_end(content, position + 7)
+            parsed_url = _css_url(content, value_start) if lowered.startswith("url", value_start) else None
+            if parsed_url is not None:
+                target, position = parsed_url
+            elif value_start < len(content) and content[value_start] in {'"', "'"}:
+                target, position = _css_string(content, value_start)
+            else:
+                position = value_start + 1
+                continue
             references.append(
                 Reference(
-                    attribute,
-                    match.group(2).strip(),
-                    line_offset + content.count("\n", 0, match.start()) + 1,
+                    "css-import",
+                    target.strip(),
+                    line_offset + content.count("\n", 0, start) + 1,
+                    "stylesheet",
                 )
             )
+            continue
+        if lowered.startswith("url", position):
+            parsed_url = _css_url(content, position)
+            if parsed_url is not None:
+                target, end = parsed_url
+                references.append(
+                    Reference(
+                        "css-url",
+                        target.strip(),
+                        line_offset + content.count("\n", 0, position) + 1,
+                    )
+                )
+                position = end
+                continue
+        if content[position] == "\\":
+            position += 2
+        else:
+            position += 1
     return references
 
 
@@ -96,6 +190,9 @@ class DocumentParser(HTMLParser):
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         values = {name.lower(): value for name, value in attrs if value is not None}
         tag = tag.lower()
+        rel = values.get("rel", "").lower().split()
+        css_mime = values.get("type", "").partition(";")[0].strip().lower() == "text/css"
+        stylesheet_link = tag == "link" and ("stylesheet" in rel or values.get("as", "").lower() == "style" or css_mime)
         if tag == "style":
             self._style_depth += 1
         if element_id := values.get("id"):
@@ -110,14 +207,14 @@ class DocumentParser(HTMLParser):
             if tag == "base" and attribute == "href":
                 continue
             if target := values.get(attribute):
-                self.document.references.append(Reference(attribute, target, self.getpos()[0]))
+                kind = "stylesheet" if stylesheet_link and attribute == "href" else "resource"
+                self.document.references.append(Reference(attribute, target, self.getpos()[0], kind))
         if srcset := values.get("srcset"):
             for target in _srcset_targets(srcset):
                 self.document.references.append(Reference("srcset", target, self.getpos()[0]))
         if style := values.get("style"):
-            self.document.references.extend(_parse_css_content(style, line_offset=self.getpos()[0] - 1))
+            self._record_css_references(style, line_offset=self.getpos()[0] - 1)
 
-        rel = values.get("rel", "").lower().split()
         if tag == "link" and "canonical" in rel and (canonical := values.get("href")):
             self.document.canonicals.append(canonical)
         if tag == "a" and (href := values.get("href", "")).startswith(EDIT_PREFIX):
@@ -125,11 +222,17 @@ class DocumentParser(HTMLParser):
 
     def handle_data(self, data: str) -> None:
         if self._style_depth:
-            self.document.references.extend(_parse_css_content(data, line_offset=self.getpos()[0] - 1))
+            self._record_css_references(data, line_offset=self.getpos()[0] - 1)
 
     def handle_endtag(self, tag: str) -> None:
         if tag.lower() == "style" and self._style_depth:
             self._style_depth -= 1
+
+    def _record_css_references(self, content: str, *, line_offset: int) -> None:
+        try:
+            self.document.references.extend(_parse_css_content(content, line_offset=line_offset))
+        except ValueError as exc:
+            self.document.parse_errors.append(f"CSS on line {line_offset + 1}: {exc}")
 
 
 def _public_path(relative_html: PurePosixPath) -> str:
@@ -151,12 +254,16 @@ def _output_path(site_dir: Path, public_path: str) -> Path:
     return candidate / "index.html"
 
 
-def _parse_html(path: Path) -> HtmlDocument:
+def _parse_html(path: Path, *, require_marimo_session: bool = False) -> HtmlDocument:
     parser = DocumentParser(path)
     content = path.read_text(encoding="utf-8")
     parser.feed(content)
     try:
-        for fragment in marimo_html_outputs(content):
+        for fragment in marimo_html_outputs(
+            content,
+            require_session=require_marimo_session,
+            require_source=require_marimo_session,
+        ):
             parser.feed(fragment)
     except ValueError as exc:
         parser.document.parse_errors.append(str(exc))
@@ -176,10 +283,18 @@ def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
     source_dir = source_dir.resolve()
     base_url = site_url.rstrip("/") + "/"
     base = urlparse(base_url)
+    base_host = (base.hostname or "").lower()
+    base_port = base.port or (443 if base.scheme == "https" else 80)
     project_prefix = base.path.rstrip("/") + "/"
 
     html_paths = sorted(site_dir.rglob("*.html"))
-    documents = {path.resolve(): _parse_html(path) for path in html_paths}
+    documents = {
+        path.resolve(): _parse_html(
+            path,
+            require_marimo_session=bool(_LEARNING_EXPORT.fullmatch(path.relative_to(site_dir).as_posix())),
+        )
+        for path in html_paths
+    }
     if not html_paths:
         errors.append(f"{site_dir}: no HTML files found")
 
@@ -199,7 +314,16 @@ def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
             errors.append(f"{origin}:{reference.line}: {reference.attribute} {raw_target!r} uses forbidden file URL")
             return None
         resolved = urlparse(urljoin(origin_url, raw_target))
-        if resolved.scheme not in {"http", "https"} or resolved.netloc != base.netloc:
+        resolved_host = (resolved.hostname or "").lower()
+        if resolved_host == base_host and base.scheme == "https" and resolved.scheme == "http":
+            errors.append(f"{origin}:{reference.line}: {reference.attribute} {raw_target!r} uses mixed-content HTTP")
+            return None
+        try:
+            resolved_port = resolved.port or (443 if resolved.scheme == "https" else 80)
+        except ValueError:
+            errors.append(f"{origin}:{reference.line}: {reference.attribute} {raw_target!r} has an invalid port")
+            return None
+        if resolved.scheme != base.scheme or resolved_host != base_host or resolved_port != base_port:
             return None
         decoded_path = unquote(resolved.path)
         if not decoded_path.startswith(project_prefix):
@@ -261,7 +385,7 @@ def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
 
         for reference in document.references:
             target_path = check_reference(relative, reference_url, reference)
-            if target_path is not None and target_path.suffix.lower() == ".css":
+            if target_path is not None and reference.kind == "stylesheet":
                 css_to_visit.append(target_path)
 
     while css_to_visit:
@@ -271,9 +395,14 @@ def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
         visited_css.add(css_path)
         css_relative = PurePosixPath(css_path.relative_to(site_dir).as_posix())
         css_url = urljoin(base_url, css_relative.as_posix())
-        for reference in _parse_css(css_path):
+        try:
+            references = _parse_css(css_path)
+        except ValueError as exc:
+            errors.append(f"{css_relative}: {exc}")
+            continue
+        for reference in references:
             target_path = check_reference(css_relative, css_url, reference)
-            if target_path is not None and target_path.suffix.lower() == ".css":
+            if target_path is not None and reference.kind == "stylesheet":
                 css_to_visit.append(target_path)
 
     sitemap = site_dir / "sitemap.xml"

--- a/scripts/check_docs_site.py
+++ b/scripts/check_docs_site.py
@@ -8,9 +8,11 @@ import re
 from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from pathlib import Path, PurePosixPath
-from typing import Literal
+from typing import Any, Literal
 from urllib.parse import unquote, urljoin, urlparse
 from xml.etree import ElementTree
+
+import tinycss2
 
 if __package__:
     from .marimo_outputs import marimo_html_outputs
@@ -33,163 +35,96 @@ class Reference:
 @dataclass
 class HtmlDocument:
     path: Path
+    context: str = ""
     ids: set[str] = field(default_factory=set)
     references: list[Reference] = field(default_factory=list)
     canonicals: list[str] = field(default_factory=list)
     edit_links: list[str] = field(default_factory=list)
     base_hrefs: list[str] = field(default_factory=list)
+    embedded_documents: list[HtmlDocument] = field(default_factory=list)
     parse_errors: list[str] = field(default_factory=list)
 
 
-def _css_comment_end(content: str, position: int) -> int:
-    end = content.find("*/", position + 2)
-    if end < 0:
-        raise ValueError("unterminated CSS comment")
-    return end + 2
-
-
-def _css_string(content: str, position: int) -> tuple[str, int]:
-    quote = content[position]
-    start = position + 1
-    position = start
-    while position < len(content):
-        if content[position] == "\\":
-            position += 2
-            continue
-        if content[position] == quote:
-            return content[start:position], position + 1
-        position += 1
-    raise ValueError("unterminated CSS string")
-
-
-def _decode_css_escapes(value: str) -> str:
-    """Decode CSS escapes in one URL or import token."""
-    decoded: list[str] = []
-    position = 0
-    while position < len(value):
-        if value[position] != "\\":
-            decoded.append(value[position])
-            position += 1
-            continue
-        position += 1
-        if position >= len(value):
-            raise ValueError("unterminated CSS escape")
-        if value[position] in "\r\n\f":
-            if value[position] == "\r" and position + 1 < len(value) and value[position + 1] == "\n":
-                position += 1
-            position += 1
-            continue
-        hex_start = position
-        while position < len(value) and position - hex_start < 6 and value[position].lower() in "0123456789abcdef":
-            position += 1
-        if position > hex_start:
-            codepoint = int(value[hex_start:position], 16)
-            if codepoint == 0 or codepoint > 0x10FFFF or 0xD800 <= codepoint <= 0xDFFF:
-                decoded.append("\N{REPLACEMENT CHARACTER}")
-            else:
-                decoded.append(chr(codepoint))
-            if position < len(value) and value[position].isspace():
-                if value[position] == "\r" and position + 1 < len(value) and value[position + 1] == "\n":
-                    position += 1
-                position += 1
-            continue
-        decoded.append(value[position])
-        position += 1
-    return "".join(decoded)
-
-
-def _css_trivia_end(content: str, position: int) -> int:
-    while position < len(content):
-        if content[position].isspace():
-            position += 1
-        elif content.startswith("/*", position):
-            position = _css_comment_end(content, position)
-        else:
-            break
-    return position
-
-
-def _css_url(content: str, position: int) -> tuple[str, int] | None:
-    after_name = position + 3
-    if position and (content[position - 1].isalnum() or content[position - 1] in "_-"):
+def _css_url_value(token: Any) -> str | None:
+    token_type = getattr(token, "type", "")
+    if token_type == "url":
+        return str(token.value)
+    if token_type != "function" or token.lower_name != "url":
         return None
-    after_name = _css_trivia_end(content, after_name)
-    if after_name >= len(content) or content[after_name] != "(":
-        return None
-    value_start = _css_trivia_end(content, after_name + 1)
-    if value_start >= len(content):
-        raise ValueError("unterminated CSS url()")
-    if content[value_start] in {'"', "'"}:
-        value, position = _css_string(content, value_start)
-        position = _css_trivia_end(content, position)
-        if position >= len(content) or content[position] != ")":
-            raise ValueError("unterminated CSS url()")
-        return _decode_css_escapes(value), position + 1
-    position = value_start
-    while position < len(content):
-        if content[position] == "\\":
-            position += 2
+    arguments = [argument for argument in token.arguments if argument.type not in {"comment", "whitespace"}]
+    if len(arguments) == 1 and arguments[0].type == "string":
+        return str(arguments[0].value)
+    if any(argument.type == "error" for argument in arguments):
+        raise ValueError("invalid CSS url()")
+    return None
+
+
+def _css_component_references(
+    tokens: list[Any],
+    *,
+    line_offset: int,
+    skip_token: Any | None = None,
+) -> list[Reference]:
+    references: list[Reference] = []
+    for token in tokens:
+        if token is skip_token or getattr(token, "type", "") in {"comment", "whitespace"}:
             continue
-        if content[position] == ")":
-            raw_value = content[value_start:position].strip()
-            return _decode_css_escapes(raw_value), position + 1
-        position += 1
-    raise ValueError("unterminated CSS url()")
+        if token.type == "error":
+            raise ValueError(
+                f"invalid CSS at line {line_offset + token.source_line}, column {token.source_column}: {token.message}"
+            )
+        target = _css_url_value(token)
+        if target is not None:
+            references.append(Reference("css-url", target.strip(), line_offset + token.source_line))
+            continue
+        nested = getattr(token, "content", None)
+        if nested is None:
+            nested = getattr(token, "arguments", None)
+        if nested is not None:
+            references.extend(_css_component_references(nested, line_offset=line_offset))
+    return references
 
 
 def _parse_css_content(content: str, *, line_offset: int = 0) -> list[Reference]:
-    """Return dependency candidates declared by CSS source text."""
+    """Return dependency candidates using the CSS Syntax parser."""
     references: list[Reference] = []
-    lowered = content.lower()
-    position = 0
-    while position < len(content):
-        if content.startswith("/*", position):
-            position = _css_comment_end(content, position)
-            continue
-        if content[position] in {'"', "'"}:
-            _, position = _css_string(content, position)
-            continue
-        if lowered.startswith("@import", position) and (
-            position + 7 == len(content) or not (content[position + 7].isalnum() or content[position + 7] in "_-")
-        ):
-            start = position
-            value_start = _css_trivia_end(content, position + 7)
-            parsed_url = _css_url(content, value_start) if lowered.startswith("url", value_start) else None
-            if parsed_url is not None:
-                target, position = parsed_url
-            elif value_start < len(content) and content[value_start] in {'"', "'"}:
-                target, position = _css_string(content, value_start)
-                target = _decode_css_escapes(target)
-            else:
-                position = value_start + 1
-                continue
-            references.append(
-                Reference(
-                    "css-import",
-                    target.strip(),
-                    line_offset + content.count("\n", 0, start) + 1,
-                    "stylesheet",
-                )
+    rules = tinycss2.parse_stylesheet(content, skip_comments=True, skip_whitespace=True)
+    for rule in rules:
+        if rule.type == "error":
+            raise ValueError(
+                f"invalid CSS at line {line_offset + rule.source_line}, column {rule.source_column}: {rule.message}"
             )
-            continue
-        if lowered.startswith("url", position):
-            parsed_url = _css_url(content, position)
-            if parsed_url is not None:
-                target, end = parsed_url
-                references.append(
-                    Reference(
-                        "css-url",
-                        target.strip(),
-                        line_offset + content.count("\n", 0, position) + 1,
+        import_token: Any | None = None
+        if rule.type == "at-rule" and rule.lower_at_keyword == "import":
+            for token in rule.prelude:
+                if token.type in {"comment", "whitespace"}:
+                    continue
+                target = _css_url_value(token)
+                if target is None and token.type == "string":
+                    target = str(token.value)
+                if target is not None:
+                    import_token = token
+                    references.append(
+                        Reference("css-import", target.strip(), line_offset + token.source_line, "stylesheet")
                     )
-                )
-                position = end
-                continue
-        if content[position] == "\\":
-            position += 2
-        else:
-            position += 1
+                break
+        references.extend(
+            _css_component_references(
+                list(getattr(rule, "prelude", [])),
+                line_offset=line_offset,
+                skip_token=import_token,
+            )
+        )
+        content_tokens = getattr(rule, "content", None)
+        if content_tokens is not None:
+            references.extend(_css_component_references(content_tokens, line_offset=line_offset))
     return references
+
+
+def _parse_css_declarations(content: str, *, line_offset: int = 0) -> list[Reference]:
+    """Return dependencies from one style attribute's component values."""
+    tokens = tinycss2.parse_component_value_list(content, skip_comments=True)
+    return _css_component_references(tokens, line_offset=line_offset)
 
 
 def _srcset_targets(srcset: str) -> list[str]:
@@ -226,9 +161,9 @@ def _srcset_targets(srcset: str) -> list[str]:
 
 
 class DocumentParser(HTMLParser):
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path, *, context: str = "") -> None:
         super().__init__(convert_charrefs=True)
-        self.document = HtmlDocument(path)
+        self.document = HtmlDocument(path, context=context)
         self._style_depth = 0
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
@@ -257,7 +192,14 @@ class DocumentParser(HTMLParser):
             for target in _srcset_targets(srcset):
                 self.document.references.append(Reference("srcset", target, self.getpos()[0]))
         if style := values.get("style"):
-            self._record_css_references(style, line_offset=self.getpos()[0] - 1)
+            self._record_css_references(style, line_offset=self.getpos()[0] - 1, declarations=True)
+        if tag == "iframe" and (srcdoc := values.get("srcdoc")):
+            line = self.getpos()[0]
+            context = f"{self.document.context} iframe[srcdoc] at line {line}".strip()
+            embedded = DocumentParser(self.document.path, context=context)
+            embedded.feed(srcdoc)
+            embedded.close()
+            self.document.embedded_documents.append(embedded.document)
 
         if tag == "link" and "canonical" in rel and (canonical := values.get("href")):
             self.document.canonicals.append(canonical)
@@ -272,9 +214,10 @@ class DocumentParser(HTMLParser):
         if tag.lower() == "style" and self._style_depth:
             self._style_depth -= 1
 
-    def _record_css_references(self, content: str, *, line_offset: int) -> None:
+    def _record_css_references(self, content: str, *, line_offset: int, declarations: bool = False) -> None:
         try:
-            self.document.references.extend(_parse_css_content(content, line_offset=line_offset))
+            parser = _parse_css_declarations if declarations else _parse_css_content
+            self.document.references.extend(parser(content, line_offset=line_offset))
         except ValueError as exc:
             self.document.parse_errors.append(f"CSS on line {line_offset + 1}: {exc}")
 
@@ -346,9 +289,10 @@ def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
     visited_css: set[Path] = set()
 
     def check_reference(
-        origin: PurePosixPath,
+        origin: str,
         origin_url: str,
         reference: Reference,
+        current_document: HtmlDocument,
     ) -> Path | None:
         raw_target = reference.target.strip()
         parsed_raw = urlparse(raw_target)
@@ -389,20 +333,28 @@ def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
             )
             return None
         if resolved.fragment and target_path.suffix.lower() == ".html":
-            target_document = documents.get(target_path)
+            target_document = (
+                current_document if target_path == current_document.path.resolve() else documents.get(target_path)
+            )
             fragment = unquote(resolved.fragment)
             if target_document is None or fragment not in target_document.ids:
                 errors.append(f"{origin}:{reference.line}: {raw_target!r} targets missing fragment #{fragment}")
         return target_path
 
-    for path, document in documents.items():
-        relative = PurePosixPath(path.relative_to(site_dir).as_posix())
-        errors.extend(f"{relative}: {error}" for error in document.parse_errors)
-        document_url = urljoin(base_url, _public_path(relative))
-        reference_url = document_url
+    def check_document(
+        document: HtmlDocument,
+        relative: PurePosixPath,
+        document_url: str,
+        *,
+        inherited_base_url: str | None = None,
+        top_level: bool = False,
+    ) -> None:
+        origin = f"{relative} {document.context}".strip()
+        errors.extend(f"{origin}: {error}" for error in document.parse_errors)
+        reference_url = inherited_base_url or document_url
         if document.base_hrefs:
             base_href = document.base_hrefs[0]
-            candidate = urlparse(urljoin(document_url, base_href))
+            candidate = urlparse(urljoin(reference_url, base_href))
             candidate_host = (candidate.hostname or "").lower()
             try:
                 candidate_port = candidate.port or (443 if candidate.scheme == "https" else 80)
@@ -421,31 +373,43 @@ def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
             ):
                 reference_url = candidate.geturl()
             else:
-                errors.append(f"{relative}: base href {base_href!r} is outside the deployment origin or project prefix")
-        expected_canonical = document_url
-        if relative.as_posix() != "404.html":
+                errors.append(f"{origin}: base href {base_href!r} is outside the deployment origin or project prefix")
+        if top_level and relative.as_posix() != "404.html":
             if len(document.canonicals) != 1:
-                errors.append(f"{relative}: expected exactly one canonical link, found {len(document.canonicals)}")
-            elif urljoin(reference_url, document.canonicals[0]) != expected_canonical:
-                errors.append(f"{relative}: canonical {document.canonicals[0]!r} does not match {expected_canonical!r}")
+                errors.append(f"{origin}: expected exactly one canonical link, found {len(document.canonicals)}")
+            elif urljoin(reference_url, document.canonicals[0]) != document_url:
+                errors.append(f"{origin}: canonical {document.canonicals[0]!r} does not match {document_url!r}")
 
-        if relative.as_posix() == "index.html":
+        if top_level and relative.as_posix() == "index.html":
             source_relative = PurePosixPath("index.md")
-        elif relative.name == "index.html":
+        elif top_level and relative.name == "index.html":
             flat_source = relative.parent.with_suffix(".md")
             nested_source = relative.parent / "index.md"
             source_relative = flat_source if (source_dir / flat_source).is_file() else nested_source
-        else:
+        elif top_level:
             source_relative = relative.with_suffix(".md")
-        if (source_dir / source_relative).is_file():
+        else:
+            source_relative = None
+        if source_relative is not None and (source_dir / source_relative).is_file():
             expected_edit = EDIT_PREFIX + source_relative.as_posix()
             if document.edit_links != [expected_edit]:
-                errors.append(f"{relative}: expected edit link {expected_edit!r}, found {document.edit_links!r}")
+                errors.append(f"{origin}: expected edit link {expected_edit!r}, found {document.edit_links!r}")
 
         for reference in document.references:
-            target_path = check_reference(relative, reference_url, reference)
+            target_path = check_reference(origin, reference_url, reference, document)
             if target_path is not None and reference.kind == "stylesheet":
                 css_to_visit.append(target_path)
+        for embedded_document in document.embedded_documents:
+            check_document(
+                embedded_document,
+                relative,
+                document_url,
+                inherited_base_url=reference_url,
+            )
+
+    for path, document in documents.items():
+        relative = PurePosixPath(path.relative_to(site_dir).as_posix())
+        check_document(document, relative, urljoin(base_url, _public_path(relative)), top_level=True)
 
     while css_to_visit:
         css_path = css_to_visit.pop()
@@ -460,7 +424,9 @@ def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
             errors.append(f"{css_relative}: {exc}")
             continue
         for reference in references:
-            target_path = check_reference(css_relative, css_url, reference)
+            target_path = check_reference(
+                str(css_relative), css_url, reference, documents.get(css_path, HtmlDocument(css_path))
+            )
             if target_path is not None and reference.kind == "stylesheet":
                 css_to_visit.append(target_path)
 

--- a/scripts/check_docs_site.py
+++ b/scripts/check_docs_site.py
@@ -10,6 +10,11 @@ from pathlib import Path, PurePosixPath
 from urllib.parse import unquote, urljoin, urlparse
 from xml.etree import ElementTree
 
+if __package__:
+    from .marimo_outputs import marimo_html_outputs
+else:
+    from marimo_outputs import marimo_html_outputs
+
 IGNORED_SCHEMES = {"data", "javascript", "mailto", "tel", "blob"}
 EDIT_PREFIX = "https://github.com/kasahart/wandas/edit/main/docs/src/"
 _CSS_URL = re.compile(r"url\(\s*(['\"]?)(.*?)\1\s*\)", flags=re.IGNORECASE)
@@ -31,6 +36,7 @@ class HtmlDocument:
     canonicals: list[str] = field(default_factory=list)
     edit_links: list[str] = field(default_factory=list)
     base_hrefs: list[str] = field(default_factory=list)
+    parse_errors: list[str] = field(default_factory=list)
 
 
 def _parse_css_content(content: str, *, line_offset: int = 0) -> list[Reference]:
@@ -147,7 +153,13 @@ def _output_path(site_dir: Path, public_path: str) -> Path:
 
 def _parse_html(path: Path) -> HtmlDocument:
     parser = DocumentParser(path)
-    parser.feed(path.read_text(encoding="utf-8"))
+    content = path.read_text(encoding="utf-8")
+    parser.feed(content)
+    try:
+        for fragment in marimo_html_outputs(content):
+            parser.feed(fragment)
+    except ValueError as exc:
+        parser.document.parse_errors.append(str(exc))
     parser.close()
     return parser.document
 
@@ -217,6 +229,7 @@ def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
 
     for path, document in documents.items():
         relative = PurePosixPath(path.relative_to(site_dir).as_posix())
+        errors.extend(f"{relative}: {error}" for error in document.parse_errors)
         document_url = urljoin(base_url, _public_path(relative))
         reference_url = document_url
         if document.base_hrefs:

--- a/scripts/check_docs_site.py
+++ b/scripts/check_docs_site.py
@@ -1,0 +1,202 @@
+"""Crawl a generated documentation site and validate its deployment contract."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
+from pathlib import Path, PurePosixPath
+from urllib.parse import unquote, urljoin, urlparse
+from xml.etree import ElementTree
+
+IGNORED_SCHEMES = {"data", "javascript", "mailto", "tel", "blob"}
+EDIT_PREFIX = "https://github.com/kasahart/wandas/edit/main/docs/src/"
+
+
+@dataclass(frozen=True)
+class Reference:
+    attribute: str
+    target: str
+    line: int
+
+
+@dataclass
+class HtmlDocument:
+    path: Path
+    ids: set[str] = field(default_factory=set)
+    references: list[Reference] = field(default_factory=list)
+    canonicals: list[str] = field(default_factory=list)
+    edit_links: list[str] = field(default_factory=list)
+
+
+class DocumentParser(HTMLParser):
+    def __init__(self, path: Path) -> None:
+        super().__init__(convert_charrefs=True)
+        self.document = HtmlDocument(path)
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = {name.lower(): value for name, value in attrs if value is not None}
+        if element_id := values.get("id"):
+            self.document.ids.add(element_id)
+        if tag.lower() == "a" and (anchor_name := values.get("name")):
+            self.document.ids.add(anchor_name)
+
+        for attribute in ("href", "src", "poster", "data"):
+            if target := values.get(attribute):
+                self.document.references.append(Reference(attribute, target, self.getpos()[0]))
+        if srcset := values.get("srcset"):
+            for candidate in srcset.split(","):
+                target = candidate.strip().split(maxsplit=1)[0]
+                if target:
+                    self.document.references.append(Reference("srcset", target, self.getpos()[0]))
+
+        rel = values.get("rel", "").lower().split()
+        if tag.lower() == "link" and "canonical" in rel and (canonical := values.get("href")):
+            self.document.canonicals.append(canonical)
+        if tag.lower() == "a" and (href := values.get("href", "")).startswith(EDIT_PREFIX):
+            self.document.edit_links.append(href)
+
+
+def _public_path(relative_html: PurePosixPath) -> str:
+    value = relative_html.as_posix()
+    if value == "index.html":
+        return ""
+    if value.endswith("/index.html"):
+        return value[: -len("index.html")]
+    return value
+
+
+def _output_path(site_dir: Path, public_path: str) -> Path:
+    decoded = unquote(public_path).lstrip("/")
+    candidate = site_dir / decoded
+    if public_path.endswith("/"):
+        return candidate / "index.html"
+    if candidate.is_file():
+        return candidate
+    return candidate / "index.html"
+
+
+def _parse_html(path: Path) -> HtmlDocument:
+    parser = DocumentParser(path)
+    parser.feed(path.read_text(encoding="utf-8"))
+    parser.close()
+    return parser.document
+
+
+def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
+    """Return every generated-site contract violation."""
+    errors: list[str] = []
+    site_dir = site_dir.resolve()
+    source_dir = source_dir.resolve()
+    base_url = site_url.rstrip("/") + "/"
+    base = urlparse(base_url)
+    project_prefix = base.path.rstrip("/") + "/"
+
+    html_paths = sorted(site_dir.rglob("*.html"))
+    documents = {path.resolve(): _parse_html(path) for path in html_paths}
+    if not html_paths:
+        errors.append(f"{site_dir}: no HTML files found")
+
+    for path, document in documents.items():
+        relative = PurePosixPath(path.relative_to(site_dir).as_posix())
+        document_url = urljoin(base_url, _public_path(relative))
+        expected_canonical = document_url
+        if relative.as_posix() != "404.html":
+            if len(document.canonicals) != 1:
+                errors.append(f"{relative}: expected exactly one canonical link, found {len(document.canonicals)}")
+            elif urljoin(document_url, document.canonicals[0]) != expected_canonical:
+                errors.append(f"{relative}: canonical {document.canonicals[0]!r} does not match {expected_canonical!r}")
+
+        if relative.as_posix() == "index.html":
+            source_relative = PurePosixPath("index.md")
+        elif relative.name == "index.html":
+            flat_source = relative.parent.with_suffix(".md")
+            nested_source = relative.parent / "index.md"
+            source_relative = flat_source if (source_dir / flat_source).is_file() else nested_source
+        else:
+            source_relative = relative.with_suffix(".md")
+        if (source_dir / source_relative).is_file():
+            expected_edit = EDIT_PREFIX + source_relative.as_posix()
+            if document.edit_links != [expected_edit]:
+                errors.append(f"{relative}: expected edit link {expected_edit!r}, found {document.edit_links!r}")
+
+        for reference in document.references:
+            raw_target = reference.target.strip()
+            parsed_raw = urlparse(raw_target)
+            if not raw_target or parsed_raw.scheme.lower() in IGNORED_SCHEMES or raw_target == "#":
+                continue
+            resolved = urlparse(urljoin(document_url, raw_target))
+            if resolved.scheme not in {"http", "https"} or resolved.netloc != base.netloc:
+                continue
+            decoded_path = unquote(resolved.path)
+            if not decoded_path.startswith(project_prefix):
+                errors.append(
+                    f"{relative}:{reference.line}: {reference.attribute} {raw_target!r} escapes "
+                    f"project prefix {project_prefix!r}"
+                )
+                continue
+            target_public_path = decoded_path[len(project_prefix) :]
+            target_path = _output_path(site_dir, target_public_path).resolve()
+            try:
+                target_path.relative_to(site_dir)
+            except ValueError:
+                errors.append(f"{relative}:{reference.line}: {raw_target!r} escapes the generated site")
+                continue
+            if not target_path.is_file():
+                errors.append(
+                    f"{relative}:{reference.line}: {reference.attribute} {raw_target!r} "
+                    f"targets missing {target_path.relative_to(site_dir)}"
+                )
+                continue
+            if resolved.fragment and target_path.suffix.lower() == ".html":
+                target_document = documents.get(target_path)
+                fragment = unquote(resolved.fragment)
+                if target_document is None or fragment not in target_document.ids:
+                    errors.append(f"{relative}:{reference.line}: {raw_target!r} targets missing fragment #{fragment}")
+
+    sitemap = site_dir / "sitemap.xml"
+    if not sitemap.is_file():
+        errors.append("sitemap.xml: missing")
+    else:
+        try:
+            root = ElementTree.parse(sitemap).getroot()
+        except ElementTree.ParseError as exc:
+            errors.append(f"sitemap.xml: invalid XML: {exc}")
+        else:
+            locations = [element.text or "" for element in root.iter() if element.tag.endswith("loc")]
+            if not locations:
+                errors.append("sitemap.xml: contains no locations")
+            for location in locations:
+                parsed = urlparse(location)
+                if (
+                    parsed.scheme != base.scheme
+                    or parsed.netloc != base.netloc
+                    or not parsed.path.startswith(project_prefix)
+                ):
+                    errors.append(f"sitemap.xml: location {location!r} is outside {base_url!r}")
+                    continue
+                target = _output_path(site_dir, unquote(parsed.path)[len(project_prefix) :])
+                if not target.is_file():
+                    errors.append(f"sitemap.xml: location {location!r} targets missing {target.relative_to(site_dir)}")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("site_dir", type=Path)
+    parser.add_argument("--source-dir", type=Path, default=Path("docs/src"))
+    parser.add_argument("--site-url", required=True)
+    args = parser.parse_args()
+    errors = check_site(args.site_dir, args.source_dir, args.site_url)
+    if errors:
+        print("Generated documentation site is invalid:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print(f"Generated documentation site is valid: {args.site_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_docs_site.py
+++ b/scripts/check_docs_site.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 from dataclasses import dataclass, field
 from html.parser import HTMLParser
 from pathlib import Path, PurePosixPath
@@ -11,6 +12,8 @@ from xml.etree import ElementTree
 
 IGNORED_SCHEMES = {"data", "javascript", "mailto", "tel", "blob"}
 EDIT_PREFIX = "https://github.com/kasahart/wandas/edit/main/docs/src/"
+_CSS_URL = re.compile(r"url\(\s*(['\"]?)(.*?)\1\s*\)", flags=re.IGNORECASE)
+_CSS_IMPORT = re.compile(r"@import\s+(['\"])(.*?)\1", flags=re.IGNORECASE)
 
 
 @dataclass(frozen=True)
@@ -83,6 +86,22 @@ def _parse_html(path: Path) -> HtmlDocument:
     return parser.document
 
 
+def _parse_css(path: Path) -> list[Reference]:
+    """Return local-dependency candidates declared by one stylesheet."""
+    content = path.read_text(encoding="utf-8")
+    references: list[Reference] = []
+    for attribute, pattern in (("css-url", _CSS_URL), ("css-import", _CSS_IMPORT)):
+        for match in pattern.finditer(content):
+            references.append(
+                Reference(
+                    attribute,
+                    match.group(2).strip(),
+                    content.count("\n", 0, match.start()) + 1,
+                )
+            )
+    return references
+
+
 def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
     """Return every generated-site contract violation."""
     errors: list[str] = []
@@ -96,6 +115,47 @@ def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
     documents = {path.resolve(): _parse_html(path) for path in html_paths}
     if not html_paths:
         errors.append(f"{site_dir}: no HTML files found")
+
+    css_to_visit: list[Path] = []
+    visited_css: set[Path] = set()
+
+    def check_reference(
+        origin: PurePosixPath,
+        origin_url: str,
+        reference: Reference,
+    ) -> Path | None:
+        raw_target = reference.target.strip()
+        parsed_raw = urlparse(raw_target)
+        if not raw_target or parsed_raw.scheme.lower() in IGNORED_SCHEMES or raw_target == "#":
+            return None
+        resolved = urlparse(urljoin(origin_url, raw_target))
+        if resolved.scheme not in {"http", "https"} or resolved.netloc != base.netloc:
+            return None
+        decoded_path = unquote(resolved.path)
+        if not decoded_path.startswith(project_prefix):
+            errors.append(
+                f"{origin}:{reference.line}: {reference.attribute} {raw_target!r} escapes "
+                f"project prefix {project_prefix!r}"
+            )
+            return None
+        target_public_path = decoded_path[len(project_prefix) :]
+        target_path = _output_path(site_dir, target_public_path).resolve()
+        try:
+            target_relative = target_path.relative_to(site_dir)
+        except ValueError:
+            errors.append(f"{origin}:{reference.line}: {raw_target!r} escapes the generated site")
+            return None
+        if not target_path.is_file():
+            errors.append(
+                f"{origin}:{reference.line}: {reference.attribute} {raw_target!r} targets missing {target_relative}"
+            )
+            return None
+        if resolved.fragment and target_path.suffix.lower() == ".html":
+            target_document = documents.get(target_path)
+            fragment = unquote(resolved.fragment)
+            if target_document is None or fragment not in target_document.ids:
+                errors.append(f"{origin}:{reference.line}: {raw_target!r} targets missing fragment #{fragment}")
+        return target_path
 
     for path, document in documents.items():
         relative = PurePosixPath(path.relative_to(site_dir).as_posix())
@@ -121,38 +181,21 @@ def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
                 errors.append(f"{relative}: expected edit link {expected_edit!r}, found {document.edit_links!r}")
 
         for reference in document.references:
-            raw_target = reference.target.strip()
-            parsed_raw = urlparse(raw_target)
-            if not raw_target or parsed_raw.scheme.lower() in IGNORED_SCHEMES or raw_target == "#":
-                continue
-            resolved = urlparse(urljoin(document_url, raw_target))
-            if resolved.scheme not in {"http", "https"} or resolved.netloc != base.netloc:
-                continue
-            decoded_path = unquote(resolved.path)
-            if not decoded_path.startswith(project_prefix):
-                errors.append(
-                    f"{relative}:{reference.line}: {reference.attribute} {raw_target!r} escapes "
-                    f"project prefix {project_prefix!r}"
-                )
-                continue
-            target_public_path = decoded_path[len(project_prefix) :]
-            target_path = _output_path(site_dir, target_public_path).resolve()
-            try:
-                target_path.relative_to(site_dir)
-            except ValueError:
-                errors.append(f"{relative}:{reference.line}: {raw_target!r} escapes the generated site")
-                continue
-            if not target_path.is_file():
-                errors.append(
-                    f"{relative}:{reference.line}: {reference.attribute} {raw_target!r} "
-                    f"targets missing {target_path.relative_to(site_dir)}"
-                )
-                continue
-            if resolved.fragment and target_path.suffix.lower() == ".html":
-                target_document = documents.get(target_path)
-                fragment = unquote(resolved.fragment)
-                if target_document is None or fragment not in target_document.ids:
-                    errors.append(f"{relative}:{reference.line}: {raw_target!r} targets missing fragment #{fragment}")
+            target_path = check_reference(relative, document_url, reference)
+            if target_path is not None and target_path.suffix.lower() == ".css":
+                css_to_visit.append(target_path)
+
+    while css_to_visit:
+        css_path = css_to_visit.pop()
+        if css_path in visited_css:
+            continue
+        visited_css.add(css_path)
+        css_relative = PurePosixPath(css_path.relative_to(site_dir).as_posix())
+        css_url = urljoin(base_url, css_relative.as_posix())
+        for reference in _parse_css(css_path):
+            target_path = check_reference(css_relative, css_url, reference)
+            if target_path is not None and target_path.suffix.lower() == ".css":
+                css_to_visit.append(target_path)
 
     sitemap = site_dir / "sitemap.xml"
     if not sitemap.is_file():
@@ -175,9 +218,15 @@ def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
                 ):
                     errors.append(f"sitemap.xml: location {location!r} is outside {base_url!r}")
                     continue
-                target = _output_path(site_dir, unquote(parsed.path)[len(project_prefix) :])
+                decoded_path = unquote(parsed.path)
+                target = _output_path(site_dir, decoded_path[len(project_prefix) :]).resolve()
+                try:
+                    target_relative = target.relative_to(site_dir)
+                except ValueError:
+                    errors.append(f"sitemap.xml: location {location!r} escapes the generated site")
+                    continue
                 if not target.is_file():
-                    errors.append(f"sitemap.xml: location {location!r} targets missing {target.relative_to(site_dir)}")
+                    errors.append(f"sitemap.xml: location {location!r} targets missing {target_relative}")
 
     return errors
 

--- a/scripts/check_docs_site.py
+++ b/scripts/check_docs_site.py
@@ -30,34 +30,100 @@ class HtmlDocument:
     references: list[Reference] = field(default_factory=list)
     canonicals: list[str] = field(default_factory=list)
     edit_links: list[str] = field(default_factory=list)
+    base_hrefs: list[str] = field(default_factory=list)
+
+
+def _parse_css_content(content: str, *, line_offset: int = 0) -> list[Reference]:
+    """Return dependency candidates declared by CSS source text."""
+    references: list[Reference] = []
+    for attribute, pattern in (("css-url", _CSS_URL), ("css-import", _CSS_IMPORT)):
+        for match in pattern.finditer(content):
+            references.append(
+                Reference(
+                    attribute,
+                    match.group(2).strip(),
+                    line_offset + content.count("\n", 0, match.start()) + 1,
+                )
+            )
+    return references
+
+
+def _srcset_targets(srcset: str) -> list[str]:
+    """Return srcset URL tokens without splitting commas inside URL data."""
+    targets: list[str] = []
+    position = 0
+    length = len(srcset)
+    while position < length:
+        while position < length and (srcset[position].isspace() or srcset[position] == ","):
+            position += 1
+        start = position
+        while position < length and not srcset[position].isspace():
+            position += 1
+        target = srcset[start:position]
+        if not target:
+            break
+        if target.endswith(","):
+            target = target.rstrip(",")
+        else:
+            parentheses = 0
+            while position < length:
+                character = srcset[position]
+                if character == "(":
+                    parentheses += 1
+                elif character == ")" and parentheses:
+                    parentheses -= 1
+                elif character == "," and not parentheses:
+                    position += 1
+                    break
+                position += 1
+        if target:
+            targets.append(target)
+    return targets
 
 
 class DocumentParser(HTMLParser):
     def __init__(self, path: Path) -> None:
         super().__init__(convert_charrefs=True)
         self.document = HtmlDocument(path)
+        self._style_depth = 0
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         values = {name.lower(): value for name, value in attrs if value is not None}
+        tag = tag.lower()
+        if tag == "style":
+            self._style_depth += 1
         if element_id := values.get("id"):
             self.document.ids.add(element_id)
-        if tag.lower() == "a" and (anchor_name := values.get("name")):
+        if tag == "a" and (anchor_name := values.get("name")):
             self.document.ids.add(anchor_name)
 
+        if tag == "base" and (base_href := values.get("href")):
+            self.document.base_hrefs.append(base_href)
+
         for attribute in ("href", "src", "poster", "data"):
+            if tag == "base" and attribute == "href":
+                continue
             if target := values.get(attribute):
                 self.document.references.append(Reference(attribute, target, self.getpos()[0]))
         if srcset := values.get("srcset"):
-            for candidate in srcset.split(","):
-                target = candidate.strip().split(maxsplit=1)[0]
-                if target:
-                    self.document.references.append(Reference("srcset", target, self.getpos()[0]))
+            for target in _srcset_targets(srcset):
+                self.document.references.append(Reference("srcset", target, self.getpos()[0]))
+        if style := values.get("style"):
+            self.document.references.extend(_parse_css_content(style, line_offset=self.getpos()[0] - 1))
 
         rel = values.get("rel", "").lower().split()
-        if tag.lower() == "link" and "canonical" in rel and (canonical := values.get("href")):
+        if tag == "link" and "canonical" in rel and (canonical := values.get("href")):
             self.document.canonicals.append(canonical)
-        if tag.lower() == "a" and (href := values.get("href", "")).startswith(EDIT_PREFIX):
+        if tag == "a" and (href := values.get("href", "")).startswith(EDIT_PREFIX):
             self.document.edit_links.append(href)
+
+    def handle_data(self, data: str) -> None:
+        if self._style_depth:
+            self.document.references.extend(_parse_css_content(data, line_offset=self.getpos()[0] - 1))
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "style" and self._style_depth:
+            self._style_depth -= 1
 
 
 def _public_path(relative_html: PurePosixPath) -> str:
@@ -88,18 +154,7 @@ def _parse_html(path: Path) -> HtmlDocument:
 
 def _parse_css(path: Path) -> list[Reference]:
     """Return local-dependency candidates declared by one stylesheet."""
-    content = path.read_text(encoding="utf-8")
-    references: list[Reference] = []
-    for attribute, pattern in (("css-url", _CSS_URL), ("css-import", _CSS_IMPORT)):
-        for match in pattern.finditer(content):
-            references.append(
-                Reference(
-                    attribute,
-                    match.group(2).strip(),
-                    content.count("\n", 0, match.start()) + 1,
-                )
-            )
-    return references
+    return _parse_css_content(path.read_text(encoding="utf-8"))
 
 
 def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
@@ -127,6 +182,9 @@ def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
         raw_target = reference.target.strip()
         parsed_raw = urlparse(raw_target)
         if not raw_target or parsed_raw.scheme.lower() in IGNORED_SCHEMES or raw_target == "#":
+            return None
+        if parsed_raw.scheme.lower() == "file":
+            errors.append(f"{origin}:{reference.line}: {reference.attribute} {raw_target!r} uses forbidden file URL")
             return None
         resolved = urlparse(urljoin(origin_url, raw_target))
         if resolved.scheme not in {"http", "https"} or resolved.netloc != base.netloc:
@@ -160,11 +218,19 @@ def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
     for path, document in documents.items():
         relative = PurePosixPath(path.relative_to(site_dir).as_posix())
         document_url = urljoin(base_url, _public_path(relative))
+        reference_url = document_url
+        if document.base_hrefs:
+            base_href = document.base_hrefs[0]
+            candidate = urlparse(urljoin(document_url, base_href))
+            if candidate.scheme in {"http", "https"} and candidate.netloc:
+                reference_url = candidate.geturl()
+            else:
+                errors.append(f"{relative}: base href {base_href!r} is not a deployable HTTP(S) URL")
         expected_canonical = document_url
         if relative.as_posix() != "404.html":
             if len(document.canonicals) != 1:
                 errors.append(f"{relative}: expected exactly one canonical link, found {len(document.canonicals)}")
-            elif urljoin(document_url, document.canonicals[0]) != expected_canonical:
+            elif urljoin(reference_url, document.canonicals[0]) != expected_canonical:
                 errors.append(f"{relative}: canonical {document.canonicals[0]!r} does not match {expected_canonical!r}")
 
         if relative.as_posix() == "index.html":
@@ -181,7 +247,7 @@ def check_site(site_dir: Path, source_dir: Path, site_url: str) -> list[str]:
                 errors.append(f"{relative}: expected edit link {expected_edit!r}, found {document.edit_links!r}")
 
         for reference in document.references:
-            target_path = check_reference(relative, document_url, reference)
+            target_path = check_reference(relative, reference_url, reference)
             if target_path is not None and target_path.suffix.lower() == ".css":
                 css_to_visit.append(target_path)
 

--- a/scripts/finalize_learning_html.py
+++ b/scripts/finalize_learning_html.py
@@ -1,0 +1,62 @@
+"""Finalize exported learning applications for the GitHub Pages project site."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from urllib.parse import urljoin
+
+LEARNING_HTML_GLOB = "0[0-8]_*.html"
+PYTHON_HREF = re.compile(
+    r"""(?P<prefix>\bhref\s*=\s*["'])(?P<target>[^"'#?]+)\.py"""
+    r"""(?P<suffix>[#?][^"']*)?(?P<quote>["'])"""
+)
+CANONICAL_LINK = re.compile(
+    r"""<link\b[^>]*\brel\s*=\s*["'][^"']*\bcanonical\b[^"']*["'][^>]*>""",
+    flags=re.IGNORECASE,
+)
+
+
+def finalize_learning_html(site_dir: Path, site_url: str) -> list[Path]:
+    """Rewrite source-only links and install canonical metadata."""
+    learning_dir = site_dir / "learning-path"
+    html_paths = sorted(learning_dir.glob(LEARNING_HTML_GLOB))
+    if len(html_paths) != 9:
+        raise ValueError(f"expected 9 exported learning applications in {learning_dir}, found {len(html_paths)}")
+
+    base_url = site_url.rstrip("/") + "/"
+    for html_path in html_paths:
+        html = html_path.read_text(encoding="utf-8")
+        html = PYTHON_HREF.sub(
+            lambda match: (
+                f"{match.group('prefix')}{match.group('target')}.html"
+                f"{match.group('suffix') or ''}{match.group('quote')}"
+            ),
+            html,
+        )
+        canonical_url = urljoin(base_url, f"learning-path/{html_path.name}")
+        canonical = f'<link rel="canonical" href="{canonical_url}">'
+        if CANONICAL_LINK.search(html):
+            html = CANONICAL_LINK.sub(canonical, html, count=1)
+        elif re.search(r"</head\s*>", html, flags=re.IGNORECASE):
+            html = re.sub(r"</head\s*>", f"  {canonical}\n</head>", html, count=1, flags=re.IGNORECASE)
+        else:
+            raise ValueError(f"{html_path} has no HTML head")
+        html_path.write_text(html, encoding="utf-8")
+
+    return html_paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("site_dir", type=Path)
+    parser.add_argument("--site-url", required=True)
+    args = parser.parse_args()
+    finalized = finalize_learning_html(args.site_dir, args.site_url)
+    print(f"Finalized {len(finalized)} learning applications")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/finalize_learning_html.py
+++ b/scripts/finalize_learning_html.py
@@ -15,6 +15,7 @@ else:
 
 LEARNING_HTML_GLOB = "0[0-8]_*.html"
 HREF = re.compile(r"""(?P<prefix>\bhref\s*=\s*["'])(?P<target>[^"']+)(?P<quote>["'])""")
+SCRIPT_BLOCK = re.compile(r"(<script\b.*?</script\s*>)", flags=re.IGNORECASE | re.DOTALL)
 CANONICAL_LINK = re.compile(
     r"""<link\b[^>]*\brel\s*=\s*["'][^"']*\bcanonical\b[^"']*["'][^>]*>""",
     flags=re.IGNORECASE,
@@ -47,8 +48,9 @@ def finalize_learning_html(site_dir: Path, site_url: str) -> list[Path]:
         def rewrite_fragment(fragment: str) -> str:
             return HREF.sub(rewrite_learning_link, fragment)
 
-        html = rewrite_fragment(html)
-        html = rewrite_marimo_html_outputs(html, rewrite_fragment)
+        static_parts = SCRIPT_BLOCK.split(html)
+        html = "".join(part if index % 2 else rewrite_fragment(part) for index, part in enumerate(static_parts))
+        html = rewrite_marimo_html_outputs(html, rewrite_fragment, require_session=True)
         canonical_url = urljoin(base_url, f"learning-path/{html_path.name}")
         canonical = f'<link rel="canonical" href="{canonical_url}">'
         if CANONICAL_LINK.search(html):

--- a/scripts/finalize_learning_html.py
+++ b/scripts/finalize_learning_html.py
@@ -3,15 +3,13 @@
 from __future__ import annotations
 
 import argparse
+import posixpath
 import re
 from pathlib import Path
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
 LEARNING_HTML_GLOB = "0[0-8]_*.html"
-PYTHON_HREF = re.compile(
-    r"""(?P<prefix>\bhref\s*=\s*["'])(?P<target>[^"'#?]+)\.py"""
-    r"""(?P<suffix>[#?][^"']*)?(?P<quote>["'])"""
-)
+HREF = re.compile(r"""(?P<prefix>\bhref\s*=\s*["'])(?P<target>[^"']+)(?P<quote>["'])""")
 CANONICAL_LINK = re.compile(
     r"""<link\b[^>]*\brel\s*=\s*["'][^"']*\bcanonical\b[^"']*["'][^>]*>""",
     flags=re.IGNORECASE,
@@ -26,15 +24,22 @@ def finalize_learning_html(site_dir: Path, site_url: str) -> list[Path]:
         raise ValueError(f"expected 9 exported learning applications in {learning_dir}, found {len(html_paths)}")
 
     base_url = site_url.rstrip("/") + "/"
+    exported_sources = {f"learning-path/{path.with_suffix('.py').name}" for path in html_paths}
     for html_path in html_paths:
         html = html_path.read_text(encoding="utf-8")
-        html = PYTHON_HREF.sub(
-            lambda match: (
-                f"{match.group('prefix')}{match.group('target')}.html"
-                f"{match.group('suffix') or ''}{match.group('quote')}"
-            ),
-            html,
-        )
+
+        def rewrite_learning_link(match: re.Match[str]) -> str:
+            target = match.group("target")
+            parsed = urlsplit(target)
+            if parsed.scheme or parsed.netloc or parsed.path.startswith("/") or not parsed.path.endswith(".py"):
+                return match.group(0)
+            deployed_path = posixpath.normpath(f"learning-path/{parsed.path}")
+            if deployed_path not in exported_sources:
+                return match.group(0)
+            rewritten = urlunsplit(("", "", f"{parsed.path[:-3]}.html", parsed.query, parsed.fragment))
+            return f"{match.group('prefix')}{rewritten}{match.group('quote')}"
+
+        html = HREF.sub(rewrite_learning_link, html)
         canonical_url = urljoin(base_url, f"learning-path/{html_path.name}")
         canonical = f'<link rel="canonical" href="{canonical_url}">'
         if CANONICAL_LINK.search(html):

--- a/scripts/finalize_learning_html.py
+++ b/scripts/finalize_learning_html.py
@@ -8,6 +8,11 @@ import re
 from pathlib import Path
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
+if __package__:
+    from .marimo_outputs import rewrite_marimo_html_outputs
+else:
+    from marimo_outputs import rewrite_marimo_html_outputs
+
 LEARNING_HTML_GLOB = "0[0-8]_*.html"
 HREF = re.compile(r"""(?P<prefix>\bhref\s*=\s*["'])(?P<target>[^"']+)(?P<quote>["'])""")
 CANONICAL_LINK = re.compile(
@@ -39,7 +44,11 @@ def finalize_learning_html(site_dir: Path, site_url: str) -> list[Path]:
             rewritten = urlunsplit(("", "", f"{parsed.path[:-3]}.html", parsed.query, parsed.fragment))
             return f"{match.group('prefix')}{rewritten}{match.group('quote')}"
 
-        html = HREF.sub(rewrite_learning_link, html)
+        def rewrite_fragment(fragment: str) -> str:
+            return HREF.sub(rewrite_learning_link, fragment)
+
+        html = rewrite_fragment(html)
+        html = rewrite_marimo_html_outputs(html, rewrite_fragment)
         canonical_url = urljoin(base_url, f"learning-path/{html_path.name}")
         canonical = f'<link rel="canonical" href="{canonical_url}">'
         if CANONICAL_LINK.search(html):

--- a/scripts/marimo_outputs.py
+++ b/scripts/marimo_outputs.py
@@ -5,80 +5,138 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Callable, Iterator, Mapping
-from typing import Any
+from typing import Any, cast
 
 _MOUNT_CONFIG = re.compile(
     r"Object\.defineProperty\(\s*window\s*,\s*['\"]__MARIMO_MOUNT_CONFIG__['\"]\s*,\s*"
     r"\{\s*value\s*:\s*Object\.freeze\(\s*"
 )
 _SESSION = re.compile(r'"session"\s*:\s*')
+_NOTEBOOK = re.compile(r'"notebook"\s*:\s*')
 _HTML_MIME_TYPES = {"text/html", "text/markdown"}
 _MIME_BUNDLE = "application/vnd.marimo+mimebundle"
 
 
-def _session_span(document: str) -> tuple[int, int, dict[str, Any]] | None:
-    """Return the rendered-session span from one marimo mount config."""
+def _mount_bounds(document: str, *, required: bool) -> tuple[int, int] | None:
     mount_match = _MOUNT_CONFIG.search(document)
     if mount_match is None:
+        if required:
+            raise ValueError("learning export has no recognizable marimo mount config")
         return None
     script_end = document.find("</script>", mount_match.end())
     if script_end < 0:
         raise ValueError("marimo mount config script is not closed")
-    invalid_session: json.JSONDecodeError | None = None
-    for match in _SESSION.finditer(document, mount_match.end(), script_end):
+    return mount_match.end(), script_end
+
+
+def _object_member_span(
+    document: str,
+    pattern: re.Pattern[str],
+    bounds: tuple[int, int],
+    *,
+    label: str,
+) -> tuple[int, int, dict[str, Any]]:
+    invalid_value: json.JSONDecodeError | None = None
+    for match in pattern.finditer(document, bounds[0], bounds[1]):
         try:
             value, consumed = json.JSONDecoder().raw_decode(document[match.end() :])
         except json.JSONDecodeError as exc:
-            invalid_session = exc
+            invalid_value = exc
             continue
         if isinstance(value, dict) and isinstance(value.get("cells"), list):
             return match.end(), match.end() + consumed, value
-    if invalid_session is not None:
-        raise ValueError(f"marimo mount config has an invalid serialized session: {invalid_session}")
-    raise ValueError("marimo mount config has no serialized session object")
+    if invalid_value is not None:
+        raise ValueError(f"marimo mount config has an invalid serialized {label}: {invalid_value}")
+    raise ValueError(f"marimo mount config has no serialized {label} object")
 
 
-def _data_mappings(session: Mapping[str, Any]) -> Iterator[dict[str, Any]]:
+def _session_span(document: str, *, required: bool = False) -> tuple[int, int, dict[str, Any]] | None:
+    """Return the rendered-session span from one marimo mount config."""
+    bounds = _mount_bounds(document, required=required)
+    if bounds is None:
+        return None
+    return _object_member_span(document, _SESSION, bounds, label="session")
+
+
+def _require_source_code(document: str) -> None:
+    bounds = _mount_bounds(document, required=True)
+    assert bounds is not None
+    _, _, notebook = _object_member_span(document, _NOTEBOOK, bounds, label="notebook")
+    cells = notebook["cells"]
+    if not all(isinstance(cell, Mapping) and isinstance(cell.get("code"), str) for cell in cells):
+        raise ValueError("marimo mount config has an unrecognized notebook cell schema")
+    if not any(cell["code"].strip() for cell in cells):
+        raise ValueError("learning export does not include notebook source code")
+
+
+def _data_mappings(session: Mapping[str, Any], *, strict: bool = False) -> Iterator[dict[str, Any]]:
     """Yield mutable MIME mappings from the supported marimo session shape."""
     cells = session.get("cells", [])
     if not isinstance(cells, list):
         return
-    for cell in cells:
-        if not isinstance(cell, Mapping):
+    for cell_index, cell in enumerate(cells):
+        if not isinstance(cell, dict):
+            if strict:
+                raise ValueError(f"marimo session cell {cell_index} has an unrecognized schema")
             continue
-        outputs = cell.get("outputs", [])
+        cell_mapping = cast(dict[str, Any], cell)
+        outputs = cell_mapping.get("outputs", [])
         if not isinstance(outputs, list):
+            if strict:
+                raise ValueError(f"marimo session cell {cell_index} has unrecognized outputs")
             continue
-        for output in outputs:
-            if not isinstance(output, Mapping):
+        for output_index, output in enumerate(outputs):
+            if not isinstance(output, dict):
+                if strict:
+                    raise ValueError(
+                        f"marimo session cell {cell_index} output {output_index} has an unrecognized schema"
+                    )
                 continue
-            data = output.get("data")
+            output_mapping = cast(dict[str, Any], output)
+            data = output_mapping.get("data")
             if isinstance(data, dict):
                 yield data
+            elif strict:
+                raise ValueError(f"marimo session cell {cell_index} output {output_index} has unrecognized data")
 
 
-def _mime_bundle(value: object) -> dict[str, Any] | None:
+def _mime_bundle(value: object, *, strict: bool = False) -> dict[str, Any] | None:
     if not isinstance(value, str):
+        if strict and value is not None:
+            raise ValueError("marimo MIME bundle has an unrecognized schema")
         return None
     try:
         decoded = json.loads(value)
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as exc:
+        if strict:
+            raise ValueError(f"marimo MIME bundle is invalid JSON: {exc}") from exc
         return None
-    return decoded if isinstance(decoded, dict) else None
+    if isinstance(decoded, dict):
+        return decoded
+    if strict:
+        raise ValueError("marimo MIME bundle has an unrecognized schema")
+    return None
 
 
-def marimo_html_outputs(document: str) -> list[str]:
+def marimo_html_outputs(
+    document: str,
+    *,
+    require_session: bool = False,
+    require_source: bool = False,
+) -> list[str]:
     """Return rendered HTML fragments from one static marimo export."""
-    span = _session_span(document)
+    span = _session_span(document, required=require_session)
     if span is None:
         return []
+    if require_source:
+        _require_source_code(document)
     fragments: list[str] = []
-    for data in _data_mappings(span[2]):
+    for data in _data_mappings(span[2], strict=require_session):
         for mime_type in _HTML_MIME_TYPES:
             value = data.get(mime_type)
             if isinstance(value, str):
                 fragments.append(value)
-        bundle = _mime_bundle(data.get(_MIME_BUNDLE))
+        bundle = _mime_bundle(data.get(_MIME_BUNDLE), strict=require_session)
         if bundle is not None:
             for mime_type in _HTML_MIME_TYPES:
                 value = bundle.get(mime_type)
@@ -87,18 +145,23 @@ def marimo_html_outputs(document: str) -> list[str]:
     return fragments
 
 
-def rewrite_marimo_html_outputs(document: str, transform: Callable[[str], str]) -> str:
+def rewrite_marimo_html_outputs(
+    document: str,
+    transform: Callable[[str], str],
+    *,
+    require_session: bool = False,
+) -> str:
     """Apply *transform* to every rendered HTML fragment in a static export."""
-    span = _session_span(document)
+    span = _session_span(document, required=require_session)
     if span is None:
         return document
     start, end, session = span
-    for data in _data_mappings(session):
+    for data in _data_mappings(session, strict=require_session):
         for mime_type in _HTML_MIME_TYPES:
             value = data.get(mime_type)
             if isinstance(value, str):
                 data[mime_type] = transform(value)
-        bundle = _mime_bundle(data.get(_MIME_BUNDLE))
+        bundle = _mime_bundle(data.get(_MIME_BUNDLE), strict=require_session)
         if bundle is not None:
             changed = False
             for mime_type in _HTML_MIME_TYPES:

--- a/scripts/marimo_outputs.py
+++ b/scripts/marimo_outputs.py
@@ -156,6 +156,8 @@ def marimo_html_outputs(
                         raise ValueError(f"marimo MIME bundle {mime_type} output has an unrecognized schema")
                     continue
                 fragments.append(value)
+    if require_session and not any(fragment.strip() for fragment in fragments):
+        raise ValueError("marimo session has no nonempty rendered HTML or Markdown output")
     return fragments
 
 
@@ -170,6 +172,7 @@ def rewrite_marimo_html_outputs(
     if span is None:
         return document
     start, end, session = span
+    rendered_fragments = 0
     for data in _data_mappings(session, strict=require_session):
         for mime_type in _HTML_MIME_TYPES:
             if mime_type not in data:
@@ -179,6 +182,8 @@ def rewrite_marimo_html_outputs(
                 if require_session:
                     raise ValueError(f"marimo {mime_type} output has an unrecognized schema")
                 continue
+            if value.strip():
+                rendered_fragments += 1
             data[mime_type] = transform(value)
         bundle = _mime_bundle(data[_MIME_BUNDLE], strict=require_session) if _MIME_BUNDLE in data else None
         if bundle is not None:
@@ -191,10 +196,15 @@ def rewrite_marimo_html_outputs(
                     if require_session:
                         raise ValueError(f"marimo MIME bundle {mime_type} output has an unrecognized schema")
                     continue
+                if value.strip():
+                    rendered_fragments += 1
                 bundle[mime_type] = transform(value)
                 changed = True
             if changed:
                 data[_MIME_BUNDLE] = json.dumps(bundle, ensure_ascii=True, separators=(",", ":"))
+
+    if require_session and rendered_fragments == 0:
+        raise ValueError("marimo session has no nonempty rendered HTML or Markdown output")
 
     serialized = json.dumps(session, ensure_ascii=True, separators=(",", ":"))
     serialized = serialized.replace("<", r"\u003C").replace(">", r"\u003E").replace("&", r"\u0026")

--- a/scripts/marimo_outputs.py
+++ b/scripts/marimo_outputs.py
@@ -80,6 +80,8 @@ def _data_mappings(session: Mapping[str, Any], *, strict: bool = False) -> Itera
                 raise ValueError(f"marimo session cell {cell_index} has an unrecognized schema")
             continue
         cell_mapping = cast(dict[str, Any], cell)
+        if strict and "outputs" not in cell_mapping:
+            raise ValueError(f"marimo session cell {cell_index} has no outputs container")
         outputs = cell_mapping.get("outputs", [])
         if not isinstance(outputs, list):
             if strict:
@@ -133,15 +135,25 @@ def marimo_html_outputs(
     fragments: list[str] = []
     for data in _data_mappings(span[2], strict=require_session):
         for mime_type in _HTML_MIME_TYPES:
-            value = data.get(mime_type)
-            if isinstance(value, str):
-                fragments.append(value)
+            if mime_type not in data:
+                continue
+            value = data[mime_type]
+            if not isinstance(value, str):
+                if require_session:
+                    raise ValueError(f"marimo {mime_type} output has an unrecognized schema")
+                continue
+            fragments.append(value)
         bundle = _mime_bundle(data.get(_MIME_BUNDLE), strict=require_session)
         if bundle is not None:
             for mime_type in _HTML_MIME_TYPES:
-                value = bundle.get(mime_type)
-                if isinstance(value, str):
-                    fragments.append(value)
+                if mime_type not in bundle:
+                    continue
+                value = bundle[mime_type]
+                if not isinstance(value, str):
+                    if require_session:
+                        raise ValueError(f"marimo MIME bundle {mime_type} output has an unrecognized schema")
+                    continue
+                fragments.append(value)
     return fragments
 
 
@@ -158,17 +170,27 @@ def rewrite_marimo_html_outputs(
     start, end, session = span
     for data in _data_mappings(session, strict=require_session):
         for mime_type in _HTML_MIME_TYPES:
-            value = data.get(mime_type)
-            if isinstance(value, str):
-                data[mime_type] = transform(value)
+            if mime_type not in data:
+                continue
+            value = data[mime_type]
+            if not isinstance(value, str):
+                if require_session:
+                    raise ValueError(f"marimo {mime_type} output has an unrecognized schema")
+                continue
+            data[mime_type] = transform(value)
         bundle = _mime_bundle(data.get(_MIME_BUNDLE), strict=require_session)
         if bundle is not None:
             changed = False
             for mime_type in _HTML_MIME_TYPES:
-                value = bundle.get(mime_type)
-                if isinstance(value, str):
-                    bundle[mime_type] = transform(value)
-                    changed = True
+                if mime_type not in bundle:
+                    continue
+                value = bundle[mime_type]
+                if not isinstance(value, str):
+                    if require_session:
+                        raise ValueError(f"marimo MIME bundle {mime_type} output has an unrecognized schema")
+                    continue
+                bundle[mime_type] = transform(value)
+                changed = True
             if changed:
                 data[_MIME_BUNDLE] = json.dumps(bundle, ensure_ascii=True, separators=(",", ":"))
 

--- a/scripts/marimo_outputs.py
+++ b/scripts/marimo_outputs.py
@@ -1,0 +1,114 @@
+"""Read and rewrite HTML fragments serialized in static marimo exports."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable, Iterator, Mapping
+from typing import Any
+
+_MOUNT_CONFIG = re.compile(
+    r"Object\.defineProperty\(\s*window\s*,\s*['\"]__MARIMO_MOUNT_CONFIG__['\"]\s*,\s*"
+    r"\{\s*value\s*:\s*Object\.freeze\(\s*"
+)
+_SESSION = re.compile(r'"session"\s*:\s*')
+_HTML_MIME_TYPES = {"text/html", "text/markdown"}
+_MIME_BUNDLE = "application/vnd.marimo+mimebundle"
+
+
+def _session_span(document: str) -> tuple[int, int, dict[str, Any]] | None:
+    """Return the rendered-session span from one marimo mount config."""
+    mount_match = _MOUNT_CONFIG.search(document)
+    if mount_match is None:
+        return None
+    script_end = document.find("</script>", mount_match.end())
+    if script_end < 0:
+        raise ValueError("marimo mount config script is not closed")
+    invalid_session: json.JSONDecodeError | None = None
+    for match in _SESSION.finditer(document, mount_match.end(), script_end):
+        try:
+            value, consumed = json.JSONDecoder().raw_decode(document[match.end() :])
+        except json.JSONDecodeError as exc:
+            invalid_session = exc
+            continue
+        if isinstance(value, dict) and isinstance(value.get("cells"), list):
+            return match.end(), match.end() + consumed, value
+    if invalid_session is not None:
+        raise ValueError(f"marimo mount config has an invalid serialized session: {invalid_session}")
+    raise ValueError("marimo mount config has no serialized session object")
+
+
+def _data_mappings(session: Mapping[str, Any]) -> Iterator[dict[str, Any]]:
+    """Yield mutable MIME mappings from the supported marimo session shape."""
+    cells = session.get("cells", [])
+    if not isinstance(cells, list):
+        return
+    for cell in cells:
+        if not isinstance(cell, Mapping):
+            continue
+        outputs = cell.get("outputs", [])
+        if not isinstance(outputs, list):
+            continue
+        for output in outputs:
+            if not isinstance(output, Mapping):
+                continue
+            data = output.get("data")
+            if isinstance(data, dict):
+                yield data
+
+
+def _mime_bundle(value: object) -> dict[str, Any] | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return decoded if isinstance(decoded, dict) else None
+
+
+def marimo_html_outputs(document: str) -> list[str]:
+    """Return rendered HTML fragments from one static marimo export."""
+    span = _session_span(document)
+    if span is None:
+        return []
+    fragments: list[str] = []
+    for data in _data_mappings(span[2]):
+        for mime_type in _HTML_MIME_TYPES:
+            value = data.get(mime_type)
+            if isinstance(value, str):
+                fragments.append(value)
+        bundle = _mime_bundle(data.get(_MIME_BUNDLE))
+        if bundle is not None:
+            for mime_type in _HTML_MIME_TYPES:
+                value = bundle.get(mime_type)
+                if isinstance(value, str):
+                    fragments.append(value)
+    return fragments
+
+
+def rewrite_marimo_html_outputs(document: str, transform: Callable[[str], str]) -> str:
+    """Apply *transform* to every rendered HTML fragment in a static export."""
+    span = _session_span(document)
+    if span is None:
+        return document
+    start, end, session = span
+    for data in _data_mappings(session):
+        for mime_type in _HTML_MIME_TYPES:
+            value = data.get(mime_type)
+            if isinstance(value, str):
+                data[mime_type] = transform(value)
+        bundle = _mime_bundle(data.get(_MIME_BUNDLE))
+        if bundle is not None:
+            changed = False
+            for mime_type in _HTML_MIME_TYPES:
+                value = bundle.get(mime_type)
+                if isinstance(value, str):
+                    bundle[mime_type] = transform(value)
+                    changed = True
+            if changed:
+                data[_MIME_BUNDLE] = json.dumps(bundle, ensure_ascii=True, separators=(",", ":"))
+
+    serialized = json.dumps(session, ensure_ascii=True, separators=(",", ":"))
+    serialized = serialized.replace("<", r"\u003C").replace(">", r"\u003E").replace("&", r"\u0026")
+    return document[:start] + serialized + document[end:]

--- a/scripts/marimo_outputs.py
+++ b/scripts/marimo_outputs.py
@@ -74,6 +74,8 @@ def _data_mappings(session: Mapping[str, Any], *, strict: bool = False) -> Itera
     cells = session.get("cells", [])
     if not isinstance(cells, list):
         return
+    if strict and not cells:
+        raise ValueError("marimo session has no cells")
     for cell_index, cell in enumerate(cells):
         if not isinstance(cell, dict):
             if strict:
@@ -104,7 +106,7 @@ def _data_mappings(session: Mapping[str, Any], *, strict: bool = False) -> Itera
 
 def _mime_bundle(value: object, *, strict: bool = False) -> dict[str, Any] | None:
     if not isinstance(value, str):
-        if strict and value is not None:
+        if strict:
             raise ValueError("marimo MIME bundle has an unrecognized schema")
         return None
     try:
@@ -143,7 +145,7 @@ def marimo_html_outputs(
                     raise ValueError(f"marimo {mime_type} output has an unrecognized schema")
                 continue
             fragments.append(value)
-        bundle = _mime_bundle(data.get(_MIME_BUNDLE), strict=require_session)
+        bundle = _mime_bundle(data[_MIME_BUNDLE], strict=require_session) if _MIME_BUNDLE in data else None
         if bundle is not None:
             for mime_type in _HTML_MIME_TYPES:
                 if mime_type not in bundle:
@@ -178,7 +180,7 @@ def rewrite_marimo_html_outputs(
                     raise ValueError(f"marimo {mime_type} output has an unrecognized schema")
                 continue
             data[mime_type] = transform(value)
-        bundle = _mime_bundle(data.get(_MIME_BUNDLE), strict=require_session)
+        bundle = _mime_bundle(data[_MIME_BUNDLE], strict=require_session) if _MIME_BUNDLE in data else None
         if bundle is not None:
             changed = False
             for mime_type in _HTML_MIME_TYPES:

--- a/tests/docs/test_docs_links.py
+++ b/tests/docs/test_docs_links.py
@@ -5,6 +5,7 @@ import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+SITE_URL = "https://kasahart.github.io/wandas/"
 
 
 def _collect_nav_paths(nav):
@@ -92,3 +93,39 @@ def test_index_images_exist():
             f"These image files are referenced in docs/src/index.md but don't exist.\n"
             f"Add the missing image files to the appropriate location in docs/src/."
         )
+
+
+def test_mkdocs_production_metadata_matches_project_site() -> None:
+    raw = (REPO_ROOT / "docs/mkdocs.yml").read_text(encoding="utf-8")
+    assert f"site_url: {SITE_URL}" in raw
+    assert "edit_uri: edit/main/docs/src/" in raw
+    assert "content.action.edit" in raw
+    assert "G-MEASUREMENT-ID" not in raw
+    assert "analytics:" not in raw
+    assert "copyright: © 2025–2026 Wandas Team" in raw
+
+
+def test_learning_path_navigation_targets_deployed_html() -> None:
+    lessons = sorted((REPO_ROOT / "learning-path").glob("0[0-8]_*.py"))
+    assert len(lessons) == 9
+
+    for index, lesson in enumerate(lessons):
+        text = lesson.read_text(encoding="utf-8")
+        assert re.search(r"\]\([^)]*\.py(?:[#?][^)]*)?\)", text) is None
+        if index:
+            assert f"]({lessons[index - 1].stem}.html)" in text
+        if index < len(lessons) - 1:
+            assert f"]({lessons[index + 1].stem}.html)" in text
+
+
+def test_docs_learning_links_use_deployment_root() -> None:
+    paths = (
+        REPO_ROOT / "docs/src/api/core.md",
+        REPO_ROOT / "docs/src/api/frames.md",
+        REPO_ROOT / "docs/src/tutorial/index.md",
+    )
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        assert 'href="../learning-path/' not in text
+        for target in re.findall(r'href="([^"]*learning-path/[^"]+)"', text):
+            assert target.startswith("/wandas/learning-path/")

--- a/tests/docs/test_docs_links.py
+++ b/tests/docs/test_docs_links.py
@@ -124,6 +124,7 @@ def test_learning_exports_run_beside_checked_in_fixtures() -> None:
         assert "working-directory: learning-path" in workflow
         assert "for file in 0{0..8}_*.py" in workflow
         assert "../docs/site/learning-path/" in workflow
+        assert "--no-include-code" not in workflow
 
 
 def test_docs_learning_links_use_deployment_root() -> None:

--- a/tests/docs/test_docs_links.py
+++ b/tests/docs/test_docs_links.py
@@ -105,17 +105,25 @@ def test_mkdocs_production_metadata_matches_project_site() -> None:
     assert "copyright: © 2025–2026 Wandas Team" in raw
 
 
-def test_learning_path_navigation_targets_deployed_html() -> None:
+def test_learning_path_source_navigation_targets_local_marimo_apps() -> None:
     lessons = sorted((REPO_ROOT / "learning-path").glob("0[0-8]_*.py"))
     assert len(lessons) == 9
 
     for index, lesson in enumerate(lessons):
         text = lesson.read_text(encoding="utf-8")
-        assert re.search(r"\]\([^)]*\.py(?:[#?][^)]*)?\)", text) is None
+        assert re.search(r"\]\([^)]*\.html(?:[#?][^)]*)?\)", text) is None
         if index:
-            assert f"]({lessons[index - 1].stem}.html)" in text
+            assert f"]({lessons[index - 1].name})" in text
         if index < len(lessons) - 1:
-            assert f"]({lessons[index + 1].stem}.html)" in text
+            assert f"]({lessons[index + 1].name})" in text
+
+
+def test_learning_exports_run_beside_checked_in_fixtures() -> None:
+    for relative_path in (".github/workflows/ci.yml", ".github/workflows/deploy-docs.yml"):
+        workflow = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+        assert "working-directory: learning-path" in workflow
+        assert "for file in 0{0..8}_*.py" in workflow
+        assert "../docs/site/learning-path/" in workflow
 
 
 def test_docs_learning_links_use_deployment_root() -> None:

--- a/tests/docs/test_docs_site.py
+++ b/tests/docs/test_docs_site.py
@@ -22,16 +22,18 @@ def _marimo_mount(
     source_code: str = "import wandas as wd",
     include_outputs: bool = True,
     empty_session: bool = False,
+    empty_outputs: bool = False,
+    unrelated_mime: bool = False,
     null_bundle: bool = False,
 ) -> str:
-    data = {"text/markdown": fragment}
+    data: dict[str, object] = {"application/json": "{}"} if unrelated_mime else {"text/markdown": fragment}
     if null_bundle:
         data["application/vnd.marimo+mimebundle"] = None
     elif bundle_fragment is not None:
         data["application/vnd.marimo+mimebundle"] = json.dumps({"text/html": bundle_fragment})
     cell = {}
     if include_outputs:
-        cell["outputs"] = [{"data": data, "type": "data"}]
+        cell["outputs"] = [] if empty_outputs else [{"data": data, "type": "data"}]
     session = {"cells": [] if empty_session else [cell]}
     notebook = {"cells": [{"code": source_code}]}
     serialized_notebook = json.dumps(notebook).replace("<", r"\u003C").replace(">", r"\u003E")
@@ -266,6 +268,31 @@ def test_generated_site_contract_decodes_css_escapes_before_resolving(
     assert check_site(site, source, SITE_URL) == []
 
 
+def test_generated_site_contract_decodes_escaped_css_identifiers(
+    valid_site: tuple[Path, Path],
+) -> None:
+    site, source = valid_site
+    index = site / "index.html"
+    index.write_text(
+        index.read_text(encoding="utf-8").replace(
+            "</head>",
+            '<link rel="stylesheet" href="/wandas/assets/theme.css"></head>',
+        ),
+        encoding="utf-8",
+    )
+    _write(site / "assets/theme.css", r'@im\70ort "nested"; body { background: u\72l("missing.png"); }')
+    _write(site / "assets/nested", "body { background: url(nested-missing.png); }")
+
+    errors = check_site(site, source, SITE_URL)
+
+    assert any("assets/theme.css" in error and "missing.png" in error for error in errors), errors
+    assert any("assets/nested" in error and "nested-missing.png" in error for error in errors), errors
+
+    _write(site / "assets/missing.png", "placeholder")
+    _write(site / "assets/nested-missing.png", "placeholder")
+    assert check_site(site, source, SITE_URL) == []
+
+
 def test_generated_site_contract_ignores_css_comments_but_preserves_quoted_markers(
     valid_site: tuple[Path, Path],
 ) -> None:
@@ -286,7 +313,7 @@ def test_generated_site_contract_ignores_css_comments_but_preserves_quoted_marke
     assert check_site(site, source, SITE_URL) == []
 
 
-def test_generated_site_contract_rejects_unterminated_css_comment(
+def test_generated_site_contract_uses_css_syntax_recovery_for_eof_comment(
     valid_site: tuple[Path, Path],
 ) -> None:
     site, source = valid_site
@@ -300,9 +327,26 @@ def test_generated_site_contract_rejects_unterminated_css_comment(
     )
     _write(site / "assets/theme.css", "body {} /* unfinished")
 
+    assert check_site(site, source, SITE_URL) == []
+
+
+def test_generated_site_contract_rejects_css_parse_errors_with_location(
+    valid_site: tuple[Path, Path],
+) -> None:
+    site, source = valid_site
+    index = site / "index.html"
+    index.write_text(
+        index.read_text(encoding="utf-8").replace(
+            "</head>",
+            '<link rel="stylesheet" href="/wandas/assets/theme.css"></head>',
+        ),
+        encoding="utf-8",
+    )
+    _write(site / "assets/theme.css", "body {\n  background: url(foo bar);\n}")
+
     errors = check_site(site, source, SITE_URL)
 
-    assert any("assets/theme.css" in error and "unterminated CSS comment" in error for error in errors), errors
+    assert any("assets/theme.css" in error and "invalid CSS at line 2" in error for error in errors), errors
 
 
 def test_generated_site_contract_respects_first_valid_html_base(
@@ -357,6 +401,50 @@ def test_generated_site_contract_checks_inline_css_dependencies(
     _write(site / "images/style.png", "placeholder")
     _write(site / "images/attribute.svg", "placeholder")
     assert check_site(site, source, SITE_URL) == []
+
+
+def test_generated_site_contract_checks_iframe_srcdoc_with_parent_base(
+    valid_site: tuple[Path, Path],
+) -> None:
+    site, source = valid_site
+    index = site / "index.html"
+    index.write_text(
+        index.read_text(encoding="utf-8")
+        .replace("</head>", '<base href="/wandas/assets/"></head>')
+        .replace(
+            "</body>",
+            '<iframe srcdoc="&lt;div id=inside&gt;&lt;img src=srcdoc-missing.png&gt;&lt;/div&gt;"></iframe></body>',
+        ),
+        encoding="utf-8",
+    )
+
+    errors = check_site(site, source, SITE_URL)
+
+    assert any("iframe[srcdoc]" in error and "assets/srcdoc-missing.png" in error for error in errors), errors
+
+    _write(site / "assets/srcdoc-missing.png", "placeholder")
+    assert check_site(site, source, SITE_URL) == []
+
+
+def test_generated_site_contract_isolates_srcdoc_fragments_and_constrains_its_base(
+    valid_site: tuple[Path, Path],
+) -> None:
+    site, source = valid_site
+    index = site / "index.html"
+    index.write_text(
+        index.read_text(encoding="utf-8").replace(
+            "</body>",
+            '<a href="#embedded-only">Wrong scope</a>'
+            '<iframe srcdoc="&lt;base href=https://example.com/&gt;'
+            '&lt;a id=embedded-only href=#embedded-only&gt;Nested&lt;/a&gt;"></iframe></body>',
+        ),
+        encoding="utf-8",
+    )
+
+    errors = check_site(site, source, SITE_URL)
+
+    assert any("targets missing fragment #embedded-only" in error and "iframe[srcdoc]" not in error for error in errors)
+    assert any("iframe[srcdoc]" in error and "base href" in error and "outside" in error for error in errors), errors
 
 
 def test_generated_site_contract_checks_serialized_marimo_outputs(
@@ -426,6 +514,21 @@ def test_generated_site_contract_requires_learning_source_code(
             "MIME bundle has an unrecognized schema",
             id="null-bundle",
         ),
+        pytest.param(
+            _marimo_mount(""),
+            "no nonempty rendered HTML or Markdown output",
+            id="empty-rendered-fragment",
+        ),
+        pytest.param(
+            _marimo_mount("<p>Rendered</p>", empty_outputs=True),
+            "no nonempty rendered HTML or Markdown output",
+            id="empty-outputs",
+        ),
+        pytest.param(
+            _marimo_mount("<p>Rendered</p>", unrelated_mime=True),
+            "no nonempty rendered HTML or Markdown output",
+            id="unsupported-output-only",
+        ),
     ],
 )
 def test_generated_site_contract_rejects_unrecognized_marimo_session_schema(
@@ -483,4 +586,17 @@ def test_finalize_learning_html_requires_recognizable_marimo_session(tmp_path: P
         _write(site / "learning-path" / f"0{index}_lesson.html", "<html><head></head><body></body></html>")
 
     with pytest.raises(ValueError, match="no recognizable marimo mount config"):
+        finalize_learning_html(site, SITE_URL)
+
+
+def test_finalize_learning_html_requires_nonempty_rendered_fragment(tmp_path: Path) -> None:
+    site = tmp_path / "site"
+    for index in range(9):
+        fragment = "" if index == 0 else "<p>Rendered lesson</p>"
+        _write(
+            site / "learning-path" / f"0{index}_lesson.html",
+            f"<html><head></head><body>{_marimo_mount(fragment)}</body></html>",
+        )
+
+    with pytest.raises(ValueError, match="no nonempty rendered HTML or Markdown output"):
         finalize_learning_html(site, SITE_URL)

--- a/tests/docs/test_docs_site.py
+++ b/tests/docs/test_docs_site.py
@@ -123,6 +123,48 @@ def test_generated_site_contract_rejects_duplicate_canonical(valid_site: tuple[P
     assert any("exactly one canonical" in error for error in check_site(site, source, SITE_URL))
 
 
+def test_generated_site_contract_rejects_encoded_sitemap_traversal(
+    valid_site: tuple[Path, Path],
+) -> None:
+    site, source = valid_site
+    _write(site.parent / "outside.md", "This file is not deployed.")
+    sitemap = site / "sitemap.xml"
+    sitemap.write_text(
+        sitemap.read_text(encoding="utf-8").replace(
+            "https://kasahart.github.io/wandas/page/",
+            "https://kasahart.github.io/wandas/%2e%2e/outside.md",
+        ),
+        encoding="utf-8",
+    )
+
+    errors = check_site(site, source, SITE_URL)
+
+    assert any("sitemap.xml" in error and "escapes the generated site" in error for error in errors), errors
+
+
+def test_generated_site_contract_recursively_checks_stylesheet_dependencies(
+    valid_site: tuple[Path, Path],
+) -> None:
+    site, source = valid_site
+    index = site / "index.html"
+    index.write_text(
+        index.read_text(encoding="utf-8").replace(
+            "</head>",
+            '<link rel="stylesheet" href="/wandas/assets/main.css"></head>',
+        ),
+        encoding="utf-8",
+    )
+    _write(site / "assets/main.css", '@import "nested/theme.css";')
+    _write(site / "assets/nested/theme.css", 'body { background: url("../../images/missing.png"); }')
+
+    errors = check_site(site, source, SITE_URL)
+
+    assert any("assets/nested/theme.css" in error and "images/missing.png" in error for error in errors), errors
+
+    _write(site / "images/missing.png", "placeholder")
+    assert check_site(site, source, SITE_URL) == []
+
+
 def test_finalize_learning_html_rewrites_navigation_and_adds_canonical(tmp_path: Path) -> None:
     site = tmp_path / "site"
     for index in range(9):

--- a/tests/docs/test_docs_site.py
+++ b/tests/docs/test_docs_site.py
@@ -21,14 +21,18 @@ def _marimo_mount(
     bundle_fragment: str | None = None,
     source_code: str = "import wandas as wd",
     include_outputs: bool = True,
+    empty_session: bool = False,
+    null_bundle: bool = False,
 ) -> str:
     data = {"text/markdown": fragment}
-    if bundle_fragment is not None:
+    if null_bundle:
+        data["application/vnd.marimo+mimebundle"] = None
+    elif bundle_fragment is not None:
         data["application/vnd.marimo+mimebundle"] = json.dumps({"text/html": bundle_fragment})
     cell = {}
     if include_outputs:
         cell["outputs"] = [{"data": data, "type": "data"}]
-    session = {"cells": [cell]}
+    session = {"cells": [] if empty_session else [cell]}
     notebook = {"cells": [{"code": source_code}]}
     serialized_notebook = json.dumps(notebook).replace("<", r"\u003C").replace(">", r"\u003E")
     serialized = json.dumps(session).replace("<", r"\u003C").replace(">", r"\u003E")
@@ -416,6 +420,12 @@ def test_generated_site_contract_requires_learning_source_code(
     [
         pytest.param(_marimo_mount(42), "text/markdown output has an unrecognized schema", id="mime-type"),
         pytest.param(_marimo_mount("<p>Rendered</p>", include_outputs=False), "no outputs container", id="outputs"),
+        pytest.param(_marimo_mount("<p>Rendered</p>", empty_session=True), "session has no cells", id="cells"),
+        pytest.param(
+            _marimo_mount("<p>Rendered</p>", null_bundle=True),
+            "MIME bundle has an unrecognized schema",
+            id="null-bundle",
+        ),
     ],
 )
 def test_generated_site_contract_rejects_unrecognized_marimo_session_schema(

--- a/tests/docs/test_docs_site.py
+++ b/tests/docs/test_docs_site.py
@@ -420,7 +420,7 @@ def test_generated_site_contract_checks_iframe_srcdoc_with_parent_base(
 
     errors = check_site(site, source, SITE_URL)
 
-    assert any("iframe[srcdoc]" in error and "assets/srcdoc-missing.png" in error for error in errors), errors
+    assert any("iframe[srcdoc]" in error and "srcdoc-missing.png" in error for error in errors), errors
 
     _write(site / "assets/srcdoc-missing.png", "placeholder")
     assert check_site(site, source, SITE_URL) == []

--- a/tests/docs/test_docs_site.py
+++ b/tests/docs/test_docs_site.py
@@ -69,10 +69,27 @@ def test_generated_site_contract_accepts_valid_project_site(valid_site: tuple[Pa
     assert check_site(site, source, SITE_URL) == []
 
 
+def test_generated_site_contract_accepts_data_url_comma_in_srcset(
+    valid_site: tuple[Path, Path],
+) -> None:
+    site, source = valid_site
+    index = site / "index.html"
+    index.write_text(
+        index.read_text(encoding="utf-8").replace(
+            "</body>",
+            '<img srcset="data:image/svg+xml,%3Csvg%3E%3C/svg%3E 1x, /wandas/assets/app.js 2x"></body>',
+        ),
+        encoding="utf-8",
+    )
+
+    assert check_site(site, source, SITE_URL) == []
+
+
 @pytest.mark.parametrize(
     ("relative_path", "old", "new", "message"),
     [
         ("index.html", "/wandas/assets/app.js", "/wandas/assets/missing.js", "targets missing"),
+        ("index.html", "/wandas/assets/app.js", "file:///tmp/app.js", "forbidden file URL"),
         ("index.html", "/wandas/page/#section", "/wandas/page/#missing", "missing fragment"),
         ("index.html", "/wandas/page/#section", "/outside/page/", "escapes project prefix"),
         (
@@ -165,12 +182,50 @@ def test_generated_site_contract_recursively_checks_stylesheet_dependencies(
     assert check_site(site, source, SITE_URL) == []
 
 
+def test_generated_site_contract_respects_first_valid_html_base(
+    valid_site: tuple[Path, Path],
+) -> None:
+    site, source = valid_site
+    index = site / "index.html"
+    index.write_text(
+        index.read_text(encoding="utf-8")
+        .replace("</head>", '<base href="/wandas/assets/"></head>')
+        .replace('src="/wandas/assets/app.js"', 'src="app.js"'),
+        encoding="utf-8",
+    )
+
+    assert check_site(site, source, SITE_URL) == []
+
+
+def test_generated_site_contract_checks_inline_css_dependencies(
+    valid_site: tuple[Path, Path],
+) -> None:
+    site, source = valid_site
+    index = site / "index.html"
+    index.write_text(
+        index.read_text(encoding="utf-8")
+        .replace("</head>", '<style>.hero { background: url("/wandas/images/style.png"); }</style></head>')
+        .replace('<body id="home">', '<body id="home" style="mask: url(\'/wandas/images/attribute.svg\')">'),
+        encoding="utf-8",
+    )
+
+    errors = check_site(site, source, SITE_URL)
+
+    assert any("images/style.png" in error and "targets missing" in error for error in errors), errors
+    assert any("images/attribute.svg" in error and "targets missing" in error for error in errors), errors
+
+    _write(site / "images/style.png", "placeholder")
+    _write(site / "images/attribute.svg", "placeholder")
+    assert check_site(site, source, SITE_URL) == []
+
+
 def test_finalize_learning_html_rewrites_navigation_and_adds_canonical(tmp_path: Path) -> None:
     site = tmp_path / "site"
     for index in range(9):
         _write(
             site / "learning-path" / f"0{index}_lesson.html",
-            '<html><head></head><body><a href="01_next.py#part">Next</a></body></html>',
+            '<html><head></head><body><a href="01_lesson.py#part">Next</a>'
+            '<a href="https://example.com/demo.py">External source</a></body></html>',
         )
 
     finalized = finalize_learning_html(site, SITE_URL)
@@ -178,6 +233,7 @@ def test_finalize_learning_html_rewrites_navigation_and_adds_canonical(tmp_path:
     assert len(finalized) == 9
     for index, path in enumerate(finalized):
         html = path.read_text(encoding="utf-8")
-        assert 'href="01_next.html#part"' in html
+        assert 'href="01_lesson.html#part"' in html
+        assert 'href="https://example.com/demo.py"' in html
         assert f'<link rel="canonical" href="{SITE_URL}learning-path/0{index}_lesson.html">' in html
         assert ".py#" not in html

--- a/tests/docs/test_docs_site.py
+++ b/tests/docs/test_docs_site.py
@@ -16,26 +16,19 @@ def _write(path: Path, content: str) -> None:
 
 
 def _marimo_mount(
-    fragment: str,
+    fragment: object,
     *,
     bundle_fragment: str | None = None,
     source_code: str = "import wandas as wd",
+    include_outputs: bool = True,
 ) -> str:
     data = {"text/markdown": fragment}
     if bundle_fragment is not None:
         data["application/vnd.marimo+mimebundle"] = json.dumps({"text/html": bundle_fragment})
-    session = {
-        "cells": [
-            {
-                "outputs": [
-                    {
-                        "data": data,
-                        "type": "data",
-                    }
-                ]
-            }
-        ]
-    }
+    cell = {}
+    if include_outputs:
+        cell["outputs"] = [{"data": data, "type": "data"}]
+    session = {"cells": [cell]}
     notebook = {"cells": [{"code": source_code}]}
     serialized_notebook = json.dumps(notebook).replace("<", r"\u003C").replace(">", r"\u003E")
     serialized = json.dumps(session).replace("<", r"\u003C").replace(">", r"\u003E")
@@ -247,6 +240,28 @@ def test_generated_site_contract_uses_typed_stylesheet_edges_without_suffixes(
     assert check_site(site, source, SITE_URL) == []
 
 
+def test_generated_site_contract_decodes_css_escapes_before_resolving(
+    valid_site: tuple[Path, Path],
+) -> None:
+    site, source = valid_site
+    index = site / "index.html"
+    index.write_text(
+        index.read_text(encoding="utf-8").replace(
+            "</head>",
+            '<link rel="stylesheet" href="/wandas/assets/theme.css"></head>',
+        ),
+        encoding="utf-8",
+    )
+    _write(site / "assets/theme.css", r"body { background: url(image\).png); }")
+
+    errors = check_site(site, source, SITE_URL)
+
+    assert any("image).png" in error and "targets missing" in error for error in errors), errors
+
+    _write(site / "assets/image).png", "placeholder")
+    assert check_site(site, source, SITE_URL) == []
+
+
 def test_generated_site_contract_ignores_css_comments_but_preserves_quoted_markers(
     valid_site: tuple[Path, Path],
 ) -> None:
@@ -299,6 +314,23 @@ def test_generated_site_contract_respects_first_valid_html_base(
     )
 
     assert check_site(site, source, SITE_URL) == []
+
+
+def test_generated_site_contract_rejects_external_html_base(
+    valid_site: tuple[Path, Path],
+) -> None:
+    site, source = valid_site
+    index = site / "index.html"
+    index.write_text(
+        index.read_text(encoding="utf-8")
+        .replace("</head>", '<base href="https://example.com/assets/"></head>')
+        .replace('src="/wandas/assets/app.js"', 'src="missing.js"'),
+        encoding="utf-8",
+    )
+
+    errors = check_site(site, source, SITE_URL)
+
+    assert any("base href" in error and "outside the deployment origin" in error for error in errors), errors
 
 
 def test_generated_site_contract_checks_inline_css_dependencies(
@@ -377,6 +409,31 @@ def test_generated_site_contract_requires_learning_source_code(
     errors = check_site(site, source, SITE_URL)
 
     assert any("does not include notebook source code" in error for error in errors), errors
+
+
+@pytest.mark.parametrize(
+    ("mount", "message"),
+    [
+        pytest.param(_marimo_mount(42), "text/markdown output has an unrecognized schema", id="mime-type"),
+        pytest.param(_marimo_mount("<p>Rendered</p>", include_outputs=False), "no outputs container", id="outputs"),
+    ],
+)
+def test_generated_site_contract_rejects_unrecognized_marimo_session_schema(
+    valid_site: tuple[Path, Path],
+    mount: str,
+    message: str,
+) -> None:
+    site, source = valid_site
+    lesson = site / "learning-path/00_intro.html"
+    lesson.write_text(
+        '<html><head><link rel="canonical" '
+        f'href="{SITE_URL}learning-path/00_intro.html"></head><body>{mount}</body></html>',
+        encoding="utf-8",
+    )
+
+    errors = check_site(site, source, SITE_URL)
+
+    assert any(message in error for error in errors), errors
 
 
 def test_finalize_learning_html_rewrites_navigation_and_adds_canonical(tmp_path: Path) -> None:

--- a/tests/docs/test_docs_site.py
+++ b/tests/docs/test_docs_site.py
@@ -1,0 +1,141 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.check_docs_site import check_site
+from scripts.finalize_learning_html import finalize_learning_html
+
+SITE_URL = "https://kasahart.github.io/wandas/"
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+@pytest.fixture()
+def valid_site(tmp_path: Path) -> tuple[Path, Path]:
+    site = tmp_path / "site"
+    source = tmp_path / "src"
+    _write(source / "index.md", "# Home")
+    _write(source / "page.md", "# Page")
+    _write(site / "assets/app.js", "console.log('ok')")
+    _write(
+        site / "index.html",
+        """
+        <html><head>
+          <link rel="canonical" href="https://kasahart.github.io/wandas/">
+          <script src="/wandas/assets/app.js"></script>
+        </head><body id="home">
+          <a href="/wandas/page/#section">Page</a>
+          <a href="/wandas/learning-path/00_intro.html">Learn</a>
+          <a href="https://github.com/kasahart/wandas/edit/main/docs/src/index.md">Edit</a>
+        </body></html>
+        """,
+    )
+    _write(
+        site / "page/index.html",
+        """
+        <html><head>
+          <link rel="canonical" href="https://kasahart.github.io/wandas/page/">
+        </head><body id="section">
+          <a href="/wandas/#home">Home</a>
+          <a href="https://github.com/kasahart/wandas/edit/main/docs/src/page.md">Edit</a>
+        </body></html>
+        """,
+    )
+    _write(
+        site / "learning-path/00_intro.html",
+        """
+        <html><head>
+          <link rel="canonical" href="https://kasahart.github.io/wandas/learning-path/00_intro.html">
+        </head><body><a href="../page/#section">Page</a></body></html>
+        """,
+    )
+    _write(
+        site / "sitemap.xml",
+        """
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <url><loc>https://kasahart.github.io/wandas/</loc></url>
+          <url><loc>https://kasahart.github.io/wandas/page/</loc></url>
+        </urlset>
+        """,
+    )
+    return site, source
+
+
+def test_generated_site_contract_accepts_valid_project_site(valid_site: tuple[Path, Path]) -> None:
+    site, source = valid_site
+    assert check_site(site, source, SITE_URL) == []
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "old", "new", "message"),
+    [
+        ("index.html", "/wandas/assets/app.js", "/wandas/assets/missing.js", "targets missing"),
+        ("index.html", "/wandas/page/#section", "/wandas/page/#missing", "missing fragment"),
+        ("index.html", "/wandas/page/#section", "/outside/page/", "escapes project prefix"),
+        (
+            "page/index.html",
+            '<link rel="canonical" href="https://kasahart.github.io/wandas/page/">',
+            '<link rel="canonical" href="https://example.com/page/">',
+            "does not match",
+        ),
+        (
+            "page/index.html",
+            "https://github.com/kasahart/wandas/edit/main/docs/src/page.md",
+            "https://github.com/kasahart/wandas/edit/main/docs/src/wrong.md",
+            "expected edit link",
+        ),
+        (
+            "sitemap.xml",
+            "https://kasahart.github.io/wandas/page/",
+            "https://wandas.github.io/page/",
+            "outside",
+        ),
+    ],
+)
+def test_generated_site_contract_rejects_broken_fixture(
+    valid_site: tuple[Path, Path],
+    relative_path: str,
+    old: str,
+    new: str,
+    message: str,
+) -> None:
+    site, source = valid_site
+    path = site / relative_path
+    path.write_text(path.read_text(encoding="utf-8").replace(old, new), encoding="utf-8")
+
+    errors = check_site(site, source, SITE_URL)
+
+    assert any(message in error for error in errors), errors
+
+
+def test_generated_site_contract_rejects_duplicate_canonical(valid_site: tuple[Path, Path]) -> None:
+    site, source = valid_site
+    path = site / "page/index.html"
+    html = path.read_text(encoding="utf-8").replace(
+        "</head>",
+        '<link rel="canonical" href="https://kasahart.github.io/wandas/page/"></head>',
+    )
+    path.write_text(html, encoding="utf-8")
+
+    assert any("exactly one canonical" in error for error in check_site(site, source, SITE_URL))
+
+
+def test_finalize_learning_html_rewrites_navigation_and_adds_canonical(tmp_path: Path) -> None:
+    site = tmp_path / "site"
+    for index in range(9):
+        _write(
+            site / "learning-path" / f"0{index}_lesson.html",
+            '<html><head></head><body><a href="01_next.py#part">Next</a></body></html>',
+        )
+
+    finalized = finalize_learning_html(site, SITE_URL)
+
+    assert len(finalized) == 9
+    for index, path in enumerate(finalized):
+        html = path.read_text(encoding="utf-8")
+        assert 'href="01_next.html#part"' in html
+        assert f'<link rel="canonical" href="{SITE_URL}learning-path/0{index}_lesson.html">' in html
+        assert ".py#" not in html

--- a/tests/docs/test_docs_site.py
+++ b/tests/docs/test_docs_site.py
@@ -1,9 +1,11 @@
+import json
 from pathlib import Path
 
 import pytest
 
 from scripts.check_docs_site import check_site
 from scripts.finalize_learning_html import finalize_learning_html
+from scripts.marimo_outputs import marimo_html_outputs
 
 SITE_URL = "https://kasahart.github.io/wandas/"
 
@@ -11,6 +13,31 @@ SITE_URL = "https://kasahart.github.io/wandas/"
 def _write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
+
+
+def _marimo_mount(fragment: str, *, bundle_fragment: str | None = None) -> str:
+    data = {"text/markdown": fragment}
+    if bundle_fragment is not None:
+        data["application/vnd.marimo+mimebundle"] = json.dumps({"text/html": bundle_fragment})
+    session = {
+        "cells": [
+            {
+                "outputs": [
+                    {
+                        "data": data,
+                        "type": "data",
+                    }
+                ]
+            }
+        ]
+    }
+    serialized = json.dumps(session).replace("<", r"\u003C").replace(">", r"\u003E")
+    return (
+        '<script data-marimo="true">Object.defineProperty(window, '
+        '"__MARIMO_MOUNT_CONFIG__", {value: Object.freeze({'
+        f'"session": {serialized}'
+        "})});</script>"
+    )
 
 
 @pytest.fixture()
@@ -219,13 +246,45 @@ def test_generated_site_contract_checks_inline_css_dependencies(
     assert check_site(site, source, SITE_URL) == []
 
 
+def test_generated_site_contract_checks_serialized_marimo_outputs(
+    valid_site: tuple[Path, Path],
+) -> None:
+    site, source = valid_site
+    lesson = site / "learning-path/00_intro.html"
+    lesson.write_text(
+        lesson.read_text(encoding="utf-8").replace(
+            "</body>",
+            _marimo_mount(
+                '<a href="/wandas/page/#missing-output">Broken fragment</a>'
+                '<img src="/wandas/images/output.png">'
+                "<span style=\"mask:url('/wandas/images/output.svg')\"></span>",
+                bundle_fragment='<img src="/wandas/images/bundle.png">',
+            )
+            + "</body>",
+        ),
+        encoding="utf-8",
+    )
+
+    errors = check_site(site, source, SITE_URL)
+
+    assert any("missing fragment #missing-output" in error for error in errors), errors
+    assert any("images/output.png" in error and "targets missing" in error for error in errors), errors
+    assert any("images/output.svg" in error and "targets missing" in error for error in errors), errors
+    assert any("images/bundle.png" in error and "targets missing" in error for error in errors), errors
+
+
 def test_finalize_learning_html_rewrites_navigation_and_adds_canonical(tmp_path: Path) -> None:
     site = tmp_path / "site"
     for index in range(9):
         _write(
             site / "learning-path" / f"0{index}_lesson.html",
             '<html><head></head><body><a href="01_lesson.py#part">Next</a>'
-            '<a href="https://example.com/demo.py">External source</a></body></html>',
+            + _marimo_mount(
+                '<a href="./01_lesson.py?mode=read#part">Rendered next</a>'
+                '<a href="https://example.com/demo.py">External source</a>',
+                bundle_fragment='<a href="../learning-path/01_lesson.py">Bundle next</a>',
+            )
+            + "</body></html>",
         )
 
     finalized = finalize_learning_html(site, SITE_URL)
@@ -234,6 +293,10 @@ def test_finalize_learning_html_rewrites_navigation_and_adds_canonical(tmp_path:
     for index, path in enumerate(finalized):
         html = path.read_text(encoding="utf-8")
         assert 'href="01_lesson.html#part"' in html
-        assert 'href="https://example.com/demo.py"' in html
+        rendered = marimo_html_outputs(html)
+        assert len(rendered) == 2
+        assert any('href="./01_lesson.html?mode=read#part"' in fragment for fragment in rendered)
+        assert any('href="https://example.com/demo.py"' in fragment for fragment in rendered)
+        assert any('href="../learning-path/01_lesson.html"' in fragment for fragment in rendered)
         assert f'<link rel="canonical" href="{SITE_URL}learning-path/0{index}_lesson.html">' in html
         assert ".py#" not in html

--- a/tests/docs/test_docs_site.py
+++ b/tests/docs/test_docs_site.py
@@ -15,7 +15,12 @@ def _write(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
-def _marimo_mount(fragment: str, *, bundle_fragment: str | None = None) -> str:
+def _marimo_mount(
+    fragment: str,
+    *,
+    bundle_fragment: str | None = None,
+    source_code: str = "import wandas as wd",
+) -> str:
     data = {"text/markdown": fragment}
     if bundle_fragment is not None:
         data["application/vnd.marimo+mimebundle"] = json.dumps({"text/html": bundle_fragment})
@@ -31,11 +36,13 @@ def _marimo_mount(fragment: str, *, bundle_fragment: str | None = None) -> str:
             }
         ]
     }
+    notebook = {"cells": [{"code": source_code}]}
+    serialized_notebook = json.dumps(notebook).replace("<", r"\u003C").replace(">", r"\u003E")
     serialized = json.dumps(session).replace("<", r"\u003C").replace(">", r"\u003E")
     return (
         '<script data-marimo="true">Object.defineProperty(window, '
         '"__MARIMO_MOUNT_CONFIG__", {value: Object.freeze({'
-        f'"session": {serialized}'
+        f'"notebook": {serialized_notebook}, "session": {serialized}'
         "})});</script>"
     )
 
@@ -76,8 +83,10 @@ def valid_site(tmp_path: Path) -> tuple[Path, Path]:
         """
         <html><head>
           <link rel="canonical" href="https://kasahart.github.io/wandas/learning-path/00_intro.html">
-        </head><body><a href="../page/#section">Page</a></body></html>
-        """,
+        </head><body><a href="../page/#section">Page</a>
+        """
+        + _marimo_mount("<p>Rendered lesson</p>")
+        + "</body></html>",
     )
     _write(
         site / "sitemap.xml",
@@ -117,6 +126,12 @@ def test_generated_site_contract_accepts_data_url_comma_in_srcset(
     [
         ("index.html", "/wandas/assets/app.js", "/wandas/assets/missing.js", "targets missing"),
         ("index.html", "/wandas/assets/app.js", "file:///tmp/app.js", "forbidden file URL"),
+        (
+            "index.html",
+            "/wandas/assets/app.js",
+            "http://kasahart.github.io/wandas/assets/app.js",
+            "mixed-content HTTP",
+        ),
         ("index.html", "/wandas/page/#section", "/wandas/page/#missing", "missing fragment"),
         ("index.html", "/wandas/page/#section", "/outside/page/", "escapes project prefix"),
         (
@@ -209,6 +224,68 @@ def test_generated_site_contract_recursively_checks_stylesheet_dependencies(
     assert check_site(site, source, SITE_URL) == []
 
 
+def test_generated_site_contract_uses_typed_stylesheet_edges_without_suffixes(
+    valid_site: tuple[Path, Path],
+) -> None:
+    site, source = valid_site
+    index = site / "index.html"
+    index.write_text(
+        index.read_text(encoding="utf-8").replace(
+            "</head>",
+            '<link rel="stylesheet" type="text/css" href="/wandas/assets/theme"></head>',
+        ),
+        encoding="utf-8",
+    )
+    _write(site / "assets/theme", '@import url("nested");')
+    _write(site / "assets/nested", 'body { background: url("images/missing.png"); }')
+
+    errors = check_site(site, source, SITE_URL)
+
+    assert any("assets/nested" in error and "images/missing.png" in error for error in errors), errors
+
+    _write(site / "assets/images/missing.png", "placeholder")
+    assert check_site(site, source, SITE_URL) == []
+
+
+def test_generated_site_contract_ignores_css_comments_but_preserves_quoted_markers(
+    valid_site: tuple[Path, Path],
+) -> None:
+    site, source = valid_site
+    index = site / "index.html"
+    index.write_text(
+        index.read_text(encoding="utf-8").replace(
+            "</head>",
+            '<link rel="stylesheet" href="/wandas/assets/theme.css"></head>',
+        ),
+        encoding="utf-8",
+    )
+    _write(
+        site / "assets/theme.css",
+        'body::before { content: "escaped \\" /* url(\\"ignored.png\\") */"; } /* background: url("missing.png"); */',
+    )
+
+    assert check_site(site, source, SITE_URL) == []
+
+
+def test_generated_site_contract_rejects_unterminated_css_comment(
+    valid_site: tuple[Path, Path],
+) -> None:
+    site, source = valid_site
+    index = site / "index.html"
+    index.write_text(
+        index.read_text(encoding="utf-8").replace(
+            "</head>",
+            '<link rel="stylesheet" href="/wandas/assets/theme.css"></head>',
+        ),
+        encoding="utf-8",
+    )
+    _write(site / "assets/theme.css", "body {} /* unfinished")
+
+    errors = check_site(site, source, SITE_URL)
+
+    assert any("assets/theme.css" in error and "unterminated CSS comment" in error for error in errors), errors
+
+
 def test_generated_site_contract_respects_first_valid_html_base(
     valid_site: tuple[Path, Path],
 ) -> None:
@@ -252,16 +329,15 @@ def test_generated_site_contract_checks_serialized_marimo_outputs(
     site, source = valid_site
     lesson = site / "learning-path/00_intro.html"
     lesson.write_text(
-        lesson.read_text(encoding="utf-8").replace(
-            "</body>",
-            _marimo_mount(
-                '<a href="/wandas/page/#missing-output">Broken fragment</a>'
-                '<img src="/wandas/images/output.png">'
-                "<span style=\"mask:url('/wandas/images/output.svg')\"></span>",
-                bundle_fragment='<img src="/wandas/images/bundle.png">',
-            )
-            + "</body>",
-        ),
+        '<html><head><link rel="canonical" '
+        f'href="{SITE_URL}learning-path/00_intro.html"></head><body>'
+        + _marimo_mount(
+            '<a href="/wandas/page/#missing-output">Broken fragment</a>'
+            '<img src="/wandas/images/output.png">'
+            "<span style=\"mask:url('/wandas/images/output.svg')\"></span>",
+            bundle_fragment='<img src="/wandas/images/bundle.png">',
+        )
+        + "</body></html>",
         encoding="utf-8",
     )
 
@@ -271,6 +347,36 @@ def test_generated_site_contract_checks_serialized_marimo_outputs(
     assert any("images/output.png" in error and "targets missing" in error for error in errors), errors
     assert any("images/output.svg" in error and "targets missing" in error for error in errors), errors
     assert any("images/bundle.png" in error and "targets missing" in error for error in errors), errors
+
+
+def test_generated_site_contract_requires_recognizable_learning_session(
+    valid_site: tuple[Path, Path],
+) -> None:
+    site, source = valid_site
+    lesson = site / "learning-path/00_intro.html"
+    lesson.write_text(
+        lesson.read_text(encoding="utf-8").replace("__MARIMO_MOUNT_CONFIG__", "__MARIMO_NEW_CONFIG__"),
+        encoding="utf-8",
+    )
+
+    errors = check_site(site, source, SITE_URL)
+
+    assert any("no recognizable marimo mount config" in error for error in errors), errors
+
+
+def test_generated_site_contract_requires_learning_source_code(
+    valid_site: tuple[Path, Path],
+) -> None:
+    site, source = valid_site
+    lesson = site / "learning-path/00_intro.html"
+    lesson.write_text(
+        lesson.read_text(encoding="utf-8").replace("import wandas as wd", ""),
+        encoding="utf-8",
+    )
+
+    errors = check_site(site, source, SITE_URL)
+
+    assert any("does not include notebook source code" in error for error in errors), errors
 
 
 def test_finalize_learning_html_rewrites_navigation_and_adds_canonical(tmp_path: Path) -> None:
@@ -283,6 +389,7 @@ def test_finalize_learning_html_rewrites_navigation_and_adds_canonical(tmp_path:
                 '<a href="./01_lesson.py?mode=read#part">Rendered next</a>'
                 '<a href="https://example.com/demo.py">External source</a>',
                 bundle_fragment='<a href="../learning-path/01_lesson.py">Bundle next</a>',
+                source_code="example = '<a href=\"01_lesson.py\">source</a>'",
             )
             + "</body></html>",
         )
@@ -298,5 +405,15 @@ def test_finalize_learning_html_rewrites_navigation_and_adds_canonical(tmp_path:
         assert any('href="./01_lesson.html?mode=read#part"' in fragment for fragment in rendered)
         assert any('href="https://example.com/demo.py"' in fragment for fragment in rendered)
         assert any('href="../learning-path/01_lesson.html"' in fragment for fragment in rendered)
+        assert r"href=\"01_lesson.py\"" in html
         assert f'<link rel="canonical" href="{SITE_URL}learning-path/0{index}_lesson.html">' in html
         assert ".py#" not in html
+
+
+def test_finalize_learning_html_requires_recognizable_marimo_session(tmp_path: Path) -> None:
+    site = tmp_path / "site"
+    for index in range(9):
+        _write(site / "learning-path" / f"0{index}_lesson.html", "<html><head></head><body></body></html>")
+
+    with pytest.raises(ValueError, match="no recognizable marimo mount config"):
+        finalize_learning_html(site, SITE_URL)

--- a/uv.lock
+++ b/uv.lock
@@ -3685,6 +3685,18 @@ wheels = [
 ]
 
 [[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3994,6 +4006,7 @@ docs = [
     { name = "mkdocs-static-i18n" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "mkdocstrings-python" },
+    { name = "tinycss2" },
 ]
 test = [
     { name = "pandas-stubs" },
@@ -4001,6 +4014,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "tinycss2" },
     { name = "tomli" },
     { name = "ty" },
     { name = "types-requests" },
@@ -4044,6 +4058,7 @@ docs = [
     { name = "mkdocs-static-i18n", specifier = ">=1.3.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.1" },
     { name = "mkdocstrings-python", specifier = ">=1.16.10" },
+    { name = "tinycss2", specifier = ">=1.4.0" },
 ]
 test = [
     { name = "pandas-stubs" },
@@ -4051,6 +4066,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "ruff", specifier = ">=0.9.9" },
+    { name = "tinycss2", specifier = ">=1.4.0" },
     { name = "tomli", specifier = ">=2.0.0" },
     { name = "ty", specifier = ">=0.0.26" },
     { name = "types-requests", specifier = ">=2.32.0.20250328" },
@@ -4095,6 +4111,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/30/6b0809f4510673dc723187aeaf24c7f5459922d01e2f794277a3dfb90345/wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605", size = 102293, upload-time = "2025-09-22T16:29:53.023Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/b5/123f13c975e9f27ab9c0770f514345bd406d0e8d3b7a0723af9d43f710af/wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1", size = 37286, upload-time = "2025-09-22T16:29:51.641Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #372

## Summary

- configure the GitHub Pages project root, production metadata, edit links, sitemap boundaries, and analytics policy for `https://kasahart.github.io/wandas/`
- export all nine checked-in learning applications with their executable source and local fixtures, then rewrite only deployed lesson navigation from `.py` to `.html`
- validate the completed site with a crawler using tinycss2 for standards-compliant CSS tokenization covering internal URLs, fragments, project-prefix/traversal escapes, canonical/edit/sitemap contracts, HTML base URLs, mixed content, typed stylesheet dependencies, CSS imports/assets, and serialized marimo output
- recursively validate iframe srcdoc documents with inherited/constrained base URLs and independent fragment scope
- fail closed when a known learning export lacks a recognized, nonempty marimo session, valid output/MIME structure, or included source code

## Major files

- `docs/mkdocs.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/deploy-docs.yml`
- `scripts/check_docs_site.py`
- `scripts/finalize_learning_html.py`
- `scripts/marimo_outputs.py`
- `tests/docs/test_docs_site.py`
- `tests/docs/test_docs_links.py`
- `docs/src/api/{core,frames}.md`, `docs/src/tutorial/index.md`
- `learning-path/00_why_wandas.py` through `08_metadata_driven_dataset_search.py`

## Tests added or updated

- generated-site fixtures cover valid project-root links and deliberately broken assets, fragments, prefixes, canonicals, edit links, sitemap traversal, file URLs, same-host HTTP mixed content, HTML base constraints, data-URL `srcset`, inline and recursive CSS, extensionless stylesheets, comments, strings, and escaped CSS targets
- marimo regressions cover missing/malformed/empty sessions, output containers and MIME bundles, rendered markdown/HTML dependencies, source-preserving finalization, and deployment-only navigation rewrites
- workflow/source-contract tests lock all nine source-including exports to the checked-in `learning-path/` fixture context and the complete 00–08 `.py` navigation chain

## Validation

- `uv run pytest tests/docs/test_docs_site.py tests/docs/test_docs_links.py -q` — 43 passed
- `uv run pytest tests/docs -q` — 107 passed, 2 existing plotting warnings
- `uv run pytest -q` — 2891 passed, 3 skipped, 33 existing warnings
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — 187 files formatted
- `uv run ty check` — passed
- `uv run marimo check learning-path/0{0..8}_*.py` — passed
- `uv run mkdocs build --strict -f docs/mkdocs.yml` — passed
- exact source-including export loop from `learning-path/` — all nine applications completed using checked-in fixtures, with no failed cells
- finalized all nine exports and ran `uv run python scripts/check_docs_site.py docs/site --source-dir docs/src --site-url https://kasahart.github.io/wandas/` — passed, including 160 rendered marimo fragments
- independent exact-head audit repeated strict-schema probes and the MkDocs → nine-export → finalize → crawler pipeline — ACTIONABLE 0
- GitHub CI for current head `0ecdb3609fad5635d515f368db9dbbe4cdbc14ba` — all 14 checks passed
- the preceding Windows matrix exposed a path-separator-only test assertion; `0ecdb360` makes that assertion portable without production changes
- `git diff --check` — passed

## Predecessor compatibility and merge order

The aggregate recommended order is `#387 → #389 → #385 → #386 → #388 → #390`.

- #387 is pairwise clean with every remaining PR, and #389 plus #388 are pairwise clean
- #385 overlaps this PR in CI/deploy workflow and documentation files; after #385 merges, rebase #388 onto latest `main` and preserve both its public-docstring gate and the learning/site checks in this PR
- #386 is independent of the #390 final-gate prerequisites, but should merge before #388 after rebasing onto #385/#389 and resolving those overlaps
- #390 remains last; after #388 merges, rebase #390 onto all predecessors, resolve the #388 workflow/MkDocs overlap, and run final-profile CI

## Codex review

- earlier Codex rounds found and drove fixes for sitemap traversal, recursive CSS, `srcset` data URLs, external `.py` preservation, file URLs, HTML base resolution, inline CSS, local source navigation, fixture context, and serialized marimo output
- the review of `ebbdf7799d0bd01c971d89d187be043a443e09d1` found five further deployment boundaries: typed extensionless stylesheet traversal, same-host HTTP mixed content, fail-open marimo recognition, CSS comments, and omitted educational source
- `5c24f6a2`, `be2264aa`, and `b7a16448` address those findings plus independent follow-up findings for CSS escapes, external base containment, typed MIME values, and empty sessions
- all 18 actionable inline threads have commit-linked responses and are resolved; unresolved review threads: 0
- independent Codex production review of `678ad6f098a47c4662d24e553158c4eeebb60e1d` completed with no actionable findings, including strict MkDocs, nine source-including exports, finalization, crawl, and 160 nonempty rendered fragments
- exact-head Codex follow-up review of `0ecdb3609fad5635d515f368db9dbbe4cdbc14ba` confirmed its sole test-only portability delta with no actionable findings
- the exact-head review fixed three further findings: escaped CSS identifiers, zero rendered fragments, and iframe srcdoc traversal; all have commit-linked replies and regressions
- GitHub automation accepted the exact-head detailed trigger, but a subsequent plain `@codex review` retry returned the account code-review usage limit before producing another automated result
- Copilot could not run because the requesting account reached its quota and produced no actionable comments

## Risks and skipped validation

- marimo exports retain existing CJK font and non-interactive plotting warnings; no cell failed
- analytics is intentionally disabled; a future production property may only be supplied from a repository secret at deploy time
- the documented #385/#389/#390 ordering and revalidation are required as those PRs land
- no requested validation was skipped
