### PR TITLE
docs: standardize docstrings on Google style

### DIFF
--- a/learning-path/01_getting_started.py
+++ b/learning-path/01_getting_started.py
@@ -350,32 +350,25 @@ def _(wd):
         指定されたパラメータで正弦波信号を生成し、ローパスフィルタを適用して
         元の信号とフィルタ済み信号を比較できるようにします。
 
-        Parameters
-        ----------
-        frequency : float, default=440
-            基本周波数 [Hz]。この周波数とその2倍の周波数（倍音）で
-            信号を生成します。A4音（440Hz）がデフォルトです。
-        duration : float, default=1.0
-            信号の長さ [秒]。生成される信号の時間長を指定します。
-        filter_cutoff : float, default=500
-            ローパスフィルタのカットオフ周波数 [Hz]。
-            この周波数以上の成分が減衰されます。
+        Args:
+            frequency: float, default=440. 基本周波数 [Hz]。この周波数とその2倍の周波数（倍音）で
+                信号を生成します。A4音（440Hz）がデフォルトです。
+            duration: float, default=1.0. 信号の長さ [秒]。生成される信号の時間長を指定します。
+            filter_cutoff: float, default=500. ローパスフィルタのカットオフ周波数 [Hz]。
+                この周波数以上の成分が減衰されます。
 
-        Returns
-        -------
-        ChannelFrame
-            元の信号とフィルタ済み信号が結合されたChannelFrame。
-            チャンネル名は元の信号が "signal"、フィルタ済みが "filtered_signal" となります。
+        Returns:
+            ChannelFrame: 元の信号とフィルタ済み信号が結合されたChannelFrame。
+                チャンネル名は元の信号が "signal"、フィルタ済みが "filtered_signal" となります。
 
-        Examples
-        --------
-        >>> # デフォルトパラメータで実行
-        >>> result = experiment_with_signal()
-        >>> result.fft().plot(overlay=True)
+        Examples:
+            >>> # デフォルトパラメータで実行
+            >>> result = experiment_with_signal()
+            >>> result.fft().plot(overlay=True)
 
-        >>> # パラメータを変更して実験
-        >>> result = experiment_with_signal(frequency=880, filter_cutoff=1500)
-        >>> result.fft().plot(overlay=True)
+            >>> # パラメータを変更して実験
+            >>> result = experiment_with_signal(frequency=880, filter_cutoff=1500)
+            >>> result.fft().plot(overlay=True)
         """
 
         # 信号生成 - 指定された周波数で基本音と倍音を作成

--- a/learning-path/05_custom_functions.py
+++ b/learning-path/05_custom_functions.py
@@ -390,14 +390,10 @@ def _(demo_signal, np, plt, sampling_rate):
         """
         周波数依存のゲインを適用
 
-        Parameters
-        ----------
-        x : ndarray
-            入力信号
-        sr : float
-            サンプリングレート（Wandasから自動取得不可のため明示的に渡す）
-        gain_curve : callable
-            周波数を受け取りゲインを返す関数
+        Args:
+            x: ndarray. 入力信号
+            sr: float. サンプリングレート（Wandasから自動取得不可のため明示的に渡す）
+            gain_curve: callable. 周波数を受け取りゲインを返す関数
         """
         result = np.zeros_like(x, dtype=complex)
         spectrum = np.fft.rfft(x, axis=1)
@@ -512,19 +508,13 @@ def _(mo):
         \"\"\"
         カスタムフィルタを適用
 
-        Parameters
-        ----------
-        x : ndarray, shape (channels, samples)
-            入力信号
-        cutoff : float
-            カットオフ周波数 [Hz]
-        order : int
-            フィルタ次数
+        Args:
+            x: ndarray, shape (channels, samples). 入力信号
+            cutoff: float. カットオフ周波数 [Hz]
+            order: int. フィルタ次数
 
-        Returns
-        -------
-        ndarray
-            フィルタ適用後の信号
+        Returns:
+            ndarray: フィルタ適用後の信号
         \"\"\"
         # 実装...
     ```

--- a/wandas/__init__.py
+++ b/wandas/__init__.py
@@ -91,17 +91,12 @@ def setup_wandas_logging(level: str | int = "INFO", add_handler: bool = True) ->
     """
     Utility function to set up logging for the wandas library.
 
-    Parameters
-    ----------
-    level : str or int
-        Logging level ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL')
-    add_handler : bool
-        If True, adds a console handler for output
+    Args:
+        level: str or int. Logging level ('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL')
+        add_handler: bool. If True, adds a console handler for output
 
-    Returns
-    -------
-    logging.Logger
-        Configured logger instance
+    Returns:
+        logging.Logger: Configured logger instance
     """
     if isinstance(level, str):
         level_map = {

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -1335,7 +1335,9 @@ class BaseFrame(ABC, Generic[T]):
         - Multidimensional indexing: `frame[0, 100:200]` (channel + axis slice)
 
         Args:
-            key: int, str, slice, list, tuple, or ndarray. - int: Single channel index (supports negative indexing)
+            key: int, str, slice, list, tuple, or ndarray. Channel selector and
+                optional semantic-axis slices. Supported forms:
+                - int: Single channel index (supports negative indexing)
                 - str: Single channel label
                 - slice: Range of channels
                 - list[int]: Multiple channel indices

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -402,45 +402,32 @@ class BaseFrame(ABC, Generic[T]):
     used in signal processing. It implements basic operations like indexing, iteration,
     and data manipulation that are shared across all frame types.
 
-    Parameters
-    ----------
-    data : DaArray
-        The signal data to process. Must be a dask array.
-    sampling_rate : float
-        The sampling rate of the signal in Hz.
-    label : str, optional
-        A label for the frame. If not provided, defaults to "unnamed_frame".
-    metadata : dict, optional
-        Additional metadata for the frame.
-    lineage : LineageNode, optional
-        Constructor override for the initial runtime lineage. When omitted, the
-        constructor creates a source node; every constructed frame therefore has
-        exactly one lineage authority. ``operation_history`` is its public JSON-safe
-        projection.
-    channel_metadata : list[ChannelMetadata | dict], optional
-        Metadata for each channel in the frame. Can be ChannelMetadata objects
-        or dicts that will be converted to ChannelMetadata objects.
-    previous : BaseFrame, optional
-        Immediate receiver frame used for runtime data comparison in notebooks.
-        For binary or multi-input operations, this strong reference follows only
-        the left/base receiver. Use ``lineage`` for complete Frame-input
-        provenance and ``RecipePlan`` for reusable execution intent and external
-        input slots. Concrete external arrays are supplied again at replay. This
-        process-local reference is not persisted in WDF.
+    Args:
+        data: DaArray. The signal data to process. Must be a dask array.
+        sampling_rate: float. The sampling rate of the signal in Hz.
+        label: str, optional. A label for the frame. If not provided, defaults to "unnamed_frame".
+        metadata: dict, optional. Additional metadata for the frame.
+        lineage: LineageNode, optional. Constructor override for the initial runtime lineage. When omitted, the
+            constructor creates a source node; every constructed frame therefore has
+            exactly one lineage authority. ``operation_history`` is its public JSON-safe
+            projection.
+        channel_metadata: list[ChannelMetadata | dict], optional. Metadata for each channel in the
+            frame. Can be ChannelMetadata objects
+            or dicts that will be converted to ChannelMetadata objects.
+        previous: BaseFrame, optional. Immediate receiver frame used for runtime data comparison in notebooks.
+            For binary or multi-input operations, this strong reference follows only
+            the left/base receiver. Use ``lineage`` for complete Frame-input
+            provenance and ``RecipePlan`` for reusable execution intent and external
+            input slots. Concrete external arrays are supplied again at replay. This
+            process-local reference is not persisted in WDF.
 
-    Attributes
-    ----------
-    sampling_rate : float
-        The sampling rate of the signal in Hz.
-    label : str
-        The label of the frame.
-    metadata : dict
-        Additional metadata for the frame.
-    lineage : LineageNode
-        Runtime computation lineage. This is always set during construction and
-        propagated through ``_create_new_instance``.
-    operation_history : list[dict]
-        Flat read-only compatibility view derived from ``lineage``.
+    Attributes:
+        sampling_rate: float. The sampling rate of the signal in Hz.
+        label: str. The label of the frame.
+        metadata: dict. Additional metadata for the frame.
+        lineage: LineageNode. Runtime computation lineage. This is always set during construction and
+            propagated through ``_create_new_instance``.
+        operation_history: list[dict]. Flat read-only compatibility view derived from ``lineage``.
     """
 
     _CHANNEL_DIM: ClassVar[str] = "channel"
@@ -1267,34 +1254,30 @@ class BaseFrame(ABC, Generic[T]):
         """
         Get channel(s) by index.
 
-        Parameters
-        ----------
-        channel_idx : int or sequence of int
-            Single channel index or sequence of channel indices.
-            Supports negative indices (e.g., -1 for the last channel).
-        query : str, re.Pattern, callable, or dict, optional
-            If a query is provided, use it to derive indices and ignore the positional channel_idx argument.
-            Query to select channels based on metadata. Supported types:
-            - str: exact label match
-            - re.Pattern: regex search against label
-            - callable(ChannelMetadata) -> bool: predicate on channel metadata
-            - dict: attribute equality on ChannelMetadata (values may be re.Pattern)
-        validate_query_keys : bool, default True
-            If True (default), dict queries that contain unknown keys (neither
-            model fields nor any channel `extra` keys) will raise `KeyError`.
-            Set to False to disable this strict validation and allow callers
-            to attempt matches without pre-validation.
-        Returns
-        -------
-        S
-            New instance containing the selected channel(s).
+        Args:
+            channel_idx: int or sequence of int. Single channel index or sequence of
+                channel indices.
+                Supports negative indices (e.g., -1 for the last channel).
+            query: str, re.Pattern, callable, or dict, optional. If a query is
+                provided, use it to derive indices and ignore the positional
+                channel_idx argument.
+                Query to select channels based on metadata. Supported types:
+                - str: exact label match
+                - re.Pattern: regex search against label
+                - callable(ChannelMetadata) -> bool: predicate on channel metadata
+                - dict: attribute equality on ChannelMetadata (values may be re.Pattern)
+            validate_query_keys: bool, default True. If True (default), dict queries that contain unknown keys (neither
+                model fields nor any channel `extra` keys) will raise `KeyError`.
+                Set to False to disable this strict validation and allow callers
+                to attempt matches without pre-validation.
+        Returns:
+            S: New instance containing the selected channel(s).
 
-        Examples
-        --------
-        >>> frame.get_channel(0)  # Single channel
-        >>> frame.get_channel([0, 2, 3])  # Multiple channels
-        >>> frame.get_channel((-1, -2))  # Last two channels
-        >>> frame.get_channel(np.array([1, 2]))  # NumPy array of indices
+        Examples:
+            >>> frame.get_channel(0)  # Single channel
+            >>> frame.get_channel([0, 2, 3])  # Multiple channels
+            >>> frame.get_channel((-1, -2))  # Last two channels
+            >>> frame.get_channel(np.array([1, 2]))  # NumPy array of indices
         """
 
         if query is not None:
@@ -1351,57 +1334,47 @@ class BaseFrame(ABC, Generic[T]):
         - Boolean mask: `frame[mask]` where mask is a boolean array
         - Multidimensional indexing: `frame[0, 100:200]` (channel + axis slice)
 
-        Parameters
-        ----------
-        key : int, str, slice, list, tuple, or ndarray
-            - int: Single channel index (supports negative indexing)
-            - str: Single channel label
-            - slice: Range of channels
-            - list[int]: Multiple channel indices
-            - list[str]: Multiple channel labels
-            - tuple: A channel selector followed by slices for semantic axes such
-              as frequency or time
-            - ndarray[int]: NumPy array of channel indices
-            - ndarray[bool]: Boolean mask for channel selection
+        Args:
+            key: int, str, slice, list, tuple, or ndarray. - int: Single channel index (supports negative indexing)
+                - str: Single channel label
+                - slice: Range of channels
+                - list[int]: Multiple channel indices
+                - list[str]: Multiple channel labels
+                - tuple: A channel selector followed by slices for semantic axes such
+                as frequency or time
+                - ndarray[int]: NumPy array of channel indices
+                - ndarray[bool]: Boolean mask for channel selection
 
-        Returns
-        -------
-        S
-            New instance containing the selected channel(s).
+        Returns:
+            S: New instance containing the selected channel(s).
 
-        Raises
-        ------
-        ValueError
-            If the key length is invalid for the shape, a non-channel selector
-            is not a slice, a time slice is stepped or reversed, or a boolean mask
-            length doesn't match the channels.
-        IndexError
-            If the channel index is out of range.
-        TypeError
-            If the key type is invalid or list contains mixed types.
-        KeyError
-            If a channel label is not found.
+        Raises:
+            ValueError: If the key length is invalid for the shape, a non-channel selector
+                is not a slice, a time slice is stepped or reversed, or a boolean mask
+                length doesn't match the channels.
+            IndexError: If the channel index is out of range.
+            TypeError: If the key type is invalid or list contains mixed types.
+            KeyError: If a channel label is not found.
 
-        Examples
-        --------
-        >>> # Single channel selection
-        >>> frame[0]  # First channel
-        >>> frame["acc_x"]  # By label
-        >>> frame[-1]  # Last channel
-        >>>
-        >>> # Multiple channel selection
-        >>> frame[[0, 2, 5]]  # Multiple indices
-        >>> frame[["acc_x", "acc_z"]]  # Multiple labels
-        >>> frame[0:3]  # Slice
-        >>>
-        >>> # NumPy array indexing
-        >>> frame[np.array([0, 2, 4])]  # Integer array
-        >>> mask = np.array([True, False, True])
-        >>> frame[mask]  # Boolean mask
-        >>>
-        >>> # Time slicing (multidimensional)
-        >>> frame[0, 100:200]  # Channel 0, samples 100-200
-        >>> frame[[0, 1], 100:200]  # Channels 0-1, continuous sample slice
+        Examples:
+            >>> # Single channel selection
+            >>> frame[0]  # First channel
+            >>> frame["acc_x"]  # By label
+            >>> frame[-1]  # Last channel
+            >>>
+            >>> # Multiple channel selection
+            >>> frame[[0, 2, 5]]  # Multiple indices
+            >>> frame[["acc_x", "acc_z"]]  # Multiple labels
+            >>> frame[0:3]  # Slice
+            >>>
+            >>> # NumPy array indexing
+            >>> frame[np.array([0, 2, 4])]  # Integer array
+            >>> mask = np.array([True, False, True])
+            >>> frame[mask]  # Boolean mask
+            >>>
+            >>> # Time slicing (multidimensional)
+            >>> frame[0, 100:200]  # Channel 0, samples 100-200
+            >>> frame[[0, 1], 100:200]  # Channels 0-1, continuous sample slice
         """
         if isinstance(key, tuple) and len(key) == 1:
             key = key[0]
@@ -1413,22 +1386,16 @@ class BaseFrame(ABC, Generic[T]):
     def _handle_multidim_indexing(self: S, key: tuple[Any, ...]) -> S:
         """Handle rank-preserving channel and non-channel axis selection.
 
-        Parameters
-        ----------
-        key : tuple
-            The first element selects channels. Each remaining element must be a
-            slice along the corresponding semantic axis, such as frequency or time.
+        Args:
+            key: tuple. The first element selects channels. Each remaining element must be a
+                slice along the corresponding semantic axis, such as frequency or time.
 
-        Returns
-        -------
-        S
-            New instance with the selected channels and axis ranges.
+        Returns:
+            S: New instance with the selected channels and axis ranges.
 
-        Raises
-        ------
-        ValueError
-            If the key length exceeds the data dimensions, a non-channel selector
-            is not a slice, or a time-axis slice is stepped or reversed.
+        Raises:
+            ValueError: If the key length exceeds the data dimensions, a non-channel selector
+                is not a slice, or a time-axis slice is stepped or reversed.
         """
         if len(key) > self._data.ndim:
             raise ValueError(f"Invalid key length: {len(key)} for shape {self.shape}")
@@ -1498,20 +1465,14 @@ class BaseFrame(ABC, Generic[T]):
         """
         Get the index from a channel label.
 
-        Parameters
-        ----------
-        label : str
-            Channel label.
+        Args:
+            label: str. Channel label.
 
-        Returns
-        -------
-        int
-            Corresponding index.
+        Returns:
+            int: Corresponding index.
 
-        Raises
-        ------
-        KeyError
-            If the channel label is not found.
+        Raises:
+            KeyError: If the channel label is not found.
         """
         for idx, ch in enumerate(self.channels):
             if ch.label == label:
@@ -1550,15 +1511,11 @@ class BaseFrame(ABC, Generic[T]):
         This private materialization boundary is for internal code that requires
         the channel-first representation, including its singleton channel axis.
 
-        Returns
-        -------
-        NDArrayReal
-            The computed data.
+        Returns:
+            NDArrayReal: The computed data.
 
-        Raises
-        ------
-        ValueError
-            If the computed result is not a NumPy array.
+        Raises:
+            ValueError: If the computed result is not a NumPy array.
         """
         logger.debug("COMPUTING DASK ARRAY - This will trigger file reading and all processing")
         result = self._effective_data.compute()
@@ -1741,43 +1698,36 @@ class BaseFrame(ABC, Generic[T]):
         that can be displayed inline. In other environments, it saves the graph to
         a file and returns None.
 
-        Parameters
-        ----------
-        filename : str, optional
-            Output filename for the graph image. If None, a unique filename
-            is generated using UUID. The file is saved in the current working
-            directory.
+        Args:
+            filename: str, optional. Output filename for the graph image. If None, a unique filename
+                is generated using UUID. The file is saved in the current working
+                directory.
 
-        Returns
-        -------
-        IPython.display.Image or None
-            In interactive Python environments: Returns an IPython.display.Image object
-            that can be displayed inline.
-            In other environments: Returns None after saving the graph to file.
+        Returns:
+            IPython.display.Image or None: In interactive Python environments: Returns an IPython.display.Image object
+                that can be displayed inline.
+                In other environments: Returns None after saving the graph to file.
 
-        Notes
-        -----
-        This method requires graphviz to be installed on your system:
-        - Ubuntu/Debian: `sudo apt-get install graphviz`
-        - macOS: `brew install graphviz`
-        - Windows: Download from https://graphviz.org/download/
+        Notes:
+            This method requires graphviz to be installed on your system:
+            - Ubuntu/Debian: `sudo apt-get install graphviz`
+            - macOS: `brew install graphviz`
+            - Windows: Download from https://graphviz.org/download/
 
-        The graph displays operation names (e.g., 'normalize', 'lowpass_filter')
-        making it easier to understand the processing pipeline.
+            The graph displays operation names (e.g., 'normalize', 'lowpass_filter')
+            making it easier to understand the processing pipeline.
 
-        Examples
-        --------
-        >>> import wandas as wd
-        >>> signal = wd.read("audio.wav")
-        >>> processed = signal.normalize().low_pass_filter(cutoff=1000)
-        >>> # In interactive environments: displays graph inline
-        >>> processed.visualize_graph()
-        >>> # Save to specific file
-        >>> processed.visualize_graph("my_graph.png")
+        Examples:
+            >>> import wandas as wd
+            >>> signal = wd.read("audio.wav")
+            >>> processed = signal.normalize().low_pass_filter(cutoff=1000)
+            >>> # In interactive environments: displays graph inline
+            >>> processed.visualize_graph()
+            >>> # Save to specific file
+            >>> processed.visualize_graph("my_graph.png")
 
-        See Also
-        --------
-        debug_info : Print detailed debug information about the frame
+        See Also:
+            debug_info : Print detailed debug information about the frame
         """
         try:
             filename = filename or f"graph_{uuid.uuid4().hex[:8]}.png"
@@ -2098,28 +2048,22 @@ class BaseFrame(ABC, Generic[T]):
         entry-point used by ``ChannelProcessingMixin`` and by
         ``ChannelFrame._apply_operation_impl``.
 
-        Parameters
-        ----------
-        operation : AudioOperation
-            Instantiated operation to apply.
-        operation_name : str, optional
-            Numerical operation name used for metadata and display handling. The
-            enclosing ``@recipe_operation`` declaration owns the history operation ID.
-        output_frame_class : type, optional
-            If provided, the result is wrapped in this frame class instead
-            of the same type as ``self``.  Enables domain transitions
-            (e.g. ChannelFrame -> SpectralFrame) from ``apply()``.
-        output_frame_kwargs : dict, optional
-            Extra constructor keyword arguments required by *output_frame_class*
-            (e.g. ``{"n_fft": 1024, "window": "hann"}``).
-        frame_metadata_updates : Mapping, optional
-            Explicit Frame-owned state updates supplied by the public method.
-            These take precedence over updates declared by the numerical operation.
-        process_data : dask.array.Array, optional
-            Internal lazy input override. By default, operations receive calibrated
-            effective data. Operation-specific adapters may pass another
-            channel-aligned lazy array when calibration is represented separately
-            by the operation's numerical contract.
+        Args:
+            operation: AudioOperation. Instantiated operation to apply.
+            operation_name: str, optional. Numerical operation name used for metadata and display handling. The
+                enclosing ``@recipe_operation`` declaration owns the history operation ID.
+            output_frame_class: type, optional. If provided, the result is wrapped in this frame class instead
+                of the same type as ``self``.  Enables domain transitions
+                (e.g. ChannelFrame -> SpectralFrame) from ``apply()``.
+            output_frame_kwargs: dict, optional. Extra constructor keyword arguments required by *output_frame_class*
+                (e.g. ``{"n_fft": 1024, "window": "hann"}``).
+            frame_metadata_updates: Mapping, optional. Explicit Frame-owned state updates supplied by the public method.
+                These take precedence over updates declared by the numerical operation.
+            process_data: dask.array.Array, optional. Internal lazy input override.
+                By default, operations receive calibrated effective data.
+                Operation-specific adapters may pass another
+                channel-aligned lazy array when calibration is represented separately
+                by the operation's numerical contract.
         """
         if operation_name is None:
             operation_name = getattr(operation, "name", "unknown_operation")
@@ -2213,30 +2157,23 @@ class BaseFrame(ABC, Generic[T]):
         the operation name, making it easier to track processing history
         and distinguish frames in plots.
 
-        Parameters
-        ----------
-        operation_name : str
-            Name of the operation (e.g., "normalize", "lowpass_filter")
-        display_name : str, optional
-            Display name for the operation. If None, uses operation_name.
-            This allows operations to provide custom, more readable labels.
+        Args:
+            operation_name: str. Name of the operation (e.g., "normalize", "lowpass_filter")
+            display_name: str, optional. Display name for the operation. If None, uses operation_name.
+                This allows operations to provide custom, more readable labels.
 
-        Returns
-        -------
-        list[ChannelMetadata]
-            New channel metadata with updated labels.
-            Original metadata is deep-copied and only labels are modified.
+        Returns:
+            list[ChannelMetadata]: New channel metadata with updated labels.
+                Original metadata is deep-copied and only labels are modified.
 
-        Examples
-        --------
-        >>> # Original label: "ch0"
-        >>> # After normalize: "normalize(ch0)"
-        >>> # After chained ops: "lowpass_filter(normalize(ch0))"
+        Examples:
+            >>> # Original label: "ch0"
+            >>> # After normalize: "normalize(ch0)"
+            >>> # After chained ops: "lowpass_filter(normalize(ch0))"
 
-        Notes
-        -----
-        Labels are nested for chained operations, allowing full
-        traceability of the processing pipeline.
+        Notes:
+            Labels are nested for chained operations, allowing full
+            traceability of the processing pipeline.
         """
         display = display_name or operation_name
         new_metadata = []
@@ -2293,16 +2230,13 @@ class BaseFrame(ABC, Generic[T]):
 
         This method is equivalent to accessing :attr:`data`.
 
-        Returns
-        -------
-        T
-            NumPy array containing the frame data.
+        Returns:
+            T: NumPy array containing the frame data.
 
-        Examples
-        --------
-        >>> cf = wd.read("audio.wav")
-        >>> data = cf.to_numpy()
-        >>> print(f"Shape: {data.shape}")  # (n_channels, n_samples)
+        Examples:
+            >>> cf = wd.read("audio.wav")
+            >>> data = cf.to_numpy()
+            >>> print(f"Shape: {data.shape}")  # (n_channels, n_samples)
         """
         return self.data
 
