### PR TITLE
ci: split fast PR lane from full compatibility validation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,13 @@ on:
             - 'v*.*.*'
 
 jobs:
+    full-compatibility:
+        name: Full compatibility validation
+        uses: ./.github/workflows/full-compatibility.yml
+        with:
+            ref: ${{ github.sha }}
+        secrets: inherit
+
     build:
         name: Build distribution
         runs-on: ubuntu-latest
@@ -26,21 +33,9 @@ jobs:
             - name: Python をセットアップ
               run: uv python install
 
-            - name: 依存関係をインストール
-              run: uv sync --all-extras --group test
-
-            - name: コード品質チェック (ruff)
-              # pyproject.tomlの設定を明示的に使用
-              run: uv run ruff check wandas tests --config=pyproject.toml
-
-            - name: 型チェック (ty)
-              run: uv run ty check wandas tests
-
-            - name: テスト実行 (pytest)
-              # pytestは自動的にpyproject.tomlを検出します
-              run: uv run pytest -n auto
-
             - name: Build a binary wheel and a source tarball
+              # Source validation is owned by Full Compatibility; this job
+              # only creates the artifacts that the release jobs publish.
               run: uv build
 
             - name: Store the distribution packages
@@ -93,6 +88,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
         needs:
         - test-installation
+        - full-compatibility
         runs-on: ubuntu-latest
         environment:
             name: pypi

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,6 +22,8 @@ jobs:
         steps:
             - name: リポジトリをチェックアウト
               uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.sha }}
 
             - name: uv をインストール
               uses: astral-sh/setup-uv@v5

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,6 +17,7 @@ jobs:
 
     build:
         name: Build distribution
+        needs: full-compatibility
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
@@ -53,6 +54,8 @@ jobs:
         steps:
             - name: リポジトリをチェックアウト
               uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.sha }}
 
             - name: uv をインストール
               uses: astral-sh/setup-uv@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,13 +116,16 @@ jobs:
         run: uv python install 3.12
 
       - name: 依存関係をインストール (docsグループ + 非ML extras)
