### PR TITLE
ci(docs): add end-to-end consistency gates

### DIFF
--- a/.github/documentation-gate-finalized
+++ b/.github/documentation-gate-finalized
@@ -1,0 +1,8 @@
+This sentinel records that the end-to-end documentation gate has been finalized.
+
+Pull-request CI checks for this path in the base commit. Once #390 has merged,
+all later pull requests must retain the complete final checker cohort even when
+a change removes every marker belonging to one checker group.
+
+Main-branch push CI checks for this path in the pushed commit and requires the
+final profile. Do not remove or rename this file.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,10 @@ jobs:
       steps:
         - name: チェックアウト
           uses: actions/checkout@v4
+          with:
+            # The documentation gate inspects the PR base commit for the
+            # permanent finalization sentinel.
+            fetch-depth: 0
 
         - name: uv をセットアップ
           uses: astral-sh/setup-uv@v5
@@ -64,8 +68,15 @@ jobs:
             --extra psychoacoustic --group docs --group test
 
         - name: End-to-end documentation consistency gate
-          # Final profile delegates to: python scripts/check_public_docstrings.py
-          run: uv run --no-sync python scripts/run_documentation_gate.py
+          # Before #390 merges, its base has no sentinel and complete predecessor
+          # subsets may integrate. Afterwards, PR bases and main pushes require
+          # the final profile, preventing downgrade by whole-checker deletion.
+          # Sentinel: .github/documentation-gate-finalized
+          env:
+            WANDAS_DOCS_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          run: >-
+            uv run --no-sync python scripts/run_documentation_gate.py
+            --ci-policy
 
   core-install-smoke:
     name: Core-only wheel install smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,18 +32,18 @@ jobs:
         run: uv sync --no-dev --extra io --extra effects --extra marimo --extra psychoacoustic --group test
 
       - name: フォーマットチェック (ruff format)
-        run: uv run --no-sync ruff format --check wandas tests
+        run: uv run --no-sync ruff format --check wandas tests scripts/run_documentation_gate.py
 
       - name: Lintチェック (ruff check)
-        run: uv run --no-sync ruff check wandas tests
+        run: uv run --no-sync ruff check wandas tests scripts/run_documentation_gate.py
 
       - name: 型チェック (ty)
-        run: uv run --no-sync ty check wandas tests
+        run: uv run --no-sync ty check wandas tests scripts/run_documentation_gate.py
 
   docs:
       name: Build Documentation
       runs-on: ubuntu-latest
-      timeout-minutes: 5
+      timeout-minutes: 30
       steps:
         - name: チェックアウト
           uses: actions/checkout@v4
@@ -57,13 +57,15 @@ jobs:
         - name: Python 3.12 をインストール
           run: uv python install 3.12
 
-        - name: 依存関係をインストール (docsグループ + 非ML extras)
+        - name: 依存関係をインストール (docs/testグループ + 非ML extras)
           # ドキュメント構築に必要なパッケージ群と非ML extrasのみをインストール
-          run: uv sync --no-dev --extra io --extra effects --extra marimo --extra psychoacoustic --group docs
+          run: >-
+            uv sync --no-dev --extra io --extra effects --extra marimo
+            --extra psychoacoustic --group docs --group test
 
-        - name: ドキュメントのビルドテスト (MkDocs)
-          # --strictフラグにより、警告（リンク切れやパースエラー）をエラーとして扱いCIを落とす
-          run: uv run --no-sync mkdocs build -f docs/mkdocs.yml --strict
+        - name: End-to-end documentation consistency gate
+          # Final profile delegates to: python scripts/check_public_docstrings.py
+          run: uv run --no-sync python scripts/run_documentation_gate.py
 
   core-install-smoke:
     name: Core-only wheel install smoke

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -25,15 +25,18 @@ jobs:
 
       - name: Install dependencies including MkDocs
         # Keep deployment aligned with the non-ML documentation CI environment.
-        run: uv sync --no-dev --extra io --extra effects --extra marimo --extra psychoacoustic --group docs
+        run: >-
+          uv sync --no-dev --extra io --extra effects --extra marimo
+          --extra psychoacoustic --group docs --group test
 
       - name: Build and validate the completed documentation site
-        # This single command orders strict build, all exports, finalization, and crawl.
+        # This single command orders source/API/numerical tests, strict build,
+        # all exports, finalization, and crawl.
         # Deployment requires the complete prerequisite checker cohort.
         # Final profile delegates to: python scripts/check_public_docstrings.py
         run: >-
           uv run --no-sync python scripts/run_documentation_gate.py
-          --require-final --site-only
+          --require-final
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,27 +24,16 @@ jobs:
           enable-cache: true # 依存関係のキャッシュを有効化
 
       - name: Install dependencies including MkDocs
-        # docsグループでドキュメント生成に必要なパッケージのみインストール
-        run: uv sync --all-extras --group docs
+        # Keep deployment aligned with the non-ML documentation CI environment.
+        run: uv sync --no-dev --extra io --extra effects --extra marimo --extra psychoacoustic --group docs
 
-      - name: Convert marimo notebooks to HTML
-        # learning-path の Python ファイルを marimo export html で HTML に変換
-        run: |
-          mkdir -p docs/src/learning-path
-          for file in learning-path/0{0..8}_*.py; do
-            if [ -f "$file" ]; then
-              echo "Converting $file to HTML..."
-              uv run marimo export html "$file" -o "docs/src/learning-path/$(basename ${file%.py}.html)"
-            fi
-          done
-
-      - name: Build MkDocs documentation
-        # uv run を使って uv の環境で mkdocs を実行
-        run: uv run mkdocs build -f docs/mkdocs.yml
-
-      - name: Copy learning-path HTML to site directory
-        # MkDocs ビルド後、learning-path フォルダを site にコピー
-        run: cp -r docs/src/learning-path docs/site/
+      - name: Build and validate the completed documentation site
+        # This single command orders strict build, all exports, finalization, and crawl.
+        # Deployment requires the complete prerequisite checker cohort.
+        # Final profile delegates to: python scripts/check_public_docstrings.py
+        run: >-
+          uv run --no-sync python scripts/run_documentation_gate.py
+          --require-final --site-only
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
       - Wandas 0.6.0: release-notes/v0.6.0.md
   - Contributing:
       - Overview: contributing.md
+      - Documentation Consistency Gates: contributing/documentation-consistency-gates.md
       - Repository Agent Harness: contributing/agent-harness.md
       - I/O Contracts: contributing/io-contracts.md
       - Extend Frames and Operations: contributing/frame-operation-extensions.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -2,7 +2,7 @@
 site_name: Wandas
 site_description: Wandas ライブラリのドキュメント
 site_author: Wandas Team
-site_url: https://wandas.github.io/
+site_url: https://kasahart.github.io/wandas/
 copyright: © 2025 Wandas Team
 
 docs_dir: src

--- a/docs/src/contributing/documentation-consistency-gates.md
+++ b/docs/src/contributing/documentation-consistency-gates.md
@@ -1,9 +1,9 @@
 # Documentation consistency gates
 
 Documentation is publishable only when its source examples, public API claims,
-numerical meaning, exported learning applications, and completed site agree. CI runs
-the same ordered gate once in its dedicated documentation job; deployment reruns the
-site-producing portion and cannot reach the publish action after a failed stage.
+numerical meaning, exported learning applications, and completed site agree. CI and
+deployment both run the complete ordered gate, and neither can reach the publish
+action after a source, API, numerical, learning, build, or site-validation failure.
 
 ## Automated contract
 
@@ -12,7 +12,7 @@ site-producing portion and cannot reach the publish action after a failed stage.
 | Navigation, source-body links, repository links, and generated internal links | `tests/docs/test_docs_links.py`, strict MkDocs, and `scripts/check_docs_site.py` |
 | Assets, fragments, canonical URLs, edit links, project prefix, and sitemap | `scripts/check_docs_site.py` plus deliberately broken generated-site fixtures |
 | README and Markdown Python examples | executable docs tests and `markdown-exec` during strict MkDocs |
-| All learning applications | exact 00–08 inventory, `marimo check`, execution/export of every app, finalization, and completed-site crawl |
+| All learning applications | exact numbered inventory (currently 00–08), isolated offline execution with checked-in fixtures, `marimo check`, export of every app, finalization, and completed-site crawl |
 | Undefined names and private, compatibility, or removed learner APIs | marimo reactive checks and the learning-path source/API policy tests |
 | Canonical public inventory, package exports, API pages, and classification drift | the inventory from Issue #369 and its deliberate export mutation test |
 | Public docstring parser/render/style | `scripts/check_public_docstrings.py`, focused malformed-style fixtures, and strict MkDocs rendering |
@@ -20,12 +20,15 @@ site-producing portion and cannot reach the publish action after a failed stage.
 | Supported Python and optional extras | package metadata tests, learning-material version checks, public API policy, and the core-only wheel smoke job |
 
 The orchestrator accepts the audit-baseline repository as a standalone profile so its
-own PR can be checked. As soon as any prerequisite checker is integrated, it requires
-the complete #365/#373/#369/#372/#367 cohort; partial integration is a hard failure.
-Deployment always requires that final profile.
+own PR can be checked. During the ordered predecessor merges, an integration profile
+accepts each fully installed checker while rejecting a half-installed multi-file
+checker. Deployment always requires the complete #365/#373/#369/#372/#367 final
+profile and does not use the source-test-skipping `--site-only` mode.
 
 ## Explicit manual checks
 
+Learning-app execution uses checked-in fixtures from a temporary workspace, so it does
+not write generated files into the repository or depend on external HTTP availability.
 Automation does not make live third-party websites, browser-specific interactive
 widgets, prose translation quality, or visual teaching clarity deterministic. Review
 those items when their content changes. External HTTP availability is deliberately

--- a/docs/src/contributing/documentation-consistency-gates.md
+++ b/docs/src/contributing/documentation-consistency-gates.md
@@ -22,8 +22,13 @@ action after a source, API, numerical, learning, build, or site-validation failu
 The orchestrator accepts the audit-baseline repository as a standalone profile so its
 own PR can be checked. During the ordered predecessor merges, an integration profile
 accepts each fully installed checker while rejecting a half-installed multi-file
-checker. Deployment always requires the complete #365/#373/#369/#372/#367 final
-profile and does not use the source-test-skipping `--site-only` mode. That mode is
+checker. PR #390 installs `.github/documentation-gate-finalized` as an irreversible
+state-transition ledger. Its own PR base lacks that sentinel and may use the integration
+profile; once merged, PR CI finds the sentinel in the base commit and main-push CI finds
+it in the current commit, so deleting a whole checker group cannot downgrade CI back to
+integration. Both then require the complete #365/#373/#369/#372/#367 final profile.
+Deployment also always requires that final profile and does not use the
+source-test-skipping `--site-only` mode. That mode is
 accepted only for manual reruns of a final-profile checkout; standalone and integration
 profiles reject it. Finalization and crawling read the canonical origin from the same
 top-level `site_url` used by `docs/mkdocs.yml` rather than maintaining a second URL.

