### PR TITLE
fix(spectral): use authoritative FFT size for N-octave synthesis

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -115,6 +115,7 @@ nav:
       - Public API Stability: explanation/public-api-stability.md
       - Pipeline Recipe Design: explanation/pipeline-recipe-design.md
   - Release Notes:
+      - Wandas 0.6.3: release-notes/v0.6.3.md
       - Wandas 0.6.2: release-notes/v0.6.2.md
       - Wandas 0.6.1: release-notes/v0.6.1.md
       - Wandas 0.6.0: release-notes/v0.6.0.md

--- a/docs/src/release-notes/v0.6.3.md
+++ b/docs/src/release-notes/v0.6.3.md
@@ -1,0 +1,21 @@
+# Wandas 0.6.3
+
+Wandas 0.6.3 makes N-octave synthesis use the authoritative FFT size stored by
+`SpectralFrame` and preserves the released Recipe v1 meaning during replay.
+
+## Changes
+
+- [Issue #398](https://github.com/kasahart/wandas/issues/398): validate N-octave
+  ratio conventions at the Operation boundary, use explicit FFT-size provenance
+  for current synthesis, and add fixed-payload Recipe compatibility coverage.
+
+## Compatibility
+
+The following numerical-correctness compatibility changes take effect in 0.6.3.
+The previous bin-count inference is not retained as a direct-operation shim because
+it cannot distinguish adjacent odd and even FFT sizes.
+
+| Affected surface or artifact | Classification | Deprecation start | Replacement or migration | Removal/change version | Exception reason and decision link |
+| --- | --- | --- | --- | --- | --- |
+| `wandas.processing.NOctSynthesis` constructor | Stable user surface | None | Pass the positive source `n_fft`; `SpectralFrame.noct_synthesis()` supplies it automatically. | 0.6.3 | Numerical-correctness exception approved by [Issue #398](https://github.com/kasahart/wandas/issues/398). |
+| `wandas.spectral.noct_synthesis` Recipe v1 | Serialized operation version | None | Existing v1 payloads replay through the legacy meaning; new public calls emit version 2. | 0.6.3 | Persisted numerical meaning is kept separate from the corrected current behavior; [Issue #398](https://github.com/kasahart/wandas/issues/398). |

--- a/tests/frames/test_channel_transform.py
+++ b/tests/frames/test_channel_transform.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest import mock
 
 import dask.array as da
@@ -356,6 +357,31 @@ class TestChannelTransform:
             "params": {"fmin": 20, "fmax": 8000, "n": 3, "G": 10, "fr": 1000},
         }
         assert not {"fmin", "fmax", "n", "G", "fr"}.intersection(result.metadata)
+
+    @pytest.mark.parametrize(
+        ("G", "error_type"),  # noqa: N803
+        [
+            pytest.param(True, TypeError, id="bool"),
+            pytest.param(2.0, TypeError, id="float"),
+            pytest.param(20, ValueError, id="unsupported"),
+        ],
+    )
+    def test_noct_spectrum_public_method_rejects_invalid_g_before_backend(
+        self,
+        G: Any,  # noqa: N803
+        error_type: type[Exception],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Public N-octave spectrum calls share operation-boundary G validation."""
+
+        def fail_backend(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError("invalid G reached an optional backend")
+
+        monkeypatch.setattr("wandas.processing.spectral.require_mosqito_center_freq", fail_backend)
+        monkeypatch.setattr("wandas.processing.spectral.noct_spectrum", fail_backend)
+
+        with pytest.raises(error_type, match="Specify G=2 or G=10"):
+            self.channel_frame.noct_spectrum(fmin=20, fmax=8000, G=G)
 
     def test_csd(self) -> None:
         """クロススペクトル密度（CSD）メソッドのテスト"""

--- a/tests/frames/test_spectral_frame.py
+++ b/tests/frames/test_spectral_frame.py
@@ -428,6 +428,37 @@ class TestSpectralFrame:
         ):
             self.frame.noct_synthesis(fmin=125.0, fmax=8000.0, n=3)
 
+    @pytest.mark.parametrize(
+        ("G", "error_type"),  # noqa: N803
+        [
+            pytest.param(False, TypeError, id="bool"),
+            pytest.param(10.0, TypeError, id="float"),
+            pytest.param(3, ValueError, id="unsupported"),
+        ],
+    )
+    def test_noct_synthesis_public_method_rejects_invalid_g_before_backend(
+        self,
+        G: Any,  # noqa: N803
+        error_type: type[Exception],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Public synthesis validates G before optional dependency execution."""
+        frame = SpectralFrame(
+            data=self.data,
+            sampling_rate=48000,
+            n_fft=_N_FFT,
+            window=_WINDOW,
+        )
+
+        def fail_backend(*_args: Any, **_kwargs: Any) -> None:
+            raise AssertionError("invalid G reached an optional backend")
+
+        monkeypatch.setattr("wandas.processing.spectral.require_mosqito_center_freq", fail_backend)
+        monkeypatch.setattr("wandas.processing.spectral.noct_synthesis", fail_backend)
+
+        with pytest.raises(error_type, match="Specify G=2 or G=10"):
+            frame.noct_synthesis(fmin=125.0, fmax=8000.0, G=G)
+
     def test_noct_synthesis(self) -> None:
         """Test noct_synthesis method"""
         # 正しいサンプリングレートでSpectralFrameを作成
@@ -466,7 +497,16 @@ class TestSpectralFrame:
             result = correct_sr_frame.noct_synthesis(fmin=fmin, fmax=fmax, n=n, G=G, fr=fr)
 
             # オペレーション作成の検証
-            mock_create_op.assert_called_once_with("noct_synthesis", 48000, fmin=fmin, fmax=fmax, n=n, G=G, fr=fr)
+            mock_create_op.assert_called_once_with(
+                "noct_synthesis",
+                48000,
+                fmin=fmin,
+                fmax=fmax,
+                n=n,
+                G=G,
+                fr=fr,
+                n_fft=correct_sr_frame.n_fft,
+            )
 
             # プロセスの呼び出し検証
             mock_noct_op.process.assert_called_once_with(correct_sr_frame._data)
@@ -524,7 +564,7 @@ class TestSpectralFrame:
         expected_params = {"fmin": 125.0, "fmax": 8000.0}
         assert result.operation_history[-1] == {
             "operation": "wandas.spectral.noct_synthesis",
-            "version": 1,
+            "version": 2,
             "params": expected_params,
         }
         for param_name in expected_params:

--- a/tests/pipeline/test_noct_synthesis_recipe_version.py
+++ b/tests/pipeline/test_noct_synthesis_recipe_version.py
@@ -16,6 +16,7 @@ from wandas.core.metadata import ChannelCalibration, ChannelMetadata
 from wandas.frames.noct import NOctFrame
 from wandas.frames.spectral import SpectralFrame
 from wandas.pipeline import RecipePlan, default_recipe_registry
+from wandas.pipeline.errors import RecipeExecutionError
 from wandas.processing.spectral import NOctSynthesis
 
 
@@ -124,6 +125,38 @@ def test_released_v1_payload_replays_legacy_frequency_axis_without_current_opera
         }
     ]
     assert replayed.previous is source
+
+
+def test_released_v1_payload_rejects_non_48000_sampling_rate() -> None:
+    """Recipe v1 preserves the public synthesis sampling-rate contract."""
+    released_payload = {
+        "schema": "wandas.recipe",
+        "version": 2,
+        "inputs": [{"id": "input-0", "name": "signal", "kind": "frame"}],
+        "nodes": [
+            {
+                "id": "node-0",
+                "operation": "wandas.spectral.noct_synthesis",
+                "version": 1,
+                "inputs": ["input-0"],
+                "params": {
+                    "$type": "map",
+                    "entries": [["fmax", 1000], ["fmin", 100]],
+                },
+            }
+        ],
+        "output": "node-0",
+    }
+    source = SpectralFrame(
+        da.from_array(np.ones((1, 5), dtype=np.complex128), chunks=(1, -1)),
+        sampling_rate=44100,
+        n_fft=9,
+    )
+
+    plan = RecipePlan.from_dict(released_payload)
+
+    with pytest.raises(RecipeExecutionError, match="48000 Hz"):
+        plan.apply({"signal": source})
 
 
 def test_public_v2_recipe_roundtrip_uses_spectral_frame_n_fft_and_preserves_contract(

--- a/tests/pipeline/test_noct_synthesis_recipe_version.py
+++ b/tests/pipeline/test_noct_synthesis_recipe_version.py
@@ -1,0 +1,217 @@
+"""Recipe compatibility for versioned N-octave synthesis semantics."""
+
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+import dask.array as da
+import numpy as np
+import pytest
+from dask.array.core import Array as DaArray
+
+import wandas.processing.spectral as spectral
+from tests.frame_helpers import channel_first_values
+from wandas.core.metadata import ChannelCalibration, ChannelMetadata
+from wandas.frames.noct import NOctFrame
+from wandas.frames.spectral import SpectralFrame
+from wandas.pipeline import RecipePlan, default_recipe_registry
+from wandas.processing.spectral import NOctSynthesis
+
+
+def _spectral_source() -> SpectralFrame:
+    """Return a lazy odd-length spectrum with complete channel provenance."""
+    return SpectralFrame(
+        da.from_array(
+            np.array(
+                [
+                    [1.0 + 0.5j, 2.0 + 0.25j, 3.0 + 0.1j, 4.0 + 0.05j, 5.0],
+                    [0.5 + 0.25j, 1.5 + 0.1j, 2.5 + 0.05j, 3.5, 4.5],
+                ],
+                dtype=np.complex128,
+            ),
+            chunks=(1, -1),
+        ),
+        sampling_rate=48000,
+        n_fft=9,
+        window="hann",
+        label="spectral-source",
+        metadata={"recording": {"take": "A"}},
+        channel_metadata=[
+            ChannelMetadata(
+                label="left",
+                calibration=ChannelCalibration(factor=2.0, unit="Pa", ref=2e-5),
+                extra={"sensor": "L"},
+            ),
+            ChannelMetadata(
+                label="right",
+                calibration=ChannelCalibration(factor=3.0, unit="Pa", ref=2e-5),
+                extra={"sensor": "R"},
+            ),
+        ],
+        channel_ids=["mic-left", "mic-right"],
+        source_time_offset=[1.25, 2.5],
+    )
+
+
+def _patch_noct_backend(monkeypatch: pytest.MonkeyPatch) -> list[np.ndarray]:
+    """Patch MoSQITo with a lazy-test backend that records only frequency axes."""
+    captured_freqs: list[np.ndarray] = []
+    monkeypatch.setattr(spectral, "require_mosqito_center_freq", lambda _feature: None)
+    monkeypatch.setattr(
+        spectral,
+        "_center_freq",
+        lambda **_kwargs: (np.arange(2), np.array([100.0, 200.0])),
+    )
+
+    def fake_noct_synthesis(
+        *, spectrum: np.ndarray, freqs: np.ndarray, **_kwargs: object
+    ) -> tuple[np.ndarray, np.ndarray]:
+        captured_freqs.append(np.array(freqs, copy=True))
+        channels = 1 if spectrum.ndim == 1 else spectrum.shape[-1]
+        values = np.arange(2 * channels, dtype=np.float64).reshape(2, channels)
+        return values, np.array([100.0, 200.0])
+
+    monkeypatch.setattr(spectral, "noct_synthesis", fake_noct_synthesis)
+    return captured_freqs
+
+
+def test_released_v1_payload_replays_legacy_frequency_axis_without_current_operation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A literal schema-2 v1 node retains the released five-bin inference."""
+    captured_freqs = _patch_noct_backend(monkeypatch)
+
+    def fail_current_kernel(_self: object, _data: object) -> object:
+        raise AssertionError("Recipe v1 invoked the current NOctSynthesis kernel")
+
+    monkeypatch.setattr(NOctSynthesis, "_process", fail_current_kernel)
+    released_payload = {
+        "schema": "wandas.recipe",
+        "version": 2,
+        "inputs": [{"id": "input-0", "name": "signal", "kind": "frame"}],
+        "nodes": [
+            {
+                "id": "node-0",
+                "operation": "wandas.spectral.noct_synthesis",
+                "version": 1,
+                "inputs": ["input-0"],
+                "params": {
+                    "$type": "map",
+                    "entries": [["fmax", 1000], ["fmin", 100]],
+                },
+            }
+        ],
+        "output": "node-0",
+    }
+
+    source = _spectral_source()
+    plan = RecipePlan.from_dict(released_payload)
+    replayed = plan.apply({"signal": source})
+
+    assert isinstance(replayed, NOctFrame)
+    assert isinstance(replayed._data, DaArray)
+    assert captured_freqs == []
+    values = channel_first_values(replayed)
+
+    np.testing.assert_allclose(captured_freqs[0], np.array([0.0, 6000.0, 12000.0, 18000.0, 24000.0]))
+    assert values.shape == (2, 2)
+    assert replayed.operation_history == [
+        {
+            "operation": "wandas.spectral.noct_synthesis",
+            "version": 1,
+            "params": {"fmin": 100, "fmax": 1000},
+        }
+    ]
+    assert replayed.previous is source
+
+
+def test_public_v2_recipe_roundtrip_uses_spectral_frame_n_fft_and_preserves_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Public v2 extraction/load/apply stays lazy and does not serialize n_fft."""
+    captured_freqs = _patch_noct_backend(monkeypatch)
+    source = _spectral_source()
+
+    with mock.patch.object(DaArray, "compute") as mock_compute:
+        direct = source.noct_synthesis(fmin=100, fmax=1000)
+        plan = RecipePlan.from_frame(direct, input_names=("signal",))
+        payload = plan.to_dict()
+        serialized = json.dumps(payload)
+        loaded = RecipePlan.from_dict(json.loads(serialized))
+        replayed = loaded.apply({"signal": source})
+        mock_compute.assert_not_called()
+
+    assert isinstance(direct, NOctFrame)
+    assert isinstance(replayed, NOctFrame)
+    assert direct._data.dtype == np.dtype(np.float64)
+    assert replayed._data.dtype == np.dtype(np.float64)
+    assert [(node.operation, node.version) for node in plan.nodes] == [("wandas.spectral.noct_synthesis", 2)]
+    assert dict(plan.nodes[0].params.entries) == {"fmin": 100, "fmax": 1000}
+    serialized_param_names = [entry[0] for entry in payload["nodes"][0]["params"]["entries"]]
+    assert serialized_param_names == ["fmax", "fmin"]
+    assert "n_fft" not in serialized_param_names
+    assert [(node.operation, node.version) for node in loaded.nodes] == [("wandas.spectral.noct_synthesis", 2)]
+    assert captured_freqs == []
+
+    direct_values = channel_first_values(direct)
+    replayed_values = channel_first_values(replayed)
+    np.testing.assert_allclose(replayed_values, direct_values)
+    np.testing.assert_allclose(captured_freqs[0], np.fft.rfftfreq(9, d=1 / 48000))
+    np.testing.assert_allclose(captured_freqs[1], np.fft.rfftfreq(9, d=1 / 48000))
+    assert direct.operation_history == [
+        {
+            "operation": "wandas.spectral.noct_synthesis",
+            "version": 2,
+            "params": {"fmin": 100, "fmax": 1000},
+        }
+    ]
+    assert replayed.operation_history == direct.operation_history
+    assert replayed.metadata == direct.metadata == source.metadata
+    assert replayed._channel_ids == direct._channel_ids == source._channel_ids
+    assert [channel.label for channel in replayed.channels] == ["left", "right"]
+    assert [channel.calibration for channel in replayed.channels] == [
+        channel.calibration for channel in source.channels
+    ]
+    assert [channel.extra for channel in replayed.channels] == [
+        {"sensor": "L"},
+        {"sensor": "R"},
+    ]
+    np.testing.assert_array_equal(replayed.source_time_offset, source.source_time_offset)
+    assert replayed.previous is source
+    assert replayed.lineage is not None
+    assert replayed.lineage.operation is not None
+    assert replayed.lineage.operation.version == 2
+
+
+def test_noct_synthesis_recipe_registry_contains_legacy_and_current_versions() -> None:
+    """The default immutable registry exposes both persisted operation meanings."""
+    registry = default_recipe_registry()
+
+    assert registry.require("wandas.spectral.noct_synthesis", 1).version == 1
+    assert registry.require("wandas.spectral.noct_synthesis", 2).version == 2
+
+
+def test_noct_synthesis_recipe_validator_rejects_invalid_g_on_load() -> None:
+    """A malformed G is rejected by the operation declaration before apply."""
+    payload = {
+        "schema": "wandas.recipe",
+        "version": 2,
+        "inputs": [{"id": "input-0", "name": "signal", "kind": "frame"}],
+        "nodes": [
+            {
+                "id": "node-0",
+                "operation": "wandas.spectral.noct_synthesis",
+                "version": 2,
+                "inputs": ["input-0"],
+                "params": {
+                    "$type": "map",
+                    "entries": [["G", 20], ["fmax", 1000], ["fmin", 100]],
+                },
+            }
+        ],
+        "output": "node-0",
+    }
+
+    with pytest.raises(ValueError, match="Recipe"):
+        RecipePlan.from_dict(payload)

--- a/tests/processing/test_display_names.py
+++ b/tests/processing/test_display_names.py
@@ -56,7 +56,12 @@ _DISPLAY_NAME_CASES = (
     pytest.param(ISTFT, {}, "iSTFT", id="istft"),
     pytest.param(Welch, {}, "Welch", id="welch"),
     pytest.param(NOctSpectrum, {"fmin": 20, "fmax": 20_000}, "Oct", id="n-octave-spectrum"),
-    pytest.param(NOctSynthesis, {"fmin": 20, "fmax": 20_000}, "Octs", id="n-octave-synthesis"),
+    pytest.param(
+        NOctSynthesis,
+        {"fmin": 20, "fmax": 20_000, "n_fft": 1_024},
+        "Octs",
+        id="n-octave-synthesis",
+    ),
     pytest.param(Coherence, _PAIRWISE_SPECTRAL_PARAMS, "Coh", id="coherence"),
     pytest.param(
         CSD,

--- a/tests/processing/test_noct_spectrum_channelwise.py
+++ b/tests/processing/test_noct_spectrum_channelwise.py
@@ -487,7 +487,6 @@ def test_noct_spectrum_dependency_failure_precedes_graph_and_kernel(
 @pytest.mark.parametrize(
     ("n", "g_base"),
     [
-        (3, 3),
         (0, 10),
     ],
 )
@@ -565,6 +564,7 @@ def test_noct_synthesis_keeps_one_whole_frame_kernel(
         n=3,
         G=_G,
         fr=_FR,
+        n_fft=2 * _SAMPLES - 2,
     )
     kernel_shapes: list[tuple[int, ...]] = []
     _patch_fixed_bands(monkeypatch, bands)

--- a/tests/processing/test_operation_lazy_metadata_contract.py
+++ b/tests/processing/test_operation_lazy_metadata_contract.py
@@ -270,7 +270,7 @@ def _operation_cases() -> list[OperationCase]:
         ),
         OperationCase(
             "noct_synthesis",
-            lambda: NOctSynthesis(48000, fmin=100, fmax=1000),
+            lambda: NOctSynthesis(48000, fmin=100, fmax=1000, n_fft=1024),
             np.ones((2, 513), dtype=np.float64),
         ),
         OperationCase("coherence", lambda: Coherence(SR, n_fft=64, win_length=64, hop_length=32), real),

--- a/tests/processing/test_spectral_operations.py
+++ b/tests/processing/test_spectral_operations.py
@@ -978,7 +978,7 @@ class TestNOctSynthesisOperation:
         dask_sig = da_from_array(np.zeros((1, self._N_FFT // 2 + 1)), chunks=(1, -1))
         with mock.patch.object(DaArray, "compute") as mock_compute:
             with mock.patch("wandas.processing.spectral.noct_synthesis") as mock_noct:
-                mock_noct.return_value = (np.zeros((1, 27)), np.zeros(27))
+                mock_noct.return_value = (np.zeros((27, 1)), np.zeros(27))
                 result = self._op().process(dask_sig)
                 mock_compute.assert_not_called()
                 _ = result.compute()

--- a/tests/processing/test_spectral_operations.py
+++ b/tests/processing/test_spectral_operations.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 from unittest import mock
 
 import numpy as np
@@ -44,7 +45,7 @@ class TestGetDisplayNames:
         assert ISTFT(sr).get_display_name() == "iSTFT"
         assert Welch(sr).get_display_name() == "Welch"
         assert NOctSpectrum(sr, 24, 12600).get_display_name() == "Oct"
-        assert NOctSynthesis(sr, 24, 12600).get_display_name() == "Octs"
+        assert NOctSynthesis(sr, 24, 12600, n_fft=32).get_display_name() == "Octs"
         assert Coherence(sr).get_display_name() == "Coh"
         assert CSD(sr).get_display_name() == "CSD"
         assert TransferFunction(sr).get_display_name() == "H"
@@ -732,7 +733,7 @@ class TestSTFTOperation:
     "operation",
     [
         NOctSpectrum(_SR, 24, 12600),
-        NOctSynthesis(_SR, 24, 12600),
+        NOctSynthesis(_SR, 24, 12600, n_fft=30),
     ],
 )
 def test_direct_noct_process_preflights_dependencies(monkeypatch: pytest.MonkeyPatch, operation: object) -> None:
@@ -805,7 +806,10 @@ def test_fractional_octave_operation_stores_configuration(
     sampling_rate: int,
 ) -> None:
     """Both fractional-octave operations expose the same configuration contract."""
-    operation = operation_type(sampling_rate, fmin=24.0, fmax=12600, n=3, G=10, fr=1000)
+    if operation_type is NOctSynthesis:
+        operation = NOctSynthesis(sampling_rate, fmin=24.0, fmax=12600, n=3, G=10, fr=1000, n_fft=1024)
+    else:
+        operation = NOctSpectrum(sampling_rate, fmin=24.0, fmax=12600, n=3, G=10, fr=1000)
 
     assert operation.sampling_rate == sampling_rate
     assert operation.fmin == 24.0
@@ -813,6 +817,86 @@ def test_fractional_octave_operation_stores_configuration(
     assert operation.n == 3
     assert operation.G == 10
     assert operation.fr == 1000
+    if isinstance(operation, NOctSynthesis):
+        assert operation.n_fft == 1024
+        assert operation.to_params()["n_fft"] == 1024
+
+
+@pytest.mark.parametrize("operation_type", [NOctSpectrum, NOctSynthesis])
+@pytest.mark.parametrize("G", [2, 10], ids=["base-2", "base-10"])  # noqa: N803
+def test_noct_operations_accept_supported_g_values(
+    operation_type: type[NOctSpectrum] | type[NOctSynthesis],
+    G: int,  # noqa: N803
+) -> None:
+    """Both N-octave operations retain the supported ratio conventions."""
+    kwargs: dict[str, Any] = {"fmin": 24.0, "fmax": 12600.0, "G": G}
+    if operation_type is NOctSynthesis:
+        kwargs["n_fft"] = 9
+
+    operation = operation_type(48000, **kwargs)
+
+    assert operation.G == G
+
+
+@pytest.mark.parametrize("operation_type", [NOctSpectrum, NOctSynthesis])
+@pytest.mark.parametrize(
+    ("G", "error_type"),  # noqa: N803
+    [
+        pytest.param(True, TypeError, id="true"),
+        pytest.param(False, TypeError, id="false"),
+        pytest.param(2.0, TypeError, id="float-2"),
+        pytest.param(10.0, TypeError, id="float-10"),
+        pytest.param(20, ValueError, id="unsupported-20"),
+        pytest.param(3, ValueError, id="unsupported-3"),
+        pytest.param("10", TypeError, id="string"),
+        pytest.param(None, TypeError, id="none"),
+    ],
+)
+def test_noct_operations_reject_invalid_g_before_optional_backend(
+    operation_type: type[NOctSpectrum] | type[NOctSynthesis],
+    G: Any,  # noqa: N803
+    error_type: type[Exception],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid G fails at construction, before MoSQITo or Dask can run."""
+
+    def fail_backend(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("invalid G reached an optional backend")
+
+    monkeypatch.setattr(spectral_module, "require_mosqito_center_freq", fail_backend)
+    monkeypatch.setattr(spectral_module, "_center_freq", fail_backend)
+    monkeypatch.setattr(spectral_module, "noct_spectrum", fail_backend)
+    monkeypatch.setattr(spectral_module, "noct_synthesis", fail_backend)
+
+    kwargs: dict[str, Any] = {"fmin": 24.0, "fmax": 12600.0, "G": G}
+    if operation_type is NOctSynthesis:
+        kwargs["n_fft"] = 9
+
+    with mock.patch.object(DaArray, "compute") as mock_compute:
+        with pytest.raises(error_type, match="Specify G=2 or G=10"):
+            operation_type(48000, **kwargs)
+        mock_compute.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("n_fft", "error_type"),
+    [
+        pytest.param(True, TypeError, id="true"),
+        pytest.param(False, TypeError, id="false"),
+        pytest.param(9.0, TypeError, id="float"),
+        pytest.param("9", TypeError, id="string"),
+        pytest.param(None, TypeError, id="none"),
+        pytest.param(0, ValueError, id="zero"),
+        pytest.param(-1, ValueError, id="negative"),
+    ],
+)
+def test_noct_synthesis_rejects_invalid_n_fft_at_operation_boundary(
+    n_fft: Any,
+    error_type: type[Exception],
+) -> None:
+    """Synthesis requires a positive integer FFT size as owned configuration."""
+    with pytest.raises(error_type, match="n_fft"):
+        NOctSynthesis(48000, fmin=24.0, fmax=12600.0, n_fft=n_fft)
 
 
 class TestNOctSynthesisOperation:
@@ -824,8 +908,9 @@ class TestNOctSynthesisOperation:
     _N: int = 3
     _G: int = 10
     _FR: int = 1000
+    _N_FFT: int = 48000
 
-    def _op(self) -> NOctSynthesis:
+    def _op(self, *, n_fft: int | None = None) -> NOctSynthesis:
         return NOctSynthesis(
             self._NOCT_SR,
             fmin=self._FMIN,
@@ -833,24 +918,24 @@ class TestNOctSynthesisOperation:
             n=self._N,
             G=self._G,
             fr=self._FR,
+            n_fft=self._N_FFT if n_fft is None else n_fft,
         )
 
     # -- Layer 1: Unit tests -----------------------------------------------
 
     def test_registry_returns_correct_class(self) -> None:
         assert get_operation("noct_synthesis") == NOctSynthesis
-        op = create_operation(
-            "noct_synthesis",
-            self._NOCT_SR,
-            fmin=100.0,
-            fmax=5000.0,
-            n=1,
-            G=20,
-            fr=1000,
-        )
-        assert isinstance(op, NOctSynthesis)
-        assert op.fmin == 100.0
-        assert op.fmax == 5000.0
+        with pytest.raises(ValueError, match="Specify G=2 or G=10"):
+            create_operation(
+                "noct_synthesis",
+                self._NOCT_SR,
+                fmin=100.0,
+                fmax=5000.0,
+                n=1,
+                G=20,
+                fr=1000,
+                n_fft=9,
+            )
 
     # -- Layer 2: Domain (immutability + lazy + shapes) ---------------------
 
@@ -883,32 +968,30 @@ class TestNOctSynthesisOperation:
             fr=self._FR,
         )
 
-        result_da = self._op().process(dask_spectrum)
+        result_da = self._op(n_fft=1024).process(dask_spectrum)
 
         assert result_da.shape == (1, len(center_freqs))
         assert result_da.compute().shape == result_da.shape
 
     def test_delayed_execution_not_computed_early(self) -> None:
         """Pillar 1: Dask lazy evaluation preserved; no premature compute()."""
-        pink, _ = _fractional_octave_noise(self._NOCT_SR)
-        sig = np.array([pink])
-        dask_sig = da_from_array(sig, chunks=(1, 1000))
+        dask_sig = da_from_array(np.zeros((1, self._N_FFT // 2 + 1)), chunks=(1, -1))
         with mock.patch.object(DaArray, "compute") as mock_compute:
             with mock.patch("wandas.processing.spectral.noct_synthesis") as mock_noct:
-                mock_noct.return_value = (np.zeros((1, self._NOCT_SR)), np.zeros(27))
+                mock_noct.return_value = (np.zeros((1, 27)), np.zeros(27))
                 result = self._op().process(dask_sig)
                 mock_compute.assert_not_called()
                 _ = result.compute()
                 mock_compute.assert_called_once()
 
     def test_odd_length_spectrum_produces_valid_output(self) -> None:
-        """Odd-length spectrum exercises the else-branch in length inference."""
+        """Odd-length spectra use their explicit source FFT size."""
         fft = FFT(self._NOCT_SR, n_fft=None, window="hann")
         rng = np.random.default_rng(99)
         test_signal = rng.standard_normal(52)
         spectrum = run_operation_eager(fft, np.array([test_signal]))
         assert spectrum.shape[-1] % 2 == 1
-        result_da = self._op().process(da_from_array(spectrum, chunks=(1, -1)))
+        result_da = self._op(n_fft=52).process(da_from_array(spectrum, chunks=(1, -1)))
         assert isinstance(result_da, DaArray)  # Pillar 1: Dask graph preserved
         result = result_da.compute()
         assert result.shape[0] == 1
@@ -927,9 +1010,7 @@ class TestNOctSynthesisOperation:
         assert isinstance(result_da, DaArray)  # Pillar 1: Dask graph preserved
         result = result_da.compute()
 
-        n = spectrum.shape[-1]
-        n = n * 2 - 1 if n % 2 == 0 else (n - 1) * 2
-        freqs = np.fft.rfftfreq(n, d=1 / self._NOCT_SR)
+        freqs = np.fft.rfftfreq(self._N_FFT, d=1 / self._NOCT_SR)
         expected_signal, _ = noct_synthesis(
             spectrum=np.abs(spectrum).T,
             freqs=freqs,
@@ -960,9 +1041,7 @@ class TestNOctSynthesisOperation:
         assert isinstance(result_da, DaArray)  # Pillar 1: Dask graph preserved
         result = result_da.compute()
 
-        n = spectrum.shape[-1]
-        n = n * 2 - 1 if n % 2 == 0 else (n - 1) * 2
-        freqs = np.fft.rfftfreq(n, d=1 / self._NOCT_SR)
+        freqs = np.fft.rfftfreq(self._N_FFT, d=1 / self._NOCT_SR)
 
         exp_ch1, _ = noct_synthesis(
             spectrum=np.abs(spectrum[0:1]).T,
@@ -1634,17 +1713,16 @@ class TestNOctSpectrumOperation:
     def test_registry_returns_correct_class(self) -> None:
         """'noct_spectrum' registry key creates NOctSpectrum instance."""
         assert get_operation("noct_spectrum") == NOctSpectrum
-        op = create_operation(
-            "noct_spectrum",
-            self._NOCT_SR,
-            fmin=100.0,
-            fmax=5000.0,
-            n=1,
-            G=20,
-            fr=1000,
-        )
-        assert isinstance(op, NOctSpectrum)
-        assert op.fmin == 100.0
+        with pytest.raises(ValueError, match="Specify G=2 or G=10"):
+            create_operation(
+                "noct_spectrum",
+                self._NOCT_SR,
+                fmin=100.0,
+                fmax=5000.0,
+                n=1,
+                G=20,
+                fr=1000,
+            )
 
     # -- Layer 2: Domain (immutability + lazy + shapes) ---------------------
 
@@ -1743,3 +1821,87 @@ class TestNOctSpectrumOperation:
         np.testing.assert_allclose(result[0], exp_ch1, rtol=1e-6)
         np.testing.assert_allclose(result[1], exp_ch2, rtol=1e-6)
         assert not np.allclose(result[0], result[1])
+
+
+@pytest.mark.parametrize("n_fft", [9, 10, 11])
+def test_noct_synthesis_passes_authoritative_rfftfreq_axis_to_backend(
+    n_fft: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Synthesis uses the explicit FFT size, including odd/even ambiguity cases."""
+    captured_freqs: list[np.ndarray] = []
+    monkeypatch.setattr(spectral_module, "require_mosqito_center_freq", lambda _feature: None)
+    monkeypatch.setattr(
+        spectral_module,
+        "_center_freq",
+        lambda **_kwargs: (np.arange(2), np.array([100.0, 200.0])),
+    )
+
+    def fake_noct_synthesis(
+        *, spectrum: np.ndarray, freqs: np.ndarray, **_kwargs: Any
+    ) -> tuple[np.ndarray, np.ndarray]:
+        captured_freqs.append(np.array(freqs, copy=True))
+        return np.zeros((2, spectrum.shape[-1])), np.array([100.0, 200.0])
+
+    monkeypatch.setattr(spectral_module, "noct_synthesis", fake_noct_synthesis)
+    operation = NOctSynthesis(48000, fmin=100.0, fmax=1000.0, n_fft=n_fft)
+    spectrum = da_from_array(np.ones((1, n_fft // 2 + 1)), chunks=(1, -1))
+
+    result = operation.process(spectrum)
+    assert isinstance(result, DaArray)
+    assert captured_freqs == []
+    assert result.compute().shape == (1, 2)
+
+    expected = np.fft.rfftfreq(n_fft, d=1 / 48000)
+    np.testing.assert_allclose(captured_freqs[0], expected)
+    assert captured_freqs[0].shape == (spectrum.shape[-1],)
+    if n_fft == 9:
+        np.testing.assert_allclose(captured_freqs[0][-1], 21_333.333333333332)
+        assert not np.isclose(captured_freqs[0][-1], 24_000.0)
+
+
+def test_noct_synthesis_distinguishes_adjacent_even_and_odd_fft_sizes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ten- and eleven-point FFTs have six bins but different frequency axes."""
+    captured_freqs: dict[int, np.ndarray] = {}
+    monkeypatch.setattr(spectral_module, "require_mosqito_center_freq", lambda _feature: None)
+    monkeypatch.setattr(
+        spectral_module,
+        "_center_freq",
+        lambda **_kwargs: (np.arange(2), np.array([100.0, 200.0])),
+    )
+
+    def fake_noct_synthesis(
+        *, spectrum: np.ndarray, freqs: np.ndarray, **_kwargs: Any
+    ) -> tuple[np.ndarray, np.ndarray]:
+        captured_freqs[int(round(48000 / (freqs[1] - freqs[0])))] = np.array(freqs, copy=True)
+        return np.zeros((2, spectrum.shape[-1])), np.array([100.0, 200.0])
+
+    monkeypatch.setattr(spectral_module, "noct_synthesis", fake_noct_synthesis)
+    for n_fft in (10, 11):
+        operation = NOctSynthesis(48000, fmin=100.0, fmax=1000.0, n_fft=n_fft)
+        operation.process(da_from_array(np.ones((1, 6)), chunks=(1, -1))).compute()
+
+    np.testing.assert_allclose(captured_freqs[10], np.fft.rfftfreq(10, d=1 / 48000))
+    np.testing.assert_allclose(captured_freqs[11], np.fft.rfftfreq(11, d=1 / 48000))
+    assert not np.array_equal(captured_freqs[10], captured_freqs[11])
+
+
+def test_noct_synthesis_rejects_wrong_input_bin_count_before_dependency_loading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit n_fft validates direct input shape before optional imports."""
+    calls: list[str] = []
+
+    def fail_dependency(feature: str) -> None:
+        calls.append(feature)
+        raise AssertionError("dependency loading happened before bin validation")
+
+    monkeypatch.setattr(spectral_module, "require_mosqito_center_freq", fail_dependency)
+    operation = NOctSynthesis(48000, fmin=100.0, fmax=1000.0, n_fft=9)
+
+    with pytest.raises(ValueError, match=r"Got: 6 bins\s+Expected: 5 bins for n_fft=9"):
+        operation.process(da_from_array(np.ones((1, 6)), chunks=(1, -1)))
+
+    assert calls == []

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 
 from wandas.pipeline.decorators import recipe_operation
+from wandas.processing.spectral import validate_noct_recipe_params
 
 from ...core.base_frame import BaseFrame
 from .protocols import TransformFrameProtocol
@@ -304,7 +305,10 @@ class ChannelTransformMixin:
             previous=self._as_base_frame,
         )
 
-    @recipe_operation("wandas.audio.noct_spectrum")
+    @recipe_operation(
+        "wandas.audio.noct_spectrum",
+        validate_params=validate_noct_recipe_params,
+    )
     def noct_spectrum(
         self: TransformFrameProtocol,
         fmin: float = 25,

--- a/wandas/frames/spectral.py
+++ b/wandas/frames/spectral.py
@@ -14,6 +14,7 @@ from wandas.utils.types import NDArrayComplex, NDArrayReal
 
 from ..core.base_frame import BaseFrame
 from ..core.metadata import ChannelMetadata
+from ..processing.spectral import validate_noct_recipe_params
 from .mixins.spectral_properties_mixin import SpectralPropertiesMixin
 
 if TYPE_CHECKING:
@@ -339,7 +340,11 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         pd = require_pandas("SpectralFrame.to_dataframe")
         return pd.Index(self.freqs, name="frequency")
 
-    @recipe_operation("wandas.spectral.noct_synthesis")
+    @recipe_operation(
+        "wandas.spectral.noct_synthesis",
+        version=2,
+        validate_params=validate_noct_recipe_params,
+    )
     def noct_synthesis(
         self,
         fmin: float,
@@ -353,7 +358,8 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
 
         This method combines frequency components into N-octave bands according to
         standard acoustical band definitions. This is commonly used in noise and
-        vibration analysis.
+        vibration analysis. The authoritative FFT size is read from this
+        ``SpectralFrame.n_fft``; it is not a new caller-supplied parameter.
 
         Args:
             fmin: float. Lower frequency bound in Hz.
@@ -368,11 +374,11 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
 
         Raises:
             ValueError: If the sampling rate is not 48000 Hz.
+            TypeError: If ``G`` is not an integer ratio convention.
         """
         if self.sampling_rate != 48000:
             raise ValueError("noct_synthesis can only be used with a sampling rate of 48000 Hz.")
         from ..processing import NOctSynthesis
-        from .noct import NOctFrame
 
         params = {"fmin": fmin, "fmax": fmax, "n": n, "G": G, "fr": fr}
         operation_name = "noct_synthesis"
@@ -380,13 +386,67 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
         from ..processing import create_operation
 
         # Create operation instance
-        operation = create_operation(operation_name, self.sampling_rate, **params)
+        operation = create_operation(operation_name, self.sampling_rate, **params, n_fft=self.n_fft)
         operation = cast("NOctSynthesis", operation)
-        # Apply processing to data
+        return self._noct_synthesis_with_operation(
+            operation,
+            fmin=fmin,
+            fmax=fmax,
+            n=n,
+            g=G,
+            fr=fr,
+        )
+
+    @recipe_operation(
+        "wandas.spectral.noct_synthesis",
+        version=1,
+        validate_params=validate_noct_recipe_params,
+    )
+    def _noct_synthesis_recipe_v1(
+        self,
+        fmin: float,
+        fmax: float,
+        n: int = 3,
+        G: int = 10,  # noqa: N803
+        fr: int = 1000,
+    ) -> NOctFrame:
+        """Replay the released Recipe v1 bin-inference contract."""
+        if self.sampling_rate != 48000:
+            raise ValueError("noct_synthesis can only be used with a sampling rate of 48000 Hz.")
+        from ..processing.spectral import _RecipeNOctSynthesisV1
+
+        operation = _RecipeNOctSynthesisV1(
+            self.sampling_rate,
+            fmin=fmin,
+            fmax=fmax,
+            n=n,
+            G=G,
+            fr=fr,
+        )
+        return self._noct_synthesis_with_operation(
+            operation,
+            fmin=fmin,
+            fmax=fmax,
+            n=n,
+            g=G,
+            fr=fr,
+        )
+
+    def _noct_synthesis_with_operation(
+        self,
+        operation: Any,
+        *,
+        fmin: float,
+        fmax: float,
+        n: int,
+        g: int,
+        fr: int,
+    ) -> NOctFrame:
+        """Build an NOctFrame from either the current or legacy operation."""
+        from .noct import NOctFrame
+
         spectrum_data = operation.process(self._data)
-
-        logger.debug(f"Created new SpectralFrame with operation {operation_name} added to graph")
-
+        logger.debug("Created new NOctFrame with N-octave synthesis operation added to graph")
         lineage = self._required_semantic_lineage()
         return NOctFrame(
             data=spectrum_data,
@@ -394,7 +454,7 @@ class SpectralFrame(SpectralPropertiesMixin, BaseFrame[NDArrayComplex]):
             fmin=fmin,
             fmax=fmax,
             n=n,
-            G=G,
+            G=g,
             fr=fr,
             label=f"1/{n}Oct of {self.label}",
             metadata=self.metadata,

--- a/wandas/processing/spectral.py
+++ b/wandas/processing/spectral.py
@@ -1,4 +1,6 @@
 import logging
+import numbers
+from collections.abc import Mapping
 from typing import Any
 
 import numpy as np
@@ -23,6 +25,33 @@ def noct_synthesis(*args: Any, **kwargs: Any) -> Any:
 
 def _center_freq(*args: Any, **kwargs: Any) -> Any:
     return require_mosqito_center_freq("NOctFrame")(*args, **kwargs)
+
+
+def _validate_noct_g(value: Any) -> None:
+    """Validate the exact N-octave ratio convention accepted by MoSQITo."""
+    if isinstance(value, bool) or not isinstance(value, numbers.Integral):
+        raise TypeError(
+            "Invalid N-octave ratio G\n"
+            f"  Got: {value!r} ({type(value).__name__})\n"
+            "  Expected: integer 2 or 10\n"
+            "N-octave ratio conventions support only G=2 or G=10.\n"
+            "Specify G=2 or G=10."
+        )
+    normalized = int(value)
+    if normalized not in (2, 10):
+        raise ValueError(
+            "Invalid N-octave ratio G\n"
+            f"  Got: {value!r}\n"
+            "  Expected: integer 2 or 10\n"
+            "N-octave ratio conventions support only G=2 or G=10.\n"
+            "Specify G=2 or G=10."
+        )
+
+
+def validate_noct_recipe_params(params: Mapping[str, Any]) -> None:
+    """Validate portable N-octave parameters without importing MoSQITo."""
+    if "G" in params:
+        _validate_noct_g(params["G"])
 
 
 def _spectral_real_dtype(input_dtype: np.dtype[Any]) -> np.dtype[Any]:
@@ -829,7 +858,29 @@ class _NOctBase(AudioOperation[NDArrayReal, NDArrayReal]):
     def ensure_dependencies(self) -> None:
         require_mosqito_center_freq("NOctFrame")
 
+    def validate_params(self) -> None:
+        """Validate common N-octave configuration before optional dependencies."""
+        _validate_noct_g(self.G)
+
+    def _validate_process_shape(self, data: Any, *inputs: Any) -> None:
+        """Validate operation-specific input shape before dependency loading."""
+
+    def _synthesize(self, x: NDArrayReal, *, n_fft: int) -> NDArrayReal:
+        """Run MoSQITo synthesis for one explicit or legacy FFT size."""
+        freqs = np.fft.rfftfreq(n_fft, d=1 / self.sampling_rate)
+        result, _ = noct_synthesis(
+            spectrum=np.abs(x).T,
+            freqs=freqs,
+            fmin=self.fmin,
+            fmax=self.fmax,
+            n=self.n,
+            G=self.G,
+            fr=self.fr,
+        )
+        return np.asarray(result).T
+
     def process(self, data: Any, *inputs: Any) -> Any:
+        self._validate_process_shape(data, *inputs)
         self.ensure_dependencies()
         return super().process(data, *inputs)
 
@@ -872,29 +923,120 @@ class NOctSpectrum(_NOctBase, ChannelIndependentAudioOperation[NDArrayReal, NDAr
 
 
 class NOctSynthesis(_NOctBase):
-    """Octave synthesis operation"""
+    """N-octave synthesis operation using an explicit original FFT size.
+
+    ``n_fft`` is required because a one-sided spectrum's bin count cannot
+    distinguish an odd FFT size from the adjacent even size. The value is
+    captured in the operation configuration and is used to construct the
+    canonical real-FFT frequency grid.
+    """
 
     name = "noct_synthesis"
     _display = "Octs"
 
-    def _process(self, x: NDArrayReal) -> NDArrayReal:
-        """Create processor function for octave synthesis"""
-        logger.debug(f"Applying NoctSynthesis to array with shape: {x.shape}")
-        # Calculate n from shape[-1]
-        n = x.shape[-1]  # Calculate n from shape[-1]
-        n = n * 2 - 1 if n % 2 == 0 else (n - 1) * 2
-        freqs = np.fft.rfftfreq(n, d=1 / self.sampling_rate)
-        result, _ = noct_synthesis(
-            spectrum=np.abs(x).T,
-            freqs=freqs,
-            fmin=self.fmin,
-            fmax=self.fmax,
-            n=self.n,
-            G=self.G,
-            fr=self.fr,
+    def __init__(
+        self,
+        sampling_rate: float,
+        fmin: float,
+        fmax: float,
+        n: int = 3,
+        G: int = 10,
+        fr: int = 1000,
+        *,
+        n_fft: int,
+    ) -> None:
+        """Initialize N-octave synthesis with the source spectrum's FFT size.
+
+        Args:
+            sampling_rate: Sampling rate in Hz. The public synthesis Frame
+                method requires 48000 Hz.
+            fmin: Lower frequency bound in Hz.
+            fmax: Upper frequency bound in Hz.
+            n: Number of bands per octave.
+            G: Exact center-frequency ratio convention, either 2 or 10.
+            fr: Reference frequency in Hz.
+            n_fft: Positive integer FFT size that produced the complete
+                one-sided input spectrum.
+
+        Raises:
+            TypeError: If ``n_fft`` is not an integer or ``G`` is not an
+                integer ratio convention.
+            ValueError: If ``n_fft`` is not positive or ``G`` is not 2 or 10.
+        """
+        AudioOperation.__init__(
+            self,
+            sampling_rate,
+            fmin=fmin,
+            fmax=fmax,
+            n=n,
+            G=G,
+            fr=fr,
+            n_fft=n_fft,
         )
-        result = result.T
+
+    @property
+    def n_fft(self) -> int:
+        """Return the source FFT size captured by this operation."""
+        return int(self._config_value("n_fft"))
+
+    def validate_params(self) -> None:
+        """Validate common N-octave parameters and the explicit FFT size."""
+        super().validate_params()
+        value = self._config_value("n_fft")
+        if isinstance(value, bool) or not isinstance(value, numbers.Integral):
+            raise TypeError(
+                "Invalid n_fft for NOctSynthesis\n"
+                f"  Got: {value!r} ({type(value).__name__})\n"
+                "  Expected: a positive integer\n"
+                "Pass the positive integer n_fft stored by SpectralFrame."
+            )
+        normalized = int(value)
+        if normalized <= 0:
+            raise ValueError(
+                "Invalid n_fft for NOctSynthesis\n"
+                f"  Got: {normalized}\n"
+                "  Expected: a positive integer\n"
+                "Pass the positive integer n_fft stored by SpectralFrame."
+            )
+
+    def _validate_process_shape(self, data: Any, *inputs: Any) -> None:
+        """Reject spectra whose bin count disagrees with the explicit FFT size."""
+        del inputs
+        expected_bins = self.n_fft // 2 + 1
+        actual_bins = data.shape[-1]
+        if actual_bins != expected_bins:
+            raise ValueError(
+                "Invalid frequency bin count for NOctSynthesis\n"
+                f"  Got: {actual_bins} bins\n"
+                f"  Expected: {expected_bins} bins for n_fft={self.n_fft}\n"
+                "Pass the complete one-sided spectrum matching the explicit n_fft."
+            )
+
+    def calculate_output_dtype(self, input_dtype: np.dtype[Any], *input_dtypes: np.dtype[Any]) -> np.dtype[Any]:
+        """Advertise the real float64 output produced by MoSQITo."""
+        return np.dtype(np.float64)
+
+    def _process(self, x: NDArrayReal) -> NDArrayReal:
+        """Create processor function for octave synthesis."""
+        logger.debug(f"Applying NoctSynthesis to array with shape: {x.shape}")
+        result = self._synthesize(x, n_fft=self.n_fft)
         logger.debug(f"NoctSynthesis applied, returning result with shape: {result.shape}")
+        return np.array(result)
+
+
+class _RecipeNOctSynthesisV1(_NOctBase):
+    """Released Recipe v1 synthesis with its original bin-count inference."""
+
+    name = "_recipe_noct_synthesis_v1"
+    _display = "Octs Recipe v1"
+
+    def _process(self, x: NDArrayReal) -> NDArrayReal:
+        """Reproduce the released v1 frequency-axis inference exactly."""
+        logger.debug(f"Applying Recipe v1 NoctSynthesis to array with shape: {x.shape}")
+        n_bins = int(x.shape[-1])
+        inferred_n_fft = n_bins * 2 - 1 if n_bins % 2 == 0 else (n_bins - 1) * 2
+        result = self._synthesize(x, n_fft=inferred_n_fft)
+        logger.debug(f"Recipe v1 NoctSynthesis applied, returning result with shape: {result.shape}")
         return np.array(result)
 
 


### PR DESCRIPTION
Closes #398

## Summary

- Validate N-octave `G` at the Operation boundary for both `NOctSpectrum` and `NOctSynthesis`, rejecting bools, floats, unsupported integers, and other types before MoSQITo import, center-frequency calculation, Dask graph construction, or kernel execution.
- Require `NOctSynthesis` to snapshot a positive integer `n_fft` in its operation-owned configuration.
- Build the current synthesis frequency axis from `np.fft.rfftfreq(n_fft, d=1 / sampling_rate)`.
- Pass `SpectralFrame.n_fft` from the existing public Frame method without adding a new public method argument or duplicating receiver-owned state in Recipe/history params.
- Keep released Recipe v1 semantics in a private replay-only handler and emit corrected public calls as Recipe v2.
- Add a minimal 0.6.3 compatibility note explaining the direct constructor change and the v1/v2 boundary.

## Design

The previous G validation only stored the value, so values such as `G=20`, `True`, and `2.0` reached optional dependency and numerical paths. The shared N-octave validator now reports WHAT/WHY/HOW and explicitly rejects bool because Python bool is an int subclass.

A one-sided real FFT has `n_fft // 2 + 1` bins, so its bin count cannot distinguish adjacent odd/even FFT sizes. For example, `n_fft=9` has five bins but the old inference treated those bins as `n_fft=8`; `n_fft=10` and `n_fft=11` both have six bins but different frequency axes. `SpectralFrame.n_fft` is therefore the authoritative domain state and is passed into the operation.

Changing released Recipe v1 in place would silently change persisted numerical meaning. The v1 replay-only Frame handler preserves the old bin-count inference, while the public handler is version 2 and uses the authoritative `n_fft`.

## Tests

- Parameterized G validation for both operations, including bool, float, unsupported integer, string, and `None`, with MoSQITo and Dask-compute sentinels.
- Captured backend frequency axes for `n_fft=9`, `10`, and `11`, independently expected with `np.fft.rfftfreq`.
- Public `SpectralFrame.noct_synthesis()` coverage for lazy graph construction, shape/dtype, metadata, channel metadata/calibration/IDs/order, source offsets, previous/lineage, and history params.
- Literal schema-2 Recipe v1 payload coverage proving the legacy five-bin axis `[0, 6000, 12000, 18000, 24000]`, version-1 history, and the preserved non-48kHz guard without invoking the current operation.
- Complete public Recipe v2 path: `from_frame -> to_dict -> JSON serialize/deserialize -> apply`, including laziness and result parity.
- v1/v2 default registry coexistence and load-time invalid-G validation.

## Validation

- Focused suites — 355 passed
- `uv run ruff check wandas tests scripts` — passed
- `uv run ruff format --check wandas tests scripts` — passed
- `uv run ty check wandas tests scripts` — passed
- `git diff --check` — passed
- `uv run coverage report -m wandas/frames/spectral.py` — 100%
- `uv run pytest -q` — 3032 passed, 3 skipped
- `uv run mkdocs build --strict -f docs/mkdocs.yml` — passed (pre-existing template-not-in-nav and font/non-interactive plotting warnings only)

## Compatibility judgment

The public `NOctSynthesis` constructor now requires `n_fft`. No compatibility shim retains the ambiguous inference because it can silently produce an incorrect frequency axis; the public `SpectralFrame.noct_synthesis()` signature remains unchanged and supplies the receiver-owned value automatically. Released Recipe v1 remains replayable, and new public calls use v2.

## Intentional non-goals

No MoSQITo, N-octave algorithm, 48 kHz contract, NOctFrame redesign, general quantity/unit contract, FFT/Welch/Cepstrum/CSD/transfer-function/coherence Recipe versioning, Recipe central model/compiler/validator/executor/serializer, or plotting changes.

## Remaining risks

Direct callers of `NOctSynthesis` must now provide the source FFT size and must provide a spectrum with exactly `n_fft // 2 + 1` bins. Optional dependency behavior remains unchanged after valid configuration.