### PR TITLE
docs: correct compatibility and recipe wording

### DIFF
--- a/docs/src/explanation/public-api-stability.md
+++ b/docs/src/explanation/public-api-stability.md
@@ -1,7 +1,7 @@
 # Public API and Compatibility Policy / 公開 API・互換性方針
 
 Wandas is a 0.x project, so compatibility changes can still occur.
-Wandasは0.xのプロジェクトのため、互換性のある変更が発生する場合があります。
+Wandasは0.xのプロジェクトのため、後方互換性を損なう変更が入る場合があります。
 
 - A change to a stable public API normally emits a runtime deprecation warning
   and keeps the replacement API available during migration.

--- a/docs/src/how-to/pipeline-recipes.md
+++ b/docs/src/how-to/pipeline-recipes.md
@@ -88,8 +88,9 @@ replayed = plan.apply({"signal": another_frame, "offset": external_array})
 ```
 
 External NumPy and Dask arrays remain named inputs; they are not embedded in the
-artifact or wrapped in temporary Frames. Use the same container and compatible
-shape at replay.
+artifact or wrapped in temporary Frames. At replay, supply a NumPy or Dask array
+with a shape and dtype accepted by the operation. The original container type and
+Dask chunking are not stored in the Recipe.
 
 ## Handle runtime-only operations
 


### PR DESCRIPTION
## Summary

- Correct the Japanese compatibility-policy sentence so it describes possible backward-incompatible changes.
- Clarify that Recipe replay accepts NumPy or Dask arrays with operation-compatible shape and dtype, and does not store the original container or Dask chunking.

This is intentionally limited to the two requested documentation files. No tests, API implementation, Recipe schema, validation, README, Learning App, or navigation changes are included.

## Validation

- `uv run pytest tests/docs -q` — 34 passed
- `uv run python scripts/check_public_docstrings.py` — passed
- `uv run mkdocs build --strict -f docs/mkdocs.yml` — passed
- `git diff --check` — passed

Known warnings are the existing coverage/no-data and headless Matplotlib/font warnings.