--- a/docs/src/contributing/documentation-consistency-gates.md
+++ b/docs/src/contributing/documentation-consistency-gates.md
@@ -23,7 +23,10 @@ The orchestrator accepts the audit-baseline repository as a standalone profile s
 own PR can be checked. During the ordered predecessor merges, an integration profile
 accepts each fully installed checker while rejecting a half-installed multi-file
 checker. Deployment always requires the complete #365/#373/#369/#372/#367 final
-profile and does not use the source-test-skipping `--site-only` mode.
+profile and does not use the source-test-skipping `--site-only` mode. That mode is
+accepted only for manual reruns of a final-profile checkout; standalone and integration
+profiles reject it. Finalization and crawling read the canonical origin from the same
+top-level `site_url` used by `docs/mkdocs.yml` rather than maintaining a second URL.
 
 ## Explicit manual checks
 

--- a/docs/src/contributing/documentation-consistency-gates.md
+++ b/docs/src/contributing/documentation-consistency-gates.md
@@ -1,0 +1,34 @@
+# Documentation consistency gates
+
+Documentation is publishable only when its source examples, public API claims,
+numerical meaning, exported learning applications, and completed site agree. CI runs
+the same ordered gate once in its dedicated documentation job; deployment reruns the
+site-producing portion and cannot reach the publish action after a failed stage.
+
+## Automated contract
+
+| Inconsistency class | Canonical automated evidence |
+| --- | --- |
+| Navigation, source-body links, repository links, and generated internal links | `tests/docs/test_docs_links.py`, strict MkDocs, and `scripts/check_docs_site.py` |
+| Assets, fragments, canonical URLs, edit links, project prefix, and sitemap | `scripts/check_docs_site.py` plus deliberately broken generated-site fixtures |
+| README and Markdown Python examples | executable docs tests and `markdown-exec` during strict MkDocs |
+| All learning applications | exact 00–08 inventory, `marimo check`, execution/export of every app, finalization, and completed-site crawl |
+| Undefined names and private, compatibility, or removed learner APIs | marimo reactive checks and the learning-path source/API policy tests |
+| Canonical public inventory, package exports, API pages, and classification drift | the inventory from Issue #369 and its deliberate export mutation test |
+| Public docstring parser/render/style | `scripts/check_public_docstrings.py`, focused malformed-style fixtures, and strict MkDocs rendering |
+| FFT, Welch, and IFFT quantities, units, scaling, and reconstruction | the independent processing/Frame numerical tests and documentation contract tests from Issue #365 |
+| Supported Python and optional extras | package metadata tests, learning-material version checks, public API policy, and the core-only wheel smoke job |
+
+The orchestrator accepts the audit-baseline repository as a standalone profile so its
+own PR can be checked. As soon as any prerequisite checker is integrated, it requires
+the complete #365/#373/#369/#372/#367 cohort; partial integration is a hard failure.
+Deployment always requires that final profile.
+
+## Explicit manual checks
+
+Automation does not make live third-party websites, browser-specific interactive
+widgets, prose translation quality, or visual teaching clarity deterministic. Review
+those items when their content changes. External HTTP availability is deliberately
+excluded from CI to avoid making releases depend on unrelated services. These manual
+checks do not replace any internal link, executable example, API, numerical, metadata,
+or generated-site gate listed above.

--- a/docs/src/contributing/documentation-consistency-gates.md
+++ b/docs/src/contributing/documentation-consistency-gates.md
@@ -23,10 +23,12 @@ The orchestrator accepts the audit-baseline repository as a standalone profile s
 own PR can be checked. During the ordered predecessor merges, an integration profile
 accepts each fully installed checker while rejecting a half-installed multi-file
 checker. PR #390 installs `.github/documentation-gate-finalized` as an irreversible
-state-transition ledger. Its own PR base lacks that sentinel and may use the integration
-profile; once merged, PR CI finds the sentinel in the base commit and main-push CI finds
-it in the current commit, so deleting a whole checker group cannot downgrade CI back to
-integration. Both then require the complete #365/#373/#369/#372/#367 final profile.
+state-transition ledger. A PR that adds the sentinel immediately requires the complete
+#365/#373/#369/#372/#367 final profile, even when its base is not finalized, so the
+closing PR cannot merge before every prerequisite checker is present. After finalization,
+PR CI accepts the sentinel from the base only when the current head retains it, and
+main-push CI requires it in the current commit; deleting the ledger or a whole checker
+group therefore cannot downgrade CI back to integration.
 Deployment also always requires that final profile and does not use the
 source-test-skipping `--site-only` mode. That mode is
 accepted only for manual reruns of a final-profile checkout; standalone and integration