@@ -2310,37 +2244,27 @@ class BaseFrame(ABC, Generic[T]):
         """
         Convert the Dask array to a tensor in the specified framework.
 
-        Parameters
-        ----------
-        framework : str, default="torch"
-            The ML framework to use ("torch" or "tensorflow").
-        device : str or None, optional
-            Device to place the tensor on. For PyTorch, use "cpu", "cuda", "cuda:0",
-            etc. For TensorFlow, use "/CPU:0", "/GPU:0", etc. If None, uses the default
-            device.
+        Args:
+            framework: str, default="torch". The ML framework to use ("torch" or "tensorflow").
+            device: str or None, optional. Device to place the tensor on. For PyTorch, use "cpu", "cuda", "cuda:0",
+                etc. For TensorFlow, use "/CPU:0", "/GPU:0", etc. If None, uses the default
+                device.
 
-        Returns
-        -------
-        torch.Tensor or tf.Tensor
-            A tensor in the specified framework.
+        Returns:
+            torch.Tensor or tf.Tensor: A tensor in the specified framework.
 
-        Raises
-        ------
-        ImportError
-            If the specified framework is not installed.
-        ValueError
-            If the framework is not supported.
-        TypeError
-            If self.data is not a Dask array.
+        Raises:
+            ImportError: If the specified framework is not installed.
+            ValueError: If the framework is not supported.
+            TypeError: If self.data is not a Dask array.
 
-        Examples
-        --------
-        >>> # PyTorch tensor on CPU
-        >>> tensor = frame.to_tensor(framework="torch", device="cpu")
-        >>> # PyTorch tensor on GPU
-        >>> tensor = frame.to_tensor(framework="torch", device="cuda:0")
-        >>> # TensorFlow tensor on GPU
-        >>> tensor = frame.to_tensor(framework="tensorflow", device="/GPU:0")
+        Examples:
+            >>> # PyTorch tensor on CPU
+            >>> tensor = frame.to_tensor(framework="torch", device="cpu")
+            >>> # PyTorch tensor on GPU
+            >>> tensor = frame.to_tensor(framework="torch", device="cuda:0")
+            >>> # TensorFlow tensor on GPU
+            >>> tensor = frame.to_tensor(framework="tensorflow", device="/GPU:0")
         """
 
         if framework == "torch":
@@ -2386,16 +2310,13 @@ class BaseFrame(ABC, Generic[T]):
         This method provides a common implementation for converting frame data
         to pandas DataFrame. Subclasses can override this method for custom behavior.
 
-        Returns
-        -------
-        pd.DataFrame
-            DataFrame with appropriate index and columns.
+        Returns:
+            pd.DataFrame: DataFrame with appropriate index and columns.
 
-        Examples
-        --------
-        >>> cf = wd.read("audio.wav")
-        >>> df = cf.to_dataframe()
-        >>> print(df.head())
+        Examples:
+            >>> cf = wd.read("audio.wav")
+            >>> df = cf.to_dataframe()
+            >>> print(df.head())
         """
         pd = require_pandas("BaseFrame.to_dataframe")
 
@@ -2424,10 +2345,8 @@ class BaseFrame(ABC, Generic[T]):
         Returns channel labels by default. Override in subclasses
         if different column names are needed.
 
-        Returns
-        -------
-        list[str]
-            List of column names.
+        Returns:
+            list[str]: List of column names.
         """
         return self.labels
 
@@ -2438,10 +2357,8 @@ class BaseFrame(ABC, Generic[T]):
         This method should be implemented by subclasses to provide
         appropriate index for the DataFrame based on the frame type.
 
-        Returns
-        -------
-        pd.Index
-            Index for the DataFrame.
+        Returns:
+            pd.Index: Index for the DataFrame.
         """
 
     def _debug_info_impl(self) -> None:

--- a/wandas/frames/cepstral.py
+++ b/wandas/frames/cepstral.py
@@ -37,49 +37,33 @@ class CepstralFrame(BaseFrame[NDArrayReal]):
     backed and preserve channel identity, metadata, source-time offsets, and
     semantic lineage.
 
-    Parameters
-    ----------
-    data : dask.array.Array
-        Real coefficients shaped ``(quefrency,)`` or
-        ``(channels, quefrency)``.
-    sampling_rate : float
-        Sampling rate in Hz that defines the quefrency-bin spacing.
-    n_fft : int
-        Positive FFT size of the complete cepstrum. Sliced data may contain fewer
-        bins but never more than this value.
-    window : str, default="hann"
-        Window used by the originating cepstrum analysis.
-    label : str, optional
-        Human-readable frame label.
-    metadata : dict, optional
-        User and recording metadata, copied on construction.
-    channel_metadata : sequence, optional
-        Metadata aligned with the channel axis.
-    channel_ids : list[str], optional
-        Stable identifiers aligned with the channel axis.
-    previous : BaseFrame, optional
-        Immediate receiver Frame for process-local data comparison. For
-        multi-input operations, follows only the left/base receiver. Not
-        persisted in WDF.
-    source_time_offset : float or sequence, default=0.0
-        Per-channel source timeline offsets, preserved across domain changes.
-    lineage : LineageNode, optional
-        Authoritative runtime semantic lineage.
-    operation_history_prefix : sequence, default=()
-        Persisted display history for a new source frame.
+    Args:
+        data: dask.array.Array. Real coefficients shaped ``(quefrency,)`` or
+            ``(channels, quefrency)``.
+        sampling_rate: float. Sampling rate in Hz that defines the quefrency-bin spacing.
+        n_fft: int. Positive FFT size of the complete cepstrum. Sliced data may contain fewer
+            bins but never more than this value.
+        window: str, default="hann". Window used by the originating cepstrum analysis.
+        label: str, optional. Human-readable frame label.
+        metadata: dict, optional. User and recording metadata, copied on construction.
+        channel_metadata: sequence, optional. Metadata aligned with the channel axis.
+        channel_ids: list[str], optional. Stable identifiers aligned with the channel axis.
+        previous: BaseFrame, optional. Immediate receiver Frame for process-local data comparison. For
+            multi-input operations, follows only the left/base receiver. Not
+            persisted in WDF.
+        source_time_offset: float or sequence, default=0.0. Per-channel source
+            timeline offsets, preserved across domain changes.
+        lineage: LineageNode, optional. Authoritative runtime semantic lineage.
+        operation_history_prefix: sequence, default=(). Persisted display history for a new source frame.
 
-    Raises
-    ------
-    TypeError
-        If coefficients are complex, ``n_fft`` is not integral, or ``window`` is
-        not a non-empty string.
-    ValueError
-        If rank, FFT size, or coefficient count violates the domain contract.
+    Raises:
+        TypeError: If coefficients are complex, ``n_fft`` is not integral, or ``window`` is
+            not a non-empty string.
+        ValueError: If rank, FFT size, or coefficient count violates the domain contract.
 
-    Examples
-    --------
-    >>> cepstrum = frame.cepstrum(n_fft=2048)
-    >>> envelope = cepstrum.lifter(0.002).to_spectral_envelope()
+    Examples:
+        >>> cepstrum = frame.cepstrum(n_fft=2048)
+        >>> envelope = cepstrum.lifter(0.002).to_spectral_envelope()
     """
 
     _xarray_dim_suffix = ("channel", "quefrency")
@@ -233,33 +217,24 @@ class CepstralFrame(BaseFrame[NDArrayReal]):
     ) -> CepstralFrame:
         """Keep low- or high-quefrency coefficients.
 
-        Parameters
-        ----------
-        cutoff : float
-            Positive quefrency boundary in seconds. It must reach at least one
-            represented bin and remain below half the complete cepstrum.
-        mode : {"low", "high"}, default="low"
-            ``"low"`` keeps the smooth-envelope region; ``"high"`` keeps the
-            complementary fine structure.
+        Args:
+            cutoff: float. Positive quefrency boundary in seconds. It must reach at least one
+                represented bin and remain below half the complete cepstrum.
+            mode: {"low", "high"}, default="low". ``"low"`` keeps the smooth-envelope region; ``"high"`` keeps the
+                complementary fine structure.
 
-        Returns
-        -------
-        CepstralFrame
-            A new lazy frame with the same axes and metadata.
+        Returns:
+            CepstralFrame: A new lazy frame with the same axes and metadata.
 
-        Raises
-        ------
-        ValueError
-            If this frame has been sliced on the quefrency axis or the lifter
-            parameters cannot be represented.
+        Raises:
+            ValueError: If this frame has been sliced on the quefrency axis or the lifter
+                parameters cannot be represented.
 
-        Notes
-        -----
-        The method builds a Dask graph and does not compute coefficients.
+        Notes:
+            The method builds a Dask graph and does not compute coefficients.
 
-        Examples
-        --------
-        >>> smooth = frame.cepstrum().lifter(0.002, mode="low")
+        Examples:
+            >>> smooth = frame.cepstrum().lifter(0.002, mode="low")
         """
         self._require_complete_quefrency_axis("lifter")
         return cast(
@@ -271,25 +246,19 @@ class CepstralFrame(BaseFrame[NDArrayReal]):
     def to_spectral_envelope(self) -> SpectralFrame:
         """Convert a complete real cepstrum to a smooth spectral envelope.
 
-        Returns
-        -------
-        SpectralFrame
-            New lazy complex-valued frequency data with zero phase, the original
-            ``n_fft`` and window, and preserved metadata and source-time offsets.
+        Returns:
+            SpectralFrame: New lazy complex-valued frequency data with zero phase, the original
+                ``n_fft`` and window, and preserved metadata and source-time offsets.
 
-        Raises
-        ------
-        ValueError
-            If this frame has been sliced on the quefrency axis. Asymmetric
-            concrete coefficients raise when the lazy result is computed.
+        Raises:
+            ValueError: If this frame has been sliced on the quefrency axis. Asymmetric
+                concrete coefficients raise when the lazy result is computed.
 
-        Notes
-        -----
-        This method builds a Dask graph. It does not compute the envelope.
+        Notes:
+            This method builds a Dask graph. It does not compute the envelope.
 
-        Examples
-        --------
-        >>> envelope = frame.cepstrum().lifter(0.002).to_spectral_envelope()
+        Examples:
+            >>> envelope = frame.cepstrum().lifter(0.002).to_spectral_envelope()
         """
         self._require_complete_quefrency_axis("to_spectral_envelope")
         from wandas.frames.spectral import SpectralFrame
@@ -343,36 +312,25 @@ class CepstralFrame(BaseFrame[NDArrayReal]):
     ) -> Axes | Iterator[Axes]:
         """Plot real coefficients against quefrency.
 
-        Parameters
-        ----------
-        plot_type : str, default="quefrency"
-            Only ``"quefrency"`` is supported.
-        ax : matplotlib.axes.Axes, optional
-            Existing axes. A new figure and axes are created when omitted.
-        title : str, optional
-            Plot title; defaults to the frame label.
-        xlabel, ylabel : str
-            Axis labels.
-        **kwargs : Any
-            Keyword arguments passed to ``Axes.plot``.
+        Args:
+            plot_type: str, default="quefrency". Only ``"quefrency"`` is supported.
+            ax: matplotlib.axes.Axes, optional. Existing axes. A new figure and axes are created when omitted.
+            title: str, optional. Plot title; defaults to the frame label.
+            xlabel: str. Horizontal axis label.
+            ylabel: str. Vertical axis label.
+            **kwargs: Any. Keyword arguments passed to ``Axes.plot``.
 
-        Returns
-        -------
-        matplotlib.axes.Axes
-            Axes containing one line per channel.
+        Returns:
+            matplotlib.axes.Axes: Axes containing one line per channel.
 
-        Raises
-        ------
-        ValueError
-            If another plot type is requested.
+        Raises:
+            ValueError: If another plot type is requested.
 
-        Notes
-        -----
-        Plotting is an explicit compute boundary and materializes coefficients.
+        Notes:
+            Plotting is an explicit compute boundary and materializes coefficients.
 
-        Examples
-        --------
-        >>> cepstrum.plot()
+        Examples:
+            >>> cepstrum.plot()
         """
         if plot_type != "quefrency":
             raise ValueError("CepstralFrame.plot supports only plot_type='quefrency'.")

--- a/wandas/frames/cepstrogram.py
+++ b/wandas/frames/cepstrogram.py
@@ -34,53 +34,34 @@ class CepstrogramFrame(BaseFrame[NDArrayReal]):
     ``to_spectral_envelope()`` returns a
     :class:`~wandas.frames.spectrogram.SpectrogramFrame`.
 
-    Parameters
-    ----------
-    data : dask.array.Array
-        Real coefficients shaped ``(quefrency, time)`` or
-        ``(channels, quefrency, time)``.
-    sampling_rate : float
-        Sampling rate in Hz defining both axis spacings.
-    n_fft : int
-        Positive FFT size of the complete cepstrum.
-    hop_length : int
-        Positive sample distance between adjacent time frames.
-    win_length : int, optional
-        Analysis-window length inherited from the source spectrogram. Defaults
-        to ``n_fft``.
-    window : str, default="hann"
-        Analysis-window name inherited from the source spectrogram.
-    label : str, optional
-        Human-readable frame label.
-    metadata : dict, optional
-        User and recording metadata, copied on construction.
-    channel_metadata : sequence, optional
-        Metadata aligned with the channel axis.
-    channel_ids : list[str], optional
-        Stable identifiers aligned with the channel axis.
-    previous : BaseFrame, optional
-        Immediate receiver Frame for process-local data comparison. For
-        multi-input operations, follows only the left/base receiver. Not
-        persisted in WDF.
-    source_time_offset : float or sequence, default=0.0
-        Per-channel source timeline offsets.
-    lineage : LineageNode, optional
-        Authoritative runtime semantic lineage.
-    operation_history_prefix : sequence, default=()
-        Persisted display history for a new source frame.
+    Args:
+        data: dask.array.Array. Real coefficients shaped ``(quefrency, time)`` or
+            ``(channels, quefrency, time)``.
+        sampling_rate: float. Sampling rate in Hz defining both axis spacings.
+        n_fft: int. Positive FFT size of the complete cepstrum.
+        hop_length: int. Positive sample distance between adjacent time frames.
+        win_length: int, optional. Analysis-window length inherited from the source spectrogram. Defaults
+            to ``n_fft``.
+        window: str, default="hann". Analysis-window name inherited from the source spectrogram.
+        label: str, optional. Human-readable frame label.
+        metadata: dict, optional. User and recording metadata, copied on construction.
+        channel_metadata: sequence, optional. Metadata aligned with the channel axis.
+        channel_ids: list[str], optional. Stable identifiers aligned with the channel axis.
+        previous: BaseFrame, optional. Immediate receiver Frame for process-local data comparison. For
+            multi-input operations, follows only the left/base receiver. Not
+            persisted in WDF.
+        source_time_offset: float or sequence, default=0.0. Per-channel source timeline offsets.
+        lineage: LineageNode, optional. Authoritative runtime semantic lineage.
+        operation_history_prefix: sequence, default=(). Persisted display history for a new source frame.
 
-    Raises
-    ------
-    TypeError
-        If coefficients are complex or domain parameters have invalid types.
-    ValueError
-        If rank, FFT size, coefficient count, or time-analysis parameters are
-        invalid.
+    Raises:
+        TypeError: If coefficients are complex or domain parameters have invalid types.
+        ValueError: If rank, FFT size, coefficient count, or time-analysis parameters are
+            invalid.
 
-    Examples
-    --------
-    >>> cepstrogram = frame.stft(n_fft=2048).cepstrum()
-    >>> envelope = cepstrogram.lifter(0.002).to_spectral_envelope()
+    Examples:
+        >>> cepstrogram = frame.stft(n_fft=2048).cepstrum()
+        >>> envelope = cepstrogram.lifter(0.002).to_spectral_envelope()
     """
 
     _xarray_dim_suffix = ("channel", "quefrency", "time")
@@ -318,28 +299,20 @@ class CepstrogramFrame(BaseFrame[NDArrayReal]):
     ) -> CepstrogramFrame:
         """Keep low- or high-quefrency coefficients at every time frame.
 
-        Parameters
-        ----------
-        cutoff : float
-            Positive quefrency boundary in seconds. It must reach at least one
-            bin and remain below half of the complete cepstrum.
-        mode : {"low", "high"}, default="low"
-            ``"low"`` keeps the smooth-envelope region; ``"high"`` keeps the
-            complementary fine structure.
+        Args:
+            cutoff: float. Positive quefrency boundary in seconds. It must reach at least one
+                bin and remain below half of the complete cepstrum.
+            mode: {"low", "high"}, default="low". ``"low"`` keeps the smooth-envelope region; ``"high"`` keeps the
+                complementary fine structure.
 
-        Returns
-        -------
-        CepstrogramFrame
-            New lazy coefficients with unchanged time and channel axes.
+        Returns:
+            CepstrogramFrame: New lazy coefficients with unchanged time and channel axes.
 
-        Raises
-        ------
-        ValueError
-            If the quefrency axis was sliced or the cutoff is not representable.
+        Raises:
+            ValueError: If the quefrency axis was sliced or the cutoff is not representable.
 
-        Notes
-        -----
-        This method only builds a Dask graph.
+        Notes:
+            This method only builds a Dask graph.
         """
         self._require_complete_quefrency_axis("lifter")
         return cast(
@@ -356,21 +329,16 @@ class CepstrogramFrame(BaseFrame[NDArrayReal]):
     def to_spectral_envelope(self) -> SpectrogramFrame:
         """Reconstruct a smooth magnitude spectrogram with zero phase.
 
-        Returns
-        -------
-        SpectrogramFrame
-            New lazy frequency-time data preserving the original STFT analysis
-            state, channels, metadata, and source-time offsets.
+        Returns:
+            SpectrogramFrame: New lazy frequency-time data preserving the original STFT analysis
+                state, channels, metadata, and source-time offsets.
 
-        Raises
-        ------
-        ValueError
-            If the quefrency axis was sliced. Asymmetric concrete coefficients
-            raise when the lazy result is computed.
+        Raises:
+            ValueError: If the quefrency axis was sliced. Asymmetric concrete coefficients
+                raise when the lazy result is computed.
 
-        Notes
-        -----
-        This method only builds a Dask graph.
+        Notes:
+            This method only builds a Dask graph.
         """
         self._require_complete_quefrency_axis("to_spectral_envelope")
         from wandas.frames.spectrogram import SpectrogramFrame
@@ -424,11 +392,9 @@ class CepstrogramFrame(BaseFrame[NDArrayReal]):
     def to_dataframe(self) -> pd.DataFrame:
         """Reject conversion because the frame has three semantic dimensions.
 
-        Raises
-        ------
-        NotImplementedError
-            Always raised. Materialize selected data when a tabular representation
-            is required.
+        Raises:
+            NotImplementedError: Always raised. Materialize selected data when a tabular representation
+                is required.
         """
         raise NotImplementedError("DataFrame conversion is not supported for CepstrogramFrame.")
 
@@ -449,36 +415,28 @@ class CepstrogramFrame(BaseFrame[NDArrayReal]):
     ) -> Axes | Iterator[Axes]:
         """Plot real coefficients over time and quefrency.
 
-        Parameters
-        ----------
-        plot_type : str, default="cepstrogram"
-            Only ``"cepstrogram"`` is supported.
-        ax : matplotlib.axes.Axes, optional
-            Existing axes for a single-channel frame. Multi-channel frames
-            create one axes per channel when omitted.
-        title : str, optional
-            Plot title prefix; defaults to the frame label.
-        xlabel, ylabel : str
-            Axis labels.
-        cmap : str, default="RdBu_r"
-            Matplotlib colormap for signed real coefficients.
-        qmin, qmax : float, optional
-            Display range on the quefrency axis in seconds.
-        vmin, vmax : float, optional
-            Shared color limits. When omitted, a symmetric robust range is
-            estimated from the displayed coefficients except the dominant
-            zero-quefrency row.
-        **kwargs : Any
-            Additional keyword arguments passed to ``Axes.pcolormesh``.
+        Args:
+            plot_type: str, default="cepstrogram". Only ``"cepstrogram"`` is supported.
+            ax: matplotlib.axes.Axes, optional. Existing axes for a single-channel frame. Multi-channel frames
+                create one axes per channel when omitted.
+            title: str, optional. Plot title prefix; defaults to the frame label.
+            xlabel: str. Horizontal axis label.
+            ylabel: str. Vertical axis label.
+            cmap: str, default="RdBu_r". Matplotlib colormap for signed real coefficients.
+            qmin: float, optional. Lower display bound on the quefrency axis in seconds.
+            qmax: float, optional. Upper display bound on the quefrency axis in seconds.
+            vmin: float, optional. Lower shared color limit. When omitted, a symmetric robust range is
+                estimated from the displayed coefficients except the dominant
+                zero-quefrency row.
+            vmax: float, optional. Upper shared color limit.
+            **kwargs: Any. Additional keyword arguments passed to ``Axes.pcolormesh``.
 
-        Returns
-        -------
-        matplotlib.axes.Axes or Iterator[matplotlib.axes.Axes]
-            One axes for mono data or an iterator for multiple channels.
+        Returns:
+            matplotlib.axes.Axes or Iterator[matplotlib.axes.Axes]: One axes for
+                mono data or an iterator for multiple channels.
 
-        Notes
-        -----
-        Plotting is an explicit compute boundary.
+        Notes:
+            Plotting is an explicit compute boundary.
         """
         if plot_type != "cepstrogram":
             raise ValueError("CepstrogramFrame.plot supports only plot_type='cepstrogram'.")

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -763,7 +763,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
 
         Returns:
             NDArrayReal of shape ``(n_channels,)`` containing the RMS value
-            for each channel in its calibrated linear unit.
+                for each channel in its calibrated linear unit.
 
         Examples:
             >>> import wandas as wd
@@ -804,7 +804,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
 
         Returns:
             NDArrayReal of shape ``(n_channels,)`` containing the crest factor
-            for each channel.  All-zero channels yield 1.0.
+                for each channel.  All-zero channels yield 1.0.
 
         Examples:
             >>> import wandas as wd
@@ -899,9 +899,8 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             ValueError: If sampling rates, dimensions, channel counts, lengths, or
                 ``align`` do not satisfy the selected contract.
 
-        Note:
-            Source-time offsets describe provenance and do not shift array positions.
-            Signals from different source-time regions can therefore be mixed directly.
+            Note:: Source-time offsets describe provenance and do not shift array positions.
+                Signals from different source-time regions can therefore be mixed directly.
         """
         if align not in {"strict", "pad", "truncate"}:
             raise ValueError("align must be 'strict', 'pad', or 'truncate'")
@@ -1137,8 +1136,8 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
 
         Returns:
             None (default). When `is_close=False`, returns a list of matplotlib Figure
-            objects created for each channel. The list length equals the number of
-            channels in the frame.
+                objects created for each channel. The list length equals the number of
+                channels in the frame.
 
         Examples:
             >>> cf = wd.read("audio.wav")
@@ -1561,7 +1560,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
 
         Returns:
             A new ChannelFrame containing Dask-backed sample data. CSV metadata
-            inspection occurs synchronously before the Frame is returned.
+                inspection occurs synchronously before the Frame is returned.
 
         Examples:
             >>> # Read CSV with default settings
@@ -1609,9 +1608,8 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         Raises:
             FileNotFoundError: If the file doesn't exist
 
-        Example:
-            >>> import wandas as wd
-            >>> cf = wd.load("audio_analysis.wdf")
+            Example:: >>> import wandas as wd
+                >>> cf = wd.load("audio_analysis.wdf")
         """
         from ..io.wdf_io import load as wdf_load
 
@@ -1823,7 +1821,7 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
 
         Returns:
             A lazy ChannelFrame preserving the remaining channels' metadata, stable
-            channel identifiers, source-time offsets, and semantic lineage.
+                channel identifiers, source-time offsets, and semantic lineage.
 
         Raises:
             IndexError: If an integer index is outside the channel range.

--- a/wandas/frames/channel.py
+++ b/wandas/frames/channel.py
@@ -899,8 +899,9 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
             ValueError: If sampling rates, dimensions, channel counts, lengths, or
                 ``align`` do not satisfy the selected contract.
 
-            Note:: Source-time offsets describe provenance and do not shift array positions.
-                Signals from different source-time regions can therefore be mixed directly.
+        Notes:
+            Source-time offsets describe provenance and do not shift array positions.
+            Signals from different source-time regions can therefore be mixed directly.
         """
         if align not in {"strict", "pad", "truncate"}:
             raise ValueError("align must be 'strict', 'pad', or 'truncate'")
