### PR TITLE
docs(api): document WDF metadata round-trip contract

### DIFF
--- a/wandas/io/wdf_io.py
+++ b/wandas/io/wdf_io.py
@@ -153,6 +153,8 @@ def save(
     The artifact retains the Frame label, user metadata, channel labels and
     metadata (units, references, calibration, and channel extras), source-time
     offsets, analysis coordinates, and the derived ``operation_history`` view.
+    Metadata fields use strict JSON encoding and therefore follow JSON value
+    semantics (for example, a tuple is loaded as a list).
     It stores the concrete Frame result; ``previous`` references and replayable
     Recipe intent are not persisted.
 
@@ -237,8 +239,9 @@ def load(path: str | Path) -> BaseFrame[Any]:
     The returned Frame restores the saved label, user metadata, channel labels
     and metadata (units, references, calibration, and channel extras),
     source-time offsets, analysis coordinates, and derived
-    ``operation_history`` view. WDF does not restore a ``previous`` reference
-    or replayable Recipe intent.
+    ``operation_history`` view. Metadata follows strict JSON value semantics;
+    for example, a tuple saved in metadata is loaded as a list. WDF does not
+    restore a ``previous`` reference or replayable Recipe intent.
 
     The returned Frame owns access to its source internally. Keep the source path
     unchanged while that Frame or Frames derived from it are in use. Obtain NumPy

--- a/wandas/io/wdf_io.py
+++ b/wandas/io/wdf_io.py
@@ -150,6 +150,12 @@ def save(
 ) -> None:
     """Save an exact built-in Frame as WDF 0.4.
 
+    The artifact retains the Frame label, user metadata, channel labels and
+    metadata (units, references, calibration, and channel extras), source-time
+    offsets, analysis coordinates, and the derived ``operation_history`` view.
+    It stores the concrete Frame result; ``previous`` references and replayable
+    Recipe intent are not persisted.
+
     Dask data is handed directly to xarray and is written synchronously; Wandas does
     not first materialize the complete tensor with ``frame._data.compute()``.
     """
@@ -227,6 +233,12 @@ def _number_vector(dataset: xr.Dataset, name: str, channel_count: int) -> np.nda
 
 def load(path: str | Path) -> BaseFrame[Any]:
     """Load a local WDF 0.4 artifact as its exact built-in Frame type.
+
+    The returned Frame restores the saved label, user metadata, channel labels
+    and metadata (units, references, calibration, and channel extras),
+    source-time offsets, analysis coordinates, and derived
+    ``operation_history`` view. WDF does not restore a ``previous`` reference
+    or replayable Recipe intent.
 
     The returned Frame owns access to its source internally. Keep the source path
     unchanged while that Frame or Frames derived from it are in use. Obtain NumPy


### PR DESCRIPTION
## Summary

This follow-up addresses the remaining review thread on PR #409 by making the generated public WDF API docstrings explicit about the metadata round-trip guarantee.

- `save` and `load` now document Frame/user metadata, channel labels and metadata, calibration, channel extras, source-time offsets, coordinates, and derived `operation_history`.
- The docstrings explicitly distinguish concrete WDF results from non-persisted `previous` references and replayable Recipe intent.
- WDF behavior, schema, format, and implementation are unchanged.

Validation: `uv run pytest tests/io/test_wdf_io.py -q` (91 passed), ruff check/format, and ty check passed.