### PR TITLE
test(docs): close remaining README contract review gaps

### DIFF
--- a/tests/docs/test_readme_examples.py
+++ b/tests/docs/test_readme_examples.py
@@ -14,9 +14,16 @@ PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 REPOSITORY_IMAGE_PREFIXES = (
     "https://raw.githubusercontent.com/kasahart/wandas/main/",
     "https://github.com/kasahart/wandas/blob/main/",
+    "https://github.com/kasahart/wandas/raw/main/",
+    "https://github.com/kasahart/wandas/raw/refs/heads/main/",
 )
 OPTIONAL_CODE_PATTERNS = (
-    re.compile(r"^\s*(?:from|import)\s+(?:h5netcdf|h5py|IPython|librosa|marimo|mosqito|tensorflow|torch)\b", re.M),
+    re.compile(
+        r"^\s*(?:from|import)\s+(?:h5netcdf|h5py|IPython|librosa|marimo|mosqito|sklearn|tensorflow|torch|"
+        r"wandas\.pipeline\.sklearn)\b",
+        re.M,
+    ),
+    re.compile(r"\bWandasOperationTransformer\s*\("),
     re.compile(r"\.\s*(?:hpss_harmonic|hpss_percussive|noct_spectrum)\s*\("),
     re.compile(r"\.\s*(?:loudness|roughness|sharpness)_[a-z0-9_]+\s*\("),
     re.compile(r"\bto_tensor\s*\(\s*framework\s*=\s*[\"'](?:tensorflow|torch)[\"']"),

--- a/tests/docs/test_readme_examples.py
+++ b/tests/docs/test_readme_examples.py
@@ -13,6 +13,7 @@ README_PATHS = (REPO_ROOT / "README.md", REPO_ROOT / "README.ja.md")
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 REPOSITORY_IMAGE_PREFIXES = (
     "https://raw.githubusercontent.com/kasahart/wandas/main/",
+    "https://raw.githubusercontent.com/kasahart/wandas/refs/heads/main/",
     "https://github.com/kasahart/wandas/blob/main/",
     "https://github.com/kasahart/wandas/raw/main/",
     "https://github.com/kasahart/wandas/raw/refs/heads/main/",
@@ -23,6 +24,7 @@ OPTIONAL_CODE_PATTERNS = (
         r"wandas\.pipeline\.sklearn)\b",
         re.M,
     ),
+    re.compile(r"^\s*from\s+wandas\.pipeline\s+import\s+sklearn\b", re.M),
     re.compile(r"\bWandasOperationTransformer\s*\("),
     re.compile(r"\.\s*(?:hpss_harmonic|hpss_percussive|noct_spectrum)\s*\("),
     re.compile(r"\.\s*(?:loudness|roughness|sharpness)_[a-z0-9_]+\s*\("),


### PR DESCRIPTION
## Summary

This follow-up closes the two actionable review threads left on the merged PR #407:

- recognize both GitHub `raw/main` and `raw/refs/heads/main` repository image URL forms;
- treat `sklearn` imports and `WandasOperationTransformer` usage as optional in the README core-only guard.

No README content, production code, numerical contract, checker, parser, crawler, dependency, workflow, or infrastructure is added. The focused docs test passes, and the branch is based on the latest `main` (`218286ee`).