@@ -1608,8 +1609,9 @@ class ChannelFrame(BaseFrame[NDArrayReal], ChannelProcessingMixin, ChannelTransf
         Raises:
             FileNotFoundError: If the file doesn't exist
 
-            Example:: >>> import wandas as wd
-                >>> cf = wd.load("audio_analysis.wdf")
+        Examples:
+            >>> import wandas as wd
+            >>> cf = wd.load("audio_analysis.wdf")
         """
         from ..io.wdf_io import load as wdf_load
 

--- a/wandas/frames/mixins/channel_processing_mixin.py
+++ b/wandas/frames/mixins/channel_processing_mixin.py
@@ -73,11 +73,9 @@ class ChannelProcessingMixin:
     ) -> list[float]:
         """Extract per-channel reference values from channel metadata.
 
-        Parameters
-        ----------
-        require_non_default : bool
-            When ``True``, return an empty list unless at least one channel
-            has a non-empty ``unit`` or a ``ref`` that differs from 1.0.
+        Args:
+            require_non_default: bool. When ``True``, return an empty list unless at least one channel
+                has a non-empty ``unit`` or a ``ref`` that differs from 1.0.
         """
         if not hasattr(self, "_channel_metadata") or not self._channel_metadata:
             return []
@@ -499,9 +497,9 @@ class ChannelProcessingMixin:
 
         Returns:
             New ChannelFrame containing the trimmed signal. The operation is a
-            lazy structural time slice: channel labels, calibration, metadata,
-            and channel IDs are preserved, while source-time offsets advance
-            to the first selected sample.
+                lazy structural time slice: channel labels, calibration, metadata,
+                and channel IDs are preserved, while source-time offsets advance
+                to the first selected sample.
 
         Raises:
             ValueError: If either time is negative or end is earlier than start
@@ -561,11 +559,11 @@ class ChannelProcessingMixin:
 
         Returns:
             New lazy ChannelFrame with shape ``(n_channels, n_frames)``.
-            Linear output retains the physical channel unit; dB output encodes
-            its original reference in the channel unit (for example,
-            ``dB SPL re 2e-05 Pa``). Its sampling rate is divided by
-            ``hop_length``. The input Frame remains unchanged and the result
-            carries the new operation in lineage.
+                Linear output retains the physical channel unit; dB output encodes
+                its original reference in the channel unit (for example,
+                ``dB SPL re 2e-05 Pa``). Its sampling rate is divided by
+                ``hop_length``. The input Frame remains unchanged and the result
+                carries the new operation in lineage.
 
         Raises:
             ValueError: If the window parameters or channel references are
@@ -646,11 +644,11 @@ class ChannelProcessingMixin:
 
         Returns:
             New lazy ChannelFrame with shape ``(n_channels, n_samples)`` and
-            the input sampling rate. Linear output retains the physical channel
-            unit; dB output encodes its original reference in the channel unit
-            (for example, ``dB SPL re 2e-05 Pa``). The input Frame remains
-            unchanged and the result preserves metadata while extending
-            lineage.
+                the input sampling rate. Linear output retains the physical channel
+                unit; dB output encodes its original reference in the channel unit
+                (for example, ``dB SPL re 2e-05 Pa``). The input Frame remains
+                unchanged and the result preserves metadata while extending
+                lineage.
 
         Raises:
             ValueError: If the frequency/time weighting or channel references
@@ -712,7 +710,7 @@ class ChannelProcessingMixin:
 
         Returns:
             New ChannelFrame containing the channel difference with the input
-            source-time offsets preserved.
+                source-time offsets preserved.
         """
         # label2index is a method of BaseFrame
         if isinstance(other_channel, str) and hasattr(self, "label2index"):
@@ -883,9 +881,9 @@ class ChannelProcessingMixin:
 
         Returns:
             New ChannelFrame containing time-varying loudness values in sones.
-            Each channel is processed independently.
-            The output sampling rate is adjusted based on the loudness
-            calculation time resolution (typically ~500 Hz for 2ms steps).
+                Each channel is processed independently.
+                The output sampling rate is adjusted based on the loudness
+                calculation time resolution (typically ~500 Hz for 2ms steps).
 
         Raises:
             ValueError: If field_type is not 'free' or 'diffuse'
@@ -1004,7 +1002,7 @@ class ChannelProcessingMixin:
 
         Returns:
             New ChannelFrame containing time-varying roughness values in asper.
-            The output sampling rate depends on the overlap parameter.
+                The output sampling rate depends on the overlap parameter.
 
         Raises:
             ValueError: If overlap is not in the range [0.0, 1.0]
@@ -1226,48 +1224,38 @@ class ChannelProcessingMixin:
         according to DIN 45692 standard, which quantifies the perceived
         sharpness of sounds.
 
-        Parameters
-        ----------
-        weighting : str, default="din"
-            Weighting type for sharpness calculation. Options:
-            - 'din': DIN 45692 method
-            - 'aures': Aures method
-            - 'bismarck': Bismarck method
-            - 'fastl': Fastl method
-        field_type : str, default="free"
-            Type of sound field. Options:
-            - 'free': Free field (sound from a specific direction)
-            - 'diffuse': Diffuse field (sound from all directions)
+        Args:
+            weighting: str, default="din". Weighting type for sharpness calculation. Options:
+                - 'din': DIN 45692 method
+                - 'aures': Aures method
+                - 'bismarck': Bismarck method
+                - 'fastl': Fastl method
+            field_type: str, default="free". Type of sound field. Options:
+                - 'free': Free field (sound from a specific direction)
+                - 'diffuse': Diffuse field (sound from all directions)
 
-        Returns
-        -------
-        T_Processing
-            New ChannelFrame containing sharpness time series in acum.
-            The output sampling rate is approximately 500 Hz (2ms time steps).
+        Returns:
+            T_Processing: New ChannelFrame containing sharpness time series in acum.
+                The output sampling rate is approximately 500 Hz (2ms time steps).
 
-        Raises
-        ------
-        ValueError
-            If the signal sampling rate is not supported by the algorithm.
+        Raises:
+            ValueError: If the signal sampling rate is not supported by the algorithm.
 
-        Examples
-        --------
-        >>> import wandas as wd
-        >>> signal = wd.read("sharp_sound.wav")
-        >>> sharpness = signal.sharpness_din(weighting="din", field_type="free")
-        >>> print(f"Mean sharpness: {sharpness.data.mean():.2f} acum")
+        Examples:
+            >>> import wandas as wd
+            >>> signal = wd.read("sharp_sound.wav")
+            >>> sharpness = signal.sharpness_din(weighting="din", field_type="free")
+            >>> print(f"Mean sharpness: {sharpness.data.mean():.2f} acum")
 
-        Notes
-        -----
-        - Sharpness is measured in acum (acum = 1 when the sound has the
+        Notes:
+            - Sharpness is measured in acum (acum = 1 when the sound has the
           same sharpness as a 2 kHz narrow-band noise at 60 dB SPL)
-        - The calculation uses MoSQITo's implementation of DIN 45692
-        - Output sampling rate is fixed at 500 Hz regardless of input rate
-        - For multi-channel signals, sharpness is calculated per channel
+            - The calculation uses MoSQITo's implementation of DIN 45692
+            - Output sampling rate is fixed at 500 Hz regardless of input rate
+            - For multi-channel signals, sharpness is calculated per channel
 
-        References
-        ----------
-        .. [1] DIN 45692:2009, "Measurement technique for the simulation of the
+        References:
+            .. [1] DIN 45692:2009, "Measurement technique for the simulation of the
                auditory sensation of sharpness"
         """
         logger.debug(
@@ -1293,47 +1281,37 @@ class ChannelProcessingMixin:
         according to DIN 45692 standard, which quantifies the perceived
         sharpness of stationary sounds.
 
-        Parameters
-        ----------
-        weighting : str, default="din"
-            Weighting type for sharpness calculation. Options:
-            - 'din': DIN 45692 method
-            - 'aures': Aures method
-            - 'bismarck': Bismarck method
-            - 'fastl': Fastl method
-        field_type : str, default="free"
-            Type of sound field. Options:
-            - 'free': Free field (sound from a specific direction)
-            - 'diffuse': Diffuse field (sound from all directions)
+        Args:
+            weighting: str, default="din". Weighting type for sharpness calculation. Options:
+                - 'din': DIN 45692 method
+                - 'aures': Aures method
+                - 'bismarck': Bismarck method
+                - 'fastl': Fastl method
+            field_type: str, default="free". Type of sound field. Options:
+                - 'free': Free field (sound from a specific direction)
+                - 'diffuse': Diffuse field (sound from all directions)
 
-        Returns
-        -------
-        NDArrayReal
-            Sharpness values in acum, one per channel. Shape: (n_channels,)
+        Returns:
+            NDArrayReal: Sharpness values in acum, one per channel. Shape: (n_channels,)
 
-        Raises
-        ------
-        ValueError
-            If the signal sampling rate is not supported by the algorithm.
+        Raises:
+            ValueError: If the signal sampling rate is not supported by the algorithm.
 
-        Examples
-        --------
-        >>> import wandas as wd
-        >>> signal = wd.read("constant_tone.wav")
-        >>> sharpness = signal.sharpness_din_st(weighting="din", field_type="free")
-        >>> print(f"Steady-state sharpness: {sharpness[0]:.2f} acum")
+        Examples:
+            >>> import wandas as wd
+            >>> signal = wd.read("constant_tone.wav")
+            >>> sharpness = signal.sharpness_din_st(weighting="din", field_type="free")
+            >>> print(f"Steady-state sharpness: {sharpness[0]:.2f} acum")
 
-        Notes
-        -----
-        - Sharpness is measured in acum (acum = 1 when the sound has the
+        Notes:
+            - Sharpness is measured in acum (acum = 1 when the sound has the
           same sharpness as a 2 kHz narrow-band noise at 60 dB SPL)
-        - The calculation uses MoSQITo's implementation of DIN 45692
-        - Output is a single value per channel, suitable for stationary signals
-        - For multi-channel signals, sharpness is calculated per channel
+            - The calculation uses MoSQITo's implementation of DIN 45692
+            - Output is a single value per channel, suitable for stationary signals
+            - For multi-channel signals, sharpness is calculated per channel
 
-        References
-        ----------
-        .. [1] DIN 45692:2009, "Measurement technique for the simulation of the
+        References:
+            .. [1] DIN 45692:2009, "Measurement technique for the simulation of the
                auditory sensation of sharpness"
         """
         from wandas.processing.psychoacoustic import SharpnessDinSt

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -28,14 +28,10 @@ def _build_cross_channel_metadata(
 ) -> list[Any]:
     """Build channel metadata for cross-channel operations (coherence, csd, tf).
 
-    Parameters
-    ----------
-    channel_metadata : list
-        Input channel metadata list.
-    operation_name : str
-        Operation name for the metadata dict key.
-    label_template : str
-        Format string with ``{in_label}`` and ``{out_label}`` placeholders.
+    Args:
+        channel_metadata: list. Input channel metadata list.
+        operation_name: str. Operation name for the metadata dict key.
+        label_template: str. Format string with ``{in_label}`` and ``{out_label}`` placeholders.
     """
     from wandas.core.metadata import ChannelMetadata
 
@@ -136,39 +132,28 @@ class ChannelTransformMixin:
     ) -> "CepstralFrame":
         """Calculate the normalized real cepstrum of each channel.
 
-        Parameters
-        ----------
-        n_fft : int, optional
-            FFT size. ``None`` uses the current sample count. Smaller values
-            truncate and larger values zero-pad the analysis input.
-        window : str, default="hann"
-            SciPy window name applied before the FFT.
-        floor : float, default=1e-12
-            Positive finite floor applied to normalized magnitude before ``log``.
+        Args:
+            n_fft: int, optional. FFT size. ``None`` uses the current sample count. Smaller values
+                truncate and larger values zero-pad the analysis input.
+            window: str, default="hann". SciPy window name applied before the FFT.
+            floor: float, default=1e-12. Positive finite floor applied to normalized magnitude before ``log``.
 
-        Returns
-        -------
-        CepstralFrame
-            New lazy real coefficients with dimensions
-            ``(channel, quefrency)``. Channel metadata, IDs, user metadata,
-            sampling rate, and source-time offsets are preserved.
+        Returns:
+            CepstralFrame: New lazy real coefficients with dimensions
+                ``(channel, quefrency)``. Channel metadata, IDs, user metadata,
+                sampling rate, and source-time offsets are preserved.
 
-        Raises
-        ------
-        TypeError
-            If the input is complex or a parameter has the wrong type.
-        ValueError
-            If ``n_fft`` or ``floor`` is invalid.
+        Raises:
+            TypeError: If the input is complex or a parameter has the wrong type.
+            ValueError: If ``n_fft`` or ``floor`` is invalid.
 
-        Notes
-        -----
-        The method only builds a Dask graph. Accessing ``data``, calling
-        ``compute()``, or plotting materializes the coefficients.
+        Notes:
+            The method only builds a Dask graph. Accessing ``data``, calling
+            ``compute()``, or plotting materializes the coefficients.
 
-        Examples
-        --------
-        >>> cepstrum = frame.cepstrum(n_fft=2048, window="hann")
-        >>> envelope = cepstrum.lifter(0.002).to_spectral_envelope()
+        Examples:
+            >>> cepstrum = frame.cepstrum(n_fft=2048, window="hann")
+            >>> envelope = cepstrum.lifter(0.002).to_spectral_envelope()
         """
         from wandas.frames.cepstral import CepstralFrame
         from wandas.processing import Cepstrum, create_operation

--- a/wandas/frames/noct.py
+++ b/wandas/frames/noct.py
@@ -38,83 +38,59 @@ class NOctFrame(BaseFrame[NDArrayReal]):
     data representing RMS amplitude in each frequency band, following standard
     acoustical band definitions. Values retain the input channel's physical unit.
 
-    Parameters
-    ----------
-    data : DaArray
-        The N-octave band data. Must be a dask array with shape:
-        - (channels, frequency_bins) for multi-channel data
-        - (frequency_bins,) for single-channel data, which will be
-          reshaped to (1, frequency_bins)
-    sampling_rate : float
-        The sampling rate of the original time-domain signal in Hz.
-    fmin : float, default=0
-        Lower frequency bound in Hz.
-    fmax : float, default=0
-        Upper frequency bound in Hz.
-    n : int, default=3
-        Number of bands per octave (e.g., 3 for third-octave bands).
-    G : int, default=10
-        Exact center-frequency ratio convention: 10 selects base
-        ``10**(3/10)`` and 2 selects base 2.
-    fr : int, default=1000
-        Reference frequency in Hz, typically 1000 Hz for acoustic analysis.
-    label : str, optional
-        A label for the frame.
-    metadata : dict, optional
-        Additional metadata for the frame.
-    lineage : LineageNode, optional
-        Constructor override for the runtime lineage. When omitted, a source node is
-        created. ``operation_history`` is its public derived projection.
-    channel_metadata : list[ChannelMetadata], optional
-        Metadata for each channel in the frame.
-    previous : BaseFrame, optional
-        Immediate receiver Frame for process-local data comparison. For
-        multi-input operations, follows only the left/base receiver. Not
-        persisted in WDF.
+    Args:
+        data: DaArray. The N-octave band data. Must be a dask array with shape:
+            - (channels, frequency_bins) for multi-channel data
+            - (frequency_bins,) for single-channel data, which will be
+            reshaped to (1, frequency_bins)
+        sampling_rate: float. The sampling rate of the original time-domain signal in Hz.
+        fmin: float, default=0. Lower frequency bound in Hz.
+        fmax: float, default=0. Upper frequency bound in Hz.
+        n: int, default=3. Number of bands per octave (e.g., 3 for third-octave bands).
+        G: int, default=10. Exact center-frequency ratio convention: 10 selects base
+            ``10**(3/10)`` and 2 selects base 2.
+        fr: int, default=1000. Reference frequency in Hz, typically 1000 Hz for acoustic analysis.
+        label: str, optional. A label for the frame.
+        metadata: dict, optional. Additional metadata for the frame.
+        lineage: LineageNode, optional. Constructor override for the runtime lineage. When omitted, a source node is
+            created. ``operation_history`` is its public derived projection.
+        channel_metadata: list[ChannelMetadata], optional. Metadata for each channel in the frame.
+        previous: BaseFrame, optional. Immediate receiver Frame for process-local data comparison. For
+            multi-input operations, follows only the left/base receiver. Not
+            persisted in WDF.
 
-    Attributes
-    ----------
-    freqs : NDArrayReal
-        The center frequencies of each band in Hz, calculated according to
-        the standard fractional octave band definitions.
-    dB : NDArrayReal
-        Band RMS amplitude level,
-        ``20 * log10(band_rms / channel_ref)``.
-    dBA : NDArrayReal
-        The A-weighted spectrum in decibels, applying frequency weighting
-        for better correlation with perceived loudness.
-    fmin : float
-        Lower frequency bound in Hz.
-    fmax : float
-        Upper frequency bound in Hz.
-    n : int
-        Number of bands per octave.
-    G : int
-        Exact center-frequency ratio convention.
-    fr : int
-        Reference frequency in Hz.
+    Attributes:
+        freqs: NDArrayReal. The center frequencies of each band in Hz, calculated according to
+            the standard fractional octave band definitions.
+        dB: NDArrayReal. Band RMS amplitude level,
+            ``20 * log10(band_rms / channel_ref)``.
+        dBA: NDArrayReal. The A-weighted spectrum in decibels, applying frequency weighting
+            for better correlation with perceived loudness.
+        fmin: float. Lower frequency bound in Hz.
+        fmax: float. Upper frequency bound in Hz.
+        n: int. Number of bands per octave.
+        G: int. Exact center-frequency ratio convention.
+        fr: int. Reference frequency in Hz.
 
-    Examples
-    --------
-    Create an N-octave band spectrum from a time-domain signal:
-    >>> signal = ChannelFrame.from_wav("audio.wav")
-    >>> spectrum = signal.noct_spectrum(fmin=20, fmax=20000, n=3)
+    Examples:
+        Create an N-octave band spectrum from a time-domain signal:
+        >>> signal = ChannelFrame.from_wav("audio.wav")
+        >>> spectrum = signal.noct_spectrum(fmin=20, fmax=20000, n=3)
 
-    Plot the N-octave band spectrum:
-    >>> spectrum.plot()
+        Plot the N-octave band spectrum:
+        >>> spectrum.plot()
 
-    Plot with A-weighting applied:
-    >>> spectrum.plot(Aw=True)
+        Plot with A-weighting applied:
+        >>> spectrum.plot(Aw=True)
 
-    Notes
-    -----
-    - Binary operations (addition, multiplication, etc.) are not currently
+    Notes:
+        - Binary operations (addition, multiplication, etc.) are not currently
       supported for N-octave band data.
-    - The actual frequency bands are determined by the parameters n, G, and fr
+        - The actual frequency bands are determined by the parameters n, G, and fr
       according to IEC 61260-1:2014 standard for fractional octave band filters.
-    - The class follows acoustic standards for band definitions and analysis,
+        - The class follows acoustic standards for band definitions and analysis,
       making it suitable for noise measurements and sound level analysis.
-    - A-weighting is available for better correlation with human hearing
+        - A-weighting is available for better correlation with human hearing
       perception, following IEC 61672-1:2013.
     """
 
@@ -192,11 +168,9 @@ class NOctFrame(BaseFrame[NDArrayReal]):
         the same physical unit as the band RMS value and is specified by each
         channel's calibration metadata.
 
-        Returns
-        -------
-        NDArrayReal
-            The spectrum in decibels. Shape matches the input data shape:
-            (channels, frequency_bins).
+        Returns:
+            NDArrayReal: The spectrum in decibels. Shape matches the input data shape:
+                (channels, frequency_bins).
         """
         return ref_weighted_dB(self.data, self._channel_metadata, self._data.ndim)
 
@@ -212,11 +186,9 @@ class NOctFrame(BaseFrame[NDArrayReal]):
 
         The weighting is applied according to IEC 61672-1:2013 standard.
 
-        Returns
-        -------
-        NDArrayReal
-            The A-weighted spectrum in decibels. Shape matches the input data shape:
-            (channels, frequency_bins).
+        Returns:
+            NDArrayReal: The A-weighted spectrum in decibels. Shape matches the input data shape:
+                (channels, frequency_bins).
         """
         # Collect dB reference values from _channel_metadata
         weighted: NDArrayReal = a_weighting_db(frequencies=self.freqs, min_db=None)
@@ -231,16 +203,12 @@ class NOctFrame(BaseFrame[NDArrayReal]):
         (n, G, fr) and the frequency bounds (fmin, fmax) according to
         IEC 61260-1:2014 standard for fractional octave band filters.
 
-        Returns
-        -------
-        NDArrayReal
-            Array of center frequencies for each frequency band.
+        Returns:
+            NDArrayReal: Array of center frequencies for each frequency band.
 
-        Raises
-        ------
-        ValueError
-            If the center frequencies cannot be calculated or the result
-            is not a numpy array.
+        Raises:
+            ValueError: If the center frequencies cannot be calculated or the result
+                is not a numpy array.
         """
         _, freqs = _center_freq(
             fmax=self.fmax,
@@ -284,49 +252,34 @@ class NOctFrame(BaseFrame[NDArrayReal]):
         Supports standard plotting configurations for acoustic analysis,
         including decibel scales and A-weighting.
 
-        Parameters
-        ----------
-        plot_type : str, default="noct"
-            Type of plot to create. The default "noct" type creates a step plot
-            suitable for displaying N-octave band data.
-        ax : matplotlib.axes.Axes, optional
-            Axes to plot on. If None, creates new axes.
-        title : str, optional
-            Title for the plot. If None, uses a default title with band specification.
-        overlay : bool, default=False
-            Whether to overlay all channels on a single plot (True)
-            or create separate subplots for each channel (False).
-        xlabel : str, optional
-            Label for the x-axis. If None, uses default "Center frequency [Hz]".
-        ylabel : str, optional
-            Label for the y-axis. If None, uses default based on data type.
-        alpha : float, default=1.0
-            Transparency level for the plot lines (0.0 to 1.0).
-        xlim : tuple[float, float], optional
-            Limits for the x-axis as (min, max) tuple.
-        ylim : tuple[float, float], optional
-            Limits for the y-axis as (min, max) tuple.
-        Aw : bool, default=False
-            Whether to apply A-weighting to the data.
-        **kwargs : dict
-            Additional matplotlib Line2D parameters
-            (e.g., color, linewidth, linestyle).
+        Args:
+            plot_type: str, default="noct". Type of plot to create. The default "noct" type creates a step plot
+                suitable for displaying N-octave band data.
+            ax: matplotlib.axes.Axes, optional. Axes to plot on. If None, creates new axes.
+            title: str, optional. Title for the plot. If None, uses a default title with band specification.
+            overlay: bool, default=False. Whether to overlay all channels on a single plot (True)
+                or create separate subplots for each channel (False).
+            xlabel: str, optional. Label for the x-axis. If None, uses default "Center frequency [Hz]".
+            ylabel: str, optional. Label for the y-axis. If None, uses default based on data type.
+            alpha: float, default=1.0. Transparency level for the plot lines (0.0 to 1.0).
+            xlim: tuple[float, float], optional. Limits for the x-axis as (min, max) tuple.
+            ylim: tuple[float, float], optional. Limits for the y-axis as (min, max) tuple.
+            Aw: bool, default=False. Whether to apply A-weighting to the data.
+            **kwargs: dict. Additional matplotlib Line2D parameters
+                (e.g., color, linewidth, linestyle).
 
-        Returns
-        -------
-        Union[Axes, Iterator[Axes]]
-            The matplotlib axes containing the plot, or an iterator of axes
-            for multi-plot outputs.
+        Returns:
+            Union[Axes, Iterator[Axes]]: The matplotlib axes containing the plot, or an iterator of axes
+                for multi-plot outputs.
 
-        Examples
-        --------
-        >>> noct = spectrum.noct(n=3)
-        >>> # Basic 1/3-octave plot
-        >>> noct.plot()
-        >>> # Overlay with A-weighting
-        >>> noct.plot(overlay=True, Aw=True)
-        >>> # Custom styling
-        >>> noct.plot(title="1/3-Octave Spectrum", color="blue", linewidth=2)
+        Examples:
+            >>> noct = spectrum.noct(n=3)
+            >>> # Basic 1/3-octave plot
+            >>> noct.plot()
+            >>> # Overlay with A-weighting
+            >>> noct.plot(overlay=True, Aw=True)
+            >>> # Custom styling
+            >>> noct.plot(title="1/3-Octave Spectrum", color="blue", linewidth=2)
         """
         from wandas.visualization.plotting import create_operation
 
@@ -368,15 +321,13 @@ class NOctFrame(BaseFrame[NDArrayReal]):
         required by NOctFrame beyond those required by BaseFrame. These include
         the N-octave band analysis parameters that define the frequency bands.
 
-        Returns
-        -------
-        dict[str, Any]
-            Additional initialization arguments specific to NOctFrame:
-            - n: Number of bands per octave
-            - G: Exact center-frequency ratio convention
-            - fr: Reference frequency
-            - fmin: Lower frequency bound
-            - fmax: Upper frequency bound
+        Returns:
+            dict[str, Any]: Additional initialization arguments specific to NOctFrame:
+                - n: Number of bands per octave
+                - G: Exact center-frequency ratio convention
+                - fr: Reference frequency
+                - fmin: Lower frequency bound
+                - fmax: Upper frequency bound
         """
         return {
             "n": self.n,

--- a/wandas/frames/roughness.py
+++ b/wandas/frames/roughness.py
@@ -30,80 +30,62 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
     The relationship between total roughness and specific roughness follows:
     R = 0.25 * sum(R_spec, axis=bark_bands)
 
-    Parameters
-    ----------
-    data : da.Array
-        Specific roughness data with shape:
-        - (n_bark_bands, n_time) for mono signals
-        - (n_channels, n_bark_bands, n_time) for multi-channel signals
-        where n_bark_bands is always 47.
-    sampling_rate : float
-        Sampling rate of the roughness time series in Hz.
-        For overlap=0.5, this is approximately 10 Hz (100ms hop).
-        For overlap=0.0, this is approximately 5 Hz (200ms hop).
-    bark_axis : NDArrayReal
-        Bark frequency axis with 47 values from 0.5 to 23.5 Bark.
-    overlap : float
-        Overlap coefficient used in the calculation (0.0 to 1.0).
-    label : str, optional
-        Frame label. Defaults to "roughness_spec".
-    metadata : dict, optional
-        Additional metadata.
-    lineage : LineageNode, optional
-        Constructor override for the runtime lineage. When omitted, a source node is
-        created. ``operation_history`` is its public derived projection.
-    channel_metadata : list[ChannelMetadata], optional
-        Metadata for each channel.
-    previous : BaseFrame, optional
-        Immediate receiver Frame for process-local data comparison. For
-        multi-input operations, follows only the left/base receiver. Not
-        persisted in WDF.
+    Args:
+        data: da.Array. Specific roughness data with shape:
+            - (n_bark_bands, n_time) for mono signals
+            - (n_channels, n_bark_bands, n_time) for multi-channel signals
+            where n_bark_bands is always 47.
+        sampling_rate: float. Sampling rate of the roughness time series in Hz.
+            For overlap=0.5, this is approximately 10 Hz (100ms hop).
+            For overlap=0.0, this is approximately 5 Hz (200ms hop).
+        bark_axis: NDArrayReal. Bark frequency axis with 47 values from 0.5 to 23.5 Bark.
+        overlap: float. Overlap coefficient used in the calculation (0.0 to 1.0).
+        label: str, optional. Frame label. Defaults to "roughness_spec".
+        metadata: dict, optional. Additional metadata.
+        lineage: LineageNode, optional. Constructor override for the runtime lineage. When omitted, a source node is
+            created. ``operation_history`` is its public derived projection.
+        channel_metadata: list[ChannelMetadata], optional. Metadata for each channel.
+        previous: BaseFrame, optional. Immediate receiver Frame for process-local data comparison. For
+            multi-input operations, follows only the left/base receiver. Not
+            persisted in WDF.
 
-    Attributes
-    ----------
-    bark_axis : NDArrayReal
-        Frequency axis in Bark scale.
-    n_bark_bands : int
-        Number of Bark bands (always 47).
-    n_time_points : int
-        Number of time points.
-    time : NDArrayReal
-        Time axis based on sampling rate.
-    overlap : float
-        Overlap coefficient used (0.0 to 1.0).
+    Attributes:
+        bark_axis: NDArrayReal. Frequency axis in Bark scale.
+        n_bark_bands: int. Number of Bark bands (always 47).
+        n_time_points: int. Number of time points.
+        time: NDArrayReal. Time axis based on sampling rate.
+        overlap: float. Overlap coefficient used (0.0 to 1.0).
 
-    Examples
-    --------
-    Create a roughness frame from a signal:
+    Examples:
+        Create a roughness frame from a signal:
 
-    >>> import wandas as wd
-    >>> signal = wd.read("motor.wav")
-    >>> roughness_spec = signal.roughness_dw_spec(overlap=0.5)
-    >>>
-    >>> # Plot Bark-Time heatmap
-    >>> roughness_spec.plot()
-    >>>
-    >>> # Find dominant Bark band
-    >>> dominant_idx = roughness_spec.data.mean(axis=1).argmax()
-    >>> dominant_bark = roughness_spec.bark_axis[dominant_idx]
-    >>> print(f"Dominant frequency: {dominant_bark:.1f} Bark")
-    >>>
-    >>> # Extract specific Bark band
-    >>> bark_10_idx = np.argmin(np.abs(roughness_spec.bark_axis - 10.0))
-    >>> roughness_at_10bark = roughness_spec.data[bark_10_idx, :]
+        >>> import wandas as wd
+        >>> signal = wd.read("motor.wav")
+        >>> roughness_spec = signal.roughness_dw_spec(overlap=0.5)
+        >>>
+        >>> # Plot Bark-Time heatmap
+        >>> roughness_spec.plot()
+        >>>
+        >>> # Find dominant Bark band
+        >>> dominant_idx = roughness_spec.data.mean(axis=1).argmax()
+        >>> dominant_bark = roughness_spec.bark_axis[dominant_idx]
+        >>> print(f"Dominant frequency: {dominant_bark:.1f} Bark")
+        >>>
+        >>> # Extract specific Bark band
+        >>> bark_10_idx = np.argmin(np.abs(roughness_spec.bark_axis - 10.0))
+        >>> roughness_at_10bark = roughness_spec.data[bark_10_idx, :]
 
-    The Daniel & Weber (1997) roughness model calculates specific roughness
-    for 47 critical bands (Bark scale) over time, then integrates them to
-    produce the total roughness:
+        The Daniel & Weber (1997) roughness model calculates specific roughness
+        for 47 critical bands (Bark scale) over time, then integrates them to
+        produce the total roughness:
 
-    .. math::
+        .. math::
         R = 0.25 \\sum_{i=1}^{47} R'_i
 
-    where R'_i is the specific roughness in the i-th Bark band.
+        where R'_i is the specific roughness in the i-th Bark band.
 
-    References
-    ----------
-    .. [1] Daniel, P., & Weber, R. (1997). "Psychoacoustical roughness:
+    References:
+        .. [1] Daniel, P., & Weber, R. (1997). "Psychoacoustical roughness:
            Implementation of an optimized model". Acta Acustica united with
            Acustica, 83(1), 113-123.
     """
@@ -174,10 +156,8 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
         For RoughnessFrame, even mono signals have 2D shape (47, n_time)
         so we don't squeeze the channel dimension.
 
-        Returns
-        -------
-        NDArrayReal
-            Computed data array.
+        Returns:
+            NDArrayReal: Computed data array.
         """
         return self._compute()
 
@@ -186,10 +166,8 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
         """
         Number of Bark bands.
 
-        Returns
-        -------
-        int
-            Always 47 for the Daniel & Weber model.
+        Returns:
+            int: Always 47 for the Daniel & Weber model.
         """
         return 47
 
@@ -198,10 +176,8 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
         """
         Number of time points in the roughness time series.
 
-        Returns
-        -------
-        int
-            Number of time frames in the analysis.
+        Returns:
+            int: Number of time frames in the analysis.
         """
         return int(self._data.shape[-1])
 
@@ -210,10 +186,8 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
         """
         Time axis based on sampling rate.
 
-        Returns
-        -------
-        NDArrayReal
-            Time values in seconds for each frame.
+        Returns:
+            NDArrayReal: Time values in seconds for each frame.
         """
         return np.arange(self.n_time_points) / self.sampling_rate
 
@@ -232,10 +206,8 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
         """
         Provide additional initialization arguments for RoughnessFrame.
 
-        Returns
-        -------
-        dict
-            Dictionary containing bark_axis and overlap
+        Returns:
+            dict: Dictionary containing bark_axis and overlap
         """
         return {
             "bark_axis": self.bark_axis,
@@ -259,10 +231,8 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
         RoughnessFrame contains 3D data (channels, bark_bands, time_frames)
         which cannot be directly converted to a 2D DataFrame.
 
-        Raises
-        ------
-        NotImplementedError
-            Always raised as DataFrame conversion is not supported.
+        Raises:
+            NotImplementedError: Always raised as DataFrame conversion is not supported.
         """
         raise NotImplementedError("DataFrame conversion is not supported for RoughnessFrame.")
 
@@ -291,47 +261,32 @@ class RoughnessFrame(BaseFrame[NDArrayReal]):
 
         For multi-channel signals, the mean across channels is plotted.
 
-        Parameters
-        ----------
-        plot_type : {"heatmap"}, default="heatmap"
-            Plot strategy. Only the Bark-time heatmap is supported.
-        ax : Axes, optional
-            Matplotlib axes to plot on. If None, a new figure is created.
-        title : str, optional
-            Plot title. If None, a default title is used.
-        cmap : str, default="viridis"
-            Colormap name for the heatmap.
-        vmin, vmax : float, optional
-            Color scale limits. If None, automatic scaling is used.
-        xlabel : str, default="Time [s]"
-            Label for the x-axis.
-        ylabel : str, default="Frequency [Bark]"
-            Label for the y-axis.
-        colorbar_label : str, default="Specific Roughness [Asper/Bark]"
-            Label for the colorbar.
-        **kwargs : Any
-            Additional keyword arguments passed to pcolormesh.
+        Args:
+            plot_type: {"heatmap"}, default="heatmap". Plot strategy. Only the Bark-time heatmap is supported.
+            ax: Axes, optional. Matplotlib axes to plot on. If None, a new figure is created.
+            title: str, optional. Plot title. If None, a default title is used.
+            cmap: str, default="viridis". Colormap name for the heatmap.
+            vmin: float, optional. Lower color scale limit. If None, automatic scaling is used.
+            vmax: float, optional. Upper color scale limit. If None, automatic scaling is used.
+            xlabel: str, default="Time [s]". Label for the x-axis.
+            ylabel: str, default="Frequency [Bark]". Label for the y-axis.
+            colorbar_label: str, default="Specific Roughness [Asper/Bark]". Label for the colorbar.
+            **kwargs: Any. Additional keyword arguments passed to pcolormesh.
 
-        Returns
-        -------
-        Axes
-            The matplotlib axes object containing the plot.
+        Returns:
+            Axes: The matplotlib axes object containing the plot.
 
-        Raises
-        ------
-        ValueError
-            If ``plot_type`` is not ``"heatmap"``.
+        Raises:
+            ValueError: If ``plot_type`` is not ``"heatmap"``.
 
-        Notes
-        -----
-        Plotting is an explicit compute boundary.
+        Notes:
+            Plotting is an explicit compute boundary.
 
-        Examples
-        --------
-        >>> import wandas as wd
-        >>> signal = wd.read("motor.wav")
-        >>> roughness_spec = signal.roughness_dw_spec(overlap=0.5)
-        >>> roughness_spec.plot(cmap="hot", title="Motor Roughness Analysis")
+        Examples:
+            >>> import wandas as wd
+            >>> signal = wd.read("motor.wav")
+            >>> roughness_spec = signal.roughness_dw_spec(overlap=0.5)
+            >>> roughness_spec.plot(cmap="hot", title="Motor Roughness Analysis")
         """
         if plot_type != "heatmap":
             raise ValueError("RoughnessFrame.plot supports only plot_type='heatmap'.")

--- a/wandas/frames/spectral.py
+++ b/wandas/frames/spectral.py
@@ -37,79 +37,59 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
     manipulation, and visualization. It handles complex-valued frequency domain data
     obtained through operations like FFT.
 
-    Parameters
-    ----------
-    data : DaArray
-        The spectral data. Must be a dask array with shape:
-        - (channels, frequency_bins) for multi-channel data
-        - (frequency_bins,) for single-channel data, which will be
-          reshaped to (1, frequency_bins)
-    sampling_rate : float
-        The sampling rate of the original time-domain signal in Hz.
-    n_fft : int
-        Required. The FFT size used to generate this spectral data. Must be a
-        positive integer and must be the same FFT size that was used to create
-        the complete one-sided spectrum (for example, 512 or 1024). The data must
-        contain exactly ``n_fft // 2 + 1`` frequency bins.
-    window : str, default="hann"
-        The window function used in the FFT.
-    label : str, optional
-        A label for the frame.
-    metadata : dict, optional
-        Additional metadata for the frame.
-    lineage : LineageNode, optional
-        Constructor override for the runtime lineage. When omitted, a source node is
-        created. ``operation_history`` is its public derived projection.
-    channel_metadata : list[ChannelMetadata], optional
-        Metadata for each channel in the frame.
-    previous : BaseFrame, optional
-        Immediate receiver Frame for process-local data comparison. For
-        multi-input operations, follows only the left/base receiver. Not
-        persisted in WDF.
+    Args:
+        data: DaArray. The spectral data. Must be a dask array with shape:
+            - (channels, frequency_bins) for multi-channel data
+            - (frequency_bins,) for single-channel data, which will be
+            reshaped to (1, frequency_bins)
+        sampling_rate: float. The sampling rate of the original time-domain signal in Hz.
+        n_fft: int. Required. The FFT size used to generate this spectral data. Must be a
+            positive integer and must be the same FFT size that was used to create
+            the complete one-sided spectrum (for example, 512 or 1024). The data must
+            contain exactly ``n_fft // 2 + 1`` frequency bins.
+        window: str, default="hann". The window function used in the FFT.
+        label: str, optional. A label for the frame.
+        metadata: dict, optional. Additional metadata for the frame.
+        lineage: LineageNode, optional. Constructor override for the runtime lineage. When omitted, a source node is
+            created. ``operation_history`` is its public derived projection.
+        channel_metadata: list[ChannelMetadata], optional. Metadata for each channel in the frame.
+        previous: BaseFrame, optional. Immediate receiver Frame for process-local data comparison. For
+            multi-input operations, follows only the left/base receiver. Not
+            persisted in WDF.
 
-    Attributes
-    ----------
-    magnitude : NDArrayReal
-        Absolute value of the stored spectral quantity. FFT and Welch results
-        are amplitudes in the input channel unit.
-    phase : NDArrayReal
-        The phase spectrum in radians.
-    unwrapped_phase : NDArrayReal
-        The unwrapped phase spectrum in radians.
-    power : NDArrayReal
-        Squared magnitude. This compatibility property is not necessarily
-        physical power or power spectral density.
-    dB : NDArrayReal
-        Magnitude level, ``20 * log10(magnitude / channel_ref)``. For FFT and
-        Welch results this is an amplitude level.
-    dBA : NDArrayReal
-        A-weighted magnitude level. For FFT and Welch results this is an
-        A-weighted amplitude level.
-    freqs : NDArrayReal
-        The frequency axis values in Hz.
+    Attributes:
+        magnitude: NDArrayReal. Absolute value of the stored spectral quantity. FFT and Welch results
+            are amplitudes in the input channel unit.
+        phase: NDArrayReal. The phase spectrum in radians.
+        unwrapped_phase: NDArrayReal. The unwrapped phase spectrum in radians.
+        power: NDArrayReal. Squared magnitude. This compatibility property is not necessarily
+            physical power or power spectral density.
+        dB: NDArrayReal. Magnitude level, ``20 * log10(magnitude / channel_ref)``. For FFT and
+            Welch results this is an amplitude level.
+        dBA: NDArrayReal. A-weighted magnitude level. For FFT and Welch results this is an
+            A-weighted amplitude level.
+        freqs: NDArrayReal. The frequency axis values in Hz.
 
-    Examples
-    --------
-    Create a SpectralFrame from FFT:
-    >>> signal = ChannelFrame.from_numpy(data, sampling_rate=44100)
-    >>> spectrum = signal.fft(n_fft=2048)
+    Examples:
+        Create a SpectralFrame from FFT:
+        >>> signal = ChannelFrame.from_numpy(data, sampling_rate=44100)
+        >>> spectrum = signal.fft(n_fft=2048)
 
-    Plot the amplitude level spectrum:
-    >>> spectrum.plot()
+        Plot the amplitude level spectrum:
+        >>> spectrum.plot()
 
-    Perform binary operations:
-    >>> scaled = spectrum * 2.0
-    >>> summed = spectrum1 + spectrum2  # Must have matching sampling rates
+        Perform binary operations:
+        >>> scaled = spectrum * 2.0
+        >>> summed = spectrum1 + spectrum2  # Must have matching sampling rates
 
-    Convert back to time domain:
-    >>> time_signal = spectrum.ifft()
+        Convert back to time domain:
+        >>> time_signal = spectrum.ifft()
 
-    Notes
-    -----
-    - All operations are performed lazily using dask arrays for efficient memory usage.
-    - Binary operations (+, -, *, /) can be performed between SpectralFrames or with
+    Notes:
+        - All operations are performed lazily using dask arrays for efficient memory usage.
+        - Binary operations (+, -, *, /) can be performed between SpectralFrames or with
       scalar values.
-    - The class maintains runtime lineage and metadata through all operations.
+        - The class maintains runtime lineage and metadata through all operations.
     """
 
     _xarray_dim_suffix = ("channel", "frequency")
@@ -180,10 +160,8 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         The unwrapped phase removes discontinuities of 2π radians, providing
         continuous phase values across frequency bins.
 
-        Returns
-        -------
-        NDArrayReal
-            The unwrapped phase angles of the complex spectrum in radians.
+        Returns:
+            NDArrayReal: The unwrapped phase angles of the complex spectrum in radians.
         """
         return np.unwrap(np.angle(self.data))
 
@@ -195,10 +173,8 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         Values are derived on access from ``sampling_rate`` and ``n_fft`` using the
         canonical one-sided real-FFT grid. They are not duplicated in Frame state.
 
-        Returns
-        -------
-        NDArrayReal
-            Array of frequency values corresponding to each frequency bin.
+        Returns:
+            NDArrayReal: Array of frequency values corresponding to each frequency bin.
 
         """
         return np.fft.rfftfreq(self.n_fft, 1.0 / self.sampling_rate)
@@ -220,51 +196,36 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         """
         Plot the spectral data using various visualization strategies.
 
-        Parameters
-        ----------
-        plot_type : str, default="frequency"
-            Type of plot to create. Options include:
-            - "frequency": Standard frequency plot
-            - "matrix": Matrix plot for comparing channels
-            - Other types as defined by available plot strategies
-        ax : matplotlib.axes.Axes, optional
-            Axes to plot on. If None, creates new axes.
-        title : str, optional
-            Title for the plot. If None, uses the frame label.
-        overlay : bool, default=False
-            Whether to overlay all channels on a single plot (True)
-            or create separate subplots for each channel (False).
-        xlabel : str, optional
-            Label for the x-axis. If None, uses default "Frequency [Hz]".
-        ylabel : str, optional
-            Label for the y-axis. If None, uses default based on data type.
-        alpha : float, default=1.0
-            Transparency level for the plot lines (0.0 to 1.0).
-        xlim : tuple[float, float], optional
-            Limits for the x-axis as (min, max) tuple.
-        ylim : tuple[float, float], optional
-            Limits for the y-axis as (min, max) tuple.
-        Aw : bool, default=False
-            Whether to apply A-weighting to the data.
-        **kwargs : dict
-            Additional matplotlib Line2D parameters
-            (e.g., color, linewidth, linestyle).
+        Args:
+            plot_type: str, default="frequency". Type of plot to create. Options include:
+                - "frequency": Standard frequency plot
+                - "matrix": Matrix plot for comparing channels
+                - Other types as defined by available plot strategies
+            ax: matplotlib.axes.Axes, optional. Axes to plot on. If None, creates new axes.
+            title: str, optional. Title for the plot. If None, uses the frame label.
+            overlay: bool, default=False. Whether to overlay all channels on a single plot (True)
+                or create separate subplots for each channel (False).
+            xlabel: str, optional. Label for the x-axis. If None, uses default "Frequency [Hz]".
+            ylabel: str, optional. Label for the y-axis. If None, uses default based on data type.
+            alpha: float, default=1.0. Transparency level for the plot lines (0.0 to 1.0).
+            xlim: tuple[float, float], optional. Limits for the x-axis as (min, max) tuple.
+            ylim: tuple[float, float], optional. Limits for the y-axis as (min, max) tuple.
+            Aw: bool, default=False. Whether to apply A-weighting to the data.
+            **kwargs: dict. Additional matplotlib Line2D parameters
+                (e.g., color, linewidth, linestyle).
 
-        Returns
-        -------
-        Union[Axes, Iterator[Axes]]
-            The matplotlib axes containing the plot, or an iterator of axes
-            for multi-plot outputs.
+        Returns:
+            Union[Axes, Iterator[Axes]]: The matplotlib axes containing the plot, or an iterator of axes
+                for multi-plot outputs.
 
-        Examples
-        --------
-        >>> spectrum = cf.fft()
-        >>> # Basic frequency plot
-        >>> spectrum.plot()
-        >>> # Overlay with A-weighting
-        >>> spectrum.plot(overlay=True, Aw=True)
-        >>> # Custom styling
-        >>> spectrum.plot(title="Frequency Spectrum", color="red", linewidth=2)
+        Examples:
+            >>> spectrum = cf.fft()
+            >>> # Basic frequency plot
+            >>> spectrum.plot()
+            >>> # Overlay with A-weighting
+            >>> spectrum.plot(overlay=True, Aw=True)
+            >>> # Custom styling
+            >>> spectrum.plot(title="Frequency Spectrum", color="red", linewidth=2)
         """
         from wandas.visualization.plotting import create_operation
 
@@ -310,11 +271,9 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         the default Hann window is not divided out because its zero-valued
         samples cannot be recovered. Graph construction remains lazy.
 
-        Returns
-        -------
-        ChannelFrame
-            A new ChannelFrame containing the windowed time-domain signal in
-            the original channel unit.
+        Returns:
+            ChannelFrame: A new ChannelFrame containing the windowed time-domain signal in
+                the original channel unit.
 
         """
         from ..processing import create_operation
@@ -367,10 +326,8 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         """
         Provide additional initialization arguments required for SpectralFrame.
 
-        Returns
-        -------
-        dict[str, Any]
-            Additional initialization arguments for SpectralFrame.
+        Returns:
+            dict[str, Any]: Additional initialization arguments for SpectralFrame.
         """
         return {
             "n_fft": self.n_fft,
@@ -398,29 +355,19 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         standard acoustical band definitions. This is commonly used in noise and
         vibration analysis.
 
-        Parameters
-        ----------
-        fmin : float
-            Lower frequency bound in Hz.
-        fmax : float
-            Upper frequency bound in Hz.
-        n : int, default=3
-            Number of bands per octave (e.g., 3 for third-octave bands).
-        G : int, default=10
-            Exact center-frequency ratio convention. Use 10 for base
-            ``10**(3/10)`` or 2 for base 2.
-        fr : int, default=1000
-            Reference frequency in Hz.
+        Args:
+            fmin: float. Lower frequency bound in Hz.
+            fmax: float. Upper frequency bound in Hz.
+            n: int, default=3. Number of bands per octave (e.g., 3 for third-octave bands).
+            G: int, default=10. Exact center-frequency ratio convention. Use 10 for base
+                ``10**(3/10)`` or 2 for base 2.
+            fr: int, default=1000. Reference frequency in Hz.
 
-        Returns
-        -------
-        NOctFrame
-            A new NOctFrame containing the N-octave band spectrum.
+        Returns:
+            NOctFrame: A new NOctFrame containing the N-octave band spectrum.
 
-        Raises
-        ------
-        ValueError
-            If the sampling rate is not 48000 Hz.
+        Raises:
+            ValueError: If the sampling rate is not 48000 Hz.
         """
         if self.sampling_rate != 48000:
             raise ValueError("noct_synthesis can only be used with a sampling rate of 48000 Hz.")
@@ -469,20 +416,15 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         This method creates a matrix plot showing relationships between channels,
         such as coherence, transfer functions, or cross-spectral density.
 
-        Parameters
-        ----------
-        plot_type : str, default="matrix"
-            Type of matrix plot to create.
-        **kwargs : dict
-            Additional plot parameters:
-            - vmin, vmax: Color scale limits
-            - cmap: Colormap name
-            - title: Plot title
+        Args:
+            plot_type: str, default="matrix". Type of matrix plot to create.
+            **kwargs: dict. Additional plot parameters:
+                - vmin, vmax: Color scale limits
+                - cmap: Colormap name
+                - title: Plot title
 
-        Returns
-        -------
-        Union[Axes, Iterator[Axes]]
-            The matplotlib axes containing the plot.
+        Returns:
+            Union[Axes, Iterator[Axes]]: The matplotlib axes containing the plot.
         """
         from wandas.visualization.plotting import create_operation
 

--- a/wandas/frames/spectrogram.py
+++ b/wandas/frames/spectrogram.py
@@ -33,73 +33,50 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
     or similar time-frequency analysis methods. It provides methods for visualization,
     manipulation, and conversion back to time domain.
 
-    Parameters
-    ----------
-    data : DaArray
-        The spectrogram data. Must be a dask array with shape:
-        - (channels, frequency_bins, time_frames) for multi-channel data
-        - (frequency_bins, time_frames) for single-channel data, which will be
-          reshaped to (1, frequency_bins, time_frames)
-    sampling_rate : float
-        The sampling rate of the original time-domain signal in Hz.
-    n_fft : int
-        The FFT size used to generate this spectrogram. The frequency dimension must
-        contain exactly ``n_fft // 2 + 1`` bins.
-    hop_length : int
-        Number of samples between successive frames.
-    win_length : int, optional
-        The window length in samples. If None, defaults to n_fft.
-    window : str, default="hann"
-        The window function to use (e.g., "hann", "hamming", "blackman").
-    label : str, optional
-        A label for the frame.
-    metadata : dict, optional
-        Additional metadata for the frame.
-    lineage : LineageNode, optional
-        Constructor override for the runtime lineage. When omitted, a source node is
-        created. ``operation_history`` is its public derived projection.
-    channel_metadata : list[ChannelMetadata], optional
-        Metadata for each channel in the frame.
-    previous : BaseFrame, optional
-        Immediate receiver Frame for process-local data comparison. For
-        multi-input operations, follows only the left/base receiver. Not
-        persisted in WDF.
+    Args:
+        data: DaArray. The spectrogram data. Must be a dask array with shape:
+            - (channels, frequency_bins, time_frames) for multi-channel data
+            - (frequency_bins, time_frames) for single-channel data, which will be
+            reshaped to (1, frequency_bins, time_frames)
+        sampling_rate: float. The sampling rate of the original time-domain signal in Hz.
+        n_fft: int. The FFT size used to generate this spectrogram. The frequency dimension must
+            contain exactly ``n_fft // 2 + 1`` bins.
+        hop_length: int. Number of samples between successive frames.
+        win_length: int, optional. The window length in samples. If None, defaults to n_fft.
+        window: str, default="hann". The window function to use (e.g., "hann", "hamming", "blackman").
+        label: str, optional. A label for the frame.
+        metadata: dict, optional. Additional metadata for the frame.
+        lineage: LineageNode, optional. Constructor override for the runtime lineage. When omitted, a source node is
+            created. ``operation_history`` is its public derived projection.
+        channel_metadata: list[ChannelMetadata], optional. Metadata for each channel in the frame.
+        previous: BaseFrame, optional. Immediate receiver Frame for process-local data comparison. For
+            multi-input operations, follows only the left/base receiver. Not
+            persisted in WDF.
 
-    Attributes
-    ----------
-    magnitude : NDArrayReal
-        The magnitude spectrogram.
-    phase : NDArrayReal
-        The phase spectrogram in radians.
-    power : NDArrayReal
-        The power spectrogram.
-    dB : NDArrayReal
-        The spectrogram in decibels relative to channel reference values.
-    dBA : NDArrayReal
-        The A-weighted spectrogram in decibels.
-    n_frames : int
-        Number of time frames.
-    n_freq_bins : int
-        Number of frequency bins.
-    freqs : NDArrayReal
-        The frequency axis values in Hz.
-    times : NDArrayReal
-        The time axis values in seconds.
+    Attributes:
+        magnitude: NDArrayReal. The magnitude spectrogram.
+        phase: NDArrayReal. The phase spectrogram in radians.
+        power: NDArrayReal. The power spectrogram.
+        dB: NDArrayReal. The spectrogram in decibels relative to channel reference values.
+        dBA: NDArrayReal. The A-weighted spectrogram in decibels.
+        n_frames: int. Number of time frames.
+        n_freq_bins: int. Number of frequency bins.
+        freqs: NDArrayReal. The frequency axis values in Hz.
+        times: NDArrayReal. The time axis values in seconds.
 
-    Examples
-    --------
-    Create a spectrogram from a time-domain signal:
-    >>> signal = ChannelFrame.from_wav("audio.wav")
-    >>> spectrogram = signal.stft(n_fft=2048, hop_length=512)
+    Examples:
+        Create a spectrogram from a time-domain signal:
+        >>> signal = ChannelFrame.from_wav("audio.wav")
+        >>> spectrogram = signal.stft(n_fft=2048, hop_length=512)
 
-    Extract a specific time frame:
-    >>> frame_at_1s = spectrogram.get_frame_at(int(1.0 * sampling_rate / hop_length))
+        Extract a specific time frame:
+        >>> frame_at_1s = spectrogram.get_frame_at(int(1.0 * sampling_rate / hop_length))
 
-    Convert back to time domain:
-    >>> reconstructed = spectrogram.to_channel_frame()
+        Convert back to time domain:
+        >>> reconstructed = spectrogram.to_channel_frame()
 
-    Plot the spectrogram:
-    >>> spectrogram.plot()
+        Plot the spectrogram:
+        >>> spectrogram.plot()
 
     """
 
@@ -195,10 +172,8 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         """
         Get the number of time frames.
 
-        Returns
-        -------
-        int
-            The number of time frames in the spectrogram.
+        Returns:
+            int: The number of time frames in the spectrogram.
         """
         return self.shape[-1]
 
@@ -207,10 +182,8 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         """
         Get the number of frequency bins.
 
-        Returns
-        -------
-        int
-            The number of frequency bins (n_fft // 2 + 1).
+        Returns:
+            int: The number of frequency bins (n_fft // 2 + 1).
         """
         return self.shape[-2]
 
@@ -222,10 +195,8 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         Values are derived on access from ``sampling_rate`` and ``n_fft`` using the
         canonical one-sided real-FFT grid.
 
-        Returns
-        -------
-        NDArrayReal
-            Array of frequency values corresponding to each frequency bin.
+        Returns:
+            NDArrayReal: Array of frequency values corresponding to each frequency bin.
         """
         return np.fft.rfftfreq(self.n_fft, 1.0 / self.sampling_rate)
 
@@ -237,10 +208,8 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         This is a zero-based local axis derived from ``hop_length`` and
         ``sampling_rate``. Absolute placement belongs to ``source_time_offset``.
 
-        Returns
-        -------
-        NDArrayReal
-            Array of time values corresponding to each time frame.
+        Returns:
+            NDArrayReal: Array of time values corresponding to each time frame.
         """
         return np.arange(self.n_frames) * self.hop_length / self.sampling_rate
 
@@ -268,50 +237,33 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         """
         Plot the spectrogram using various visualization strategies.
 
-        Parameters
-        ----------
-        plot_type : str, default="spectrogram"
-            Type of plot to create.
-        ax : matplotlib.axes.Axes, optional
-            Axes to plot on. If None, creates new axes.
-        title : str, optional
-            Title for the plot. If None, uses the frame label.
-        cmap : str, default="jet"
-            Colormap name for the spectrogram visualization.
-        vmin : float, optional
-            Minimum value for colormap scaling (dB). Auto-calculated if None.
-        vmax : float, optional
-            Maximum value for colormap scaling (dB). Auto-calculated if None.
-        fmin : float, default=0
-            Minimum frequency to display (Hz).
-        fmax : float, optional
-            Maximum frequency to display (Hz). If None, uses Nyquist frequency.
-        xlim : tuple[float, float], optional
-            Time axis limits as (start_time, end_time) in seconds.
-        ylim : tuple[float, float], optional
-            Frequency axis limits as (min_freq, max_freq) in Hz.
-        Aw : bool, default=False
-            Whether to apply A-weighting to the spectrogram.
-        overlay : bool, default=False
-            Whether to overlay channels on a single axes.
-        **kwargs : dict
-            Additional keyword arguments passed to Matplotlib plotting methods.
+        Args:
+            plot_type: str, default="spectrogram". Type of plot to create.
+            ax: matplotlib.axes.Axes, optional. Axes to plot on. If None, creates new axes.
+            title: str, optional. Title for the plot. If None, uses the frame label.
+            cmap: str, default="jet". Colormap name for the spectrogram visualization.
+            vmin: float, optional. Minimum value for colormap scaling (dB). Auto-calculated if None.
+            vmax: float, optional. Maximum value for colormap scaling (dB). Auto-calculated if None.
+            fmin: float, default=0. Minimum frequency to display (Hz).
+            fmax: float, optional. Maximum frequency to display (Hz). If None, uses Nyquist frequency.
+            xlim: tuple[float, float], optional. Time axis limits as (start_time, end_time) in seconds.
+            ylim: tuple[float, float], optional. Frequency axis limits as (min_freq, max_freq) in Hz.
+            Aw: bool, default=False. Whether to apply A-weighting to the spectrogram.
+            overlay: bool, default=False. Whether to overlay channels on a single axes.
+            **kwargs: dict. Additional keyword arguments passed to Matplotlib plotting methods.
 
-        Returns
-        -------
-        Union[Axes, Iterator[Axes]]
-            The matplotlib axes containing the plot, or an iterator of axes
-            for multi-plot outputs.
+        Returns:
+            Union[Axes, Iterator[Axes]]: The matplotlib axes containing the plot, or an iterator of axes
+                for multi-plot outputs.
 
-        Examples
-        --------
-        >>> stft = cf.stft()
-        >>> # Basic spectrogram
-        >>> stft.plot()
-        >>> # Custom color scale and frequency range
-        >>> stft.plot(vmin=-80, vmax=-20, fmin=100, fmax=5000)
-        >>> # A-weighted spectrogram
-        >>> stft.plot(Aw=True, cmap="viridis")
+        Examples:
+            >>> stft = cf.stft()
+            >>> # Basic spectrogram
+            >>> stft.plot()
+            >>> # Custom color scale and frequency range
+            >>> stft.plot(vmin=-80, vmax=-20, fmin=100, fmax=5000)
+            >>> # A-weighted spectrogram
+            >>> stft.plot(Aw=True, cmap="viridis")
         """
         from wandas.visualization.plotting import create_operation
 
@@ -355,26 +307,19 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         A convenience method that calls plot() with Aw=True, applying A-weighting
         to the spectrogram before plotting.
 
-        Parameters
-        ----------
-        plot_type : str, default="spectrogram"
-            Type of plot to create.
-        ax : matplotlib.axes.Axes, optional
-            Axes to plot on. If None, creates new axes.
-        **kwargs : dict
-            Additional keyword arguments passed to plot().
-            Accepts all parameters from plot() except Aw (which is set to True).
+        Args:
+            plot_type: str, default="spectrogram". Type of plot to create.
+            ax: matplotlib.axes.Axes, optional. Axes to plot on. If None, creates new axes.
+            **kwargs: dict. Additional keyword arguments passed to plot().
+                Accepts all parameters from plot() except Aw (which is set to True).
 
-        Returns
-        -------
-        Union[Axes, Iterator[Axes]]
-            The matplotlib axes containing the plot.
+        Returns:
+            Union[Axes, Iterator[Axes]]: The matplotlib axes containing the plot.
 
-        Examples
-        --------
-        >>> stft = cf.stft()
-        >>> # A-weighted spectrogram with custom settings
-        >>> stft.plot_Aw(vmin=-60, vmax=-10, cmap="magma")
+        Examples:
+            >>> stft = cf.stft()
+            >>> # A-weighted spectrogram with custom settings
+            >>> stft.plot_Aw(vmin=-60, vmax=-10, cmap="magma")
         """
         return self.plot(plot_type=plot_type, ax=ax, Aw=True, **kwargs)
 
@@ -382,37 +327,28 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
     def cepstrum(self, floor: float = 1e-12) -> "CepstrogramFrame":
         """Calculate a real cepstrum independently at every time frame.
 
-        Parameters
-        ----------
-        floor : float, default=1e-12
-            Positive finite floor applied to normalized STFT magnitude before
-            taking the logarithm.
+        Args:
+            floor: float, default=1e-12. Positive finite floor applied to normalized STFT magnitude before
+                taking the logarithm.
 
-        Returns
-        -------
-        CepstrogramFrame
-            New lazy coefficients shaped ``(channel, quefrency, time)``. The
-            source FFT size, hop length, window state, channels, metadata, and
-            source-time offsets are preserved.
+        Returns:
+            CepstrogramFrame: New lazy coefficients shaped ``(channel, quefrency, time)``. The
+                source FFT size, hop length, window state, channels, metadata, and
+                source-time offsets are preserved.
 
-        Raises
-        ------
-        TypeError
-            If ``floor`` is not a real number.
-        ValueError
-            If ``floor`` is non-positive or non-finite.
+        Raises:
+            TypeError: If ``floor`` is not a real number.
+            ValueError: If ``floor`` is non-positive or non-finite.
 
-        Notes
-        -----
-        The source ``SpectrogramFrame`` already contains normalized one-sided
-        STFT amplitudes. This method computes
-        ``irfft(log(max(abs(stft), floor)))`` along its frequency axis without
-        recomputing the time-domain STFT. It only builds a Dask graph.
+        Notes:
+            The source ``SpectrogramFrame`` already contains normalized one-sided
+            STFT amplitudes. This method computes
+            ``irfft(log(max(abs(stft), floor)))`` along its frequency axis without
+            recomputing the time-domain STFT. It only builds a Dask graph.
 
-        Examples
-        --------
-        >>> cepstrogram = frame.stft(n_fft=2048).cepstrum()
-        >>> envelope = cepstrogram.lifter(0.002).to_spectral_envelope()
+        Examples:
+            >>> cepstrogram = frame.stft(n_fft=2048).cepstrum()
+            >>> envelope = cepstrogram.lifter(0.002).to_spectral_envelope()
         """
         from wandas.frames.cepstrogram import CepstrogramFrame
         from wandas.processing import SpectrogramCepstrum, create_operation
@@ -451,18 +387,15 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         spectrogram, converting the complex-valued data to real-valued magnitude data.
         The result remains a SpectrogramFrame but carries a real numeric dtype.
 
-        Returns
-        -------
-        SpectrogramFrame
-            A new SpectrogramFrame containing real-valued magnitudes.
+        Returns:
+            SpectrogramFrame: A new SpectrogramFrame containing real-valued magnitudes.
 
-        Examples
-        --------
-        >>> signal = ChannelFrame.from_wav("audio.wav")
-        >>> spectrogram = signal.stft(n_fft=2048, hop_length=512)
-        >>> magnitude_spectrogram = spectrogram.abs()
-        >>> # The magnitude can be accessed via the magnitude property or data
-        >>> print(magnitude_spectrogram.magnitude.shape)
+        Examples:
+            >>> signal = ChannelFrame.from_wav("audio.wav")
+            >>> spectrogram = signal.stft(n_fft=2048, hop_length=512)
+            >>> magnitude_spectrogram = spectrogram.abs()
+            >>> # The magnitude can be accessed via the magnitude property or data
+            >>> print(magnitude_spectrogram.magnitude.shape)
         """
         logger.debug("Computing absolute value (magnitude) of spectrogram")
 
@@ -486,20 +419,14 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         """
         Extract spectral data at a specific time frame.
 
-        Parameters
-        ----------
-        time_idx : int
-            Index of the time frame to extract.
+        Args:
+            time_idx: int. Index of the time frame to extract.
 
-        Returns
-        -------
-        SpectralFrame
-            A new SpectralFrame containing the spectral data at the specified time.
+        Returns:
+            SpectralFrame: A new SpectralFrame containing the spectral data at the specified time.
 
-        Raises
-        ------
-        IndexError
-            If time_idx is out of range.
+        Raises:
+            IndexError: If time_idx is out of range.
         """
         from wandas.frames.spectral import SpectralFrame
 
@@ -536,14 +463,11 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         This method performs an inverse Short-Time Fourier Transform (ISTFT) to
         reconstruct the time-domain signal from the spectrogram.
 
-        Returns
-        -------
-        ChannelFrame
-            A new ChannelFrame containing the reconstructed time-domain signal.
+        Returns:
+            ChannelFrame: A new ChannelFrame containing the reconstructed time-domain signal.
 
-        See Also
-        --------
-        istft : Alias for this method with more intuitive naming.
+        See Also:
+            istft : Alias for this method with more intuitive naming.
         """
         from wandas.frames.channel import ChannelFrame
         from wandas.processing import ISTFT, create_operation
@@ -587,20 +511,16 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         It performs an inverse Short-Time Fourier Transform (ISTFT) to
         reconstruct the time-domain signal from the spectrogram.
 
-        Returns
-        -------
-        ChannelFrame
-            A new ChannelFrame containing the reconstructed time-domain signal.
+        Returns:
+            ChannelFrame: A new ChannelFrame containing the reconstructed time-domain signal.
 
-        See Also
-        --------
-        to_channel_frame : The underlying implementation.
+        See Also:
+            to_channel_frame : The underlying implementation.
 
-        Examples
-        --------
-        >>> signal = ChannelFrame.from_wav("audio.wav")
-        >>> spectrogram = signal.stft(n_fft=2048, hop_length=512)
-        >>> reconstructed = spectrogram.istft()
+        Examples:
+            >>> signal = ChannelFrame.from_wav("audio.wav")
+            >>> spectrogram = signal.stft(n_fft=2048, hop_length=512)
+            >>> reconstructed = spectrogram.istft()
         """
         return self.to_channel_frame()
 
@@ -611,10 +531,8 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         This internal method provides the additional initialization arguments
         required by SpectrogramFrame beyond those required by BaseFrame.
 
-        Returns
-        -------
-        dict[str, Any]
-            Additional initialization arguments.
+        Returns:
+            dict[str, Any]: Additional initialization arguments.
         """
         return {
             "n_fft": self.n_fft,
@@ -635,10 +553,8 @@ class SpectrogramFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         get_frame_at() to extract a specific time frame as a SpectralFrame,
         then convert that to a DataFrame.
 
-        Raises
-        ------
-        NotImplementedError
-            Always raised as DataFrame conversion is not supported.
+        Raises:
+            NotImplementedError: Always raised as DataFrame conversion is not supported.
         """
         raise NotImplementedError(
             "DataFrame conversion is not supported for SpectrogramFrame. "

--- a/wandas/io/read.py
+++ b/wandas/io/read.py
@@ -149,8 +149,8 @@ def read(
 
     Returns:
         A Dask-backed :class:`~wandas.frames.channel.ChannelFrame` with
-        channel-first ``float64`` data. Audio decoding is deferred; CSV has the
-        synchronous metadata pass described above.
+            channel-first ``float64`` data. Audio decoding is deferred; CSV has the
+            synchronous metadata pass described above.
 
     Raises:
         FileNotFoundError: If a local source path does not exist.

--- a/wandas/io/readers.py
+++ b/wandas/io/readers.py
@@ -100,11 +100,11 @@ class FileReader(ABC):
 
         Returns:
             Dictionary containing file information including:
-            - samplerate: Sampling rate in Hz
-            - channels: Number of channels
-            - frames: Total number of frames
-            - format: File format
-            - duration: Duration in seconds
+                - samplerate: Sampling rate in Hz
+                - channels: Number of channels
+                - frames: Total number of frames
+                - format: File format
+                - duration: Duration in seconds
         """
         # pragma: no cover
 
@@ -242,35 +242,29 @@ class CSVFileReader(FileReader):
     ) -> dict[str, Any]:
         """Get basic information about the CSV file.
 
-        Parameters
-        ----------
-        path : Union[str, Path]
-            Path to the CSV file.
-        **kwargs : Any
-            Additional parameters for CSV reading. Supported parameters:
+        Args:
+            path: Union[str, Path]. Path to the CSV file.
+            **kwargs: Any. Additional parameters for CSV reading. Supported parameters:
 
-            - delimiter : str, default=","
+                - delimiter : str, default=","
                 Delimiter character.
-            - header : Optional[int], default=0
+                - header : Optional[int], default=0
                 Row number to use as header. Set to None if no header.
-            - time_column : Union[int, str], default=0
+                - time_column : Union[int, str], default=0
                 Index or name of the time column.
 
-        Returns
-        -------
-        dict[str, Any]
-            Dictionary containing file information including:
-            - samplerate: Estimated sampling rate in Hz
-            - channels: Number of data channels (excluding time column)
-            - frames: Total number of frames
-            - format: "CSV"
-            - duration: Duration in seconds (or None if cannot be calculated)
-            - ch_labels: List of channel labels
+        Returns:
+            dict[str, Any]: Dictionary containing file information including:
+                - samplerate: Estimated sampling rate in Hz
+                - channels: Number of data channels (excluding time column)
+                - frames: Total number of frames
+                - format: "CSV"
+                - duration: Duration in seconds (or None if cannot be calculated)
+                - ch_labels: List of channel labels
 
-        Notes
-        -----
-        This method accepts CSV-specific parameters through kwargs.
-        See CSVFileInfoParams for supported parameter types.
+        Notes:
+            This method accepts CSV-specific parameters through kwargs.
+            See CSVFileInfoParams for supported parameter types.
         """
         # Extract parameters with defaults
         delimiter: str = kwargs.get("delimiter", ",")
@@ -323,35 +317,26 @@ class CSVFileReader(FileReader):
     ) -> ArrayLike:
         """Read data from the CSV file.
 
-        Parameters
-        ----------
-        path : Union[str, Path]
-            Path to the CSV file.
-        channels : list[int]
-            List of channel indices to read.
-        start_idx : int
-            Starting frame index.
-        frames : int
-            Number of frames to read.
-        **kwargs : Any
-            Additional parameters for CSV reading. Supported parameters:
+        Args:
+            path: Union[str, Path]. Path to the CSV file.
+            channels: list[int]. List of channel indices to read.
+            start_idx: int. Starting frame index.
+            frames: int. Number of frames to read.
+            **kwargs: Any. Additional parameters for CSV reading. Supported parameters:
 
-            - delimiter : str, default=","
+                - delimiter : str, default=","
                 Delimiter character.
-            - header : Optional[int], default=0
+                - header : Optional[int], default=0
                 Row number to use as header.
-            - time_column : Union[int, str], default=0
+                - time_column : Union[int, str], default=0
                 Index or name of the time column.
 
-        Returns
-        -------
-        ArrayLike
-            Array of shape (channels, frames) containing the data.
+        Returns:
+            ArrayLike: Array of shape (channels, frames) containing the data.
 
-        Notes
-        -----
-        This method accepts CSV-specific parameters through kwargs.
-        See CSVGetDataParams for supported parameter types.
+        Notes:
+            This method accepts CSV-specific parameters through kwargs.
+            See CSVGetDataParams for supported parameter types.
         """
         # Extract parameters with defaults
         time_column: int | str = kwargs.get("time_column", 0)

--- a/wandas/io/wav_io.py
+++ b/wandas/io/wav_io.py
@@ -15,19 +15,13 @@ def write_wav(filename: str, target: "ChannelFrame", format: str | None = None) 
     """
     Write a ChannelFrame object to a WAV file.
 
-    Parameters
-    ----------
-    filename : str
-        Path to the WAV file.
-    target : ChannelFrame
-        ChannelFrame object containing the data to write.
-    format : str, optional
-        File format. If None, determined from file extension.
+    Args:
+        filename: str. Path to the WAV file.
+        target: ChannelFrame. ChannelFrame object containing the data to write.
+        format: str, optional. File format. If None, determined from file extension.
 
-    Raises
-    ------
-    ValueError
-        If target is not a ChannelFrame object.
+    Raises:
+        ValueError: If target is not a ChannelFrame object.
     """
     from wandas.frames.channel import ChannelFrame
 

--- a/wandas/pipeline/decorators.py
+++ b/wandas/pipeline/decorators.py
@@ -120,7 +120,7 @@ def recipe_operation(
 
     Returns:
         A method decorator that preserves the wrapped signature and exposes its
-        Recipe declaration through :func:`recipe_definition`.
+            Recipe declaration through :func:`recipe_definition`.
 
     Raises:
         TypeError: If ``capture`` is supplied but is not callable.

--- a/wandas/pipeline/model.py
+++ b/wandas/pipeline/model.py
@@ -214,8 +214,8 @@ class RecipePlan:
 
         Returns:
             The output Frame with semantic lineage, metadata, and Dask laziness
-            preserved by its public operations. An identity plan with no nodes returns
-            its input Frame unchanged.
+                preserved by its public operations. An identity plan with no nodes returns
+                its input Frame unchanged.
 
         Raises:
             RecipeExecutionError: If names or runtime value kinds do not match, an

--- a/wandas/pipeline/registry.py
+++ b/wandas/pipeline/registry.py
@@ -188,7 +188,7 @@ def default_recipe_registry() -> RecipeRegistry:
 
     Returns:
         A process-wide immutable registry. Use :meth:`RecipeRegistry.with_operation`
-        to derive an extension registry without mutating the built-in value.
+            to derive an extension registry without mutating the built-in value.
     """
     from wandas.pipeline.builtins import builtin_recipe_operations
 

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -202,16 +202,12 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
         """
         Initialize AudioOperation.
 
-        Parameters
-        ----------
-        sampling_rate : float
-            Sampling rate (Hz)
-        pure : bool, default=True
-            Whether the operation is pure (deterministic with no side effects).
-            When True, Dask can cache results for identical inputs.
-            Set to False only if the operation has side effects or is non-deterministic.
-        **params : Any
-            Operation-specific parameters
+        Args:
+            sampling_rate: float. Sampling rate (Hz)
+            pure: bool, default=True. Whether the operation is pure (deterministic with no side effects).
+                When True, Dask can cache results for identical inputs.
+                Set to False only if the operation has side effects or is non-deterministic.
+            **params: Any. Operation-specific parameters
         """
         object.__setattr__(self, "_sampling_rate", float(sampling_rate))
         object.__setattr__(
@@ -264,32 +260,28 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
         This method allows operations to specify how metadata should be
         updated after processing. By default, no metadata is updated.
 
-        Returns
-        -------
-        dict
-            Dictionary of metadata updates. Can include:
-            - 'sampling_rate': New sampling rate (float)
-            - Other metadata keys as needed
+        Returns:
+            dict: Dictionary of metadata updates. Can include:
+                - 'sampling_rate': New sampling rate (float)
+                - Other metadata keys as needed
 
-        Examples
-        --------
-        Return empty dict for operations that don't change metadata:
+        Examples:
+            Return empty dict for operations that don't change metadata:
 
-        >>> return {}
+            >>> return {}
 
-        Return new sampling rate for operations that resample:
+            Return new sampling rate for operations that resample:
 
-        >>> return {"sampling_rate": self.target_sr}
+            >>> return {"sampling_rate": self.target_sr}
 
-        Notes
-        -----
-        This method is called by the framework after processing to update
-        the frame metadata. Subclasses should override this method if they
-        need to update metadata (e.g., changing sampling rate).
+        Notes:
+            This method is called by the framework after processing to update
+            the frame metadata. Subclasses should override this method if they
+            need to update metadata (e.g., changing sampling rate).
 
-        Design principle: Operations should use parameters provided at
-        initialization (via __init__). All necessary information should be
-        available as instance variables.
+            Design principle: Operations should use parameters provided at
+            initialization (via __init__). All necessary information should be
+            available as instance variables.
         """
         return {}
 
@@ -334,15 +326,11 @@ class AudioOperation(Generic[InputArrayType, OutputArrayType]):
         Subclasses that alter the shape (e.g. FFT, STFT, resampling) **must**
         override this method.
 
-        Parameters
-        ----------
-        input_shape : tuple
-            Input data shape
+        Args:
+            input_shape: tuple. Input data shape
 
-        Returns
-        -------
-        tuple
-            Output data shape
+        Returns:
+            tuple: Output data shape
         """
         return input_shape
 

--- a/wandas/processing/cepstral.py
+++ b/wandas/processing/cepstral.py
@@ -84,24 +84,16 @@ class Cepstrum(AudioOperation[NDArrayReal, NDArrayReal]):
     applies a positive floor, and returns ``irfft(log(magnitude))``. Processing
     is lazy when called through :meth:`AudioOperation.process`.
 
-    Parameters
-    ----------
-    sampling_rate : float
-        Sampling rate in Hz.
-    n_fft : int, optional
-        FFT size. ``None`` uses the input sample count. A smaller value truncates
-        the input and a larger value zero-pads it.
-    window : str, default="hann"
-        SciPy window name applied before the FFT.
-    floor : float, default=1e-12
-        Positive finite floor applied to normalized magnitudes before ``log``.
+    Args:
+        sampling_rate: float. Sampling rate in Hz.
+        n_fft: int, optional. FFT size. ``None`` uses the input sample count. A smaller value truncates
+            the input and a larger value zero-pads it.
+        window: str, default="hann". SciPy window name applied before the FFT.
+        floor: float, default=1e-12. Positive finite floor applied to normalized magnitudes before ``log``.
 
-    Raises
-    ------
-    TypeError
-        If ``n_fft`` is not an integer or ``window`` is not a non-empty string.
-    ValueError
-        If ``n_fft`` or ``floor`` is not positive and finite.
+    Raises:
+        TypeError: If ``n_fft`` is not an integer or ``window`` is not a non-empty string.
+        ValueError: If ``n_fft`` or ``floor`` is not positive and finite.
     """
 
     name = "cepstrum"
@@ -216,22 +208,15 @@ class SpectrogramCepstrum(AudioOperation[NDArrayComplex, NDArrayReal]):
     positive log floor, and performs ``irfft`` along the frequency axis. The
     result is shaped ``(channel, quefrency, time)``.
 
-    Parameters
-    ----------
-    sampling_rate : float
-        Sampling rate in Hz.
-    n_fft : int
-        FFT size used to create the input spectrogram.
-    floor : float, default=1e-12
-        Positive finite floor applied to magnitude before ``log``.
+    Args:
+        sampling_rate: float. Sampling rate in Hz.
+        n_fft: int. FFT size used to create the input spectrogram.
+        floor: float, default=1e-12. Positive finite floor applied to magnitude before ``log``.
 
-    Raises
-    ------
-    TypeError
-        If ``n_fft`` is not an integer or ``floor`` is not real.
-    ValueError
-        If ``n_fft`` or ``floor`` is not positive, or input shape disagrees
-        with the FFT size.
+    Raises:
+        TypeError: If ``n_fft`` is not an integer or ``floor`` is not real.
+        ValueError: If ``n_fft`` or ``floor`` is not positive, or input shape disagrees
+            with the FFT size.
     """
 
     name = "spectrogram_cepstrum"
@@ -310,27 +295,19 @@ class SpectrogramCepstrum(AudioOperation[NDArrayComplex, NDArrayReal]):
 class Lifter(AudioOperation[NDArrayReal, NDArrayReal]):
     """Keep low- or high-quefrency real-cepstrum coefficients.
 
-    Parameters
-    ----------
-    sampling_rate : float
-        Sampling rate in Hz; its reciprocal is the quefrency-bin spacing.
-    cutoff : float
-        Positive quefrency boundary in seconds. The represented bin and its
-        circularly mirrored negative-quefrency bins are included in low mode.
-    mode : {"low", "high"}, default="low"
-        ``"low"`` keeps the smooth spectral-envelope region. ``"high"`` keeps
-        the complementary fine structure.
-    axis : int, default=-1
-        Non-channel quefrency axis. ``CepstrogramFrame`` uses ``-2``.
+    Args:
+        sampling_rate: float. Sampling rate in Hz; its reciprocal is the quefrency-bin spacing.
+        cutoff: float. Positive quefrency boundary in seconds. The represented bin and its
+            circularly mirrored negative-quefrency bins are included in low mode.
+        mode: {"low", "high"}, default="low". ``"low"`` keeps the smooth spectral-envelope region. ``"high"`` keeps
+            the complementary fine structure.
+        axis: int, default=-1. Non-channel quefrency axis. ``CepstrogramFrame`` uses ``-2``.
 
-    Raises
-    ------
-    TypeError
-        If ``cutoff`` is not a real number or ``axis`` is not an integer.
-    ValueError
-        If the cutoff is non-positive, non-finite, smaller than one bin, or
-        overlaps the mirrored half of the concrete cepstrum; or if ``mode`` is
-        unknown or ``axis`` does not identify a non-channel input axis.
+    Raises:
+        TypeError: If ``cutoff`` is not a real number or ``axis`` is not an integer.
+        ValueError: If the cutoff is non-positive, non-finite, smaller than one bin, or
+            overlaps the mirrored half of the concrete cepstrum; or if ``mode`` is
+            unknown or ``axis`` does not identify a non-channel input axis.
     """
 
     name = "lifter"
@@ -450,20 +427,14 @@ class SpectralEnvelope(AudioOperation[NDArrayReal, NDArrayComplex]):
     with zero phase so it can be represented by ``SpectralFrame``. Processing is
     lazy through :meth:`AudioOperation.process`.
 
-    Parameters
-    ----------
-    sampling_rate : float
-        Sampling rate in Hz.
-    axis : int, default=-1
-        Non-channel quefrency axis. ``CepstrogramFrame`` uses ``-2``.
+    Args:
+        sampling_rate: float. Sampling rate in Hz.
+        axis: int, default=-1. Non-channel quefrency axis. ``CepstrogramFrame`` uses ``-2``.
 
-    Raises
-    ------
-    TypeError
-        If ``axis`` is not an integer or concrete input is complex-valued.
-    ValueError
-        If ``axis`` is invalid or concrete coefficients are not circularly
-        symmetric.
+    Raises:
+        TypeError: If ``axis`` is not an integer or concrete input is complex-valued.
+        ValueError: If ``axis`` is invalid or concrete coefficients are not circularly
+            symmetric.
     """
 
     name = "spectral_envelope"

--- a/wandas/processing/custom.py
+++ b/wandas/processing/custom.py
@@ -26,23 +26,17 @@ class CustomOperation(AudioOperation[InputArrayType, OutputArrayType]):
         """
         Initialize CustomOperation.
 
-        Parameters
-        ----------
-        sampling_rate : float
-            Sampling rate (Hz)
-        func : Callable
-            Function to apply to the data.
-        output_shape_func : Callable, optional
-            Function to calculate output shape from input shape.
-        dask_pure : bool, default=True
-            Dask execution-control flag for the delayed task. Set to ``False``
-            for non-deterministic or side-effecting custom functions. This is
-            not forwarded to the custom function or recorded in lineage params.
-        **params : Any
-            Additional parameters to pass to the function. ``pure`` and
-            ``dask_pure`` are reserved for operation purity and Dask task
-            semantics; use different custom parameter names such as
-            ``is_pure``.
+        Args:
+            sampling_rate: float. Sampling rate (Hz)
+            func: Callable. Function to apply to the data.
+            output_shape_func: Callable, optional. Function to calculate output shape from input shape.
+            dask_pure: bool, default=True. Dask execution-control flag for the delayed task. Set to ``False``
+                for non-deterministic or side-effecting custom functions. This is
+                not forwarded to the custom function or recorded in lineage params.
+            **params: Any. Additional parameters to pass to the function. ``pure`` and
+                ``dask_pure`` are reserved for operation purity and Dask task
+                semantics; use different custom parameter names such as
+                ``is_pure``.
         """
         # Store callables privately so a frame lineage operation cannot alter a
         # pending Dask graph by reassigning public attributes before compute.

--- a/wandas/processing/effects.py
+++ b/wandas/processing/effects.py
@@ -127,33 +127,25 @@ class Normalize(AudioOperation[NDArrayReal, NDArrayReal]):
         """
         Initialize normalization operation
 
-        Parameters
-        ----------
-        sampling_rate : float
-            Sampling rate (Hz)
-        norm : float or np.inf, default=np.inf
-            Norm type. Supported values:
-            - np.inf: Maximum absolute value normalization
-            - -np.inf: Minimum absolute value normalization
-            - 0: Pseudo L0 normalization (divide by number of non-zero elements)
-            - float: Lp norm
-            - None: No normalization
-        axis : int or None, default=-1
-            Axis along which to normalize.
-            - -1: Normalize along time axis (each channel independently)
-            - None: Global normalization across all axes
-            - int: Normalize along specified axis
-        threshold : float or None, optional
-            Threshold below which values are considered zero.
-            If None, no threshold is applied.
-        fill : bool or None, optional
-            Value to fill when the norm is zero.
-            If None, the zero vector remains zero.
+        Args:
+            sampling_rate: float. Sampling rate (Hz)
+            norm: float or np.inf, default=np.inf. Norm type. Supported values:
+                - np.inf: Maximum absolute value normalization
+                - -np.inf: Minimum absolute value normalization
+                - 0: Pseudo L0 normalization (divide by number of non-zero elements)
+                - float: Lp norm
+                - None: No normalization
+            axis: int or None, default=-1. Axis along which to normalize.
+                - -1: Normalize along time axis (each channel independently)
+                - None: Global normalization across all axes
+                - int: Normalize along specified axis
+            threshold: float or None, optional. Threshold below which values are considered zero.
+                If None, no threshold is applied.
+            fill: bool or None, optional. Value to fill when the norm is zero.
+                If None, the zero vector remains zero.
 
-        Raises
-        ------
-        ValueError
-            If norm parameter is invalid or threshold is negative
+        Raises:
+            ValueError: If norm parameter is invalid or threshold is negative
         """
         # Validate norm parameter
         if norm is not None and not isinstance(norm, int | float):
@@ -277,10 +269,8 @@ class RemoveDC(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
     def __init__(self, sampling_rate: float):
         """Initialize DC removal operation.
 
-        Parameters
-        ----------
-        sampling_rate : float
-            Sampling rate (Hz)
+        Args:
+            sampling_rate: float. Sampling rate (Hz)
         """
         super().__init__(sampling_rate)
         logger.debug("Initialized RemoveDC operation")
@@ -293,15 +283,11 @@ class RemoveDC(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
     def _process(self, x: NDArrayReal) -> NDArrayReal:
         """Perform DC removal processing.
 
-        Parameters
-        ----------
-        x : NDArrayReal
-            Input signal array (channels, samples)
+        Args:
+            x: NDArrayReal. Input signal array (channels, samples)
 
-        Returns
-        -------
-        NDArrayReal
-            Signal with DC component removed
+        Returns:
+            NDArrayReal: Signal with DC component removed
         """
         logger.debug(f"Removing DC component from array with shape: {x.shape}")
 
@@ -324,12 +310,9 @@ class AddWithSNR(AudioOperation[NDArrayReal, NDArrayReal]):
         """
         Initialize addition operation considering SNR
 
-        Parameters
-        ----------
-        sampling_rate : float
-            Sampling rate (Hz)
-        snr : float
-            Signal-to-noise ratio (dB)
+        Args:
+            sampling_rate: float. Sampling rate (Hz)
+            snr: float. Signal-to-noise ratio (dB)
         """
         super().__init__(sampling_rate, snr=snr)
         logger.debug(f"Initialized AddWithSNR operation with SNR: {snr} dB")
@@ -395,24 +378,18 @@ class Fade(AudioOperation[NDArrayReal, NDArrayReal]):
         For symmetric fade-in/fade-out, alpha = 2 * fade_len / n_samples ensures
         that each side's taper has exactly fade_len samples.
 
-        Parameters
-        ----------
-        fade_len : int
-            Desired fade length in samples for each end (in and out).
-        n_samples : int
-            Total number of samples in the signal.
+        Args:
+            fade_len: int. Desired fade length in samples for each end (in and out).
+            n_samples: int. Total number of samples in the signal.
 
-        Returns
-        -------
-        float
-            Alpha parameter for scipy.signal.windows.tukey, clamped to [0, 1].
+        Returns:
+            float: Alpha parameter for scipy.signal.windows.tukey, clamped to [0, 1].
 
-        Examples
-        --------
-        >>> Fade.calculate_tukey_alpha(fade_len=20, n_samples=200)
-        0.2
-        >>> Fade.calculate_tukey_alpha(fade_len=100, n_samples=100)
-        1.0
+        Examples:
+            >>> Fade.calculate_tukey_alpha(fade_len=20, n_samples=200)
+            0.2
+            >>> Fade.calculate_tukey_alpha(fade_len=100, n_samples=100)
+            1.0
         """
         alpha = float(2 * fade_len) / float(n_samples)
         return min(1.0, alpha)

--- a/wandas/processing/filters.py
+++ b/wandas/processing/filters.py
@@ -18,19 +18,13 @@ logger = logging.getLogger(__name__)
 def _validate_cutoff(cutoff: float, sampling_rate: float, label: str = "Cutoff") -> None:
     """Validate a single cutoff frequency against the Nyquist limit.
 
-    Parameters
-    ----------
-    cutoff : float
-        Cutoff frequency in Hz.
-    sampling_rate : float
-        Sampling rate in Hz.
-    label : str
-        Human-readable name for error messages (e.g. "Lower cutoff").
+    Args:
+        cutoff: float. Cutoff frequency in Hz.
+        sampling_rate: float. Sampling rate in Hz.
+        label: str. Human-readable name for error messages (e.g. "Lower cutoff").
 
-    Raises
-    ------
-    ValueError
-        If cutoff is not in the open interval (0, Nyquist).
+    Raises:
+        ValueError: If cutoff is not in the open interval (0, Nyquist).
     """
     nyquist = sampling_rate / 2
     if cutoff <= 0 or cutoff >= nyquist:
@@ -130,23 +124,16 @@ class BandPassFilter(_ButterworthFilter):
         """
         Initialize band-pass filter
 
-        Parameters
-        ----------
-        sampling_rate : float
-            Sampling rate (Hz)
-        low_cutoff : float
-            Lower cutoff frequency (Hz). Must be between 0 and Nyquist frequency.
-        high_cutoff : float
-            Higher cutoff frequency (Hz). Must be between 0 and Nyquist frequency
-            and greater than low_cutoff.
-        order : int, optional
-            Filter order, default is 4
+        Args:
+            sampling_rate: float. Sampling rate (Hz)
+            low_cutoff: float. Lower cutoff frequency (Hz). Must be between 0 and Nyquist frequency.
+            high_cutoff: float. Higher cutoff frequency (Hz). Must be between 0 and Nyquist frequency
+                and greater than low_cutoff.
+            order: int, optional. Filter order, default is 4
 
-        Raises
-        ------
-        ValueError
-            If either cutoff frequency is not within valid range (0 < cutoff < Nyquist),
-            or if low_cutoff >= high_cutoff
+        Raises:
+            ValueError: If either cutoff frequency is not within valid range (0 < cutoff < Nyquist),
+                or if low_cutoff >= high_cutoff
         """
         # Skip single-cutoff _ButterworthFilter.__init__
         AudioOperation.__init__(self, sampling_rate, low_cutoff=low_cutoff, high_cutoff=high_cutoff, order=order)
@@ -208,10 +195,8 @@ class AWeighting(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
         """
         Initialize A-weighting filter
 
-        Parameters
-        ----------
-        sampling_rate : float
-            Sampling rate (Hz)
+        Args:
+            sampling_rate: float. Sampling rate (Hz)
         """
         super().__init__(sampling_rate)
 

--- a/wandas/processing/psychoacoustic.py
+++ b/wandas/processing/psychoacoustic.py
@@ -64,17 +64,13 @@ def _process_per_channel(
 ) -> NDArrayReal:
     """Run *func* on each channel of *x* and collect results.
 
-    Parameters
-    ----------
-    x : NDArrayReal
-        Input array, shape ``(channels, samples)`` or ``(samples,)``.
-    func : callable
-        ``func(channel_1d) -> result``. *result* is a 1-D array for
-        time-varying metrics or a scalar for steady-state metrics.
-    scalar : bool
-        If ``True`` each *func* return is a scalar and results are
-        stacked into shape ``(channels, 1)``.  Otherwise results are
-        ``np.stack``-ed along axis 0.
+    Args:
+        x: NDArrayReal. Input array, shape ``(channels, samples)`` or ``(samples,)``.
+        func: callable. ``func(channel_1d) -> result``. *result* is a 1-D array for
+            time-varying metrics or a scalar for steady-state metrics.
+        scalar: bool. If ``True`` each *func* return is a scalar and results are
+            stacked into shape ``(channels, 1)``.  Otherwise results are
+            ``np.stack``-ed along axis 0.
     """
     if x.ndim == 1:
         x = x.reshape(1, -1)
@@ -176,43 +172,34 @@ class LoudnessZwtv(_ZwickerTimeVaryingBase):
     The loudness is calculated in sones, a unit of perceived loudness where a doubling
     of sones corresponds to a doubling of perceived loudness.
 
-    Parameters
-    ----------
-    sampling_rate : float
-        Sampling rate in Hz. The signal should be sampled at a rate appropriate
-        for the analysis (typically 44100 Hz or 48000 Hz for audio).
-    field_type : str, default="free"
-        Type of sound field. Options:
-        - 'free': Free field (sound arriving from a specific direction)
-        - 'diffuse': Diffuse field (sound arriving uniformly from all directions)
+    Args:
+        sampling_rate: float. Sampling rate in Hz. The signal should be sampled at a rate appropriate
+            for the analysis (typically 44100 Hz or 48000 Hz for audio).
+        field_type: str, default="free". Type of sound field. Options:
+            - 'free': Free field (sound arriving from a specific direction)
+            - 'diffuse': Diffuse field (sound arriving uniformly from all directions)
 
-    Attributes
-    ----------
-    name : str
-        Operation name: "loudness_zwtv"
-    field_type : str
-        The sound field type used for calculation
+    Attributes:
+        name: str. Operation name: "loudness_zwtv"
+        field_type: str. The sound field type used for calculation
 
-    Examples
-    --------
-    Calculate loudness for a signal:
-    >>> import wandas as wd
-    >>> signal = wd.read("audio.wav")
-    >>> loudness = signal.loudness_zwtv(field_type="free")
+    Examples:
+        Calculate loudness for a signal:
+        >>> import wandas as wd
+        >>> signal = wd.read("audio.wav")
+        >>> loudness = signal.loudness_zwtv(field_type="free")
 
-    Notes
-    -----
-    - The output contains time-varying loudness values in sones
-    - For mono signals, the loudness is calculated directly
-    - For multi-channel signals, loudness is calculated per channel
-    - The method follows ISO 532-1:2017 standard for time-varying loudness
-    - Typical loudness values: 1 sone ≈ 40 phon (loudness level)
+    Notes:
+        - The output contains time-varying loudness values in sones
+        - For mono signals, the loudness is calculated directly
+        - For multi-channel signals, loudness is calculated per channel
+        - The method follows ISO 532-1:2017 standard for time-varying loudness
+        - Typical loudness values: 1 sone ≈ 40 phon (loudness level)
 
-    References
-    ----------
-    .. [1] ISO 532-1:2017, "Acoustics — Methods for calculating loudness —
+    References:
+        .. [1] ISO 532-1:2017, "Acoustics — Methods for calculating loudness —
            Part 1: Zwicker method"
-    .. [2] MoSQITo documentation:
+        .. [2] MoSQITo documentation:
            https://mosqito.readthedocs.io/en/latest/
     """
 
@@ -241,15 +228,11 @@ class LoudnessZwtv(_ZwickerTimeVaryingBase):
         """
         Process array to calculate loudness.
 
-        Parameters
-        ----------
-        x : NDArrayReal
-            Input signal array with shape (channels, samples) or (samples,)
+        Args:
+            x: NDArrayReal. Input signal array with shape (channels, samples) or (samples,)
 
-        Returns
-        -------
-        NDArrayReal
-            Time-varying loudness in sones for each channel.
+        Returns:
+            NDArrayReal: Time-varying loudness in sones for each channel.
             Shape: (channels, time_samples)
         """
         logger.debug(f"Calculating loudness for signal with shape: {x.shape}, field_type: {self.field_type}")
@@ -276,46 +259,37 @@ class LoudnessZwst(_SteadyStateBase):
     The loudness is calculated in sones, a unit of perceived loudness where a doubling
     of sones corresponds to a doubling of perceived loudness.
 
-    Parameters
-    ----------
-    sampling_rate : float
-        Sampling rate in Hz. The signal should be sampled at a rate appropriate
-        for the analysis (typically 44100 Hz or 48000 Hz for audio).
-    field_type : str, default="free"
-        Type of sound field. Options:
-        - 'free': Free field (sound arriving from a specific direction)
-        - 'diffuse': Diffuse field (sound arriving uniformly from all directions)
+    Args:
+        sampling_rate: float. Sampling rate in Hz. The signal should be sampled at a rate appropriate
+            for the analysis (typically 44100 Hz or 48000 Hz for audio).
+        field_type: str, default="free". Type of sound field. Options:
+            - 'free': Free field (sound arriving from a specific direction)
+            - 'diffuse': Diffuse field (sound arriving uniformly from all directions)
 
-    Attributes
-    ----------
-    name : str
-        Operation name: "loudness_zwst"
-    field_type : str
-        The sound field type used for calculation
+    Attributes:
+        name: str. Operation name: "loudness_zwst"
+        field_type: str. The sound field type used for calculation
 
-    Examples
-    --------
-    Calculate steady-state loudness for a signal:
-    >>> import wandas as wd
-    >>> signal = wd.read("fan_noise.wav")
-    >>> loudness = signal.loudness_zwst(field_type="free")
-    >>> print(f"Steady-state loudness: {loudness.data[0]:.2f} sones")
+    Examples:
+        Calculate steady-state loudness for a signal:
+        >>> import wandas as wd
+        >>> signal = wd.read("fan_noise.wav")
+        >>> loudness = signal.loudness_zwst(field_type="free")
+        >>> print(f"Steady-state loudness: {loudness.data[0]:.2f} sones")
 
-    Notes
-    -----
-    - The output contains a single loudness value in sones for each channel
-    - For mono signals, the loudness is calculated directly
-    - For multi-channel signals, loudness is calculated per channel
-    - The method follows ISO 532-1:2017 standard for steady-state loudness
-    - Typical loudness values: 1 sone ≈ 40 phon (loudness level)
-    - This method is suitable for stationary signals such as fan noise,
+    Notes:
+        - The output contains a single loudness value in sones for each channel
+        - For mono signals, the loudness is calculated directly
+        - For multi-channel signals, loudness is calculated per channel
+        - The method follows ISO 532-1:2017 standard for steady-state loudness
+        - Typical loudness values: 1 sone ≈ 40 phon (loudness level)
+        - This method is suitable for stationary signals such as fan noise,
       constant machinery sounds, or other steady sounds
 
-    References
-    ----------
-    .. [1] ISO 532-1:2017, "Acoustics — Methods for calculating loudness —
+    References:
+        .. [1] ISO 532-1:2017, "Acoustics — Methods for calculating loudness —
            Part 1: Zwicker method"
-    .. [2] MoSQITo documentation:
+        .. [2] MoSQITo documentation:
            https://mosqito.readthedocs.io/en/latest/
     """
 
@@ -344,15 +318,11 @@ class LoudnessZwst(_SteadyStateBase):
         """
         Process array to calculate steady-state loudness.
 
-        Parameters
-        ----------
-        x : NDArrayReal
-            Input signal array with shape (channels, samples) or (samples,)
+        Args:
+            x: NDArrayReal. Input signal array with shape (channels, samples) or (samples,)
 
-        Returns
-        -------
-        NDArrayReal
-            Steady-state loudness in sones for each channel.
+        Returns:
+            NDArrayReal: Steady-state loudness in sones for each channel.
             Shape: (channels, 1)
         """
         logger.debug(
@@ -429,47 +399,38 @@ class RoughnessDw(_RoughnessBase):
     The calculation follows the standard formula:
     R = 0.25 * sum(R'_i) for i=1 to 47 Bark bands
 
-    Parameters
-    ----------
-    sampling_rate : float
-        Sampling rate in Hz. The signal should be sampled at a rate appropriate
-        for the analysis (typically 44100 Hz or 48000 Hz for audio).
-    overlap : float, default=0.5
-        Overlapping coefficient for the analysis windows (0.0 to 1.0).
-        The analysis uses 200ms windows:
-        - overlap=0.5: 100ms hop size → ~10 Hz output sampling rate
-        - overlap=0.0: 200ms hop size → ~5 Hz output sampling rate
+    Args:
+        sampling_rate: float. Sampling rate in Hz. The signal should be sampled at a rate appropriate
+            for the analysis (typically 44100 Hz or 48000 Hz for audio).
+        overlap: float, default=0.5. Overlapping coefficient for the analysis windows (0.0 to 1.0).
+            The analysis uses 200ms windows:
+            - overlap=0.5: 100ms hop size → ~10 Hz output sampling rate
+            - overlap=0.0: 200ms hop size → ~5 Hz output sampling rate
 
-    Attributes
-    ----------
-    name : str
-        Operation name: "roughness_dw"
-    overlap : float
-        The overlapping coefficient used for calculation
+    Attributes:
+        name: str. Operation name: "roughness_dw"
+        overlap: float. The overlapping coefficient used for calculation
 
-    Examples
-    --------
-    Calculate roughness for a signal:
-    >>> import wandas as wd
-    >>> signal = wd.read("motor_noise.wav")
-    >>> roughness = signal.roughness_dw(overlap=0.5)
-    >>> print(f"Mean roughness: {roughness.data.mean():.2f} asper")
+    Examples:
+        Calculate roughness for a signal:
+        >>> import wandas as wd
+        >>> signal = wd.read("motor_noise.wav")
+        >>> roughness = signal.roughness_dw(overlap=0.5)
+        >>> print(f"Mean roughness: {roughness.data.mean():.2f} asper")
 
-    Notes
-    -----
-    - The output contains time-varying roughness values in asper
-    - For mono signals, the roughness is calculated directly
-    - For multi-channel signals, roughness is calculated per channel
-    - The method follows Daniel & Weber (1997) standard
-    - Typical roughness values: 0-2 asper for most sounds
-    - Higher overlap values provide better time resolution but increase
+    Notes:
+        - The output contains time-varying roughness values in asper
+        - For mono signals, the roughness is calculated directly
+        - For multi-channel signals, roughness is calculated per channel
+        - The method follows Daniel & Weber (1997) standard
+        - Typical roughness values: 0-2 asper for most sounds
+        - Higher overlap values provide better time resolution but increase
       computational cost
 
-    References
-    ----------
-    .. [1] Daniel, P., & Weber, R. (1997). "Psychoacoustical roughness:
+    References:
+        .. [1] Daniel, P., & Weber, R. (1997). "Psychoacoustical roughness:
            Implementation of an optimized model." Acustica, 83, 113-123.
-    .. [2] MoSQITo documentation:
+        .. [2] MoSQITo documentation:
            https://mosqito.readthedocs.io/en/latest/
     """
 
@@ -479,12 +440,9 @@ class RoughnessDw(_RoughnessBase):
         """
         Initialize Roughness calculation operation.
 
-        Parameters
-        ----------
-        sampling_rate : float
-            Sampling rate (Hz)
-        overlap : float, default=0.5
-            Overlapping coefficient (0.0 to 1.0)
+        Args:
+            sampling_rate: float. Sampling rate (Hz)
+            overlap: float, default=0.5. Overlapping coefficient (0.0 to 1.0)
         """
         self._overlap = overlap
         super().__init__(sampling_rate, overlap=overlap)
@@ -497,15 +455,11 @@ class RoughnessDw(_RoughnessBase):
         """
         Process array to calculate roughness.
 
-        Parameters
-        ----------
-        x : NDArrayReal
-            Input signal array with shape (channels, samples) or (samples,)
+        Args:
+            x: NDArrayReal. Input signal array with shape (channels, samples) or (samples,)
 
-        Returns
-        -------
-        NDArrayReal
-            Time-varying roughness in asper for each channel.
+        Returns:
+            NDArrayReal: Time-varying roughness in asper for each channel.
             Shape: (channels, time_samples)
         """
         logger.debug(f"Calculating roughness for signal with shape: {x.shape}, overlap: {self._overlap}")
@@ -646,52 +600,41 @@ class SharpnessDin(_ZwickerTimeVaryingBase):
     in acum (acum = 1 when the sound has the same sharpness as a
     2 kHz narrow-band noise with a level of 60 dB).
 
-    Parameters
-    ----------
-    sampling_rate : float
-        Sampling rate in Hz. The signal should be sampled at a rate appropriate
-        for the analysis (typically 44100 Hz or 48000 Hz for audio).
-    weighting : str, default="din"
-        Weighting function used for the sharpness computation. Options:
-        - 'din': DIN 45692 method
-        - 'aures': Aures method
-        - 'bismarck': Bismarck method
-        - 'fastl': Fastl method
-    field_type : str, default="free"
-        Type of sound field. Options:
-        - 'free': Free field (sound arriving from a specific direction)
-        - 'diffuse': Diffuse field (sound arriving uniformly from all directions)
+    Args:
+        sampling_rate: float. Sampling rate in Hz. The signal should be sampled at a rate appropriate
+            for the analysis (typically 44100 Hz or 48000 Hz for audio).
+        weighting: str, default="din". Weighting function used for the sharpness computation. Options:
+            - 'din': DIN 45692 method
+            - 'aures': Aures method
+            - 'bismarck': Bismarck method
+            - 'fastl': Fastl method
+        field_type: str, default="free". Type of sound field. Options:
+            - 'free': Free field (sound arriving from a specific direction)
+            - 'diffuse': Diffuse field (sound arriving uniformly from all directions)
 
-    Attributes
-    ----------
-    name : str
-        Operation name: "sharpness_din"
-    weighting : str
-        The weighting function used for sharpness calculation
-    field_type : str
-        The sound field type used for calculation
+    Attributes:
+        name: str. Operation name: "sharpness_din"
+        weighting: str. The weighting function used for sharpness calculation
+        field_type: str. The sound field type used for calculation
 
-    Examples
-    --------
-    Calculate sharpness for a signal:
-    >>> import wandas as wd
-    >>> signal = wd.read("sharp_sound.wav")
-    >>> sharpness = signal.sharpness_din(weighting="din", field_type="free")
-    >>> print(f"Mean sharpness: {sharpness.data.mean():.2f} acum")
+    Examples:
+        Calculate sharpness for a signal:
+        >>> import wandas as wd
+        >>> signal = wd.read("sharp_sound.wav")
+        >>> sharpness = signal.sharpness_din(weighting="din", field_type="free")
+        >>> print(f"Mean sharpness: {sharpness.data.mean():.2f} acum")
 
-    Notes
-    -----
-    - The output contains time-varying sharpness values in acum
-    - For mono signals, the sharpness is calculated directly
-    - For multi-channel signals, sharpness is calculated per channel
-    - The method follows DIN 45692 standard
-    - Typical sharpness values: 0-5 acum for most sounds
+    Notes:
+        - The output contains time-varying sharpness values in acum
+        - For mono signals, the sharpness is calculated directly
+        - For multi-channel signals, sharpness is calculated per channel
+        - The method follows DIN 45692 standard
+        - Typical sharpness values: 0-5 acum for most sounds
 
-    References
-    ----------
-    .. [1] DIN 45692:2009, "Measurement technique for the simulation of the
+    References:
+        .. [1] DIN 45692:2009, "Measurement technique for the simulation of the
            auditory sensation of sharpness"
-    .. [2] MoSQITo documentation:
+        .. [2] MoSQITo documentation:
            https://mosqito.readthedocs.io/en/latest/
     """
 
@@ -726,15 +669,11 @@ class SharpnessDin(_ZwickerTimeVaryingBase):
         """
         Process array to calculate sharpness.
 
-        Parameters
-        ----------
-        x : NDArrayReal
-            Input signal array with shape (channels, samples) or (samples,)
+        Args:
+            x: NDArrayReal. Input signal array with shape (channels, samples) or (samples,)
 
-        Returns
-        -------
-        NDArrayReal
-            Time-varying sharpness in acum for each channel.
+        Returns:
+            NDArrayReal: Time-varying sharpness in acum for each channel.
             Shape: (channels, time_samples)
         """
         logger.debug(f"Calculating sharpness for signal with shape: {x.shape}")
@@ -768,54 +707,43 @@ class SharpnessDinSt(_SteadyStateBase):
     in acum (acum = 1 when the sound has the same sharpness as a
     2 kHz narrow-band noise with a level of 60 dB).
 
-    Parameters
-    ----------
-    sampling_rate : float
-        Sampling rate in Hz. The signal should be sampled at a rate appropriate
-        for the analysis (typically 44100 Hz or 48000 Hz for audio).
-    weighting : str, default="din"
-        Weighting function used for the sharpness computation. Options:
-        - 'din': DIN 45692 method
-        - 'aures': Aures method
-        - 'bismarck': Bismarck method
-        - 'fastl': Fastl method
-    field_type : str, default="free"
-        Type of sound field. Options:
-        - 'free': Free field (sound arriving from a specific direction)
-        - 'diffuse': Diffuse field (sound arriving uniformly from all directions)
+    Args:
+        sampling_rate: float. Sampling rate in Hz. The signal should be sampled at a rate appropriate
+            for the analysis (typically 44100 Hz or 48000 Hz for audio).
+        weighting: str, default="din". Weighting function used for the sharpness computation. Options:
+            - 'din': DIN 45692 method
+            - 'aures': Aures method
+            - 'bismarck': Bismarck method
+            - 'fastl': Fastl method
+        field_type: str, default="free". Type of sound field. Options:
+            - 'free': Free field (sound arriving from a specific direction)
+            - 'diffuse': Diffuse field (sound arriving uniformly from all directions)
 
-    Attributes
-    ----------
-    name : str
-        Operation name: "sharpness_din_st"
-    weighting : str
-        The weighting function used for sharpness calculation
-    field_type : str
-        The sound field type used for calculation
+    Attributes:
+        name: str. Operation name: "sharpness_din_st"
+        weighting: str. The weighting function used for sharpness calculation
+        field_type: str. The sound field type used for calculation
 
-    Examples
-    --------
-    Calculate steady-state sharpness for a signal:
-    >>> import wandas as wd
-    >>> signal = wd.read("constant_tone.wav")
-    >>> sharpness = signal.sharpness_din_st(weighting="din", field_type="free")
-    >>> print(f"Steady-state sharpness: {sharpness.data[0]:.2f} acum")
+    Examples:
+        Calculate steady-state sharpness for a signal:
+        >>> import wandas as wd
+        >>> signal = wd.read("constant_tone.wav")
+        >>> sharpness = signal.sharpness_din_st(weighting="din", field_type="free")
+        >>> print(f"Steady-state sharpness: {sharpness.data[0]:.2f} acum")
 
-    Notes
-    -----
-    - The output contains a single sharpness value in acum for each channel
-    - For mono signals, the sharpness is calculated directly
-    - For multi-channel signals, sharpness is calculated per channel
-    - The method follows DIN 45692 standard for steady-state sharpness
-    - Typical sharpness values: 0-5 acum for most sounds
-    - This method is suitable for stationary signals such as constant tones,
+    Notes:
+        - The output contains a single sharpness value in acum for each channel
+        - For mono signals, the sharpness is calculated directly
+        - For multi-channel signals, sharpness is calculated per channel
+        - The method follows DIN 45692 standard for steady-state sharpness
+        - Typical sharpness values: 0-5 acum for most sounds
+        - This method is suitable for stationary signals such as constant tones,
       steady noise, or other unchanging sounds
 
-    References
-    ----------
-    .. [1] DIN 45692:2009, "Measurement technique for the simulation of the
+    References:
+        .. [1] DIN 45692:2009, "Measurement technique for the simulation of the
            auditory sensation of sharpness"
-    .. [2] MoSQITo documentation:
+        .. [2] MoSQITo documentation:
            https://mosqito.readthedocs.io/en/latest/
     """
 
@@ -850,15 +778,11 @@ class SharpnessDinSt(_SteadyStateBase):
         """
         Process array to calculate steady-state sharpness.
 
-        Parameters
-        ----------
-        x : NDArrayReal
-            Input signal array with shape (channels, samples) or (samples,)
+        Args:
+            x: NDArrayReal. Input signal array with shape (channels, samples) or (samples,)
 
-        Returns
-        -------
-        NDArrayReal
-            Steady-state sharpness in acum for each channel.
+        Returns:
+            NDArrayReal: Steady-state sharpness in acum for each channel.
             Shape: (channels, 1)
         """
         logger.debug(

--- a/wandas/processing/spectral.py
+++ b/wandas/processing/spectral.py
@@ -89,26 +89,17 @@ def _validate_spectral_params(
     """
     Validate and compute spectral analysis parameters.
 
-    Parameters
-    ----------
-    n_fft : int
-        FFT size
-    win_length : int or None
-        Window length (None means use n_fft)
-    hop_length : int or None
-        Hop length (None means use win_length // 4)
-    method_name : str
-        Name of the method for error messages (e.g., "STFT", "Welch method")
+    Args:
+        n_fft: int. FFT size
+        win_length: int or None. Window length (None means use n_fft)
+        hop_length: int or None. Hop length (None means use win_length // 4)
+        method_name: str. Name of the method for error messages (e.g., "STFT", "Welch method")
 
-    Returns
-    -------
-    tuple[int, int]
-        (actual_win_length, actual_hop_length)
+    Returns:
+        tuple[int, int]: (actual_win_length, actual_hop_length)
 
-    Raises
-    ------
-    ValueError
-        If parameters are invalid
+    Raises:
+        ValueError: If parameters are invalid
     """
     # Validate n_fft
     if n_fft <= 0:
@@ -198,19 +189,13 @@ class FFT(AudioOperation[NDArrayReal, NDArrayComplex]):
         """
         Initialize FFT operation
 
-        Parameters
-        ----------
-        sampling_rate : float
-            Sampling rate (Hz)
-        n_fft : int, optional
-            FFT size, default is None (determined by input size)
-        window : str, optional
-            Window function type, default is 'hann'
+        Args:
+            sampling_rate: float. Sampling rate (Hz)
+            n_fft: int, optional. FFT size, default is None (determined by input size)
+            window: str, optional. Window function type, default is 'hann'
 
-        Raises
-        ------
-        ValueError
-            If n_fft is not a positive integer
+        Raises:
+            ValueError: If n_fft is not a positive integer
         """
         # Validate n_fft parameter
         if n_fft is not None and n_fft <= 0:
@@ -239,15 +224,11 @@ class FFT(AudioOperation[NDArrayReal, NDArrayComplex]):
         """
         Calculate output data shape after the operation.
 
-        Parameters
-        ----------
-        input_shape : tuple
-            Input data shape (channels, samples).
+        Args:
+            input_shape: tuple. Input data shape (channels, samples).
 
-        Returns
-        -------
-        tuple
-            Output data shape (channels, freqs).
+        Returns:
+            tuple: Output data shape (channels, freqs).
         """
         n_fft = self.n_fft
         n_freqs = n_fft // 2 + 1 if n_fft else input_shape[-1] // 2 + 1
@@ -292,14 +273,10 @@ class IFFT(AudioOperation[NDArrayComplex, NDArrayReal]):
         """
         Initialize IFFT operation
 
-        Parameters
-        ----------
-        sampling_rate : float
-            Sampling rate (Hz)
-        n_fft : Optional[int], optional
-            IFFT size, default is None (determined based on input size)
-        window : str, optional
-            Window function type, default is 'hann'
+        Args:
+            sampling_rate: float. Sampling rate (Hz)
+            n_fft: Optional[int], optional. IFFT size, default is None (determined based on input size)
+            window: str, optional. Window function type, default is 'hann'
         """
         super().__init__(sampling_rate, n_fft=n_fft, window=window)
 
@@ -317,15 +294,11 @@ class IFFT(AudioOperation[NDArrayComplex, NDArrayReal]):
         """
         Calculate output data shape after operation
 
-        Parameters
-        ----------
-        input_shape : tuple
-            Input data shape (channels, freqs)
+        Args:
+            input_shape: tuple. Input data shape (channels, freqs)
 
-        Returns
-        -------
-        tuple
-            Output data shape (channels, samples)
+        Returns:
+            tuple: Output data shape (channels, samples)
         """
         n_fft = self.n_fft
         n_samples = 2 * (input_shape[-1] - 1) if n_fft is None else n_fft
@@ -395,23 +368,15 @@ class STFT(AudioOperation[NDArrayReal, NDArrayComplex]):
         """
         Initialize STFT operation
 
-        Parameters
-        ----------
-        sampling_rate : float
-            Sampling rate (Hz)
-        n_fft : int
-            FFT size, default is 2048
-        hop_length : int, optional
-            Number of samples between frames. Default is win_length // 4
-        win_length : int, optional
-            Window length. Default is n_fft
-        window : str
-            Window type, default is 'hann'
+        Args:
+            sampling_rate: float. Sampling rate (Hz)
+            n_fft: int. FFT size, default is 2048
+            hop_length: int, optional. Number of samples between frames. Default is win_length // 4
+            win_length: int, optional. Window length. Default is n_fft
+            window: str. Window type, default is 'hann'
 
-        Raises
-        ------
-        ValueError
-            If n_fft is not positive, win_length > n_fft, or hop_length is invalid
+        Raises:
+            ValueError: If n_fft is not positive, win_length > n_fft, or hop_length is invalid
         """
         # Validate and compute parameters
         actual_win_length, actual_hop_length = _validate_spectral_params(n_fft, win_length, hop_length, "STFT")
@@ -455,15 +420,11 @@ class STFT(AudioOperation[NDArrayReal, NDArrayComplex]):
         """
         Calculate output data shape after operation
 
-        Parameters
-        ----------
-        input_shape : tuple
-            Input data shape
+        Args:
+            input_shape: tuple. Input data shape
 
-        Returns
-        -------
-        tuple
-            Output data shape
+        Returns:
+            tuple: Output data shape
         """
         n_channels = input_shape[0]
         n_samples = input_shape[-1]
@@ -512,25 +473,16 @@ class ISTFT(AudioOperation[NDArrayComplex, NDArrayReal]):
         """
         Initialize ISTFT operation
 
-        Parameters
-        ----------
-        sampling_rate : float
-            Sampling rate (Hz)
-        n_fft : int
-            FFT size, default is 2048
-        hop_length : int, optional
-            Number of samples between frames. Default is win_length // 4
-        win_length : int, optional
-            Window length. Default is n_fft
-        window : str
-            Window type, default is 'hann'
-        length : int, optional
-            Length of output signal. Default is None (determined from input)
+        Args:
+            sampling_rate: float. Sampling rate (Hz)
+            n_fft: int. FFT size, default is 2048
+            hop_length: int, optional. Number of samples between frames. Default is win_length // 4
+            win_length: int, optional. Window length. Default is n_fft
+            window: str. Window type, default is 'hann'
+            length: int, optional. Length of output signal. Default is None (determined from input)
 
-        Raises
-        ------
-        ValueError
-            If n_fft is not positive, win_length > n_fft, or hop_length is invalid
+        Raises:
+            ValueError: If n_fft is not positive, win_length > n_fft, or hop_length is invalid
         """
         # Validate and compute parameters
         actual_win_length, actual_hop_length = _validate_spectral_params(n_fft, win_length, hop_length, "ISTFT")
@@ -586,51 +538,45 @@ class ISTFT(AudioOperation[NDArrayComplex, NDArrayReal]):
         output length based on the input spectrogram dimensions and output range
         parameters (k0, k1).
 
-        Parameters
-        ----------
-        input_shape : tuple
-            Input spectrogram shape (channels, n_freqs, n_frames)
-            where n_freqs = n_fft // 2 + 1 and n_frames is the number of time frames.
+        Args:
+            input_shape: tuple. Input spectrogram shape (channels, n_freqs, n_frames)
+                where n_freqs = n_fft // 2 + 1 and n_frames is the number of time frames.
 
-        Returns
-        -------
-        tuple
-            Output shape (channels, output_samples) where output_samples is the
-            reconstructed signal length determined by the output range [k0, k1).
+        Returns:
+            tuple: Output shape (channels, output_samples) where output_samples is the
+                reconstructed signal length determined by the output range [k0, k1).
 
-        Notes
-        -----
-        The calculation follows SciPy's ShortTimeFFT.istft() implementation.
-        When k1 is None (default), the maximum reconstructible signal length is
-        computed as:
+        Notes:
+            The calculation follows SciPy's ShortTimeFFT.istft() implementation.
+            When k1 is None (default), the maximum reconstructible signal length is
+            computed as:
 
-        .. math::
+            .. math::
 
             q_{max} = n_{frames} + p_{min}
 
             k_{max} = (q_{max} - 1) \\cdot hop + m_{num} - m_{num\\_mid}
 
-        The output length is then:
+            The output length is then:
 
-        .. math::
+            .. math::
 
             output\\_samples = k_1 - k_0
 
-        where k0 defaults to 0 and k1 defaults to k_max.
+            where k0 defaults to 0 and k1 defaults to k_max.
 
-        Parameters that affect the calculation:
-        - n_frames: number of time frames in the STFT
-        - p_min: minimum frame index (ShortTimeFFT property)
-        - hop: hop length (samples between frames)
-        - m_num: window length
-        - m_num_mid: window midpoint position
-        - length: optional length override (if set, limits output)
+            Parameters that affect the calculation:
+            - n_frames: number of time frames in the STFT
+            - p_min: minimum frame index (ShortTimeFFT property)
+            - hop: hop length (samples between frames)
+            - m_num: window length
+            - m_num_mid: window midpoint position
+            - length: optional length override (if set, limits output)
 
-        References
-        ----------
-        - SciPy ShortTimeFFT.istft:
+        References:
+            - SciPy ShortTimeFFT.istft:
           https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.ShortTimeFFT.istft.html
-        - SciPy Source: https://github.com/scipy/scipy/blob/main/scipy/signal/_short_time_fft.py
+            - SciPy Source: https://github.com/scipy/scipy/blob/main/scipy/signal/_short_time_fft.py
         """
         n_channels = input_shape[0]
         n_frames = input_shape[-1]  # time_frames
@@ -723,27 +669,17 @@ class Welch(AudioOperation[NDArrayReal, NDArrayReal]):
         """
         Initialize Welch operation
 
-        Parameters
-        ----------
-        sampling_rate : float
-            Sampling rate (Hz)
-        n_fft : int, optional
-            FFT size, default is 2048
-        hop_length : int, optional
-            Number of samples between frames. Default is win_length // 4
-        win_length : int, optional
-            Window length. Default is n_fft
-        window : str, optional
-            Window function type, default is 'hann'
-        average : str, optional
-            Averaging method, default is 'mean'
-        detrend : str, optional
-            Detrend method, default is 'constant'
+        Args:
+            sampling_rate: float. Sampling rate (Hz)
+            n_fft: int, optional. FFT size, default is 2048
+            hop_length: int, optional. Number of samples between frames. Default is win_length // 4
+            win_length: int, optional. Window length. Default is n_fft
+            window: str, optional. Window function type, default is 'hann'
+            average: str, optional. Averaging method, default is 'mean'
+            detrend: str, optional. Detrend method, default is 'constant'
 
-        Raises
-        ------
-        ValueError
-            If n_fft, win_length, or hop_length are invalid
+        Raises:
+            ValueError: If n_fft, win_length, or hop_length are invalid
         """
         # Validate and compute parameters
         actual_win_length, actual_hop_length = _validate_spectral_params(n_fft, win_length, hop_length, "Welch method")
@@ -797,15 +733,11 @@ class Welch(AudioOperation[NDArrayReal, NDArrayReal]):
         """
         Calculate output data shape after operation
 
-        Parameters
-        ----------
-        input_shape : tuple
-            Input data shape (channels, samples)
+        Args:
+            input_shape: tuple. Input data shape (channels, samples)
 
-        Returns
-        -------
-        tuple
-            Output data shape (channels, freqs)
+        Returns:
+            tuple: Output data shape (channels, freqs)
         """
         n_freqs = self.n_fft // 2 + 1
         return (*input_shape[:-1], n_freqs)

--- a/wandas/processing/stats.py
+++ b/wandas/processing/stats.py
@@ -19,10 +19,8 @@ class ABS(AudioOperation[NDArrayReal, NDArrayReal]):
         """
         Initialize absolute value operation
 
-        Parameters
-        ----------
-        sampling_rate : float
-            Sampling rate (Hz)
+        Args:
+            sampling_rate: float. Sampling rate (Hz)
         """
         super().__init__(sampling_rate)
 
@@ -40,12 +38,9 @@ class Power(AudioOperation[NDArrayReal, NDArrayReal]):
         """
         Initialize power operation
 
-        Parameters
-        ----------
-        sampling_rate : float
-            Sampling rate (Hz)
-        exponent : float
-            Power exponent
+        Args:
+            sampling_rate: float. Sampling rate (Hz)
+            exponent: float. Power exponent
         """
         super().__init__(sampling_rate, exponent=exponent)
 
@@ -93,12 +88,9 @@ class ChannelDifference(AudioOperation[NDArrayReal, NDArrayReal]):
         """
         Initialize channel difference calculation
 
-        Parameters
-        ----------
-        sampling_rate : float
-            Sampling rate (Hz)
-        other_channel : int
-            Channel to calculate difference with, default is 0
+        Args:
+            sampling_rate: float. Sampling rate (Hz)
+            other_channel: int. Channel to calculate difference with, default is 0
         """
         super().__init__(sampling_rate, other_channel=other_channel)
 

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -468,8 +468,9 @@ class ReSampling(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
         Returns:
             dict: Metadata updates with the new sampling rate.
 
-            Note:: Resampling always produces output at ``target_sr``, regardless of
-                the input sampling rate.
+        Notes:
+            Resampling always produces output at ``target_sr``, regardless of the
+            input sampling rate.
         """
         return {"sampling_rate": self.target_sr}
 

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -468,9 +468,8 @@ class ReSampling(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
         Returns:
             dict: Metadata updates with the new sampling rate.
 
-        Note:
-            Resampling always produces output at ``target_sr``, regardless of
-            the input sampling rate.
+            Note:: Resampling always produces output at ``target_sr``, regardless of
+                the input sampling rate.
         """
         return {"sampling_rate": self.target_sr}
 
@@ -611,7 +610,7 @@ class FixLength(AudioOperation[NDArrayReal, NDArrayReal]):
 
         Returns:
             Shape with the same leading dimensions and ``target_length`` as
-            the final dimension.
+                the final dimension.
         """
         return (*input_shape[:-1], self.target_length)
 
@@ -750,8 +749,8 @@ class RmsTrend(AudioOperation[NDArrayReal, NDArrayReal]):
 
         Returns:
             A mapping containing ``sampling_rate`` set to
-            ``sampling_rate / hop_length``. The returned value describes the
-            window centers, not the original sample rate.
+                ``sampling_rate / hop_length``. The returned value describes the
+                window centers, not the original sample rate.
         """
         new_sr = self.sampling_rate / self.hop_length
         return {"sampling_rate": new_sr}
@@ -765,7 +764,7 @@ class RmsTrend(AudioOperation[NDArrayReal, NDArrayReal]):
 
         Returns:
             The input leading dimensions followed by the number of centered
-            windows, so a two-dimensional input returns ``(channels, frames)``.
+                windows, so a two-dimensional input returns ``(channels, frames)``.
 
         Raises:
             ValueError: If dB output uses a reference or calibration scale that
@@ -1072,7 +1071,7 @@ class SoundLevel(AudioOperation[NDArrayReal, NDArrayReal]):
 
         Returns:
             The unchanged input shape. ``sound_level`` is sample-wise and keeps
-            the input sampling rate.
+                the input sampling rate.
 
         Raises:
             ValueError: If a per-channel reference or calibration scale cannot

--- a/wandas/processing/weighting.py
+++ b/wandas/processing/weighting.py
@@ -71,7 +71,7 @@ def ABC_weighting(curve: str = "A") -> tuple[NDArrayReal, NDArrayReal, float]:
 
     Returns:
         A tuple ``(z, p, k)`` containing zero locations, pole locations, and
-        gain normalized to 0 dB at 1 kHz.
+            gain normalized to 0 dB at 1 kHz.
 
     Raises:
         ValueError: If ``curve`` is not ``"A"``, ``"B"``, or ``"C"``.

--- a/wandas/processing/weighting.py
+++ b/wandas/processing/weighting.py
@@ -70,8 +70,8 @@ def ABC_weighting(curve: str = "A") -> tuple[NDArrayReal, NDArrayReal, float]:
         curve: Weighting curve type: ``"A"``, ``"B"``, or ``"C"``.
 
     Returns:
-        A tuple ``(z, p, k)`` containing zero locations, pole locations, and
-            gain normalized to 0 dB at 1 kHz.
+        tuple[NDArrayReal, NDArrayReal, float]: A tuple ``(z, p, k)`` containing
+            zero locations, pole locations, and gain normalized to 0 dB at 1 kHz.
 
     Raises:
         ValueError: If ``curve`` is not ``"A"``, ``"B"``, or ``"C"``.

--- a/wandas/utils/frame_dataset.py
+++ b/wandas/utils/frame_dataset.py
@@ -357,21 +357,16 @@ class FrameDataset(Generic[F], ABC):
         """
         Get all frames matching the given label (filename).
 
-        Parameters
-        ----------
-        label : str
-            The filename (label) to search for (e.g., 'sample_1.wav').
+        Args:
+            label: str. The filename (label) to search for (e.g., 'sample_1.wav').
 
-        Returns
-        -------
-        list[F]
-            A list of frames matching the label.
-            If none are found, returns an empty list.
+        Returns:
+            list[F]: A list of frames matching the label.
+                If none are found, returns an empty list.
 
-        Notes
-        -----
-        - Search is performed against the filename portion only (i.e. Path.name).
-        - Each matched frame will be loaded (triggering lazy load) via `_ensure_loaded`.
+        Notes:
+            - Search is performed against the filename portion only (i.e. Path.name).
+            - Each matched frame will be loaded (triggering lazy load) via `_ensure_loaded`.
         """
         matches: list[F] = []
         for i, lazy_frame in enumerate(self._lazy_frames):
@@ -391,37 +386,28 @@ class FrameDataset(Generic[F], ABC):
         """
         Get the frame by index (int) or label (str).
 
-        Parameters
-        ----------
-        key : int or str
-            Index (int) or filename/label (str).
+        Args:
+            key: int or str. Index (int) or filename/label (str).
 
-        Returns
-        -------
-        F | None or list[F]
-            If ``key`` is an int, returns the cached Frame or ``None`` when loading
-            or transformation failed. If ``key`` is a str, returns all successfully
-            loaded matching Frames; the list is empty when no match loads.
+        Returns:
+            F | None or list[F]: If ``key`` is an int, returns the cached Frame or ``None`` when loading
+                or transformation failed. If ``key`` is a str, returns all successfully
+                loaded matching Frames; the list is empty when no match loads.
 
-        Raises
-        ------
-        IndexError
-            If an integer index is outside ``0 <= key < len(dataset)``. Negative
-            indexing is not supported.
-        TypeError
-            If ``key`` is neither an integer nor a string.
+        Raises:
+            IndexError: If an integer index is outside ``0 <= key < len(dataset)``. Negative
+                indexing is not supported.
+            TypeError: If ``key`` is neither an integer nor a string.
 
-        Notes
-        -----
-        A ``None`` result is cached as an attempted item and is not retried
-        automatically. Exceptions are also logged. Frame creation may inspect a file
-        header, but sample values remain Dask-lazy until a Frame materialization API
-        is used.
+        Notes:
+            A ``None`` result is cached as an attempted item and is not retried
+            automatically. Exceptions are also logged. Frame creation may inspect a file
+            header, but sample values remain Dask-lazy until a Frame materialization API
+            is used.
 
-        Examples
-        --------
-        >>> frame = dataset[0]  # by index
-        >>> frames = dataset["sample_1.wav"]  # list of matches by filename
+        Examples:
+            >>> frame = dataset[0]  # by index
+            >>> frames = dataset["sample_1.wav"]  # list of matches by filename
         """
         if isinstance(key, int):
             return self._ensure_loaded(key)
@@ -466,10 +452,8 @@ class FrameDataset(Generic[F], ABC):
         Saving individual Frames is supported through the Frame API. This method is
         retained only to fail explicitly and must not be used as a persistence path.
 
-        Raises
-        ------
-        NotImplementedError
-            Always raised because ``FrameDataset.save()`` is unsupported.
+        Raises:
+            NotImplementedError: Always raised because ``FrameDataset.save()`` is unsupported.
         """
         raise NotImplementedError("The save method is not currently implemented.")
 

--- a/wandas/utils/generate_sample.py
+++ b/wandas/utils/generate_sample.py
@@ -66,37 +66,27 @@ def generate_sin(
     """
     Generate sample sine wave signals.
 
-    Parameters
-    ----------
-    freqs : real number or list of real numbers, default=1000.0
-        Positive finite frequency of each sine wave in Hz. A scalar creates one
-        channel; a list creates one channel per element. Python and NumPy integer
-        and floating scalars are accepted and normalized to ``float``.
-    sampling_rate : int, default=16000
-        Sampling rate in Hz.
-    duration : float, default=1.0
-        Duration of the signal in seconds.
-    label : str, optional
-        Label for the entire signal.
+    Args:
+        freqs: real number or list of real numbers, default=1000.0. Positive
+            finite frequency of each sine wave in Hz. A scalar creates one
+            channel; a list creates one channel per element. Python and NumPy integer
+            and floating scalars are accepted and normalized to ``float``.
+        sampling_rate: int, default=16000. Sampling rate in Hz.
+        duration: float, default=1.0. Duration of the signal in seconds.
+        label: str, optional. Label for the entire signal.
 
-    Returns
-    -------
-    ChannelFrame
-        Dask-backed ChannelFrame containing the sine wave(s).
+    Returns:
+        ChannelFrame: Dask-backed ChannelFrame containing the sine wave(s).
 
-    Raises
-    ------
-    TypeError
-        If ``freqs`` or one of its elements is not a real numeric scalar.
-    ValueError
-        If a frequency list is empty or a frequency is non-finite or not positive.
+    Raises:
+        TypeError: If ``freqs`` or one of its elements is not a real numeric scalar.
+        ValueError: If a frequency list is empty or a frequency is non-finite or not positive.
 
-    Examples
-    --------
-    >>> import wandas as wd
-    >>> signal = wd.generate_sin()
-    >>> signal.sampling_rate
-    16000
+    Examples:
+        >>> import wandas as wd
+        >>> signal = wd.generate_sin()
+        >>> signal.sampling_rate
+        16000
     """
     return generate_sin_lazy(freqs=freqs, sampling_rate=sampling_rate, duration=duration, label=label)
 
@@ -110,35 +100,25 @@ def generate_sin_lazy(
     """
     Generate sample sine wave signals using lazy computation.
 
-    Parameters
-    ----------
-    freqs : real number or list of real numbers, default=1000.0
-        Positive finite frequency of each sine wave in Hz. A scalar creates one
-        channel; a list creates one channel per element. Python and NumPy integer
-        and floating scalars are accepted and normalized to ``float``.
-    sampling_rate : int, default=16000
-        Sampling rate in Hz.
-    duration : float, default=1.0
-        Duration of the signal in seconds.
-    label : str, optional
-        Label for the entire signal.
+    Args:
+        freqs: real number or list of real numbers, default=1000.0. Positive
+            finite frequency of each sine wave in Hz. A scalar creates one
+            channel; a list creates one channel per element. Python and NumPy integer
+            and floating scalars are accepted and normalized to ``float``.
+        sampling_rate: int, default=16000. Sampling rate in Hz.
+        duration: float, default=1.0. Duration of the signal in seconds.
+        label: str, optional. Label for the entire signal.
 
-    Returns
-    -------
-    ChannelFrame
-        Dask-backed ChannelFrame containing the sine wave(s).
+    Returns:
+        ChannelFrame: Dask-backed ChannelFrame containing the sine wave(s).
 
-    Raises
-    ------
-    TypeError
-        If ``freqs`` or one of its elements is not a real numeric scalar.
-    ValueError
-        If a frequency list is empty or a frequency is non-finite or not positive.
+    Raises:
+        TypeError: If ``freqs`` or one of its elements is not a real numeric scalar.
+        ValueError: If a frequency list is empty or a frequency is non-finite or not positive.
 
-    Notes
-    -----
-    This is the low-level implementation name used by ``generate_sin``. It is not
-    exported from the top-level ``wandas`` namespace.
+    Notes:
+        This is the low-level implementation name used by ``generate_sin``. It is not
+        exported from the top-level ``wandas`` namespace.
     """
     from wandas.frames.channel import ChannelFrame
 

--- a/wandas/utils/introspection.py
+++ b/wandas/utils/introspection.py
@@ -20,8 +20,8 @@ def accepted_kwargs(func: Callable[..., Any]) -> tuple[set[str], bool]:
 
     Returns:
         A tuple containing:
-        - set[str]: Set of explicit keyword argument names accepted by func.
-        - bool: Whether the function accepts variable keyword arguments (**kwargs).
+            - set[str]: Set of explicit keyword argument names accepted by func.
+            - bool: Whether the function accepts variable keyword arguments (**kwargs).
     """
     # Return empty set and unlimited flag for mock objects
     if hasattr(func, "__module__") and func.__module__ == "unittest.mock":

--- a/wandas/utils/util.py
+++ b/wandas/utils/util.py
@@ -36,19 +36,13 @@ def ref_weighted_dB(
 ) -> NDArrayReal:
     """Compute dB level relative to per-channel reference values.
 
-    Parameters
-    ----------
-    data : NDArrayReal
-        Non-negative amplitude data (already absolute-valued if complex).
-    channel_metadata : list
-        Objects with a ``.ref`` attribute (one per channel).
-    ndim : int
-        Number of dimensions in the underlying dask array.
+    Args:
+        data: NDArrayReal. Non-negative amplitude data (already absolute-valued if complex).
+        channel_metadata: list. Objects with a ``.ref`` attribute (one per channel).
+        ndim: int. Number of dimensions in the underlying dask array.
 
-    Returns
-    -------
-    NDArrayReal
-        Decibel values: ``20 * log10(max(data / ref, DB_FLOOR))``
+    Returns:
+        NDArrayReal: Decibel values: ``20 * log10(max(data / ref, DB_FLOOR))``
     """
     ref = np.array([ch.ref for ch in channel_metadata])
     extra_dims = ndim - 1
@@ -81,23 +75,17 @@ def validate_sampling_rate(sampling_rate: float, param_name: str = "sampling_rat
     """
     Validate that sampling rate is positive.
 
-    Parameters
-    ----------
-    sampling_rate : float
-        Sampling rate in Hz to validate.
-    param_name : str, default="sampling_rate"
-        Name of the parameter being validated (for error messages).
+    Args:
+        sampling_rate: float. Sampling rate in Hz to validate.
+        param_name: str, default="sampling_rate". Name of the parameter being validated (for error messages).
 
-    Raises
-    ------
-    ValueError
-        If sampling_rate is not positive (i.e., <= 0).
+    Raises:
+        ValueError: If sampling_rate is not positive (i.e., <= 0).
 
-    Examples
-    --------
-    >>> validate_sampling_rate(44100)  # No error
-    >>> validate_sampling_rate(0)  # Raises ValueError
-    >>> validate_sampling_rate(-100)  # Raises ValueError
+    Examples:
+        >>> validate_sampling_rate(44100)  # No error
+        >>> validate_sampling_rate(0)  # Raises ValueError
+        >>> validate_sampling_rate(-100)  # Raises ValueError
     """
     _normalize_sampling_rate(sampling_rate, param_name)
 
@@ -106,16 +94,12 @@ def unit_to_ref(unit: str) -> float:
     """
     Convert unit to reference value.
 
-    Parameters
-    ----------
-    unit : str
-        Unit string.
+    Args:
+        unit: str. Unit string.
 
-    Returns
-    -------
-    float
-        Reference value for the unit. For 'Pa', returns 2e-5 (20 μPa).
-        For other units, returns 1.0.
+    Returns:
+        float: Reference value for the unit. For 'Pa', returns 2e-5 (20 μPa).
+            For other units, returns 1.0.
     """
     if unit == "Pa":
         return PA_REFERENCE
@@ -127,17 +111,13 @@ def calculate_rms(wave: "NDArrayReal") -> "NDArrayReal":
     """
     Calculate the root mean square of the wave.
 
-    Parameters
-    ----------
-    wave : NDArrayReal
-        Input waveform data. Can be multi-channel (shape: [channels, samples])
-        or single channel (shape: [samples]).
+    Args:
+        wave: NDArrayReal. Input waveform data. Can be multi-channel (shape: [channels, samples])
+            or single channel (shape: [samples]).
 
-    Returns
-    -------
-    Union[float, NDArray[np.float64]]
-        RMS value(s). For multi-channel input, returns an array of RMS values,
-        one per channel. For single-channel input, returns a single RMS value.
+    Returns:
+        Union[float, NDArray[np.float64]]: RMS value(s). For multi-channel input, returns an array of RMS values,
+            one per channel. For single-channel input, returns a single RMS value.
     """
     # Calculate RMS considering axis (over the last dimension)
     axis_to_use = -1 if wave.ndim > 1 else None
@@ -149,18 +129,13 @@ def calculate_desired_noise_rms(clean_rms: "NDArrayReal", snr: float) -> "NDArra
     """
     Calculate the desired noise RMS based on clean signal RMS and target SNR.
 
-    Parameters
-    ----------
-    clean_rms : "NDArrayReal"
-        RMS value(s) of the clean signal.
-        Can be a single value or an array for multi-channel.
-    snr : float
-        Target Signal-to-Noise Ratio in dB.
+    Args:
+        clean_rms: "NDArrayReal". RMS value(s) of the clean signal.
+            Can be a single value or an array for multi-channel.
+        snr: float. Target Signal-to-Noise Ratio in dB.
 
-    Returns
-    -------
-    "NDArrayReal"
-        Desired noise RMS value(s) to achieve the target SNR.
+    Returns:
+        "NDArrayReal": Desired noise RMS value(s) to achieve the target SNR.
     """
     a = snr / 20
     noise_rms = clean_rms / (10**a)
@@ -171,17 +146,12 @@ def amplitude_to_db(amplitude: "NDArrayReal", ref: float) -> "NDArrayReal":
     """
     Convert amplitude to decibel.
 
-    Parameters
-    ----------
-    amplitude : NDArrayReal
-        Input amplitude data.
-    ref : float
-        Reference value for conversion.
+    Args:
+        amplitude: NDArrayReal. Input amplitude data.
+        ref: float. Reference value for conversion.
 
-    Returns
-    -------
-    NDArrayReal
-        Amplitude data converted to decibels.
+    Returns:
+        NDArrayReal: Amplitude data converted to decibels.
     """
     magnitude = np.abs(amplitude)
     ref_magnitude = abs(ref)
@@ -193,21 +163,14 @@ def level_trigger(data: "NDArrayReal", level: float, offset: int = 0, hold: int 
     """
     Find points where the signal crosses the specified level from below.
 
-    Parameters
-    ----------
-    data : NDArrayReal
-        Input signal data.
-    level : float
-        Threshold level for triggering.
-    offset : int, default=0
-        Offset to add to trigger points.
-    hold : int, default=1
-        Minimum number of samples between successive trigger points.
+    Args:
+        data: NDArrayReal. Input signal data.
+        level: float. Threshold level for triggering.
+        offset: int, default=0. Offset to add to trigger points.
+        hold: int, default=1. Minimum number of samples between successive trigger points.
 
-    Returns
-    -------
-    list of int
-        List of sample indices where the signal crosses the level.
+    Returns:
+        list of int: List of sample indices where the signal crosses the level.
     """
     trig_point: list[int] = []
 
@@ -239,24 +202,16 @@ def cut_sig(
     """
     Cut segments from signal at specified points.
 
-    Parameters
-    ----------
-    data : NDArrayReal
-        Input signal data.
-    point_list : list of int
-        List of starting points for cutting.
-    cut_len : int
-        Length of each segment to cut.
-    taper_rate : float, default=0
-        Taper rate for Tukey window applied to segments.
-        A value of 0 means no tapering, 1 means full tapering.
-    dc_cut : bool, default=False
-        Whether to remove DC component (mean) from segments.
+    Args:
+        data: NDArrayReal. Input signal data.
+        point_list: list of int. List of starting points for cutting.
+        cut_len: int. Length of each segment to cut.
+        taper_rate: float, default=0. Taper rate for Tukey window applied to segments.
+            A value of 0 means no tapering, 1 means full tapering.
+        dc_cut: bool, default=False. Whether to remove DC component (mean) from segments.
 
-    Returns
-    -------
-    NDArrayReal
-        Array containing cut segments with shape (n_segments, cut_len).
+    Returns:
+        NDArrayReal: Array containing cut segments with shape (n_segments, cut_len).
     """
     length = len(data)
     point_list_ = [p for p in point_list if p >= 0 and p + cut_len <= length]

--- a/wandas/visualization/plotting.py
+++ b/wandas/visualization/plotting.py
@@ -89,25 +89,18 @@ def _resolve_channel_label(
 ) -> str:
     """Resolve the label for a single channel in the non-overlay (per-subplot) path.
 
-    Parameters
-    ----------
-    label : str | Sequence[str] | None
-        User-supplied label override.  When a sequence is given its element at
-        *channel_index* is used; when a plain string is given that string is
-        used for every channel; when ``None`` the channel metadata label is
-        used.
-    ch_meta : ChannelMetadata
-        Metadata for the current channel (provides the default label).
-    channel_index : int
-        Zero-based index of the current channel in the frame.
-    n_channels : int
-        Total number of channels in the frame. Used to validate per-channel
-        label sequences before indexing.
+    Args:
+        label: str | Sequence[str] | None. User-supplied label override.  When a sequence is given its element at
+            *channel_index* is used; when a plain string is given that string is
+            used for every channel; when ``None`` the channel metadata label is
+            used.
+        ch_meta: ChannelMetadata. Metadata for the current channel (provides the default label).
+        channel_index: int. Zero-based index of the current channel in the frame.
+        n_channels: int. Total number of channels in the frame. Used to validate per-channel
+            label sequences before indexing.
 
-    Returns
-    -------
-    str
-        The resolved label string.
+    Returns:
+        str: The resolved label string.
     """
     if label is None:
         return str(ch_meta.label)
@@ -132,15 +125,11 @@ def _reshape_to_2d(data: Any) -> Any:
     This function ensures that data has at least 2 dimensions for plotting operations.
     If the input data is 1D, it will be reshaped to (1, -1).
 
-    Parameters
-    ----------
-    data : array-like
-        Input data that may be 1D or already 2D+
+    Args:
+        data: array-like. Input data that may be 1D or already 2D+
 
-    Returns
-    -------
-    array-like
-        Data reshaped to ensure at least 2 dimensions
+    Returns:
+        array-like: Data reshaped to ensure at least 2 dimensions
     """
     if data.ndim == 1:
         data = data.reshape(1, -1)
@@ -154,15 +143,11 @@ def _reshape_spectrogram_data(data: Any) -> Any:
     This function ensures that spectrogram data has 3 dimensions:
     (channels, freqs, time). Handles both 1D and 2D input data.
 
-    Parameters
-    ----------
-    data : array-like
-        Input spectrogram data that may be 1D, 2D, or already 3D
+    Args:
+        data: array-like. Input spectrogram data that may be 1D, 2D, or already 3D
 
-    Returns
-    -------
-    array-like
-        Data reshaped to ensure 3 dimensions for spectrogram plotting
+    Returns:
+        array-like: Data reshaped to ensure 3 dimensions for spectrogram plotting
     """
     if data.ndim == 1:
         # 1D data: reshape to (1, freqs, 1) - single channel, single time frame
@@ -195,20 +180,14 @@ def _plot_line_layout(
 
     Handles overlay (single axes) and multi-subplot (per-channel) modes.
 
-    Parameters
-    ----------
-    strategy : PlotStrategy
-        The strategy whose ``channel_plot`` method will be called.
-    bf : BaseFrame
-        The frame being plotted (provides ``n_channels``, ``channels``, ``labels``).
-    x_data : array-like
-        X-axis values (e.g. ``bf.time`` or ``bf.freqs``).
-    data_2d : array-like
-        2-D array of shape ``(n_channels, n_samples)`` already reshaped via
-        ``_reshape_to_2d``.
-    per_channel_ylabel_fn : callable, optional
-        ``(ylabel, ch_meta) -> str`` override for per-channel y-labels
-        (e.g. to append a unit suffix).
+    Args:
+        strategy: PlotStrategy. The strategy whose ``channel_plot`` method will be called.
+        bf: BaseFrame. The frame being plotted (provides ``n_channels``, ``channels``, ``labels``).
+        x_data: array-like. X-axis values (e.g. ``bf.time`` or ``bf.freqs``).
+        data_2d: array-like. 2-D array of shape ``(n_channels, n_samples)`` already reshaped via
+            ``_reshape_to_2d``.
+        per_channel_ylabel_fn: callable, optional. ``(ylabel, ch_meta) -> str`` override for per-channel y-labels
+            (e.g. to append a unit suffix).
     """
     plot_kwargs = plot_kwargs or {}
     ax_set = ax_set or {}


### PR DESCRIPTION
## 方針

#392で採用したdocstring-first構成を完成させる追補PRです。公開APIと学習素材内のdocstringをGoogle styleへ統一し、NumPy-styleの見出し・区切り線を残しません。

- `wandas` と `learning-path` のdocstringをGoogle styleへ移行
- API契約の内容、数値処理、Frame挙動、lineage、Recipe、Dask lazinessは変更なし
- 独自parser、形式判定器、差分検証器、公開API inventoryは追加しない
- API Markdownは#392のmodule overview + mkdocstrings構成を維持

## Validation

- `uv run ruff check wandas tests scripts` — passed
- `uv run ruff format --check wandas tests scripts` — passed
- `uv run ty check wandas tests scripts` — passed
- `uv run python -m compileall -q wandas learning-path` — passed
- `uv run python scripts/check_public_docstrings.py` — passed
- `uv run pytest tests/docs -q` — 71 passed
- `uv run marimo check --strict learning-path/*.py` — passed
- `uv run mkdocs build --strict -f docs/mkdocs.yml` — passed
- NumPy-style section scan over Python sources — no matches

This is a follow-up to the merged #392 integration PR; it addresses the remaining format-unification gap found during final audit.