### PR TITLE
test(docs): address post-merge review findings

### DIFF
--- a/tests/docs/test_docs_links.py
+++ b/tests/docs/test_docs_links.py
@@ -68,6 +68,7 @@ def test_mkdocs_nav_targets_exist():
 
 def test_learning_path_source_navigation_targets_exported_apps() -> None:
     lessons = sorted((REPO_ROOT / "learning-path").glob("[0-9][0-9]_*.py"))
+    assert lessons, "learning-path must contain at least one numbered lesson"
     names = {lesson.with_suffix(".html").name for lesson in lessons}
 
     for lesson in lessons:

--- a/tests/docs/test_learning_path_executable_contracts.py
+++ b/tests/docs/test_learning_path_executable_contracts.py
@@ -11,7 +11,6 @@ import wandas as wd
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LEARNING_PATH = REPO_ROOT / "learning-path"
 APPS = tuple(sorted(LEARNING_PATH.glob("[0-9][0-9]_*.py")))
-OFFLINE_APPS = tuple(path for path in APPS if path.name != "06_skill_validation.py")
 
 
 def _load_app(path: Path):
@@ -45,7 +44,7 @@ def test_learning_apps_execute_offline_with_checked_in_fixtures(tmp_path, monkey
     monkeypatch.setattr(urllib.request, "urlretrieve", reject_network)
     monkeypatch.chdir(tmp_path)
 
-    for path in OFFLINE_APPS:
+    for path in APPS:
         module = _load_app(path)
         with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
             _outputs, definitions = module.app.run()

--- a/tests/docs/test_learning_path_public_api.py
+++ b/tests/docs/test_learning_path_public_api.py
@@ -21,7 +21,6 @@ def test_learning_path_uses_frame_data_as_the_value_boundary() -> None:
     findings = {
         path.relative_to(REPO_ROOT).as_posix(): [token for token in PRIVATE_API_TOKENS if token in text]
         for path in sorted(LEARNING_PATH.glob("*.py"))
-        if path.name != "06_skill_validation.py"
         if (text := path.read_text(encoding="utf-8"))
         if any(token in text for token in PRIVATE_API_TOKENS)
     }

--- a/tests/docs/test_metadata_search_demo.py
+++ b/tests/docs/test_metadata_search_demo.py
@@ -18,7 +18,7 @@ def test_metadata_search_demo_files_match_sidecar() -> None:
     assert {int(row["priority"]) for row in rows} == {1, 2}
 
 
-def test_metadata_search_demo_wavs_are_tiny_and_consistent() -> None:
+def test_metadata_search_demo_wavs_are_readable_and_nonempty() -> None:
     wav_paths = sorted(DEMO_ROOT.rglob("*.wav"))
 
     assert wav_paths

--- a/tests/docs/test_readme_examples.py
+++ b/tests/docs/test_readme_examples.py
@@ -17,7 +17,8 @@ REPOSITORY_IMAGE_PREFIXES = (
 )
 OPTIONAL_CODE_PATTERNS = (
     re.compile(r"^\s*(?:from|import)\s+(?:h5netcdf|h5py|IPython|librosa|marimo|mosqito|tensorflow|torch)\b", re.M),
-    re.compile(r"\.\s*(?:hpss_harmonic|loudness|noct_spectrum|roughness|sharpness)_[a-z0-9_]*\s*\("),
+    re.compile(r"\.\s*(?:hpss_harmonic|noct_spectrum)\s*\("),
+    re.compile(r"\.\s*(?:loudness|roughness|sharpness)_[a-z0-9_]+\s*\("),
     re.compile(r"\bto_tensor\s*\(\s*framework\s*=\s*[\"'](?:tensorflow|torch)[\"']"),
     re.compile(r"\.\s*(?:load|save)\s*\("),
 )

--- a/tests/docs/test_readme_examples.py
+++ b/tests/docs/test_readme_examples.py
@@ -17,8 +17,9 @@ REPOSITORY_IMAGE_PREFIXES = (
 )
 OPTIONAL_CODE_PATTERNS = (
     re.compile(r"^\s*(?:from|import)\s+(?:h5netcdf|h5py|IPython|librosa|marimo|mosqito|tensorflow|torch)\b", re.M),
-    re.compile(r"\.\s*(?:loudness|roughness|sharpness)_[a-z0-9_]+\s*\("),
+    re.compile(r"\.\s*(?:hpss_harmonic|loudness|noct_spectrum|roughness|sharpness)_[a-z0-9_]*\s*\("),
     re.compile(r"\bto_tensor\s*\(\s*framework\s*=\s*[\"'](?:tensorflow|torch)[\"']"),
+    re.compile(r"\.\s*(?:load|save)\s*\("),
 )
 
 
@@ -54,8 +55,8 @@ def _readme_image_paths(markdown: str) -> Iterator[Path]:
         candidate = (REPO_ROOT / target).resolve()
         try:
             candidate.relative_to(REPO_ROOT.resolve())
-        except ValueError:
-            continue
+        except ValueError as exc:
+            raise AssertionError(f"README image target escapes the repository: {target}") from exc
         yield candidate
 
 

--- a/tests/docs/test_readme_examples.py
+++ b/tests/docs/test_readme_examples.py
@@ -17,7 +17,7 @@ REPOSITORY_IMAGE_PREFIXES = (
 )
 OPTIONAL_CODE_PATTERNS = (
     re.compile(r"^\s*(?:from|import)\s+(?:h5netcdf|h5py|IPython|librosa|marimo|mosqito|tensorflow|torch)\b", re.M),
-    re.compile(r"\.\s*(?:hpss_harmonic|noct_spectrum)\s*\("),
+    re.compile(r"\.\s*(?:hpss_harmonic|hpss_percussive|noct_spectrum)\s*\("),
     re.compile(r"\.\s*(?:loudness|roughness|sharpness)_[a-z0-9_]+\s*\("),
     re.compile(r"\bto_tensor\s*\(\s*framework\s*=\s*[\"'](?:tensorflow|torch)[\"']"),
     re.compile(r"\.\s*(?:load|save)\s*\("),

--- a/tests/docs/test_readme_examples.py
+++ b/tests/docs/test_readme_examples.py
@@ -11,6 +11,15 @@ from matplotlib import pyplot as plt
 REPO_ROOT = Path(__file__).resolve().parents[2]
 README_PATHS = (REPO_ROOT / "README.md", REPO_ROOT / "README.ja.md")
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+REPOSITORY_IMAGE_PREFIXES = (
+    "https://raw.githubusercontent.com/kasahart/wandas/main/",
+    "https://github.com/kasahart/wandas/blob/main/",
+)
+OPTIONAL_CODE_PATTERNS = (
+    re.compile(r"^\s*(?:from|import)\s+(?:h5netcdf|h5py|IPython|librosa|marimo|mosqito|tensorflow|torch)\b", re.M),
+    re.compile(r"\.\s*(?:loudness|roughness|sharpness)_[a-z0-9_]+\s*\("),
+    re.compile(r"\bto_tensor\s*\(\s*framework\s*=\s*[\"'](?:tensorflow|torch)[\"']"),
+)
 
 
 def _python_blocks(markdown: str) -> list[str]:
@@ -34,13 +43,25 @@ def _repository_links(markdown: str) -> Iterator[str]:
 def _readme_image_paths(markdown: str) -> Iterator[Path]:
     for target in re.findall(r"!\[[^]]*\]\(([^)]+)\)", markdown):
         target = target.split(maxsplit=1)[0].split("#", maxsplit=1)[0].split("?", maxsplit=1)[0]
-        match = re.search(r"(?:^|/)images/(.+)$", target)
-        if match:
-            yield REPO_ROOT / "images" / match.group(1)
+        for prefix in REPOSITORY_IMAGE_PREFIXES:
+            if target.startswith(prefix):
+                target = target.removeprefix(prefix)
+                break
+        else:
+            if re.match(r"(?:[a-z][a-z0-9+.-]*:|/)", target):
+                continue
+
+        candidate = (REPO_ROOT / target).resolve()
+        try:
+            candidate.relative_to(REPO_ROOT.resolve())
+        except ValueError:
+            continue
+        yield candidate
 
 
 def _is_minimally_valid_image(path: Path) -> bool:
-    data = path.read_bytes()
+    with path.open("rb") as stream:
+        data = stream.read(12)
     if path.suffix.lower() == ".png":
         return data.startswith(PNG_SIGNATURE)
     if path.suffix.lower() in {".jpg", ".jpeg"}:
@@ -118,13 +139,12 @@ def test_readme_referenced_images_exist_and_have_valid_headers() -> None:
 
 def test_readme_python_examples_do_not_require_optional_extras() -> None:
     """Core README examples must not accidentally become optional-dependency examples."""
-    optional_imports = ("librosa", "mosqito", "marimo", "torch", "tensorflow")
     offenders = [
-        f"{path.name}: {module}"
+        f"{path.name}: {pattern.pattern}"
         for path in README_PATHS
         for block in _python_blocks(path.read_text(encoding="utf-8"))
-        for module in optional_imports
-        if re.search(rf"^\s*(?:from|import)\s+{re.escape(module)}\b", block, flags=re.M)
+        for pattern in OPTIONAL_CODE_PATTERNS
+        if pattern.search(block)
     ]
 
     assert offenders == []

--- a/tests/io/test_wav_io.py
+++ b/tests/io/test_wav_io.py
@@ -45,22 +45,22 @@ def test_wav_float_roundtrip(known_signal_frame, tmp_path) -> None:
     """
     wav_path = tmp_path / "float_roundtrip.wav"
     # Capture original data before write to verify immutability (Pillar 1)
-    original_data = channel_first_values(known_signal_frame).copy()
+    original_data = np.asarray(known_signal_frame.data).copy()
     known_signal_frame.to_wav(str(wav_path))
 
     # Verify original frame is unchanged after write (Pillar 1: side-effect free)
     np.testing.assert_array_equal(
-        channel_first_values(known_signal_frame), original_data, err_msg="to_wav must not mutate original frame data"
+        np.asarray(known_signal_frame.data), original_data, err_msg="to_wav must not mutate original frame data"
     )
 
     loaded = ChannelFrame.read_wav(str(wav_path))
-    loaded_values = channel_first_values(loaded)
+    loaded_values = np.asarray(loaded.data)
 
     assert sf.info(wav_path).subtype == "FLOAT"
     assert loaded.sampling_rate == known_signal_frame.sampling_rate
     assert loaded.n_channels == known_signal_frame.n_channels
     assert loaded_values.dtype == np.dtype(np.float64)
-    encoded = channel_first_values(known_signal_frame).astype(np.float32).astype(np.float64)
+    encoded = np.asarray(known_signal_frame.data).astype(np.float32).astype(np.float64)
     np.testing.assert_array_equal(loaded_values, encoded, err_msg="Float WAV round-trip data mismatch")
 
 

--- a/tests/io/test_wav_io.py
+++ b/tests/io/test_wav_io.py
@@ -54,13 +54,14 @@ def test_wav_float_roundtrip(known_signal_frame, tmp_path) -> None:
     )
 
     loaded = ChannelFrame.read_wav(str(wav_path))
+    loaded_values = channel_first_values(loaded)
 
     assert sf.info(wav_path).subtype == "FLOAT"
     assert loaded.sampling_rate == known_signal_frame.sampling_rate
     assert loaded.n_channels == known_signal_frame.n_channels
-    assert loaded._data.dtype == np.dtype(np.float64)
+    assert loaded_values.dtype == np.dtype(np.float64)
     encoded = channel_first_values(known_signal_frame).astype(np.float32).astype(np.float64)
-    np.testing.assert_array_equal(channel_first_values(loaded), encoded, err_msg="Float WAV round-trip data mismatch")
+    np.testing.assert_array_equal(loaded_values, encoded, err_msg="Float WAV round-trip data mismatch")
 
 
 def test_read_wav_stereo_dc_signal(tmp_path) -> None:

--- a/tests/utils/test_frame_dataset.py
+++ b/tests/utils/test_frame_dataset.py
@@ -737,6 +737,15 @@ class TestChannelFrameDataset:
         sampled = dataset.sample(seed=42)
         assert len(sampled) == max(1, int(len(dataset) * 0.1))
 
+    def test_sample_default_caps_at_ten_for_large_dataset(self, tmp_path: Path) -> None:
+        """Default sampling keeps large datasets bounded without loading files."""
+        for index in range(250):
+            (tmp_path / f"sample_{index:03}.wav").touch()
+
+        dataset = ChannelFrameDataset(str(tmp_path), lazy_loading=True)
+
+        assert len(dataset.sample(seed=42)) == 10
+
     def test_sample_exceeding_total_caps_at_total(self, create_test_files: Path) -> None:
         """Requesting more samples than available caps at total count."""
         folder_path = create_test_files


### PR DESCRIPTION
Follow-up to #405.

This small follow-up addresses actionable review findings without restoring editorial contracts that #405 intentionally removed.

Changes:
- use public materialized WAV values once instead of private `_data` in the round-trip product test;
- validate repository-relative README image references (including non-`images/` paths) and read only image headers;
- extend the README core-only guard to optional imports and optional API calls;
- make Learning App discovery non-vacuous and remove obsolete no-op exclusions;
- rename the metadata demo test to describe its remaining runtime checks;
- retain the unique large-dataset `FrameDataset.sample()` cap as a normal product test.

Intentionally not restored:
- exact docstring wording/removal-version assertions;
- spectral lesson label/prose assertions;
- fixed metadata-fixture size/shape/appearance assertions.

Validation:
- focused pytest: 162 passed;
- focused ruff check and format check: passed;
- commit hooks: ruff, format, ty passed.