-        run: uv sync --no-dev --extra io --extra effects --extra marimo --extra psychoacoustic --group docs
+        run: uv sync --no-dev --extra io --extra effects --extra marimo --extra psychoacoustic --group docs --group test
 
       - name: 公開exportとdocstringの軽量チェック
         run: uv run --no-sync python scripts/check_public_docstrings.py
 
       - name: Learning applicationsのsource check
         run: uv run --no-sync marimo check --strict learning-path/*.py
+
+      - name: Documentation contract tests
+        run: uv run --no-sync pytest tests/docs -q --no-cov
 
       - name: ドキュメントのビルドテスト (MkDocs)
         run: uv run --no-sync mkdocs build --strict -f docs/mkdocs.yml
@@ -305,6 +308,22 @@ jobs:
         shell: bash
         run: |
           set -u
+
+          required_outputs=(NATIVE_REQUIRED LINT_REQUIRED DOCS_REQUIRED WHEEL_REQUIRED PYODIDE_REQUIRED)
+          invalid_outputs=()
+          for output_name in "${required_outputs[@]}"; do
+            output_value="${!output_name-}"
+            case "$output_value" in
+              true|false) ;;
+              *) invalid_outputs+=("$output_name=${output_value:-<empty>}") ;;
+            esac
+          done
+
+          if (( ${#invalid_outputs[@]} > 0 )); then
+            echo "Invalid CI routing outputs: ${invalid_outputs[*]}" >&2
+            exit 1
+          fi
+
           if [[ "$ROUTE_RESULT" != "success" ]]; then
             echo "The CI routing job did not succeed: $ROUTE_RESULT" >&2
             exit 1

--- a/.github/workflows/full-compatibility.yml
+++ b/.github/workflows/full-compatibility.yml
@@ -1,79 +1,34 @@
-name: CI
+name: Full Compatibility
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  schedule:
+    - cron: "17 2 * * *"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to validate; leave blank for the selected workflow ref"
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to validate"
+        required: false
+        type: string
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+permissions:
+  contents: read
 
 jobs:
-  route:
-    name: Determine required checks
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      native: ${{ steps.classify.outputs.native }}
-      lint: ${{ steps.classify.outputs.lint }}
-      docs: ${{ steps.classify.outputs.docs }}
-      wheel: ${{ steps.classify.outputs.wheel }}
-      pyodide: ${{ steps.classify.outputs.pyodide }}
-      unknown: ${{ steps.classify.outputs.unknown }}
-    steps:
-      - name: チェックアウト
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: uv をセットアップ
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          version: "latest"
-
-      - name: Python 3.12 をインストール
-        run: uv python install 3.12
-
-      - name: 変更ファイルを収集
-        id: changed-files
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BEFORE_SHA: ${{ github.event.before }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          CURRENT_SHA: ${{ github.sha }}
-        run: |
-          set -u
-          changed_file_path="$RUNNER_TEMP/wandas-changed-files"
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            if ! git diff --name-only "$BASE_SHA" "$CURRENT_SHA" > "$changed_file_path"; then
-              printf '%s\n' '__ci_route_unknown__' > "$changed_file_path"
-            fi
-          elif [[ -n "$BEFORE_SHA" && ! "$BEFORE_SHA" =~ ^0+$ ]]; then
-            if ! git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" > "$changed_file_path"; then
-              printf '%s\n' '__ci_route_unknown__' > "$changed_file_path"
-            fi
-          elif ! git ls-tree -r --name-only "$CURRENT_SHA" > "$changed_file_path"; then
-            printf '%s\n' '__ci_route_unknown__' > "$changed_file_path"
-          fi
-          printf 'path=%s\n' "$changed_file_path" >> "$GITHUB_OUTPUT"
-
-      - name: 変更パスを保守的に分類
-        id: classify
-        run: uv run --no-project --python 3.12 python scripts/ci_route.py --github-output "$GITHUB_OUTPUT" < "${{ steps['changed-files'].outputs.path }}"
-
   lint:
     name: Lint and Type Check
-    if: needs.route.outputs.lint == 'true'
-    needs: route
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: チェックアウト
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: uv をセットアップ
         uses: astral-sh/setup-uv@v5
@@ -98,13 +53,13 @@ jobs:
 
   docs:
     name: Build Documentation
-    if: needs.route.outputs.docs == 'true'
-    needs: route
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: チェックアウト
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: uv をセットアップ
         uses: astral-sh/setup-uv@v5
@@ -129,13 +84,13 @@ jobs:
 
   core-install-smoke:
     name: Core-only wheel install smoke
-    if: needs.route.outputs.wheel == 'true'
-    needs: route
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: チェックアウト
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: uv をセットアップ
         uses: astral-sh/setup-uv@v5
@@ -201,13 +156,13 @@ jobs:
 
   pyodide:
     name: Pyodide 314.0.3
-    if: needs.route.outputs.pyodide == 'true'
-    needs: route
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: チェックアウト
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: uv をセットアップ
         uses: astral-sh/setup-uv@v5
@@ -233,8 +188,6 @@ jobs:
 
   native-test:
     name: Test on ${{ matrix.os }} / Python ${{ matrix.python-version }}
-    if: needs.route.outputs.native == 'true'
-    needs: route
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
@@ -245,14 +198,37 @@ jobs:
             python-version: "3.10"
             coverage: false
           - os: ubuntu-latest
+            python-version: "3.11"
+            coverage: false
+          - os: ubuntu-latest
+            python-version: "3.12"
+            coverage: false
+          - os: ubuntu-latest
+            python-version: "3.13"
+            coverage: false
+          - os: ubuntu-latest
             python-version: "3.14"
             coverage: true
+          - os: windows-latest
+            python-version: "3.10"
+            coverage: false
+          - os: windows-latest
+            python-version: "3.11"
+            coverage: false
+          - os: windows-latest
+            python-version: "3.12"
+            coverage: false
+          - os: windows-latest
+            python-version: "3.13"
+            coverage: false
           - os: windows-latest
             python-version: "3.14"
             coverage: false
     steps:
       - name: チェックアウト
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: uv をインストール
         uses: astral-sh/setup-uv@v5
@@ -272,8 +248,6 @@ jobs:
 
       - name: テスト実行 (pytest、カバレッジあり)
         if: matrix.coverage == true
-        env:
-          MPLBACKEND: ${{ matrix.os == 'windows-latest' && 'Agg' || '' }}
         run: uv run --no-sync pytest -n auto -vv
 
       - name: Upload coverage reports to Codecov
@@ -283,53 +257,37 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: kasahart/wandas
 
-  ci-gate:
-    name: CI Gate
+  full-gate:
+    name: Full Compatibility Gate
     if: always()
-    needs: [route, lint, docs, core-install-smoke, pyodide, native-test]
+    needs: [lint, docs, core-install-smoke, pyodide, native-test]
     runs-on: ubuntu-latest
     steps:
-      - name: 選択されたチェックの結果を検証
+      - name: 完全互換性チェックの結果を検証
         env:
-          ROUTE_RESULT: ${{ needs.route.result }}
-          NATIVE_REQUIRED: ${{ needs.route.outputs.native }}
-          NATIVE_RESULT: ${{ needs['native-test'].result }}
-          LINT_REQUIRED: ${{ needs.route.outputs.lint }}
           LINT_RESULT: ${{ needs.lint.result }}
-          DOCS_REQUIRED: ${{ needs.route.outputs.docs }}
           DOCS_RESULT: ${{ needs.docs.result }}
-          WHEEL_REQUIRED: ${{ needs.route.outputs.wheel }}
           WHEEL_RESULT: ${{ needs['core-install-smoke'].result }}
-          PYODIDE_REQUIRED: ${{ needs.route.outputs.pyodide }}
           PYODIDE_RESULT: ${{ needs.pyodide.result }}
+          NATIVE_RESULT: ${{ needs['native-test'].result }}
         shell: bash
         run: |
           set -u
-          if [[ "$ROUTE_RESULT" != "success" ]]; then
-            echo "The CI routing job did not succeed: $ROUTE_RESULT" >&2
-            exit 1
-          fi
-
           failed_checks=()
-          if [[ "$NATIVE_REQUIRED" == "true" && "$NATIVE_RESULT" != "success" ]]; then
-            failed_checks+=(native-test:$NATIVE_RESULT)
-          fi
-          if [[ "$LINT_REQUIRED" == "true" && "$LINT_RESULT" != "success" ]]; then
-            failed_checks+=(lint:$LINT_RESULT)
-          fi
-          if [[ "$DOCS_REQUIRED" == "true" && "$DOCS_RESULT" != "success" ]]; then
-            failed_checks+=(docs:$DOCS_RESULT)
-          fi
-          if [[ "$WHEEL_REQUIRED" == "true" && "$WHEEL_RESULT" != "success" ]]; then
-            failed_checks+=(core-install-smoke:$WHEEL_RESULT)
-          fi
-          if [[ "$PYODIDE_REQUIRED" == "true" && "$PYODIDE_RESULT" != "success" ]]; then
-            failed_checks+=(pyodide:$PYODIDE_RESULT)
-          fi
+          for check in \
+            "lint:$LINT_RESULT" \
+            "docs:$DOCS_RESULT" \
+            "core-install-smoke:$WHEEL_RESULT" \
+            "pyodide:$PYODIDE_RESULT" \
+            "native-test:$NATIVE_RESULT"; do
+            if [[ "${check#*:}" != "success" ]]; then
+              failed_checks+=("$check")
+            fi
+          done
 
           if (( ${#failed_checks[@]} > 0 )); then
-            echo "Selected CI checks did not succeed: ${failed_checks[*]}" >&2
+            echo "Full compatibility checks did not succeed: ${failed_checks[*]}" >&2
             exit 1
           fi
 
-          echo "All selected CI checks succeeded; intentionally skipped checks are accepted."
+          echo "All full compatibility checks succeeded."

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -59,39 +59,16 @@ Tests are located in the `tests/` directory.
 
 ## CI Validation Lanes / CI検証レーン
 
-Pull requests and pushes to `main` use the fast CI lane. A change-routing job
-selects only the checks relevant to the changed paths; unknown paths are
-treated conservatively and select every check. Native tests use exactly these
-representative environments:
-PRと`main`へのpushでは高速CIレーンを使用します。変更パスのルーティングjobが関連する
-checkだけを選択し、未知のパスは保守的にすべてのcheckを選択します。native testは以下の
-代表環境で実行します:
+Pull requests and pushes to `main` use a representative fast lane; uncertain
+changes select broader validation. PRと`main`へのpushでは代表的なfast laneを使い、
+不確かな変更では検証範囲を広げます。
 
-- Ubuntu / Python 3.10
-- Ubuntu / Python 3.14 (the single coverage upload / カバレッジをuploadするjob)
-- Windows / Python 3.14
+`Full Compatibility` runs Ubuntu and Windows on Python 3.10–3.14, plus lint,
+type checking, docs, core-only wheel smoke, and Pyodide. `Full Compatibility`は
+Ubuntu/WindowsのPython 3.10–3.14、lint、type check、docs、core-only wheel smoke、
+Pyodideを実行します。
 
-Documentation-only changes do not run the native test matrix. Changes to
-package configuration, workflows, or uncertain paths select the relevant
-checks more broadly. The final `CI Gate` job is the stable required-check name;
-configure branch protection for `main` to require `CI Gate` rather than a
-matrix job name.
-ドキュメントのみの変更ではnative test matrixを実行しません。package設定、workflow、または
-不確かなパスの変更は、より広いcheckを選択します。最後の`CI Gate`が安定したrequired check名
-なので、`main`のbranch protectionではmatrix job名ではなく`CI Gate`を必須に設定します。
-
-The `Full Compatibility` workflow runs the complete Ubuntu and Windows ×
-Python 3.10–3.14 matrix together with lint, type checking, documentation,
-core-only wheel installation, and Pyodide validation. It runs daily, can be
-started manually for a branch, tag, or SHA, and is required by the release
-workflow before publishing to PyPI.
-`Full Compatibility` workflowはUbuntu/Windows × Python 3.10–3.14の完全matrixに加え、lint、
-type check、documentation、core-only wheel installation、Pyodide validationを実行します。
-毎日実行され、branch・tag・SHAを指定して手動実行でき、PyPI公開前にはrelease workflowから
-必須で呼び出されます。
-
-Run the full lane manually from the repository root:
-リポジトリrootからfull laneを手動実行します:
+Run it manually from the repository root: リポジトリrootから手動実行します:
 
 ```bash
 gh workflow run full-compatibility.yml \
@@ -100,12 +77,9 @@ gh workflow run full-compatibility.yml \
   -f ref=main
 ```
 
-For the rollout record, compare the Actions run summary before and after this
-change: median time to required checks becoming green, total runner-minutes,
-jobs per pull-request revision, and native full-suite executions per revision.
-ロールアウト時は、この変更の前後でActionsのrun summaryを比較し、required checkがgreenになる
-までの中央値、総runner-minute、pull-request revisionあたりのjob数、revisionあたりのnative
-full suite実行数をimplementing pull requestに記録します。
+`CI Gate` is the stable required check for `main`; configure branch protection
+to require it instead of a matrix job. `CI Gate`を`main`のstable required checkとし、
+branch protectionではmatrix job名ではなくこれを必須に設定します。
 
 ## Code Quality Checks / コード品質チェック
 

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -57,6 +57,56 @@ Tests are located in the `tests/` directory.
   uv run pytest -n auto --cov=wandas --cov-report=term-missing
   ```
 
+## CI Validation Lanes / CI検証レーン
+
+Pull requests and pushes to `main` use the fast CI lane. A change-routing job
+selects only the checks relevant to the changed paths; unknown paths are
+treated conservatively and select every check. Native tests use exactly these
+representative environments:
+PRと`main`へのpushでは高速CIレーンを使用します。変更パスのルーティングjobが関連する
+checkだけを選択し、未知のパスは保守的にすべてのcheckを選択します。native testは以下の
+代表環境で実行します:
+
+- Ubuntu / Python 3.10
+- Ubuntu / Python 3.14 (the single coverage upload / カバレッジをuploadするjob)
+- Windows / Python 3.14
+
+Documentation-only changes do not run the native test matrix. Changes to
+package configuration, workflows, or uncertain paths select the relevant
+checks more broadly. The final `CI Gate` job is the stable required-check name;
+configure branch protection for `main` to require `CI Gate` rather than a
+matrix job name.
+ドキュメントのみの変更ではnative test matrixを実行しません。package設定、workflow、または
+不確かなパスの変更は、より広いcheckを選択します。最後の`CI Gate`が安定したrequired check名
+なので、`main`のbranch protectionではmatrix job名ではなく`CI Gate`を必須に設定します。
+
+The `Full Compatibility` workflow runs the complete Ubuntu and Windows ×
+Python 3.10–3.14 matrix together with lint, type checking, documentation,
+core-only wheel installation, and Pyodide validation. It runs daily, can be
+started manually for a branch, tag, or SHA, and is required by the release
+workflow before publishing to PyPI.
+`Full Compatibility` workflowはUbuntu/Windows × Python 3.10–3.14の完全matrixに加え、lint、
+type check、documentation、core-only wheel installation、Pyodide validationを実行します。
+毎日実行され、branch・tag・SHAを指定して手動実行でき、PyPI公開前にはrelease workflowから
+必須で呼び出されます。
+
+Run the full lane manually from the repository root:
+リポジトリrootからfull laneを手動実行します:
+
+```bash
+gh workflow run full-compatibility.yml \
+  --repo kasahart/wandas \
+  --ref main \
+  -f ref=main
+```
+
+For the rollout record, compare the Actions run summary before and after this
+change: median time to required checks becoming green, total runner-minutes,
+jobs per pull-request revision, and native full-suite executions per revision.
+ロールアウト時は、この変更の前後でActionsのrun summaryを比較し、required checkがgreenになる
+までの中央値、総runner-minute、pull-request revisionあたりのjob数、revisionあたりのnative
+full suite実行数をimplementing pull requestに記録します。
+
 ## Code Quality Checks / コード品質チェック
 
 Please perform the following checks before submitting a pull request.

--- a/scripts/ci_route.py
+++ b/scripts/ci_route.py
@@ -37,7 +37,10 @@ _PYODIDE_PATH_PREFIXES = (
 def _normalize(path: str) -> str:
     """Return a repository-relative POSIX path for a changed-file entry."""
 
-    return path.strip().replace("\\", "/").lstrip("./")
+    normalized = path.strip().replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
 
 
 def _under(path: str, prefix: str) -> bool:

--- a/scripts/ci_route.py
+++ b/scripts/ci_route.py
@@ -1,0 +1,164 @@
+"""Classify changed paths for the pull-request CI workflow.
+
+The classifier deliberately owns only routing policy.  It has no GitHub API
+dependency, so the same rules can be exercised locally and in the repository's
+contract tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+
+CHECKS = ("native", "lint", "docs", "wheel", "pyodide")
+_ROOT_CONFIG_FILES = frozenset(
+    {
+        ".pre-commit-config.yaml",
+        "MANIFEST.in",
+        "hatch.toml",
+        "mkdocs.yml",
+        "pyproject.toml",
+        "setup.cfg",
+        "setup.py",
+        "tox.ini",
+        "uv.lock",
+    }
+)
+_PACKAGING_SCRIPT_NAMES = frozenset({"build.py", "package.py", "test_installation.py"})
+_PYODIDE_PATH_PREFIXES = (
+    "scripts/pyodide/",
+    "tests/pyodide/",
+    "docs/src/how-to/pyodide",
+)
+
+
+def _normalize(path: str) -> str:
+    """Return a repository-relative POSIX path for a changed-file entry."""
+
+    return path.strip().replace("\\", "/").lstrip("./")
+
+
+def _under(path: str, prefix: str) -> bool:
+    return path == prefix.rstrip("/") or path.startswith(prefix)
+
+
+def _is_build_configuration(path: str) -> bool:
+    if path in _ROOT_CONFIG_FILES:
+        return True
+    return path.startswith(("build/", "packaging/")) or path.startswith(("setup.", "hatch."))
+
+
+def _is_python_source(path: str) -> bool:
+    return path.endswith((".py", ".pyi")) and path.startswith(("wandas/", "tests/", "scripts/", "learning-path/"))
+
+
+def _is_test_related_script(path: str) -> bool:
+    if not path.startswith("scripts/"):
+        return False
+    name = path.removeprefix("scripts/")
+    return name.startswith(("test_", "run_")) or name.startswith("ci_")
+
+
+def _is_pyodide_path(path: str) -> bool:
+    return path.startswith(_PYODIDE_PATH_PREFIXES) or path in {
+        "scripts/test_pyodide.sh",
+        "scripts/run_pyodide_tests.py",
+        "scripts/run_pyodide_tests.mjs",
+    }
+
+
+def _is_known_path(path: str) -> bool:
+    return (
+        path in {"README.md", "README.ja.md"}
+        or path in _ROOT_CONFIG_FILES
+        or path.startswith(
+            (
+                ".github/workflows/",
+                "docs/",
+                "learning-path/",
+                "scripts/",
+                "tests/",
+                "wandas/",
+            )
+        )
+    )
+
+
+def classify_paths(paths: Iterable[str]) -> dict[str, bool]:
+    """Return the CI jobs selected by ``paths``.
+
+    Unknown paths select every job.  This is intentional: a routing miss must
+    increase validation rather than silently reduce it.
+    """
+
+    normalized = tuple(path for raw_path in paths if (path := _normalize(raw_path)))
+    if not normalized:
+        return {**{check: True for check in CHECKS}, "unknown": True}
+
+    selected = {check: False for check in CHECKS}
+    unknown = False
+
+    for path in normalized:
+        if not _is_known_path(path):
+            unknown = True
+            continue
+
+        is_workflow = _under(path, ".github/workflows/")
+        is_build_config = _is_build_configuration(path)
+        is_source = _is_python_source(path)
+        is_test_script = _is_test_related_script(path)
+        is_pyodide = _is_pyodide_path(path)
+
+        selected["native"] |= (
+            _under(path, "wandas/") or _under(path, "tests/") or is_build_config or is_workflow or is_test_script
+        )
+        selected["lint"] |= is_source or is_build_config or is_workflow
+        selected["docs"] |= (
+            _under(path, "docs/")
+            or _under(path, "learning-path/")
+            or _under(path, "wandas/")
+            or path in {"README.md", "README.ja.md"}
+            or path == "scripts/check_public_docstrings.py"
+            or is_build_config
+            or is_workflow
+        )
+        selected["wheel"] |= (
+            _under(path, "wandas/")
+            or is_build_config
+            or is_workflow
+            or path.removeprefix("scripts/") in _PACKAGING_SCRIPT_NAMES
+        )
+        selected["pyodide"] |= is_pyodide or _under(path, "wandas/") or is_build_config or is_workflow
+
+    if unknown:
+        selected = {check: True for check in CHECKS}
+
+    selected["unknown"] = unknown
+    return selected
+
+
+def _write_github_outputs(output_path: Path, decision: dict[str, bool]) -> None:
+    with output_path.open("a", encoding="utf-8") as output:
+        for key, value in decision.items():
+            output.write(f"{key}={'true' if value else 'false'}\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--github-output", type=Path)
+    parser.add_argument("paths", nargs="*", help="changed paths; defaults to newline-delimited stdin")
+    args = parser.parse_args(argv)
+
+    paths = args.paths or sys.stdin.read().splitlines()
+    decision = classify_paths(paths)
+    if args.github_output is not None:
+        _write_github_outputs(args.github_output, decision)
+    for key, value in decision.items():
+        print(f"{key}={'true' if value else 'false'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci_route.py
+++ b/scripts/ci_route.py
@@ -27,6 +27,7 @@ _ROOT_CONFIG_FILES = frozenset(
     }
 )
 _PACKAGING_SCRIPT_NAMES = frozenset({"build.py", "package.py", "test_installation.py"})
+_KNOWN_SCRIPT_PATHS = frozenset({"scripts/check_public_docstrings.py", "scripts/ci_route.py"})
 _PYODIDE_PATH_PREFIXES = (
     "scripts/pyodide/",
     "tests/pyodide/",
@@ -76,12 +77,15 @@ def _is_known_path(path: str) -> bool:
     return (
         path in {"README.md", "README.ja.md"}
         or path in _ROOT_CONFIG_FILES
+        or path in _KNOWN_SCRIPT_PATHS
+        or _is_test_related_script(path)
+        or _is_pyodide_path(path)
+        or path.removeprefix("scripts/") in _PACKAGING_SCRIPT_NAMES
         or path.startswith(
             (
                 ".github/workflows/",
                 "docs/",
                 "learning-path/",
-                "scripts/",
                 "tests/",
                 "wandas/",
             )
@@ -113,11 +117,17 @@ def classify_paths(paths: Iterable[str]) -> dict[str, bool]:
         is_source = _is_python_source(path)
         is_test_script = _is_test_related_script(path)
         is_pyodide = _is_pyodide_path(path)
+        is_routing_script = path == "scripts/ci_route.py"
 
         selected["native"] |= (
-            _under(path, "wandas/") or _under(path, "tests/") or is_build_config or is_workflow or is_test_script
+            _under(path, "wandas/")
+            or _under(path, "tests/")
+            or is_build_config
+            or is_workflow
+            or is_test_script
+            or is_routing_script
         )
-        selected["lint"] |= is_source or is_build_config or is_workflow
+        selected["lint"] |= is_source or is_build_config or is_workflow or is_routing_script
         selected["docs"] |= (
             _under(path, "docs/")
             or _under(path, "learning-path/")
@@ -126,14 +136,18 @@ def classify_paths(paths: Iterable[str]) -> dict[str, bool]:
             or path == "scripts/check_public_docstrings.py"
             or is_build_config
             or is_workflow
+            or is_routing_script
         )
         selected["wheel"] |= (
             _under(path, "wandas/")
             or is_build_config
             or is_workflow
             or path.removeprefix("scripts/") in _PACKAGING_SCRIPT_NAMES
+            or is_routing_script
         )
-        selected["pyodide"] |= is_pyodide or _under(path, "wandas/") or is_build_config or is_workflow
+        selected["pyodide"] |= (
+            is_pyodide or _under(path, "wandas/") or is_build_config or is_workflow or is_routing_script
+        )
 
     if unknown:
         selected = {check: True for check in CHECKS}

--- a/tests/docs/test_ci_routing.py
+++ b/tests/docs/test_ci_routing.py
@@ -1,13 +1,19 @@
 """Contract tests for CI path routing and validation lanes."""
 
+import os
+import subprocess
 from pathlib import Path
 from typing import Any
 
+import pytest
 import yaml
 
 from scripts.ci_route import CHECKS, classify_paths
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+BASH_GATE_ONLY = pytest.mark.skipif(os.name == "nt", reason="CI Gate runs Bash on ubuntu-latest")
+REQUIRED_OUTPUT_NAMES = ("NATIVE_REQUIRED", "LINT_REQUIRED", "DOCS_REQUIRED", "WHEEL_REQUIRED", "PYODIDE_REQUIRED")
+RESULT_NAMES = ("NATIVE_RESULT", "LINT_RESULT", "DOCS_RESULT", "WHEEL_RESULT", "PYODIDE_RESULT")
 
 
 def _workflow(name: str) -> dict[str, Any]:
@@ -21,9 +27,45 @@ def _decision(**selected: bool) -> dict[str, bool]:
     return {**{check: False for check in CHECKS}, "unknown": False, **selected}
 
 
+def _gate_script() -> str:
+    workflow = _workflow("ci.yml")
+    steps = workflow["jobs"]["ci-gate"]["steps"]
+    assert len(steps) == 1
+    script = steps[0]["run"]
+    assert isinstance(script, str)
+    return script
+
+
+def _run_gate(
+    *,
+    route_result: str = "success",
+    required: dict[str, str] | None = None,
+    results: dict[str, str] | None = None,
+    omit_required: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    environment = {
+        "ROUTE_RESULT": route_result,
+        **dict.fromkeys(REQUIRED_OUTPUT_NAMES, "false"),
+        **dict.fromkeys(RESULT_NAMES, "skipped"),
+    }
+    environment.update(required or {})
+    environment.update(results or {})
+    if omit_required is not None:
+        environment.pop(omit_required)
+    return subprocess.run(
+        ["bash"],
+        input=_gate_script(),
+        text=True,
+        capture_output=True,
+        check=False,
+        env={**os.environ, **environment},
+    )
+
+
 def test_documentation_only_paths_skip_native_validation() -> None:
     assert classify_paths(["docs/src/contributing.md"]) == _decision(docs=True)
     assert classify_paths(["README.md"]) == _decision(docs=True)
+    assert classify_paths(["README.ja.md"]) == _decision(docs=True)
     assert classify_paths(["learning-path/03_working_with_frames.py"]) == _decision(lint=True, docs=True)
 
 
@@ -47,6 +89,7 @@ def test_product_and_configuration_paths_select_required_checks() -> None:
         lint=True,
         pyodide=True,
     )
+    assert classify_paths(["tests/docs/test_readme_examples.py"]) == _decision(native=True, lint=True)
 
 
 def test_unknown_or_empty_paths_select_everything() -> None:
@@ -68,6 +111,21 @@ def test_fast_lane_has_three_representative_native_environments() -> None:
     assert "--no-cov" in workflow["jobs"]["native-test"]["steps"][3]["run"]
     assert workflow["jobs"]["ci-gate"]["if"] == "always()"
     assert workflow["jobs"]["ci-gate"]["name"] == "CI Gate"
+
+
+def test_documentation_job_runs_contract_tests_without_coverage() -> None:
+    workflow = _workflow("ci.yml")
+    docs_job = workflow["jobs"]["docs"]
+    steps = docs_job["steps"]
+
+    sync_commands = [step["run"] for step in steps if isinstance(step, dict) and "uv sync" in step.get("run", "")]
+    contract_commands = [
+        step["run"] for step in steps if isinstance(step, dict) and "tests/docs" in step.get("run", "")
+    ]
+
+    assert len(sync_commands) == 1
+    assert "--group docs --group test" in sync_commands[0]
+    assert contract_commands == ["uv run --no-sync pytest tests/docs -q --no-cov"]
 
 
 def test_full_lane_preserves_the_ten_environment_compatibility_matrix() -> None:
@@ -95,3 +153,55 @@ def test_release_publish_waits_for_full_compatibility() -> None:
     assert full_job["uses"] == "./.github/workflows/full-compatibility.yml"
     assert full_job["with"]["ref"] == "${{ github.sha }}"
     assert "full-compatibility" in publish_job["needs"]
+
+
+@BASH_GATE_ONLY
+def test_ci_gate_rejects_route_failure() -> None:
+    result = _run_gate(route_result="failure")
+
+    assert result.returncode != 0
+    assert "routing job" in result.stderr
+
+
+@pytest.mark.parametrize("output_name", REQUIRED_OUTPUT_NAMES)
+@BASH_GATE_ONLY
+def test_ci_gate_rejects_missing_required_outputs(output_name: str) -> None:
+    result = _run_gate(omit_required=output_name)
+
+    assert result.returncode != 0
+    assert "Invalid CI routing outputs" in result.stderr
+
+
+@pytest.mark.parametrize("output_name", REQUIRED_OUTPUT_NAMES)
+@pytest.mark.parametrize("invalid_value", ["", "TRUE", "unexpected"])
+@BASH_GATE_ONLY
+def test_ci_gate_rejects_missing_or_invalid_required_outputs(output_name: str, invalid_value: str) -> None:
+    result = _run_gate(required={output_name: invalid_value})
+
+    assert result.returncode != 0
+    assert "Invalid CI routing outputs" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("required_name", "result_name"),
+    list(zip(REQUIRED_OUTPUT_NAMES, RESULT_NAMES, strict=True)),
+)
+@pytest.mark.parametrize("job_result", ["failure", "cancelled", "skipped"])
+@BASH_GATE_ONLY
+def test_ci_gate_rejects_non_success_for_required_jobs(
+    required_name: str,
+    result_name: str,
+    job_result: str,
+) -> None:
+    result = _run_gate(required={required_name: "true"}, results={result_name: job_result})
+
+    assert result.returncode != 0
+    assert "Selected CI checks did not succeed" in result.stderr
+
+
+@BASH_GATE_ONLY
+def test_ci_gate_accepts_intentionally_skipped_non_required_jobs() -> None:
+    result = _run_gate()
+
+    assert result.returncode == 0
+    assert "intentionally skipped checks are accepted" in result.stdout

--- a/tests/docs/test_ci_routing.py
+++ b/tests/docs/test_ci_routing.py
@@ -1,0 +1,97 @@
+"""Contract tests for CI path routing and validation lanes."""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.ci_route import CHECKS, classify_paths
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _workflow(name: str) -> dict[str, Any]:
+    path = REPO_ROOT / ".github" / "workflows" / name
+    data = yaml.load(path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    assert isinstance(data, dict)
+    return data
+
+
+def _decision(**selected: bool) -> dict[str, bool]:
+    return {**{check: False for check in CHECKS}, "unknown": False, **selected}
+
+
+def test_documentation_only_paths_skip_native_validation() -> None:
+    assert classify_paths(["docs/src/contributing.md"]) == _decision(docs=True)
+    assert classify_paths(["README.md"]) == _decision(docs=True)
+    assert classify_paths(["learning-path/03_working_with_frames.py"]) == _decision(lint=True, docs=True)
+
+
+def test_product_and_configuration_paths_select_required_checks() -> None:
+    assert classify_paths(["wandas/frames/base.py"]) == _decision(
+        native=True,
+        lint=True,
+        docs=True,
+        wheel=True,
+        pyodide=True,
+    )
+    assert classify_paths(["pyproject.toml"]) == _decision(
+        native=True,
+        lint=True,
+        docs=True,
+        wheel=True,
+        pyodide=True,
+    )
+    assert classify_paths(["tests/pyodide/test_wav_smoke.py"]) == _decision(
+        native=True,
+        lint=True,
+        pyodide=True,
+    )
+
+
+def test_unknown_or_empty_paths_select_everything() -> None:
+    expected = {**{check: True for check in CHECKS}, "unknown": True}
+
+    assert classify_paths([".vscode/settings.json"]) == expected
+    assert classify_paths([]) == expected
+
+
+def test_fast_lane_has_three_representative_native_environments() -> None:
+    workflow = _workflow("ci.yml")
+    matrix = workflow["jobs"]["native-test"]["strategy"]["matrix"]["include"]
+
+    assert {(item["os"], item["python-version"], item["coverage"]) for item in matrix} == {
+        ("ubuntu-latest", "3.10", "false"),
+        ("ubuntu-latest", "3.14", "true"),
+        ("windows-latest", "3.14", "false"),
+    }
+    assert "--no-cov" in workflow["jobs"]["native-test"]["steps"][3]["run"]
+    assert workflow["jobs"]["ci-gate"]["if"] == "always()"
+    assert workflow["jobs"]["ci-gate"]["name"] == "CI Gate"
+
+
+def test_full_lane_preserves_the_ten_environment_compatibility_matrix() -> None:
+    workflow = _workflow("full-compatibility.yml")
+    matrix = workflow["jobs"]["native-test"]["strategy"]["matrix"]["include"]
+
+    assert len(matrix) == 10
+    assert {(item["os"], item["python-version"]) for item in matrix} == {
+        (os_name, python_version)
+        for os_name in ("ubuntu-latest", "windows-latest")
+        for python_version in ("3.10", "3.11", "3.12", "3.13", "3.14")
+    }
+    assert sum(item["coverage"] == "true" for item in matrix) == 1
+    assert workflow["on"]["schedule"]
+    assert "workflow_dispatch" in workflow["on"]
+    assert "workflow_call" in workflow["on"]
+    assert workflow["jobs"]["full-gate"]["if"] == "always()"
+
+
+def test_release_publish_waits_for_full_compatibility() -> None:
+    workflow = _workflow("cd.yml")
+    full_job = workflow["jobs"]["full-compatibility"]
+    publish_job = workflow["jobs"]["publish-to-pypi"]
+
+    assert full_job["uses"] == "./.github/workflows/full-compatibility.yml"
+    assert full_job["with"]["ref"] == "${{ github.sha }}"
+    assert "full-compatibility" in publish_job["needs"]

--- a/tests/test_ci_route.py
+++ b/tests/test_ci_route.py
@@ -10,7 +10,7 @@ import yaml
 
 from scripts.ci_route import CHECKS, classify_paths
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = Path(__file__).resolve().parents[1]
 BASH_GATE_ONLY = pytest.mark.skipif(os.name == "nt", reason="CI Gate runs Bash on ubuntu-latest")
 REQUIRED_OUTPUT_NAMES = ("NATIVE_REQUIRED", "LINT_REQUIRED", "DOCS_REQUIRED", "WHEEL_REQUIRED", "PYODIDE_REQUIRED")
 RESULT_NAMES = ("NATIVE_RESULT", "LINT_RESULT", "DOCS_RESULT", "WHEEL_RESULT", "PYODIDE_RESULT")
@@ -84,6 +84,14 @@ def test_product_and_configuration_paths_select_required_checks() -> None:
         wheel=True,
         pyodide=True,
     )
+    assert classify_paths(["uv.lock"]) == _decision(
+        native=True,
+        lint=True,
+        docs=True,
+        wheel=True,
+        pyodide=True,
+    )
+    assert classify_paths(["tests/io/test_wav_io.py"]) == _decision(native=True, lint=True)
     assert classify_paths(["tests/pyodide/test_wav_smoke.py"]) == _decision(
         native=True,
         lint=True,
@@ -92,10 +100,34 @@ def test_product_and_configuration_paths_select_required_checks() -> None:
     assert classify_paths(["tests/docs/test_readme_examples.py"]) == _decision(native=True, lint=True)
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "docs/src/how-to/pyodide-browser.md",
+        "examples/pyodide/index.html",
+        "scripts/test_pyodide.sh",
+        "scripts/run_pyodide_tests.mjs",
+    ],
+)
+def test_pyodide_guide_example_and_harness_select_pyodide(path: str) -> None:
+    assert classify_paths([path])["pyodide"] is True
+
+
+def test_workflow_changes_select_every_check() -> None:
+    assert classify_paths([".github/workflows/ci.yml"]) == _decision(
+        native=True,
+        lint=True,
+        docs=True,
+        wheel=True,
+        pyodide=True,
+    )
+
+
 def test_unknown_or_empty_paths_select_everything() -> None:
     expected = {**{check: True for check in CHECKS}, "unknown": True}
 
     assert classify_paths([".vscode/settings.json"]) == expected
+    assert classify_paths(["__ci_route_unknown__"]) == expected
     assert classify_paths([]) == expected
 
 
@@ -143,6 +175,12 @@ def test_full_lane_preserves_the_ten_environment_compatibility_matrix() -> None:
     assert "workflow_dispatch" in workflow["on"]
     assert "workflow_call" in workflow["on"]
     assert workflow["jobs"]["full-gate"]["if"] == "always()"
+    for job_name in ("lint", "docs", "core-install-smoke", "pyodide", "native-test"):
+        checkout_steps = [
+            step for step in workflow["jobs"][job_name]["steps"] if step.get("uses") == "actions/checkout@v4"
+        ]
+        assert len(checkout_steps) == 1
+        assert checkout_steps[0]["with"]["ref"] == "${{ inputs.ref || github.ref }}"
 
 
 def test_release_publish_waits_for_full_compatibility() -> None:

--- a/tests/test_ci_route.py
+++ b/tests/test_ci_route.py
@@ -123,10 +123,21 @@ def test_workflow_changes_select_every_check() -> None:
     )
 
 
+def test_routing_script_changes_select_every_check() -> None:
+    assert classify_paths(["scripts/ci_route.py"]) == _decision(
+        native=True,
+        lint=True,
+        docs=True,
+        wheel=True,
+        pyodide=True,
+    )
+
+
 def test_unknown_or_empty_paths_select_everything() -> None:
     expected = {**{check: True for check in CHECKS}, "unknown": True}
 
     assert classify_paths([".vscode/settings.json"]) == expected
+    assert classify_paths(["scripts/new_tool.sh"]) == expected
     assert classify_paths(["__ci_route_unknown__"]) == expected
     assert classify_paths([]) == expected
 
@@ -187,14 +198,19 @@ def test_release_publish_waits_for_full_compatibility() -> None:
     workflow = _workflow("cd.yml")
     full_job = workflow["jobs"]["full-compatibility"]
     build_job = workflow["jobs"]["build"]
+    installation_job = workflow["jobs"]["test-installation"]
     publish_job = workflow["jobs"]["publish-to-pypi"]
 
     assert full_job["uses"] == "./.github/workflows/full-compatibility.yml"
     assert full_job["with"]["ref"] == "${{ github.sha }}"
+    assert build_job["needs"] == "full-compatibility"
     assert "full-compatibility" in publish_job["needs"]
     build_checkout = [step for step in build_job["steps"] if step.get("uses") == "actions/checkout@v4"]
     assert len(build_checkout) == 1
     assert build_checkout[0]["with"]["ref"] == "${{ github.sha }}"
+    installation_checkout = [step for step in installation_job["steps"] if step.get("uses") == "actions/checkout@v4"]
+    assert len(installation_checkout) == 1
+    assert installation_checkout[0]["with"]["ref"] == "${{ github.sha }}"
 
 
 @BASH_GATE_ONLY

--- a/tests/test_ci_route.py
+++ b/tests/test_ci_route.py
@@ -186,11 +186,15 @@ def test_full_lane_preserves_the_ten_environment_compatibility_matrix() -> None:
 def test_release_publish_waits_for_full_compatibility() -> None:
     workflow = _workflow("cd.yml")
     full_job = workflow["jobs"]["full-compatibility"]
+    build_job = workflow["jobs"]["build"]
     publish_job = workflow["jobs"]["publish-to-pypi"]
 
     assert full_job["uses"] == "./.github/workflows/full-compatibility.yml"
     assert full_job["with"]["ref"] == "${{ github.sha }}"
     assert "full-compatibility" in publish_job["needs"]
+    build_checkout = [step for step in build_job["steps"] if step.get("uses") == "actions/checkout@v4"]
+    assert len(build_checkout) == 1
+    assert build_checkout[0]["with"]["ref"] == "${{ github.sha }}"
 
 
 @BASH_GATE_ONLY


### PR DESCRIPTION
Related: #411

## Summary

- split pull-request CI into conservative path routing, a three-environment fast native test lane, and a stable `CI Gate`;
- keep routing policy tests in `tests/test_ci_route.py`, outside `tests/docs`;
- add the reusable `Full Compatibility` workflow for daily, manual, and release-commit validation across Ubuntu/Windows and Python 3.10–3.14;
- make PyPI publication depend on Full Compatibility for the exact release commit, build the release artifact after that validation, and pin all release checkouts to the same SHA;
- keep the Contributor Guide to a short explanation of fast lane, Full Compatibility, manual execution, and `CI Gate` branch protection.

## Routing and gate coverage

The routing tests cover docs-only paths, README, `wandas/**`, `tests/**`, `pyproject.toml`, `uv.lock`, Pyodide guide/example/harness, workflow changes, routing-script changes, unknown paths, empty input, ambiguous scripts, and the fetch-failure fallback sentinel.

The gate tests cover `always()`, route failure, missing/invalid outputs, selected failure/cancelled/skipped results, and intentionally skipped non-required jobs. Unknown or ambiguous routing remains fail-closed (all checks selected).

## Metrics

Baseline: representative pre-change PR #412 CI run [30721508638](https://github.com/kasahart/wandas/actions/runs/30721508638), using the old full matrix. It had 14 jobs, 10 native full-suite executions, 41.63 summed runner-minutes, and 321 seconds from run creation to completion.

After: this PR's final head run [30723314160](https://github.com/kasahart/wandas/actions/runs/30723314160) at `0f8e306898fb2d1dcd153baa08aaae48e911aacb`. It had 9 jobs, 3 native full-suite executions, 11.73 summed runner-minutes, and 258 seconds from run creation to `CI Gate` completion.

Runner-minutes are the sum of each completed job's wall-clock duration, not a provider billing figure. The baseline workflow had no stable `CI Gate`; its run completion is used as the comparable green endpoint. Job counts and durations are from the Actions run metadata; no values are estimated.

## Validation

- clean-worktree `uv run pytest tests/docs -q` — 34 passed
- clean-worktree `uv run pytest tests/test_ci_route.py -q` — 50 passed
- clean-worktree `uv run pytest -q` — 3083 passed, 3 skipped
- `ruff check`, `ruff format --check`, and `ty check` for `wandas tests scripts learning-path` — passed
- `scripts/check_public_docstrings.py` — passed
- strict MkDocs build — passed
- all workflow YAML parsed with the safe `yaml.BaseLoader`
- `git diff --check` — passed
- fixed-head independent review — APPROVE

Known warnings are the existing headless Matplotlib/Japanese glyph, coverage no-data, WAV reader, mosqito, introspection, and GitHub Actions Node.js migration warnings. No new checker, parser, framework, dependency, workflow, API, Recipe schema, WDF format, README, Learning App, or numerical-contract change was introduced.