--- a/scripts/run_documentation_gate.py
+++ b/scripts/run_documentation_gate.py
@@ -118,9 +118,10 @@ def ci_requires_final(
         if not base_sha:
             raise GateConfigurationError("pull-request documentation CI requires WANDAS_DOCS_BASE_SHA")
         base_is_finalized = path_exists(repo_root, base_sha, FINALIZATION_SENTINEL)
-        if base_is_finalized and not path_exists(repo_root, "HEAD", FINALIZATION_SENTINEL):
+        head_is_finalized = path_exists(repo_root, "HEAD", FINALIZATION_SENTINEL)
+        if base_is_finalized and not head_is_finalized:
             raise GateConfigurationError(f"finalized pull request is missing {FINALIZATION_SENTINEL}")
-        return base_is_finalized
+        return base_is_finalized or head_is_finalized
     if event_name == "push":
         if not path_exists(repo_root, "HEAD", FINALIZATION_SENTINEL):
             raise GateConfigurationError(f"finalized main push is missing {FINALIZATION_SENTINEL}")

--- a/scripts/run_documentation_gate.py
+++ b/scripts/run_documentation_gate.py
@@ -85,8 +85,8 @@ class GateConfigurationError(RuntimeError):
     """Raised when prerequisite checkers are only partly integrated."""
 
 
-def git_path_exists(repo_root: Path, ref: str, path: Path) -> bool:
-    """Return whether *path* exists at a verified Git commit *ref*."""
+def git_path_is_blob(repo_root: Path, ref: str, path: Path) -> bool:
+    """Return whether *path* is a regular Git blob at verified commit *ref*."""
     verified = subprocess.run(
         ("git", "rev-parse", "--verify", f"{ref}^{{commit}}"),
         cwd=repo_root,
@@ -96,14 +96,14 @@ def git_path_exists(repo_root: Path, ref: str, path: Path) -> bool:
     )
     if verified.returncode:
         raise GateConfigurationError(f"cannot resolve documentation-gate baseline commit: {ref}")
-    found = subprocess.run(
-        ("git", "cat-file", "-e", f"{ref}:{path.as_posix()}"),
+    object_type = subprocess.run(
+        ("git", "cat-file", "-t", f"{ref}:{path.as_posix()}"),
         cwd=repo_root,
         capture_output=True,
         text=True,
         check=False,
     )
-    return found.returncode == 0
+    return object_type.returncode == 0 and object_type.stdout.strip() == "blob"
 
 
 def ci_requires_final(
@@ -111,19 +111,19 @@ def ci_requires_final(
     *,
     event_name: str,
     base_sha: str | None,
-    path_exists: Callable[[Path, str, Path], bool] = git_path_exists,
+    path_is_blob: Callable[[Path, str, Path], bool] = git_path_is_blob,
 ) -> bool:
     """Apply the irreversible CI transition recorded by the finalization sentinel."""
     if event_name == "pull_request":
         if not base_sha:
             raise GateConfigurationError("pull-request documentation CI requires WANDAS_DOCS_BASE_SHA")
-        base_is_finalized = path_exists(repo_root, base_sha, FINALIZATION_SENTINEL)
-        head_is_finalized = path_exists(repo_root, "HEAD", FINALIZATION_SENTINEL)
+        base_is_finalized = path_is_blob(repo_root, base_sha, FINALIZATION_SENTINEL)
+        head_is_finalized = path_is_blob(repo_root, "HEAD", FINALIZATION_SENTINEL)
         if base_is_finalized and not head_is_finalized:
             raise GateConfigurationError(f"finalized pull request is missing {FINALIZATION_SENTINEL}")
         return base_is_finalized or head_is_finalized
     if event_name == "push":
-        if not path_exists(repo_root, "HEAD", FINALIZATION_SENTINEL):
+        if not path_is_blob(repo_root, "HEAD", FINALIZATION_SENTINEL):
             raise GateConfigurationError(f"finalized main push is missing {FINALIZATION_SENTINEL}")
         return True
     raise GateConfigurationError(f"documentation CI policy does not support event {event_name!r}")

--- a/scripts/run_documentation_gate.py
+++ b/scripts/run_documentation_gate.py
@@ -1,0 +1,273 @@
+"""Run the documentation consistency contract once, in deployment order.
+
+The gate has two intentional profiles:
+
+* ``standalone`` uses checks already present on the Issue #375 audit baseline.
+* ``final`` is selected only when the complete prerequisite checker cohort is
+  present. A partial cohort is an error, so integration can never silently skip
+  a predecessor check.
+
+The final profile delegates each domain to its canonical predecessor
+implementation. This module owns only orchestration and fail-fast propagation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SITE_URL = "https://kasahart.github.io/wandas/"
+
+PREREQUISITE_MARKERS = {
+    "#365 spectral numerical contracts": (Path("tests/docs/test_spectral_numerical_contracts.py"),),
+    "#373 docstring governance": (
+        Path("scripts/check_public_docstrings.py"),
+        Path("tests/docs/test_public_docstrings.py"),
+    ),
+    "#369 public API inventory": (
+        Path("wandas/_public_api.py"),
+        Path("tests/docs/test_public_api_inventory.py"),
+    ),
+    "#372 generated-site contract": (
+        Path("scripts/check_docs_site.py"),
+        Path("scripts/finalize_learning_html.py"),
+        Path("tests/docs/test_docs_site.py"),
+    ),
+    "#367 executable learning path": (Path("tests/docs/test_learning_path_executable_contracts.py"),),
+}
+
+NUMERICAL_CONTRACT_TESTS = (
+    "tests/processing/test_spectral_operations.py",
+    "tests/frames/test_spectral_frame.py",
+)
+
+
+@dataclass(frozen=True)
+class Stage:
+    """One fail-fast command in the documentation gate."""
+
+    name: str
+    command: tuple[str, ...]
+
+
+class GateConfigurationError(RuntimeError):
+    """Raised when prerequisite checkers are only partly integrated."""
+
+
+def detect_profile(repo_root: Path, *, require_final: bool = False) -> str:
+    """Return ``standalone`` or ``final`` without allowing a partial cohort."""
+    complete = {
+        name: all((repo_root / marker).is_file() for marker in markers)
+        for name, markers in PREREQUISITE_MARKERS.items()
+    }
+    any_marker = any((repo_root / marker).is_file() for markers in PREREQUISITE_MARKERS.values() for marker in markers)
+    if all(complete.values()):
+        return "final"
+    if any_marker:
+        details = ", ".join(f"{name}={'complete' if found else 'incomplete'}" for name, found in complete.items())
+        raise GateConfigurationError(f"partial documentation-gate prerequisite cohort: {details}")
+    if require_final:
+        required = ", ".join(PREREQUISITE_MARKERS)
+        raise GateConfigurationError(f"final documentation gate requires prerequisite checkers: {required}")
+    return "standalone"
+
+
+def learning_apps(repo_root: Path) -> tuple[Path, ...]:
+    """Return all nine versioned learning applications or fail."""
+    apps = tuple(sorted((repo_root / "learning-path").glob("0[0-8]_*.py")))
+    prefixes = [path.name[:2] for path in apps]
+    expected = [f"{index:02d}" for index in range(9)]
+    if prefixes != expected:
+        raise GateConfigurationError(f"expected learning applications {expected!r}, found {prefixes!r}")
+    return apps
+
+
+def build_stages(
+    repo_root: Path,
+    site_dir: Path,
+    *,
+    profile: str,
+    site_only: bool = False,
+) -> tuple[Stage, ...]:
+    """Build the ordered, single-job documentation validation plan."""
+    python = sys.executable
+    apps = learning_apps(repo_root)
+    stages: list[Stage] = []
+
+    if not site_only:
+        stages.append(
+            Stage(
+                "documentation, API, and numerical contract tests",
+                (
+                    python,
+                    "-m",
+                    "pytest",
+                    "-q",
+                    "tests/docs",
+                    "tests/test_init.py",
+                    *NUMERICAL_CONTRACT_TESTS,
+                ),
+            )
+        )
+
+    if profile == "final":
+        stages.append(
+            Stage(
+                "public docstring parser contract",
+                (python, "scripts/check_public_docstrings.py"),
+            )
+        )
+
+    stages.append(
+        Stage(
+            "all learning applications: static/reactive check",
+            (python, "-m", "marimo", "check", "--strict", *(str(path.relative_to(repo_root)) for path in apps)),
+        )
+    )
+    stages.append(
+        Stage(
+            "strict MkDocs build",
+            (
+                python,
+                "-m",
+                "mkdocs",
+                "build",
+                "--strict",
+                "--clean",
+                "-f",
+                "docs/mkdocs.yml",
+                "-d",
+                str(site_dir),
+            ),
+        )
+    )
+    stages.append(
+        Stage(
+            "prepare clean learning export directory",
+            (
+                python,
+                "-c",
+                (
+                    "from pathlib import Path; "
+                    f"Path({str(learning_output := site_dir / 'learning-path')!r}).mkdir(parents=True, exist_ok=True)"
+                ),
+            ),
+        )
+    )
+
+    for app in apps:
+        output = learning_output / app.with_suffix(".html").name
+        stages.append(
+            Stage(
+                f"execute/export {app.name}",
+                (
+                    python,
+                    "-m",
+                    "marimo",
+                    "export",
+                    "html",
+                    str(app.relative_to(repo_root)),
+                    "-o",
+                    str(output),
+                    "--no-include-code",
+                    "-f",
+                ),
+            )
+        )
+
+    if profile == "final":
+        stages.extend(
+            (
+                Stage(
+                    "finalize learning application URLs and canonical metadata",
+                    (
+                        python,
+                        "scripts/finalize_learning_html.py",
+                        str(site_dir),
+                        "--site-url",
+                        SITE_URL,
+                    ),
+                ),
+                Stage(
+                    "crawl completed generated site",
+                    (
+                        python,
+                        "scripts/check_docs_site.py",
+                        str(site_dir),
+                        "--source-dir",
+                        "docs/src",
+                        "--site-url",
+                        SITE_URL,
+                    ),
+                ),
+            )
+        )
+    return tuple(stages)
+
+
+def run_stages(
+    stages: Sequence[Stage],
+    *,
+    repo_root: Path,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> None:
+    """Run *stages* in order and stop at the first non-zero command."""
+    for stage in stages:
+        print(f"::group::{stage.name}", flush=True)
+        completed = runner(stage.command, cwd=repo_root, text=True, check=False)
+        print("::endgroup::", flush=True)
+        if completed.returncode:
+            rendered = " ".join(stage.command)
+            raise RuntimeError(f"documentation gate failed at {stage.name!r}: {rendered}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--site-dir", type=Path, default=Path("docs/site"))
+    parser.add_argument(
+        "--require-final",
+        action="store_true",
+        help="require the complete prerequisite checker cohort (used by deployment)",
+    )
+    parser.add_argument(
+        "--site-only",
+        action="store_true",
+        help="skip pytest while retaining parser, learning, strict build, finalize, and crawl stages",
+    )
+    args = parser.parse_args()
+
+    try:
+        profile = detect_profile(REPO_ROOT, require_final=args.require_final)
+        site_dir = args.site_dir if args.site_dir.is_absolute() else REPO_ROOT / args.site_dir
+        site_dir = site_dir.resolve()
+        docs_root = (REPO_ROOT / "docs").resolve()
+        try:
+            site_dir.relative_to(docs_root)
+        except ValueError as exc:
+            raise GateConfigurationError(f"site directory must be under {docs_root}: {site_dir}") from exc
+
+        # MkDocs --clean owns the site directory. Remove only the learning
+        # subdirectory so stale exports cannot satisfy the exact-nine check.
+        learning_output = site_dir / "learning-path"
+        if learning_output.exists():
+            shutil.rmtree(learning_output)
+
+        stages = build_stages(REPO_ROOT, site_dir, profile=profile, site_only=args.site_only)
+        print(f"Documentation consistency profile: {profile}", flush=True)
+        run_stages(stages, repo_root=REPO_ROOT)
+    except (GateConfigurationError, RuntimeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Documentation consistency gate passed ({profile})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_documentation_gate.py
+++ b/scripts/run_documentation_gate.py
@@ -1,11 +1,12 @@
 """Run the documentation consistency contract once, in deployment order.
 
-The gate has two intentional profiles:
+The gate has three intentional profiles:
 
 * ``standalone`` uses checks already present on the Issue #375 audit baseline.
+* ``integration`` accepts fully installed predecessor checkers while the closing
+  cohort is merging, but still rejects a half-installed multi-file checker.
 * ``final`` is selected only when the complete prerequisite checker cohort is
-  present. A partial cohort is an error, so integration can never silently skip
-  a predecessor check.
+  present and is mandatory before deployment.
 
 The final profile delegates each domain to its canonical predecessor
 implementation. This module owns only orchestration and fail-fast propagation.
@@ -14,9 +15,11 @@ implementation. This module owns only orchestration and fail-fast propagation.
 from __future__ import annotations
 
 import argparse
+import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -47,6 +50,19 @@ NUMERICAL_CONTRACT_TESTS = (
     "tests/frames/test_spectral_frame.py",
 )
 
+LEARNING_APP_NAMES = (
+    "00_why_wandas.py",
+    "01_getting_started.py",
+    "02_working_with_data.py",
+    "03_signal_processing_basics.py",
+    "04_advanced_processing.py",
+    "05_custom_functions.py",
+    "06_reusable_pipeline_recipes.py",
+    "07_per_channel_calibration.py",
+    "08_metadata_driven_dataset_search.py",
+)
+LEARNING_FIXTURES = ("sample_audio.wav", "sensor_data.csv")
+
 
 @dataclass(frozen=True)
 class Stage:
@@ -54,6 +70,7 @@ class Stage:
 
     name: str
     command: tuple[str, ...]
+    cwd: Path | None = None
 
 
 class GateConfigurationError(RuntimeError):
@@ -61,31 +78,54 @@ class GateConfigurationError(RuntimeError):
 
 
 def detect_profile(repo_root: Path, *, require_final: bool = False) -> str:
-    """Return ``standalone`` or ``final`` without allowing a partial cohort."""
+    """Return the safe profile without allowing a half-installed checker."""
     complete = {
         name: all((repo_root / marker).is_file() for marker in markers)
         for name, markers in PREREQUISITE_MARKERS.items()
     }
-    any_marker = any((repo_root / marker).is_file() for markers in PREREQUISITE_MARKERS.values() for marker in markers)
+    partial = {
+        name: any((repo_root / marker).is_file() for marker in markers) and not complete[name]
+        for name, markers in PREREQUISITE_MARKERS.items()
+    }
+    if any(partial.values()):
+        details = ", ".join(
+            f"{name}={'complete' if complete[name] else 'partial' if partial[name] else 'absent'}"
+            for name in PREREQUISITE_MARKERS
+        )
+        raise GateConfigurationError(f"partially installed documentation-gate checker: {details}")
     if all(complete.values()):
         return "final"
-    if any_marker:
-        details = ", ".join(f"{name}={'complete' if found else 'incomplete'}" for name, found in complete.items())
-        raise GateConfigurationError(f"partial documentation-gate prerequisite cohort: {details}")
     if require_final:
-        required = ", ".join(PREREQUISITE_MARKERS)
-        raise GateConfigurationError(f"final documentation gate requires prerequisite checkers: {required}")
-    return "standalone"
+        missing = ", ".join(name for name, found in complete.items() if not found)
+        raise GateConfigurationError(f"final documentation gate requires prerequisite checkers: {missing}")
+    return "integration" if any(complete.values()) else "standalone"
 
 
 def learning_apps(repo_root: Path) -> tuple[Path, ...]:
-    """Return all nine versioned learning applications or fail."""
-    apps = tuple(sorted((repo_root / "learning-path").glob("0[0-8]_*.py")))
-    prefixes = [path.name[:2] for path in apps]
-    expected = [f"{index:02d}" for index in range(9)]
-    if prefixes != expected:
-        raise GateConfigurationError(f"expected learning applications {expected!r}, found {prefixes!r}")
+    """Return the exact numbered learning application inventory or fail."""
+    learning_root = repo_root / "learning-path"
+    apps = tuple(sorted(path for path in learning_root.glob("*.py") if re.fullmatch(r"\d+_.+\.py", path.name)))
+    found = tuple(path.name for path in apps)
+    if found != LEARNING_APP_NAMES:
+        raise GateConfigurationError(f"expected learning applications {LEARNING_APP_NAMES!r}, found {found!r}")
     return apps
+
+
+def prepare_learning_workspace(repo_root: Path, workspace: Path) -> None:
+    """Copy checked-in learning fixtures into an isolated execution directory."""
+    repo_root = repo_root.resolve()
+    workspace = workspace.resolve()
+    if workspace == repo_root or workspace.is_relative_to(repo_root):
+        raise GateConfigurationError(f"learning workspace must be outside the repository: {workspace}")
+    source_root = repo_root / "learning-path"
+    workspace.mkdir(parents=True, exist_ok=True)
+    if any(workspace.iterdir()):
+        raise GateConfigurationError(f"learning workspace must start empty: {workspace}")
+    for name in LEARNING_FIXTURES:
+        source = source_root / name
+        if not source.is_file():
+            raise GateConfigurationError(f"missing checked-in learning fixture: {source}")
+        shutil.copy2(source, workspace / name)
 
 
 def build_stages(
@@ -93,6 +133,7 @@ def build_stages(
     site_dir: Path,
     *,
     profile: str,
+    learning_workspace: Path,
     site_only: bool = False,
 ) -> tuple[Stage, ...]:
     """Build the ordered, single-job documentation validation plan."""
@@ -172,12 +213,13 @@ def build_stages(
                     "marimo",
                     "export",
                     "html",
-                    str(app.relative_to(repo_root)),
+                    str(app.resolve()),
                     "-o",
                     str(output),
                     "--no-include-code",
                     "-f",
                 ),
+                cwd=learning_workspace,
             )
         )
 
@@ -220,7 +262,12 @@ def run_stages(
     """Run *stages* in order and stop at the first non-zero command."""
     for stage in stages:
         print(f"::group::{stage.name}", flush=True)
-        completed = runner(stage.command, cwd=repo_root, text=True, check=False)
+        completed = runner(
+            stage.command,
+            cwd=stage.cwd or repo_root,
+            text=True,
+            check=False,
+        )
         print("::endgroup::", flush=True)
         if completed.returncode:
             rendered = " ".join(stage.command)
@@ -258,9 +305,18 @@ def main() -> int:
         if learning_output.exists():
             shutil.rmtree(learning_output)
 
-        stages = build_stages(REPO_ROOT, site_dir, profile=profile, site_only=args.site_only)
-        print(f"Documentation consistency profile: {profile}", flush=True)
-        run_stages(stages, repo_root=REPO_ROOT)
+        with tempfile.TemporaryDirectory(prefix="wandas-learning-gate-") as temporary_directory:
+            learning_workspace = Path(temporary_directory)
+            prepare_learning_workspace(REPO_ROOT, learning_workspace)
+            stages = build_stages(
+                REPO_ROOT,
+                site_dir,
+                profile=profile,
+                learning_workspace=learning_workspace,
+                site_only=args.site_only,
+            )
+            print(f"Documentation consistency profile: {profile}", flush=True)
+            run_stages(stages, repo_root=REPO_ROOT)
     except (GateConfigurationError, RuntimeError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1

--- a/scripts/run_documentation_gate.py
+++ b/scripts/run_documentation_gate.py
@@ -23,9 +23,9 @@ import tempfile
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlparse
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-SITE_URL = "https://kasahart.github.io/wandas/"
 
 PREREQUISITE_MARKERS = {
     "#365 spectral numerical contracts": (Path("tests/docs/test_spectral_numerical_contracts.py"),),
@@ -48,6 +48,12 @@ PREREQUISITE_MARKERS = {
 NUMERICAL_CONTRACT_TESTS = (
     "tests/processing/test_spectral_operations.py",
     "tests/frames/test_spectral_frame.py",
+)
+SOURCE_CONTRACT_TESTS = (
+    "tests/docs",
+    "tests/test_init.py",
+    "tests/test_optional_dependencies.py",
+    *NUMERICAL_CONTRACT_TESTS,
 )
 
 LEARNING_APP_NAMES = (
@@ -101,6 +107,34 @@ def detect_profile(repo_root: Path, *, require_final: bool = False) -> str:
     return "integration" if any(complete.values()) else "standalone"
 
 
+def validate_mode(profile: str, *, site_only: bool) -> None:
+    """Reject source-test-skipping mode unless every final checker is present."""
+    if site_only and profile != "final":
+        raise GateConfigurationError(f"site-only documentation gate requires final profile; detected {profile}")
+
+
+def mkdocs_site_url(repo_root: Path) -> str:
+    """Read and validate the one canonical site origin from the MkDocs config."""
+    config = repo_root / "docs/mkdocs.yml"
+    matches = [
+        line.partition(":")[2].strip()
+        for line in config.read_text(encoding="utf-8").splitlines()
+        if line.startswith("site_url:")
+    ]
+    if len(matches) != 1:
+        raise GateConfigurationError(f"expected exactly one top-level site_url in {config}, found {len(matches)}")
+
+    site_url = matches[0]
+    if len(site_url) >= 2 and site_url[0] == site_url[-1] and site_url[0] in {'"', "'"}:
+        site_url = site_url[1:-1]
+    parsed = urlparse(site_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc or parsed.query or parsed.fragment:
+        raise GateConfigurationError(
+            f"MkDocs site_url must be an absolute HTTP(S) origin without query or fragment: {site_url!r}"
+        )
+    return site_url.rstrip("/") + "/"
+
+
 def learning_apps(repo_root: Path) -> tuple[Path, ...]:
     """Return the exact numbered learning application inventory or fail."""
     learning_root = repo_root / "learning-path"
@@ -150,9 +184,7 @@ def build_stages(
                     "-m",
                     "pytest",
                     "-q",
-                    "tests/docs",
-                    "tests/test_init.py",
-                    *NUMERICAL_CONTRACT_TESTS,
+                    *SOURCE_CONTRACT_TESTS,
                 ),
             )
         )
@@ -224,6 +256,7 @@ def build_stages(
         )
 
     if profile == "final":
+        site_url = mkdocs_site_url(repo_root)
         stages.extend(
             (
                 Stage(
@@ -233,7 +266,7 @@ def build_stages(
                         "scripts/finalize_learning_html.py",
                         str(site_dir),
                         "--site-url",
-                        SITE_URL,
+                        site_url,
                     ),
                 ),
                 Stage(
@@ -245,7 +278,7 @@ def build_stages(
                         "--source-dir",
                         "docs/src",
                         "--site-url",
-                        SITE_URL,
+                        site_url,
                     ),
                 ),
             )
@@ -291,6 +324,7 @@ def main() -> int:
 
     try:
         profile = detect_profile(REPO_ROOT, require_final=args.require_final)
+        validate_mode(profile, site_only=args.site_only)
         site_dir = args.site_dir if args.site_dir.is_absolute() else REPO_ROOT / args.site_dir
         site_dir = site_dir.resolve()
         docs_root = (REPO_ROOT / "docs").resolve()

--- a/scripts/run_documentation_gate.py
+++ b/scripts/run_documentation_gate.py
@@ -117,12 +117,21 @@ def ci_requires_final(
     if event_name == "pull_request":
         if not base_sha:
             raise GateConfigurationError("pull-request documentation CI requires WANDAS_DOCS_BASE_SHA")
-        return path_exists(repo_root, base_sha, FINALIZATION_SENTINEL)
+        base_is_finalized = path_exists(repo_root, base_sha, FINALIZATION_SENTINEL)
+        if base_is_finalized and not path_exists(repo_root, "HEAD", FINALIZATION_SENTINEL):
+            raise GateConfigurationError(f"finalized pull request is missing {FINALIZATION_SENTINEL}")
+        return base_is_finalized
     if event_name == "push":
         if not path_exists(repo_root, "HEAD", FINALIZATION_SENTINEL):
             raise GateConfigurationError(f"finalized main push is missing {FINALIZATION_SENTINEL}")
         return True
     raise GateConfigurationError(f"documentation CI policy does not support event {event_name!r}")
+
+
+def require_worktree_finalization_sentinel(repo_root: Path) -> None:
+    """Require deployment's permanent finalization ledger in the current tree."""
+    if not (repo_root / FINALIZATION_SENTINEL).is_file():
+        raise GateConfigurationError(f"final documentation gate is missing {FINALIZATION_SENTINEL}")
 
 
 def detect_profile(repo_root: Path, *, require_final: bool = False) -> str:
@@ -202,6 +211,30 @@ def prepare_learning_workspace(repo_root: Path, workspace: Path) -> None:
         if not source.is_file():
             raise GateConfigurationError(f"missing checked-in learning fixture: {source}")
         shutil.copy2(source, workspace / name)
+
+
+def remove_stale_learning_exports(repo_root: Path, site_dir: Path) -> Path:
+    """Validate the site destination before removing its stale learning exports."""
+    repo_root = repo_root.resolve()
+    site_dir = site_dir.resolve()
+    docs_root = (repo_root / "docs").resolve()
+    source_root = (docs_root / "src").resolve()
+    try:
+        site_dir.relative_to(docs_root)
+    except ValueError as exc:
+        raise GateConfigurationError(f"site directory must be under {docs_root}: {site_dir}") from exc
+
+    if site_dir.is_relative_to(source_root) or source_root.is_relative_to(site_dir):
+        raise GateConfigurationError(
+            f"site directory must be disjoint from documentation sources at {source_root}: {site_dir}"
+        )
+
+    # MkDocs --clean owns the site directory. Remove only the learning
+    # subdirectory so stale exports cannot satisfy the exact-nine check.
+    learning_output = site_dir / "learning-path"
+    if learning_output.exists():
+        shutil.rmtree(learning_output)
+    return site_dir
 
 
 def build_stages(
@@ -378,21 +411,12 @@ def main() -> int:
                 event_name=os.environ.get("GITHUB_EVENT_NAME", ""),
                 base_sha=os.environ.get("WANDAS_DOCS_BASE_SHA"),
             )
+        elif args.require_final:
+            require_worktree_finalization_sentinel(REPO_ROOT)
         profile = detect_profile(REPO_ROOT, require_final=require_final)
         validate_mode(profile, site_only=args.site_only)
         site_dir = args.site_dir if args.site_dir.is_absolute() else REPO_ROOT / args.site_dir
-        site_dir = site_dir.resolve()
-        docs_root = (REPO_ROOT / "docs").resolve()
-        try:
-            site_dir.relative_to(docs_root)
-        except ValueError as exc:
-            raise GateConfigurationError(f"site directory must be under {docs_root}: {site_dir}") from exc
-
-        # MkDocs --clean owns the site directory. Remove only the learning
-        # subdirectory so stale exports cannot satisfy the exact-nine check.
-        learning_output = site_dir / "learning-path"
-        if learning_output.exists():
-            shutil.rmtree(learning_output)
+        site_dir = remove_stale_learning_exports(REPO_ROOT, site_dir)
 
         with tempfile.TemporaryDirectory(prefix="wandas-learning-gate-") as temporary_directory:
             learning_workspace = Path(temporary_directory)

--- a/scripts/run_documentation_gate.py
+++ b/scripts/run_documentation_gate.py
@@ -15,6 +15,7 @@ implementation. This module owns only orchestration and fail-fast propagation.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import shutil
 import subprocess
@@ -26,6 +27,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+FINALIZATION_SENTINEL = Path(".github/documentation-gate-finalized")
 
 PREREQUISITE_MARKERS = {
     "#365 spectral numerical contracts": (Path("tests/docs/test_spectral_numerical_contracts.py"),),
@@ -81,6 +83,46 @@ class Stage:
 
 class GateConfigurationError(RuntimeError):
     """Raised when prerequisite checkers are only partly integrated."""
+
+
+def git_path_exists(repo_root: Path, ref: str, path: Path) -> bool:
+    """Return whether *path* exists at a verified Git commit *ref*."""
+    verified = subprocess.run(
+        ("git", "rev-parse", "--verify", f"{ref}^{{commit}}"),
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if verified.returncode:
+        raise GateConfigurationError(f"cannot resolve documentation-gate baseline commit: {ref}")
+    found = subprocess.run(
+        ("git", "cat-file", "-e", f"{ref}:{path.as_posix()}"),
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return found.returncode == 0
+
+
+def ci_requires_final(
+    repo_root: Path,
+    *,
+    event_name: str,
+    base_sha: str | None,
+    path_exists: Callable[[Path, str, Path], bool] = git_path_exists,
+) -> bool:
+    """Apply the irreversible CI transition recorded by the finalization sentinel."""
+    if event_name == "pull_request":
+        if not base_sha:
+            raise GateConfigurationError("pull-request documentation CI requires WANDAS_DOCS_BASE_SHA")
+        return path_exists(repo_root, base_sha, FINALIZATION_SENTINEL)
+    if event_name == "push":
+        if not path_exists(repo_root, "HEAD", FINALIZATION_SENTINEL):
+            raise GateConfigurationError(f"finalized main push is missing {FINALIZATION_SENTINEL}")
+        return True
+    raise GateConfigurationError(f"documentation CI policy does not support event {event_name!r}")
 
 
 def detect_profile(repo_root: Path, *, require_final: bool = False) -> str:
@@ -310,10 +352,16 @@ def run_stages(
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--site-dir", type=Path, default=Path("docs/site"))
-    parser.add_argument(
+    profile_group = parser.add_mutually_exclusive_group()
+    profile_group.add_argument(
         "--require-final",
         action="store_true",
         help="require the complete prerequisite checker cohort (used by deployment)",
+    )
+    profile_group.add_argument(
+        "--ci-policy",
+        action="store_true",
+        help="require final according to the permanent base/main finalization sentinel",
     )
     parser.add_argument(
         "--site-only",
@@ -323,7 +371,14 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        profile = detect_profile(REPO_ROOT, require_final=args.require_final)
+        require_final = args.require_final
+        if args.ci_policy:
+            require_final = ci_requires_final(
+                REPO_ROOT,
+                event_name=os.environ.get("GITHUB_EVENT_NAME", ""),
+                base_sha=os.environ.get("WANDAS_DOCS_BASE_SHA"),
+            )
+        profile = detect_profile(REPO_ROOT, require_final=require_final)
         validate_mode(profile, site_only=args.site_only)
         site_dir = args.site_dir if args.site_dir.is_absolute() else REPO_ROOT / args.site_dir
         site_dir = site_dir.resolve()

--- a/tests/docs/test_end_to_end_documentation_gate.py
+++ b/tests/docs/test_end_to_end_documentation_gate.py
@@ -388,7 +388,7 @@ def test_ci_and_deploy_use_the_single_gate_with_different_safety_profiles() -> N
     assert "--ci-policy" in ci
     assert "WANDAS_DOCS_BASE_SHA: ${{ github.event.pull_request.base.sha }}" in ci
     assert "fetch-depth: 0" in ci
-    assert str(FINALIZATION_SENTINEL) in ci
+    assert FINALIZATION_SENTINEL.as_posix() in ci
     assert "--require-final" in deploy
     assert "--site-only" not in deploy
     assert "--group docs --group test" in deploy

--- a/tests/docs/test_end_to_end_documentation_gate.py
+++ b/tests/docs/test_end_to_end_documentation_gate.py
@@ -20,6 +20,7 @@ from scripts.run_documentation_gate import (
     build_stages,
     ci_requires_final,
     detect_profile,
+    git_path_is_blob,
     learning_apps,
     mkdocs_site_url,
     prepare_learning_workspace,
@@ -151,7 +152,7 @@ def test_ci_finalization_state_transition_matrix(
     paths: set[tuple[str, Path]],
     expected: bool,
 ) -> None:
-    def path_exists(repo_root: Path, ref: str, path: Path) -> bool:
+    def path_is_blob(repo_root: Path, ref: str, path: Path) -> bool:
         assert repo_root == tmp_path, state
         return (ref, path) in paths
 
@@ -160,10 +161,58 @@ def test_ci_finalization_state_transition_matrix(
             tmp_path,
             event_name=event_name,
             base_sha=base_sha,
-            path_exists=path_exists,
+            path_is_blob=path_is_blob,
         )
         is expected
     )
+
+
+@pytest.mark.parametrize(
+    ("object_kind", "expected"),
+    [("blob", True), ("tree", False), ("gitlink", False)],
+)
+def test_git_finalization_sentinel_requires_blob_object(
+    tmp_path: Path,
+    object_kind: str,
+    expected: bool,
+) -> None:
+    repo = tmp_path / object_kind
+    repo.mkdir()
+
+    def git(*args: str) -> str:
+        return subprocess.run(
+            ("git", *args),
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    git("init", "--quiet")
+    git("config", "user.email", "docs-gate@example.invalid")
+    git("config", "user.name", "Documentation Gate Test")
+    git("commit", "--quiet", "--allow-empty", "-m", "initial")
+
+    sentinel = repo / FINALIZATION_SENTINEL
+    if object_kind == "blob":
+        sentinel.parent.mkdir(parents=True)
+        sentinel.write_text("finalized\n", encoding="utf-8")
+        git("add", FINALIZATION_SENTINEL.as_posix())
+    elif object_kind == "tree":
+        sentinel.mkdir(parents=True)
+        (sentinel / "entry").write_text("not a sentinel file\n", encoding="utf-8")
+        git("add", f"{FINALIZATION_SENTINEL.as_posix()}/entry")
+    else:
+        commit = git("rev-parse", "HEAD")
+        git(
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            f"160000,{commit},{FINALIZATION_SENTINEL.as_posix()}",
+        )
+    git("commit", "--quiet", "-m", object_kind)
+
+    assert git_path_is_blob(repo, "HEAD", FINALIZATION_SENTINEL) is expected
 
 
 def test_finalized_main_push_rejects_removed_sentinel(tmp_path: Path) -> None:
@@ -172,7 +221,7 @@ def test_finalized_main_push_rejects_removed_sentinel(tmp_path: Path) -> None:
             tmp_path,
             event_name="push",
             base_sha=None,
-            path_exists=lambda _root, _ref, _path: False,
+            path_is_blob=lambda _root, _ref, _path: False,
         )
 
 
@@ -181,7 +230,7 @@ def test_closing_pr_sentinel_requires_complete_prerequisite_cohort(tmp_path: Pat
         tmp_path,
         event_name="pull_request",
         base_sha="pre-final-base",
-        path_exists=lambda _root, ref, path: (ref, path) == ("HEAD", FINALIZATION_SENTINEL),
+        path_is_blob=lambda _root, ref, path: (ref, path) == ("HEAD", FINALIZATION_SENTINEL),
     )
 
     assert require_final is True
@@ -199,7 +248,7 @@ def test_finalized_pull_request_rejects_removed_sentinel(tmp_path: Path) -> None
             tmp_path,
             event_name="pull_request",
             base_sha="finalized-base",
-            path_exists=lambda _root, ref, _path: ref == "finalized-base",
+            path_is_blob=lambda _root, ref, _path: ref == "finalized-base",
         )
 
 
@@ -209,6 +258,11 @@ def test_final_deployment_rejects_removed_worktree_sentinel(tmp_path: Path) -> N
 
     sentinel = tmp_path / FINALIZATION_SENTINEL
     sentinel.parent.mkdir(parents=True)
+    sentinel.mkdir()
+    with pytest.raises(GateConfigurationError, match="final documentation gate is missing"):
+        require_worktree_finalization_sentinel(tmp_path)
+
+    sentinel.rmdir()
     sentinel.touch()
     require_worktree_finalization_sentinel(tmp_path)
 

--- a/tests/docs/test_end_to_end_documentation_gate.py
+++ b/tests/docs/test_end_to_end_documentation_gate.py
@@ -129,7 +129,7 @@ def test_profile_is_final_only_when_every_predecessor_is_present(tmp_path: Path)
     ("state", "event_name", "base_sha", "paths", "expected"),
     [
         ("pre-final PR", "pull_request", "pre-final-base", set(), False),
-        ("closing PR", "pull_request", "closing-base", {("HEAD", FINALIZATION_SENTINEL)}, False),
+        ("closing PR", "pull_request", "closing-base", {("HEAD", FINALIZATION_SENTINEL)}, True),
         (
             "post-final checker deletion PR",
             "pull_request",
@@ -174,6 +174,23 @@ def test_finalized_main_push_rejects_removed_sentinel(tmp_path: Path) -> None:
             base_sha=None,
             path_exists=lambda _root, _ref, _path: False,
         )
+
+
+def test_closing_pr_sentinel_requires_complete_prerequisite_cohort(tmp_path: Path) -> None:
+    require_final = ci_requires_final(
+        tmp_path,
+        event_name="pull_request",
+        base_sha="pre-final-base",
+        path_exists=lambda _root, ref, path: (ref, path) == ("HEAD", FINALIZATION_SENTINEL),
+    )
+
+    assert require_final is True
+    with pytest.raises(GateConfigurationError, match="requires prerequisite checkers"):
+        detect_profile(tmp_path, require_final=require_final)
+
+    _install_markers(tmp_path, set(PREREQUISITE_MARKERS))
+
+    assert detect_profile(tmp_path, require_final=require_final) == "final"
 
 
 def test_finalized_pull_request_rejects_removed_sentinel(tmp_path: Path) -> None:

--- a/tests/docs/test_end_to_end_documentation_gate.py
+++ b/tests/docs/test_end_to_end_documentation_gate.py
@@ -9,6 +9,7 @@ import pytest
 
 import wandas
 from scripts.run_documentation_gate import (
+    FINALIZATION_SENTINEL,
     LEARNING_APP_NAMES,
     LEARNING_FIXTURES,
     NUMERICAL_CONTRACT_TESTS,
@@ -17,6 +18,7 @@ from scripts.run_documentation_gate import (
     GateConfigurationError,
     Stage,
     build_stages,
+    ci_requires_final,
     detect_profile,
     learning_apps,
     mkdocs_site_url,
@@ -119,6 +121,69 @@ def test_profile_is_final_only_when_every_predecessor_is_present(tmp_path: Path)
     _install_markers(tmp_path, set(PREREQUISITE_MARKERS))
 
     assert detect_profile(tmp_path, require_final=True) == "final"
+
+
+@pytest.mark.parametrize(
+    ("state", "event_name", "base_sha", "paths", "expected"),
+    [
+        ("pre-final PR", "pull_request", "pre-final-base", set(), False),
+        ("closing PR", "pull_request", "closing-base", {("HEAD", FINALIZATION_SENTINEL)}, False),
+        (
+            "post-final checker deletion PR",
+            "pull_request",
+            "finalized-base",
+            {("finalized-base", FINALIZATION_SENTINEL)},
+            True,
+        ),
+        ("finalized main push", "push", None, {("HEAD", FINALIZATION_SENTINEL)}, True),
+    ],
+)
+def test_ci_finalization_state_transition_matrix(
+    tmp_path: Path,
+    state: str,
+    event_name: str,
+    base_sha: str | None,
+    paths: set[tuple[str, Path]],
+    expected: bool,
+) -> None:
+    def path_exists(repo_root: Path, ref: str, path: Path) -> bool:
+        assert repo_root == tmp_path, state
+        return (ref, path) in paths
+
+    assert (
+        ci_requires_final(
+            tmp_path,
+            event_name=event_name,
+            base_sha=base_sha,
+            path_exists=path_exists,
+        )
+        is expected
+    )
+
+
+def test_finalized_main_push_rejects_removed_sentinel(tmp_path: Path) -> None:
+    with pytest.raises(GateConfigurationError, match="finalized main push is missing"):
+        ci_requires_final(
+            tmp_path,
+            event_name="push",
+            base_sha=None,
+            path_exists=lambda _root, _ref, _path: False,
+        )
+
+
+def test_ci_policy_rejects_missing_or_unexpected_event_context(tmp_path: Path) -> None:
+    with pytest.raises(GateConfigurationError, match="requires WANDAS_DOCS_BASE_SHA"):
+        ci_requires_final(
+            tmp_path,
+            event_name="pull_request",
+            base_sha=None,
+        )
+    with pytest.raises(GateConfigurationError, match="does not support event"):
+        ci_requires_final(
+            tmp_path,
+            event_name="workflow_dispatch",
+            base_sha=None,
+        )
 
 
 def test_learning_inventory_rejects_additional_numbered_apps(tmp_path: Path) -> None:
@@ -320,6 +385,10 @@ def test_ci_and_deploy_use_the_single_gate_with_different_safety_profiles() -> N
 
     assert ci.count(command) == 1
     assert deploy.count(command) == 1
+    assert "--ci-policy" in ci
+    assert "WANDAS_DOCS_BASE_SHA: ${{ github.event.pull_request.base.sha }}" in ci
+    assert "fetch-depth: 0" in ci
+    assert str(FINALIZATION_SENTINEL) in ci
     assert "--require-final" in deploy
     assert "--site-only" not in deploy
     assert "--group docs --group test" in deploy

--- a/tests/docs/test_end_to_end_documentation_gate.py
+++ b/tests/docs/test_end_to_end_documentation_gate.py
@@ -23,6 +23,8 @@ from scripts.run_documentation_gate import (
     learning_apps,
     mkdocs_site_url,
     prepare_learning_workspace,
+    remove_stale_learning_exports,
+    require_worktree_finalization_sentinel,
     run_stages,
     validate_mode,
 )
@@ -132,7 +134,10 @@ def test_profile_is_final_only_when_every_predecessor_is_present(tmp_path: Path)
             "post-final checker deletion PR",
             "pull_request",
             "finalized-base",
-            {("finalized-base", FINALIZATION_SENTINEL)},
+            {
+                ("finalized-base", FINALIZATION_SENTINEL),
+                ("HEAD", FINALIZATION_SENTINEL),
+            },
             True,
         ),
         ("finalized main push", "push", None, {("HEAD", FINALIZATION_SENTINEL)}, True),
@@ -169,6 +174,26 @@ def test_finalized_main_push_rejects_removed_sentinel(tmp_path: Path) -> None:
             base_sha=None,
             path_exists=lambda _root, _ref, _path: False,
         )
+
+
+def test_finalized_pull_request_rejects_removed_sentinel(tmp_path: Path) -> None:
+    with pytest.raises(GateConfigurationError, match="finalized pull request is missing"):
+        ci_requires_final(
+            tmp_path,
+            event_name="pull_request",
+            base_sha="finalized-base",
+            path_exists=lambda _root, ref, _path: ref == "finalized-base",
+        )
+
+
+def test_final_deployment_rejects_removed_worktree_sentinel(tmp_path: Path) -> None:
+    with pytest.raises(GateConfigurationError, match="final documentation gate is missing"):
+        require_worktree_finalization_sentinel(tmp_path)
+
+    sentinel = tmp_path / FINALIZATION_SENTINEL
+    sentinel.parent.mkdir(parents=True)
+    sentinel.touch()
+    require_worktree_finalization_sentinel(tmp_path)
 
 
 def test_ci_policy_rejects_missing_or_unexpected_event_context(tmp_path: Path) -> None:
@@ -232,6 +257,36 @@ def test_learning_workspace_rejects_repository_paths_and_stale_content(
     (stale_workspace / "output").mkdir()
     with pytest.raises(GateConfigurationError, match="must start empty"):
         prepare_learning_workspace(repo_root, stale_workspace)
+
+
+@pytest.mark.parametrize("relative_site_dir", ["docs", "docs/src", "docs/src/generated"])
+def test_site_output_rejects_source_overlap_before_removing_stale_exports(
+    tmp_path: Path,
+    relative_site_dir: str,
+) -> None:
+    repo_root = tmp_path / "repo"
+    site_dir = repo_root / relative_site_dir
+    stale_export = site_dir / "learning-path/stale.html"
+    stale_export.parent.mkdir(parents=True)
+    stale_export.touch()
+
+    with pytest.raises(GateConfigurationError, match="must be disjoint"):
+        remove_stale_learning_exports(repo_root, site_dir)
+
+    assert stale_export.is_file()
+
+
+def test_site_output_removes_only_stale_exports_from_safe_destination(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    site_dir = repo_root / "docs/site"
+    stale_exports = site_dir / "learning-path"
+    stale_exports.mkdir(parents=True)
+    (stale_exports / "stale.html").touch()
+
+    assert remove_stale_learning_exports(repo_root, site_dir) == site_dir.resolve()
+    assert not stale_exports.exists()
 
 
 def test_final_plan_uses_canonical_checkers_and_one_ordered_site_pipeline(

--- a/tests/docs/test_end_to_end_documentation_gate.py
+++ b/tests/docs/test_end_to_end_documentation_gate.py
@@ -131,6 +131,7 @@ def test_ci_and_deploy_use_the_single_gate_with_different_safety_profiles() -> N
 
 
 def test_deliberately_broken_markdown_link_fails_strict_build(tmp_path: Path) -> None:
+    pytest.importorskip("mkdocs", reason="broken-link mutation runs in the dedicated docs job")
     docs = tmp_path / "docs"
     docs.mkdir()
     (docs / "index.md").write_text("[missing](missing.md)", encoding="utf-8")

--- a/tests/docs/test_end_to_end_documentation_gate.py
+++ b/tests/docs/test_end_to_end_documentation_gate.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import wandas
+from scripts.run_documentation_gate import (
+    NUMERICAL_CONTRACT_TESTS,
+    PREREQUISITE_MARKERS,
+    GateConfigurationError,
+    Stage,
+    build_stages,
+    detect_profile,
+    run_stages,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _install_markers(root: Path, names: set[str]) -> None:
+    for name, markers in PREREQUISITE_MARKERS.items():
+        if name not in names:
+            continue
+        for marker in markers:
+            path = root / marker
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch()
+
+
+def test_profile_is_standalone_without_predecessors(tmp_path: Path) -> None:
+    assert detect_profile(tmp_path) == "standalone"
+
+
+def test_profile_requires_the_complete_canonical_checker_cohort(tmp_path: Path) -> None:
+    one_name = next(iter(PREREQUISITE_MARKERS))
+    _install_markers(tmp_path, {one_name})
+
+    with pytest.raises(GateConfigurationError, match="partial documentation-gate prerequisite cohort"):
+        detect_profile(tmp_path)
+
+    with pytest.raises(GateConfigurationError, match="requires prerequisite checkers"):
+        detect_profile(tmp_path / "empty", require_final=True)
+
+
+def test_profile_rejects_one_marker_from_a_multi_file_checker(tmp_path: Path) -> None:
+    markers = next(markers for markers in PREREQUISITE_MARKERS.values() if len(markers) > 1)
+    marker = tmp_path / markers[0]
+    marker.parent.mkdir(parents=True)
+    marker.touch()
+
+    with pytest.raises(GateConfigurationError, match="partial documentation-gate prerequisite cohort"):
+        detect_profile(tmp_path)
+
+
+def test_profile_is_final_only_when_every_predecessor_is_present(tmp_path: Path) -> None:
+    _install_markers(tmp_path, set(PREREQUISITE_MARKERS))
+
+    assert detect_profile(tmp_path, require_final=True) == "final"
+
+
+def test_final_plan_uses_canonical_checkers_and_one_ordered_site_pipeline() -> None:
+    stages = build_stages(REPO_ROOT, REPO_ROOT / "docs/site", profile="final")
+    names = [stage.name for stage in stages]
+    commands = [" ".join(stage.command) for stage in stages]
+
+    assert names.index("strict MkDocs build") < names.index("execute/export 00_why_wandas.py")
+    assert names.index("execute/export 08_metadata_driven_dataset_search.py") < names.index(
+        "finalize learning application URLs and canonical metadata"
+    )
+    assert names.index("finalize learning application URLs and canonical metadata") < names.index(
+        "crawl completed generated site"
+    )
+    assert sum(name.startswith("execute/export ") for name in names) == 9
+    assert any("scripts/check_public_docstrings.py" in command for command in commands)
+    assert any("scripts/finalize_learning_html.py" in command for command in commands)
+    assert any("scripts/check_docs_site.py" in command for command in commands)
+    assert all(any(test in command for command in commands) for test in NUMERICAL_CONTRACT_TESTS)
+
+
+@pytest.mark.parametrize(
+    "failing_stage",
+    [
+        "broken source/body/generated link",
+        "undefined learning example",
+        "canonical public API drift",
+        "FFT/Welch/IFFT numerical mismatch",
+    ],
+)
+def test_each_consistency_failure_stops_the_gate(failing_stage: str, tmp_path: Path) -> None:
+    executed: list[str] = []
+    stages = (
+        Stage("precondition", ("true",)),
+        Stage(failing_stage, ("deliberate-mutation", failing_stage)),
+        Stage("deployment", ("must-not-run",)),
+    )
+
+    def runner(
+        command: tuple[str, ...],
+        *,
+        cwd: Path,
+        text: bool,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        assert cwd == tmp_path
+        assert text is True
+        assert check is False
+        executed.append(command[0])
+        return subprocess.CompletedProcess(command, 1 if command[0] == "deliberate-mutation" else 0)
+
+    with pytest.raises(RuntimeError, match=failing_stage):
+        run_stages(stages, repo_root=tmp_path, runner=runner)
+
+    assert executed == ["true", "deliberate-mutation"]
+
+
+def test_ci_and_deploy_use_the_single_gate_with_different_safety_profiles() -> None:
+    ci = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    deploy = (REPO_ROOT / ".github/workflows/deploy-docs.yml").read_text(encoding="utf-8")
+    command = "python scripts/run_documentation_gate.py"
+
+    assert ci.count(command) == 1
+    assert deploy.count(command) == 1
+    assert "--require-final --site-only" in deploy
+    assert "mkdocs build" not in deploy
+    assert "marimo export" not in deploy
+    assert deploy.index(command) < deploy.index("uses: peaceiris/actions-gh-pages")
+
+
+def test_deliberately_broken_markdown_link_fails_strict_build(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "index.md").write_text("[missing](missing.md)", encoding="utf-8")
+    config = tmp_path / "mkdocs.yml"
+    config.write_text("site_name: fixture\ndocs_dir: docs\nnav:\n  - Home: index.md\n", encoding="utf-8")
+
+    completed = subprocess.run(
+        [sys.executable, "-m", "mkdocs", "build", "--strict", "-f", str(config)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode != 0
+    assert "missing.md" in completed.stdout + completed.stderr
+
+
+def test_deliberately_undefined_learning_name_fails_marimo_export(tmp_path: Path) -> None:
+    app = tmp_path / "undefined_learning.py"
+    app.write_text(
+        """\
+import marimo
+
+__generated_with = "0.23.9"
+app = marimo.App()
+
+@app.cell
+def _(undefined_learning_name):
+    rendered = undefined_learning_name
+    return (rendered,)
+
+if __name__ == "__main__":
+    app.run()
+""",
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "marimo",
+            "export",
+            "html",
+            str(app),
+            "-o",
+            str(tmp_path / "undefined.html"),
+            "--no-include-code",
+            "-f",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode != 0
+    assert "undefined_learning_name" in completed.stdout + completed.stderr
+
+
+def test_deliberate_public_api_drift_fails_the_inventory_baseline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tests import test_init
+
+    monkeypatch.setattr(wandas, "__all__", [*wandas.__all__, "deliberate_drift"])
+
+    with pytest.raises(AssertionError):
+        test_init.test_top_level_all_is_curated_primary_api()
+
+
+def test_deliberate_fft_numerical_mismatch_fails_reference_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tests.processing.test_spectral_operations import TestFFTOperation
+    from wandas.processing.spectral import FFT
+
+    def wrong_fft(self: FFT, data: np.ndarray) -> np.ndarray:
+        n_fft = self.n_fft or data.shape[-1]
+        return np.zeros((data.shape[0], n_fft // 2 + 1), dtype=np.complex128)
+
+    monkeypatch.setattr(FFT, "_process", wrong_fft)
+
+    with pytest.raises(AssertionError):
+        TestFFTOperation().test_fft_amplitude_matches_numpy_rfft_reference()

--- a/tests/docs/test_end_to_end_documentation_gate.py
+++ b/tests/docs/test_end_to_end_documentation_gate.py
@@ -376,6 +376,13 @@ def test_final_plan_uses_mkdocs_site_url_as_the_single_canonical_origin(
     assert all(command[-1] == "https://docs.example.test/project/" for command in final_commands.values())
 
 
+def test_mkdocs_site_url_matches_the_published_pages_origin() -> None:
+    site_url = mkdocs_site_url(REPO_ROOT)
+
+    assert site_url == "https://kasahart.github.io/wandas/"
+    assert f"[Documentation]({site_url})" in (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+
+
 @pytest.mark.parametrize(
     "config",
     [

--- a/tests/docs/test_end_to_end_documentation_gate.py
+++ b/tests/docs/test_end_to_end_documentation_gate.py
@@ -13,13 +13,16 @@ from scripts.run_documentation_gate import (
     LEARNING_FIXTURES,
     NUMERICAL_CONTRACT_TESTS,
     PREREQUISITE_MARKERS,
+    SOURCE_CONTRACT_TESTS,
     GateConfigurationError,
     Stage,
     build_stages,
     detect_profile,
     learning_apps,
+    mkdocs_site_url,
     prepare_learning_workspace,
     run_stages,
+    validate_mode,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -62,6 +65,16 @@ def test_profile_matrix_classifies_every_complete_checker_subset(
 
         expected = "standalone" if not selected else "final" if len(selected) == len(names) else "integration"
         assert detect_profile(root) == expected
+
+        validate_mode(expected, site_only=False)
+        if expected == "final":
+            validate_mode(expected, site_only=True)
+        else:
+            with pytest.raises(
+                GateConfigurationError,
+                match=f"requires final profile; detected {expected}",
+            ):
+                validate_mode(expected, site_only=True)
 
         if expected == "final":
             assert detect_profile(root, require_final=True) == "final"
@@ -183,7 +196,85 @@ def test_final_plan_uses_canonical_checkers_and_one_ordered_site_pipeline(
     assert any("scripts/check_public_docstrings.py" in command for command in commands)
     assert any("scripts/finalize_learning_html.py" in command for command in commands)
     assert any("scripts/check_docs_site.py" in command for command in commands)
-    assert all(any(test in command for command in commands) for test in NUMERICAL_CONTRACT_TESTS)
+    assert all(any(test in command for command in commands) for test in SOURCE_CONTRACT_TESTS)
+
+
+def test_source_contract_inventory_includes_dependency_metadata() -> None:
+    assert "tests/test_optional_dependencies.py" in SOURCE_CONTRACT_TESTS
+    assert set(NUMERICAL_CONTRACT_TESTS).issubset(SOURCE_CONTRACT_TESTS)
+
+
+def test_final_site_only_plan_retains_every_final_site_checker(
+    tmp_path: Path,
+) -> None:
+    stages = build_stages(
+        REPO_ROOT,
+        tmp_path / "site",
+        profile="final",
+        learning_workspace=tmp_path / "isolated-learning",
+        site_only=True,
+    )
+    commands = [" ".join(stage.command) for stage in stages]
+
+    assert not any("-m pytest" in command for command in commands)
+    assert any("scripts/check_public_docstrings.py" in command for command in commands)
+    assert any("scripts/finalize_learning_html.py" in command for command in commands)
+    assert any("scripts/check_docs_site.py" in command for command in commands)
+
+
+def test_final_plan_uses_mkdocs_site_url_as_the_single_canonical_origin(
+    tmp_path: Path,
+) -> None:
+    learning_root = tmp_path / "learning-path"
+    learning_root.mkdir()
+    for name in LEARNING_APP_NAMES:
+        (learning_root / name).touch()
+    docs_root = tmp_path / "docs"
+    docs_root.mkdir()
+    (docs_root / "mkdocs.yml").write_text(
+        "site_name: fixture\nsite_url: https://docs.example.test/project/\n",
+        encoding="utf-8",
+    )
+
+    stages = build_stages(
+        tmp_path,
+        docs_root / "site",
+        profile="final",
+        learning_workspace=tmp_path.parent / "isolated-learning",
+    )
+    final_commands = {
+        stage.name: stage.command
+        for stage in stages
+        if stage.name
+        in {
+            "finalize learning application URLs and canonical metadata",
+            "crawl completed generated site",
+        }
+    }
+
+    assert mkdocs_site_url(tmp_path) == "https://docs.example.test/project/"
+    assert all(command[-1] == "https://docs.example.test/project/" for command in final_commands.values())
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        "site_name: missing\n",
+        "site_url: https://one.example/\nsite_url: https://two.example/\n",
+        "site_url: /relative/site/\n",
+        "site_url: https://example.test/site/?preview=true\n",
+    ],
+)
+def test_mkdocs_site_url_rejects_missing_ambiguous_or_noncanonical_values(
+    tmp_path: Path,
+    config: str,
+) -> None:
+    docs_root = tmp_path / "docs"
+    docs_root.mkdir()
+    (docs_root / "mkdocs.yml").write_text(config, encoding="utf-8")
+
+    with pytest.raises(GateConfigurationError):
+        mkdocs_site_url(tmp_path)
 
 
 @pytest.mark.parametrize(

--- a/tests/docs/test_end_to_end_documentation_gate.py
+++ b/tests/docs/test_end_to_end_documentation_gate.py
@@ -9,12 +9,16 @@ import pytest
 
 import wandas
 from scripts.run_documentation_gate import (
+    LEARNING_APP_NAMES,
+    LEARNING_FIXTURES,
     NUMERICAL_CONTRACT_TESTS,
     PREREQUISITE_MARKERS,
     GateConfigurationError,
     Stage,
     build_stages,
     detect_profile,
+    learning_apps,
+    prepare_learning_workspace,
     run_stages,
 )
 
@@ -35,15 +39,38 @@ def test_profile_is_standalone_without_predecessors(tmp_path: Path) -> None:
     assert detect_profile(tmp_path) == "standalone"
 
 
-def test_profile_requires_the_complete_canonical_checker_cohort(tmp_path: Path) -> None:
+def test_profile_accepts_complete_predecessors_but_requires_all_for_deploy(
+    tmp_path: Path,
+) -> None:
     one_name = next(iter(PREREQUISITE_MARKERS))
     _install_markers(tmp_path, {one_name})
 
-    with pytest.raises(GateConfigurationError, match="partial documentation-gate prerequisite cohort"):
-        detect_profile(tmp_path)
+    assert detect_profile(tmp_path) == "integration"
 
     with pytest.raises(GateConfigurationError, match="requires prerequisite checkers"):
-        detect_profile(tmp_path / "empty", require_final=True)
+        detect_profile(tmp_path, require_final=True)
+
+
+def test_profile_matrix_classifies_every_complete_checker_subset(
+    tmp_path: Path,
+) -> None:
+    names = tuple(PREREQUISITE_MARKERS)
+    for mask in range(1 << len(names)):
+        root = tmp_path / f"subset-{mask}"
+        selected = {name for index, name in enumerate(names) if mask & (1 << index)}
+        _install_markers(root, selected)
+
+        expected = "standalone" if not selected else "final" if len(selected) == len(names) else "integration"
+        assert detect_profile(root) == expected
+
+        if expected == "final":
+            assert detect_profile(root, require_final=True) == "final"
+        else:
+            with pytest.raises(
+                GateConfigurationError,
+                match="requires prerequisite checkers",
+            ):
+                detect_profile(root, require_final=True)
 
 
 def test_profile_rejects_one_marker_from_a_multi_file_checker(tmp_path: Path) -> None:
@@ -52,7 +79,26 @@ def test_profile_rejects_one_marker_from_a_multi_file_checker(tmp_path: Path) ->
     marker.parent.mkdir(parents=True)
     marker.touch()
 
-    with pytest.raises(GateConfigurationError, match="partial documentation-gate prerequisite cohort"):
+    with pytest.raises(GateConfigurationError, match="partially installed documentation-gate checker"):
+        detect_profile(tmp_path)
+
+
+def test_profile_rejects_partial_checker_among_complete_predecessors(
+    tmp_path: Path,
+) -> None:
+    multi_name, multi_markers = next(
+        (name, markers) for name, markers in PREREQUISITE_MARKERS.items() if len(markers) > 1
+    )
+    complete_name = next(name for name in PREREQUISITE_MARKERS if name != multi_name)
+    _install_markers(tmp_path, {complete_name})
+    marker = tmp_path / multi_markers[0]
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.touch()
+
+    with pytest.raises(
+        GateConfigurationError,
+        match=f"{multi_name}=partial",
+    ):
         detect_profile(tmp_path)
 
 
@@ -62,10 +108,67 @@ def test_profile_is_final_only_when_every_predecessor_is_present(tmp_path: Path)
     assert detect_profile(tmp_path, require_final=True) == "final"
 
 
-def test_final_plan_uses_canonical_checkers_and_one_ordered_site_pipeline() -> None:
-    stages = build_stages(REPO_ROOT, REPO_ROOT / "docs/site", profile="final")
+def test_learning_inventory_rejects_additional_numbered_apps(tmp_path: Path) -> None:
+    learning_root = tmp_path / "learning-path"
+    learning_root.mkdir()
+    for name in LEARNING_APP_NAMES:
+        (learning_root / name).touch()
+    (learning_root / "09_new_topic.py").touch()
+
+    with pytest.raises(GateConfigurationError, match="09_new_topic.py"):
+        learning_apps(tmp_path)
+
+
+def test_learning_workspace_uses_checked_in_fixtures_outside_repository(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    source_root = repo_root / "learning-path"
+    source_root.mkdir(parents=True)
+    for name in LEARNING_FIXTURES:
+        (source_root / name).write_bytes(f"fixture:{name}".encode())
+    workspace = tmp_path / "isolated"
+
+    prepare_learning_workspace(repo_root, workspace)
+
+    assert not workspace.is_relative_to(repo_root)
+    assert {path.name: path.read_bytes() for path in workspace.iterdir()} == {
+        name: f"fixture:{name}".encode() for name in LEARNING_FIXTURES
+    }
+
+
+def test_learning_workspace_rejects_repository_paths_and_stale_content(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    source_root = repo_root / "learning-path"
+    source_root.mkdir(parents=True)
+    for name in LEARNING_FIXTURES:
+        (source_root / name).write_bytes(b"fixture")
+
+    with pytest.raises(GateConfigurationError, match="outside the repository"):
+        prepare_learning_workspace(repo_root, repo_root / "generated")
+
+    stale_workspace = tmp_path / "stale"
+    stale_workspace.mkdir()
+    (stale_workspace / "output").mkdir()
+    with pytest.raises(GateConfigurationError, match="must start empty"):
+        prepare_learning_workspace(repo_root, stale_workspace)
+
+
+def test_final_plan_uses_canonical_checkers_and_one_ordered_site_pipeline(
+    tmp_path: Path,
+) -> None:
+    learning_workspace = tmp_path / "isolated-learning"
+    stages = build_stages(
+        REPO_ROOT,
+        tmp_path / "site",
+        profile="final",
+        learning_workspace=learning_workspace,
+    )
     names = [stage.name for stage in stages]
     commands = [" ".join(stage.command) for stage in stages]
+    export_stages = [stage for stage in stages if stage.name.startswith("execute/export ")]
 
     assert names.index("strict MkDocs build") < names.index("execute/export 00_why_wandas.py")
     assert names.index("execute/export 08_metadata_driven_dataset_search.py") < names.index(
@@ -75,6 +178,8 @@ def test_final_plan_uses_canonical_checkers_and_one_ordered_site_pipeline() -> N
         "crawl completed generated site"
     )
     assert sum(name.startswith("execute/export ") for name in names) == 9
+    assert all(stage.cwd == learning_workspace for stage in export_stages)
+    assert all(str(REPO_ROOT / "learning-path") in " ".join(stage.command) for stage in export_stages)
     assert any("scripts/check_public_docstrings.py" in command for command in commands)
     assert any("scripts/finalize_learning_html.py" in command for command in commands)
     assert any("scripts/check_docs_site.py" in command for command in commands)
@@ -124,10 +229,35 @@ def test_ci_and_deploy_use_the_single_gate_with_different_safety_profiles() -> N
 
     assert ci.count(command) == 1
     assert deploy.count(command) == 1
-    assert "--require-final --site-only" in deploy
+    assert "--require-final" in deploy
+    assert "--site-only" not in deploy
+    assert "--group docs --group test" in deploy
     assert "mkdocs build" not in deploy
     assert "marimo export" not in deploy
     assert deploy.index(command) < deploy.index("uses: peaceiris/actions-gh-pages")
+
+
+def test_stage_specific_working_directory_is_respected(tmp_path: Path) -> None:
+    isolated = tmp_path / "isolated"
+    seen: list[Path] = []
+
+    def runner(
+        command: tuple[str, ...],
+        *,
+        cwd: Path,
+        text: bool,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        seen.append(cwd)
+        return subprocess.CompletedProcess(command, 0)
+
+    run_stages(
+        (Stage("isolated learning export", ("true",), cwd=isolated),),
+        repo_root=tmp_path,
+        runner=runner,
+    )
+
+    assert seen == [isolated]
 
 
 def test_deliberately_broken_markdown_link_fails_strict_build(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #375

## Summary

- Add one fail-fast documentation orchestrator for source/API/numerical/package-metadata contracts, all numbered learning apps, strict MkDocs, and final-profile docstring/generated-site validation.
- Execute all nine learning apps from an empty temporary workspace outside the repository, using checked-in fixtures and absolute app paths. This removes external HTTP dependence and checkout side effects.
- Discover every numbered `learning-path/*.py` and compare it with the exact 00–08 inventory, so an added app such as `09_new_topic.py` cannot be silently omitted.
- Make Pages deployment install docs and test dependencies and run the full `--require-final` gate before publishing.
- Use `docs/mkdocs.yml` as the single canonical `site_url` authority for MkDocs, learning-page finalization, and completed-site crawling.
- Add a permanent `.github/documentation-gate-finalized` ledger: #390 may use the integration profile while its base lacks the ledger; after it merges, PR-base and main-push policy irreversibly require the complete final cohort and retention of the ledger.
- Validate that the site destination is under `docs` and disjoint from `docs/src` before deleting stale learning exports.

## Prerequisites and recommended merge order

This is the closing cross-cutting gate. Its required prerequisite set is #385, #387, #388, and #389. PR #386 is independent of this final gate, but should merge before #388 so the remaining conflict resolution stays linear.

Recommended aggregate order:

1. #387 — merge first; its reviewed head is pairwise clean with every remaining PR
2. #389 — merge next
3. #385 — merge after #389
4. #386 — independent of this final gate; rebase onto latest `main` and resolve the #385 public-API-stability and #389 overlap before merging
5. #388 — rebase onto latest `main`, resolve the #385 workflow/docs overlap while retaining both contracts, then merge; #389 and #388 are pairwise clean
6. #390 — rebase onto all predecessors, resolve the #388 workflow/MkDocs overlap, and rerun the complete final-profile GitHub CI before merge

Normal CI permits each fully installed predecessor group only before the finalization ledger exists in the PR base. A partially installed multi-file group always fails. After #390 merges, PR CI consults the base SHA and current `HEAD`, while main-push CI consults current `HEAD`; all require the ledger and complete #365/#373/#369/#372/#367 cohort, so deleting the ledger or a whole checker group cannot downgrade back to integration. Deployment independently requires both the ledger and `--require-final`; `--site-only` is also rejected outside final.

## Major files

- `scripts/run_documentation_gate.py`
- `tests/docs/test_end_to_end_documentation_gate.py`
- `.github/workflows/ci.yml`
- `.github/workflows/deploy-docs.yml`
- `.github/documentation-gate-finalized`
- `docs/src/contributing/documentation-consistency-gates.md`
- `docs/mkdocs.yml`

## Tests added or updated

- all 32 checker subsets across normal and `--site-only` modes
- pre-final PR, closing PR, post-final checker/sentinel deletion, deployment, and main-push state transitions
- missing sentinel/base SHA and unsupported CI-event failures
- partial multi-file checker rejection, including complete-plus-partial collision
- exact numbered app inventory and `09_*.py` rejection
- guarded repository-external fixture workspace, absolute app paths, and stage `cwd`
- source inventory including optional-dependency metadata and numerical suites
- MkDocs `site_url` mutation propagation and invalid-value mutations
- safe site-destination cleanup plus rejected `docs`, `docs/src`, and `docs/src/generated` mutations that preserve stale files
- ordered contract test, build, export, finalize, crawl, and publish barriers
- fail-fast mutations for links, learning names, public API drift, and FFT results
- cross-platform workflow path assertion using the POSIX path serialized in YAML

## Validation

Current head `4d181f57`:

- `uv run pytest -q tests/docs/test_end_to_end_documentation_gate.py` — 44 passed
- current-base CI policy (`GITHUB_EVENT_NAME=pull_request`, base `14aa4e80`, `--ci-policy`) — intentionally rejected: the sentinel-bearing closing PR requires missing #373/#369/#372/#367 prerequisites
  - documentation/API/numerical/package-metadata contracts: 333 passed
  - all 9 apps: strict check and execute/export passed
  - strict MkDocs build passed
  - repository-root learning side effects: none
- finalized-base/current-head, finalized deployment, and finalized main-push sentinel-removal mutations — correctly rejected
- source-overlapping site destination mutations — correctly rejected before deletion
- `uv run pytest -q` — 2889 passed, 3 skipped, 33 known warnings
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run ty check` — passed
- workflow YAML parsing — passed
- `git diff --check` — passed
- GitHub Actions are expected to keep the documentation job blocked on current `main`; final green CI must be rerun after the prerequisite merge/rebase sequence below

## Codex review responses

- Isolated learning execution from the checkout and external HTTP with checked-in fixtures and guarded temporary `cwd` values.
- Enumerated all numbered apps before exact inventory comparison.
- Replaced deployment's source-skipping path with the full contract barrier.
- Added optional-dependency metadata tests to the publication inventory.
- Removed the hard-coded canonical URL in favor of MkDocs `site_url`.
- Restricted `--site-only` to final and covered the cohort/mode matrix.
- Closed the post-final integration-downgrade hole with the durable base/current-SHA finalization ledger and state-transition tests.
- Fixed the sole Windows CI regression by comparing the sentinel path in the POSIX form used by workflow YAML.
- Required finalized PR heads and deployment worktrees to retain the sentinel.
- Rejected source-overlapping site destinations before any stale-export deletion.
- Corrected MkDocs’ single canonical authority to the deployed `https://kasahart.github.io/wandas/` Pages origin and bound it to the README production link.
- Made a sentinel in either the PR base or current head require the complete final cohort; a premature closing PR now fails before merge instead of breaking main after merge.
- Required the Git sentinel object itself to be a blob; real Git fixtures reject tree and gitlink objects, and deployment rejects a worktree directory.
- Replied to and resolved all twelve external Codex threads. Fresh external Codex review of exact head `4d181f57b3` reported no major issues.

## Risks and manual checks

- This PR must remain last. Its required prerequisites are #385, #387, #388, and #389; #386 is independent of the final gate but should merge before #388. Follow `#387 → #389 → #385 → #386 → #388 → #390`, rebase this branch onto all predecessors, resolve the #388 workflow/MkDocs overlap, and rerun the complete final-profile GitHub CI before merge. Its current documentation-job failure is the intended dependency block, and the ledger intentionally makes incomplete future PRs and main pushes fail.
- Existing CJK font and non-interactive Matplotlib warnings remain; no learning check or export failed.
- Browser-only widget interaction, prose translation quality, and visual teaching clarity remain change-triggered manual checks. External HTTP is deliberately excluded from CI.
- The scalability benchmark was not run because this PR changes no Frame materialization, Dask graph, RecipePlan, `AudioOperation.process`, numerical kernel, or dependency scalability behavior.
