### PR TITLE
fix(recipe): version FFT, Welch, and Cepstrum contracts

### DIFF
--- a/docs/src/release-notes/v0.6.3.md
+++ b/docs/src/release-notes/v0.6.3.md
@@ -8,6 +8,9 @@ Wandas 0.6.3 makes N-octave synthesis use the authoritative FFT size stored by
 - [Issue #398](https://github.com/kasahart/wandas/issues/398): validate N-octave
   ratio conventions at the Operation boundary, use explicit FFT-size provenance
   for current synthesis, and add fixed-payload Recipe compatibility coverage.
+- [Issue #397](https://github.com/kasahart/wandas/issues/397) (parent [#391](https://github.com/kasahart/wandas/issues/391)):
+  preserve released Recipe v1 replay and emit Recipe v2 for the corrected
+  `wandas.audio.fft`, `wandas.audio.welch`, and `wandas.audio.cepstrum` calls.
 
 ## Compatibility
 
@@ -19,3 +22,4 @@ it cannot distinguish adjacent odd and even FFT sizes.
 | --- | --- | --- | --- | --- | --- |
 | `wandas.processing.NOctSynthesis` constructor | Stable user surface | None | Pass the positive source `n_fft`; `SpectralFrame.noct_synthesis()` supplies it automatically. | 0.6.3 | Numerical-correctness exception approved by [Issue #398](https://github.com/kasahart/wandas/issues/398). |
 | `wandas.spectral.noct_synthesis` Recipe v1 | Serialized operation version | None | Existing v1 payloads replay through the legacy meaning; new public calls emit version 2. | 0.6.3 | Persisted numerical meaning is kept separate from the corrected current behavior; [Issue #398](https://github.com/kasahart/wandas/issues/398). |
+| `wandas.audio.fft`, `wandas.audio.welch`, and `wandas.audio.cepstrum` Recipe v1 | Serialized operation versions | None | Existing v1 payloads replay through the released meaning; new public calls emit version 2. | 0.6.3 | Persisted numerical meaning is kept separate from the corrected current behavior; [Issue #397](https://github.com/kasahart/wandas/issues/397), parent [#391](https://github.com/kasahart/wandas/issues/391). |

--- a/tests/frames/test_cepstral_frame.py
+++ b/tests/frames/test_cepstral_frame.py
@@ -61,7 +61,7 @@ def test_channel_cepstrum_returns_lazy_typed_frame_with_atomic_state() -> None:
     assert result.operation_history == [
         {
             "operation": "wandas.audio.cepstrum",
-            "version": 1,
+            "version": 2,
             "params": {"floor": 1e-9, "n_fft": 32, "window": "boxcar"},
         }
     ]

--- a/tests/frames/test_channel_transform.py
+++ b/tests/frames/test_channel_transform.py
@@ -65,7 +65,7 @@ class TestChannelTransform:
             np.testing.assert_array_equal(result.source_time_offset, np.array([2.75, 2.75]))
             assert result.operation_history[-1] == {
                 "operation": "wandas.audio.fft",
-                "version": 1,
+                "version": 2,
                 "params": {"n_fft": 4096, "window": "hamming"},
             }
             assert result.lineage.operation is not None
@@ -89,7 +89,7 @@ class TestChannelTransform:
         assert result.lineage.operation.operation_id == "wandas.audio.fft"
         assert result.operation_history[-1] == {
             "operation": "wandas.audio.fft",
-            "version": 1,
+            "version": 2,
             "params": {},
         }
         assert "n_fft" not in result.metadata
@@ -158,7 +158,7 @@ class TestChannelTransform:
             np.testing.assert_array_equal(result.source_time_offset, np.array([2.75, 2.75]))
             assert result.operation_history[-1] == {
                 "operation": "wandas.audio.welch",
-                "version": 1,
+                "version": 2,
                 "params": {
                     "n_fft": 2048,
                     "hop_length": 256,
@@ -188,7 +188,7 @@ class TestChannelTransform:
         operation_record = result.operation_history[-1]
         assert operation_record == {
             "operation": "wandas.audio.welch",
-            "version": 1,
+            "version": 2,
             "params": {},
         }
         assert not set(operation_record["params"]).intersection(result.metadata)

--- a/tests/pipeline/test_recipe_execution.py
+++ b/tests/pipeline/test_recipe_execution.py
@@ -43,7 +43,7 @@ def test_fft_ifft_typed_transition_chain_replays() -> None:
     replayed = RecipePlan.from_dict(plan.to_dict()).apply({"signal": source})
 
     assert [node.operation for node in plan.nodes] == ["wandas.audio.fft", "wandas.spectral.ifft"]
-    assert [node.version for node in plan.nodes] == [1, 2]
+    assert [node.version for node in plan.nodes] == [2, 2]
     np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(processed))
 
 

--- a/tests/pipeline/test_spectral_recipe_versions.py
+++ b/tests/pipeline/test_spectral_recipe_versions.py
@@ -19,6 +19,7 @@ from wandas.frames.cepstral import CepstralFrame
 from wandas.frames.channel import ChannelFrame
 from wandas.frames.spectral import SpectralFrame
 from wandas.pipeline import RecipePlan, default_recipe_registry
+from wandas.pipeline.errors import RecipeExecutionError
 from wandas.processing import get_operation
 from wandas.processing.cepstral import Cepstrum, _RecipeCepstrumV1
 from wandas.processing.spectral import FFT, Welch, _RecipeFFTV1, _RecipeWelchV1
@@ -221,8 +222,43 @@ def test_spectral_recipe_v1_defensive_and_truncation_branches() -> None:
         welch_operation._process(cast(Any, da.from_array(np.ones((1, 5)), chunks=(1, 5))))
 
     source = _source(np.ones((1, 5), dtype=np.float64))
-    with pytest.raises(ValueError, match="Invalid FFT size for Welch method"):
-        source._welch_recipe_v1(n_fft=0)
+    fallback_payload = {
+        "schema": "wandas.recipe",
+        "version": 2,
+        "inputs": [{"id": "input-0", "name": "signal", "kind": "frame"}],
+        "nodes": [
+            {
+                "id": "node-0",
+                "operation": "wandas.audio.welch",
+                "version": 1,
+                "inputs": ["input-0"],
+                "params": {
+                    "$type": "map",
+                    "entries": [
+                        ["average", "mean"],
+                        ["hop_length", 5],
+                        ["n_fft", 0],
+                        ["win_length", 5],
+                        ["window", "boxcar"],
+                    ],
+                },
+            }
+        ],
+        "output": "node-0",
+    }
+    fallback_replayed = RecipePlan.from_dict(fallback_payload).apply({"signal": source})
+    expected_fallback = _welch_oracle(
+        np.ones((1, 5), dtype=np.float64),
+        n_fft=5,
+        win_length=5,
+        hop_length=5,
+        window="boxcar",
+        detrend="constant",
+        legacy_scaling=True,
+    )
+    np.testing.assert_allclose(channel_first_values(fallback_replayed), expected_fallback)
+    assert fallback_replayed.n_fft == 5
+    assert fallback_replayed.operation_history[-1]["params"]["n_fft"] == 0
 
 
 def test_released_welch_v1_payload_preserves_odd_final_positive_bin() -> None:
@@ -370,6 +406,12 @@ def test_released_cepstrum_v1_payload_replays_legacy_window_before_padding() -> 
     }
 
     plan = RecipePlan.from_dict(released_payload)
+    complex_source = _source(values.astype(np.complex128), offset=2.5)
+    with pytest.raises(RecipeExecutionError, match="Recipe operation failed") as error:
+        plan.apply({"signal": complex_source})
+    assert isinstance(error.value.__cause__, TypeError)
+    assert "real-valued input" in str(error.value)
+
     with (
         patch.object(DaArray, "compute", autospec=True) as compute,
         patch.object(Cepstrum, "_process", side_effect=AssertionError("Recipe v1 invoked current Cepstrum")),

--- a/tests/pipeline/test_spectral_recipe_versions.py
+++ b/tests/pipeline/test_spectral_recipe_versions.py
@@ -220,6 +220,10 @@ def test_spectral_recipe_v1_defensive_and_truncation_branches() -> None:
     with pytest.raises(ValueError, match="requires a numpy ndarray"):
         welch_operation._process(cast(Any, da.from_array(np.ones((1, 5)), chunks=(1, 5))))
 
+    source = _source(np.ones((1, 5), dtype=np.float64))
+    with pytest.raises(ValueError, match="Invalid FFT size for Welch method"):
+        source._welch_recipe_v1(n_fft=0)
+
 
 def test_released_welch_v1_payload_preserves_odd_final_positive_bin() -> None:
     """A literal schema-2 payload preserves v1's odd-size Welch endpoint."""

--- a/tests/pipeline/test_spectral_recipe_versions.py
+++ b/tests/pipeline/test_spectral_recipe_versions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any, cast
 from unittest.mock import patch
 
 import dask.array as da
@@ -19,8 +20,8 @@ from wandas.frames.channel import ChannelFrame
 from wandas.frames.spectral import SpectralFrame
 from wandas.pipeline import RecipePlan, default_recipe_registry
 from wandas.processing import get_operation
-from wandas.processing.cepstral import Cepstrum
-from wandas.processing.spectral import FFT, Welch
+from wandas.processing.cepstral import Cepstrum, _RecipeCepstrumV1
+from wandas.processing.spectral import FFT, Welch, _RecipeFFTV1, _RecipeWelchV1
 
 _SAMPLING_RATE = 8_000
 _FLOOR = 1e-6
@@ -189,6 +190,35 @@ def test_released_fft_v1_payload_replays_legacy_window_before_padding() -> None:
     assert replayed.lineage.operation.version == 1
     assert direct_v2.operation_history[-1]["version"] == 2
     _assert_source_unchanged(source, values)
+
+
+def test_spectral_recipe_v1_defensive_and_truncation_branches() -> None:
+    """Cover v1 validation guards and the released FFT truncation path."""
+    complex_operation = _RecipeCepstrumV1(_SAMPLING_RATE, n_fft=8, window="hamming", floor=_FLOOR)
+    with pytest.raises(TypeError, match="real-valued input"):
+        complex_operation._process(cast(Any, np.array([[1.0 + 0.0j]], dtype=np.complex128)))
+
+    empty_operation = _RecipeCepstrumV1(_SAMPLING_RATE, n_fft=1, window="boxcar", floor=_FLOOR)
+    with pytest.raises(ValueError, match="Invalid window gain"):
+        empty_operation._process(np.empty((1, 0), dtype=np.float64))
+
+    values = np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float64)
+    fft_operation = _RecipeFFTV1(_SAMPLING_RATE, n_fft=3, window="hamming")
+    np.testing.assert_allclose(
+        fft_operation._process(values),
+        _rfft_amplitude_oracle(values, n_fft=3, window="hamming", pad_before_window=False),
+    )
+
+    welch_operation = _RecipeWelchV1(
+        _SAMPLING_RATE,
+        n_fft=5,
+        hop_length=5,
+        win_length=5,
+        window="boxcar",
+        average="mean",
+    )
+    with pytest.raises(ValueError, match="requires a numpy ndarray"):
+        welch_operation._process(cast(Any, da.from_array(np.ones((1, 5)), chunks=(1, 5))))
 
 
 def test_released_welch_v1_payload_preserves_odd_final_positive_bin() -> None:

--- a/tests/pipeline/test_spectral_recipe_versions.py
+++ b/tests/pipeline/test_spectral_recipe_versions.py
@@ -1,0 +1,467 @@
+"""Recipe v1 replay and v2 publication contracts for spectral operations."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import dask.array as da
+import numpy as np
+import pytest
+from dask.array.core import Array as DaArray
+from scipy.signal import get_window
+from scipy.signal import welch as scipy_welch
+
+from tests.frame_helpers import channel_first_values
+from wandas.core.metadata import ChannelCalibration, ChannelMetadata
+from wandas.frames.cepstral import CepstralFrame
+from wandas.frames.channel import ChannelFrame
+from wandas.frames.spectral import SpectralFrame
+from wandas.pipeline import RecipePlan, default_recipe_registry
+from wandas.processing import get_operation
+from wandas.processing.cepstral import Cepstrum
+from wandas.processing.spectral import FFT, Welch
+
+_SAMPLING_RATE = 8_000
+_FLOOR = 1e-6
+
+
+def _source(values: np.ndarray, *, offset: float = 0.25) -> ChannelFrame:
+    """Build a lazy source with stable channel and recording metadata."""
+    channel_count = values.shape[0]
+    return ChannelFrame(
+        data=da.from_array(values, chunks=(1, -1)),
+        sampling_rate=_SAMPLING_RATE,
+        label="recipe-source",
+        metadata={"recording": {"take": "A"}},
+        channel_metadata=[
+            ChannelMetadata(
+                label=f"channel-{index}",
+                calibration=ChannelCalibration(factor=1.0, unit="Pa", ref=2e-5),
+                extra={"sensor": f"S{index}"},
+            )
+            for index in range(channel_count)
+        ],
+        channel_ids=[f"channel-id-{index}" for index in range(channel_count)],
+        source_time_offset=np.arange(channel_count, dtype=float) + offset,
+    )
+
+
+def _rfft_amplitude_oracle(
+    values: np.ndarray,
+    *,
+    n_fft: int,
+    window: str,
+    pad_before_window: bool,
+) -> np.ndarray:
+    """Calculate FFT amplitude values independently of Wandas operations."""
+    analysis = values[..., :n_fft]
+    if pad_before_window and analysis.shape[-1] < n_fft:
+        analysis = np.pad(analysis, [(0, 0)] * (analysis.ndim - 1) + [(0, n_fft - analysis.shape[-1])])
+    window_values = get_window(window, n_fft if pad_before_window else analysis.shape[-1])
+    spectrum = np.fft.rfft(analysis * window_values, n=n_fft, axis=-1)
+    spectrum = np.asarray(spectrum, dtype=np.complex128)
+    spectrum[..., 1 : -1 if n_fft % 2 == 0 else None] *= 2.0
+    return spectrum / np.sum(window_values)
+
+
+def _cepstrum_oracle(
+    values: np.ndarray,
+    *,
+    n_fft: int,
+    window: str,
+    floor: float,
+    pad_before_window: bool,
+) -> np.ndarray:
+    """Calculate the normalized real cepstrum from the independent FFT oracle."""
+    magnitude = np.abs(
+        _rfft_amplitude_oracle(
+            values,
+            n_fft=n_fft,
+            window=window,
+            pad_before_window=pad_before_window,
+        )
+    )
+    return np.asarray(np.fft.irfft(np.log(np.maximum(magnitude, floor)), n=n_fft, axis=-1), dtype=np.float64)
+
+
+def _welch_oracle(
+    values: np.ndarray,
+    *,
+    n_fft: int,
+    win_length: int,
+    hop_length: int,
+    window: str,
+    detrend: str | None,
+    legacy_scaling: bool,
+) -> np.ndarray:
+    """Calculate Welch peak amplitudes with an explicit independent bin rule."""
+    _, power = scipy_welch(
+        values,
+        nperseg=win_length,
+        noverlap=win_length - hop_length,
+        nfft=n_fft,
+        window=window,
+        average="mean",
+        detrend=detrend,
+        scaling="spectrum",
+        axis=-1,
+    )
+    amplitude = np.sqrt(power)
+    if legacy_scaling:
+        amplitude[..., 1:-1] *= np.sqrt(2.0)
+    else:
+        amplitude[..., 1 : -1 if n_fft % 2 == 0 else None] *= np.sqrt(2.0)
+    return amplitude
+
+
+def _assert_frame_contract(result: ChannelFrame | SpectralFrame | CepstralFrame, source: ChannelFrame) -> None:
+    """Check metadata and process-local provenance shared by replay results."""
+    assert result.sampling_rate == source.sampling_rate
+    assert result.metadata == source.metadata
+    assert result._channel_ids == source._channel_ids
+    assert [channel.label for channel in result.channels] == [channel.label for channel in source.channels]
+    assert [channel.calibration for channel in result.channels] == [channel.calibration for channel in source.channels]
+    assert [channel.extra for channel in result.channels] == [channel.extra for channel in source.channels]
+    np.testing.assert_array_equal(result.source_time_offset, source.source_time_offset)
+    assert result.previous is source
+    assert result.lineage is not None
+    assert result.lineage.operation is not None
+
+
+def _assert_source_unchanged(source: ChannelFrame, values: np.ndarray) -> None:
+    """Check that direct execution and replay did not mutate the input Frame."""
+    np.testing.assert_array_equal(channel_first_values(source), values)
+    assert source.operation_history == []
+    assert source.lineage is not None
+    assert source.lineage.operation is None
+
+
+def test_released_fft_v1_payload_replays_legacy_window_before_padding() -> None:
+    """A literal schema-2 payload preserves the released short-input FFT values."""
+    values = np.array([[1.0, 2.0, 3.0], [2.0, 1.0, 4.0]], dtype=np.float64)
+    source = _source(values)
+    direct_v2 = source.fft(n_fft=8, window="hamming")
+    direct_v2_values = channel_first_values(direct_v2)
+
+    released_payload = {
+        "schema": "wandas.recipe",
+        "version": 2,
+        "inputs": [{"id": "input-0", "name": "signal", "kind": "frame"}],
+        "nodes": [
+            {
+                "id": "node-0",
+                "operation": "wandas.audio.fft",
+                "version": 1,
+                "inputs": ["input-0"],
+                "params": {
+                    "$type": "map",
+                    "entries": [["n_fft", 8], ["window", "hamming"]],
+                },
+            }
+        ],
+        "output": "node-0",
+    }
+
+    plan = RecipePlan.from_dict(released_payload)
+    with (
+        patch.object(DaArray, "compute", autospec=True) as compute,
+        patch.object(FFT, "_process", side_effect=AssertionError("Recipe v1 invoked current FFT")),
+    ):
+        replayed = plan.apply({"signal": source})
+        compute.assert_not_called()
+
+    expected_v1 = _rfft_amplitude_oracle(values, n_fft=8, window="hamming", pad_before_window=False)
+    expected_v2 = _rfft_amplitude_oracle(values, n_fft=8, window="hamming", pad_before_window=True)
+    np.testing.assert_allclose(channel_first_values(replayed), expected_v1)
+    np.testing.assert_allclose(direct_v2_values, expected_v2)
+    assert not np.allclose(expected_v1, expected_v2)
+    assert isinstance(replayed, SpectralFrame)
+    assert isinstance(replayed._data, DaArray)
+    assert replayed._data.shape == (2, 5)
+    assert replayed._data.dtype == np.dtype(np.complex128)
+    assert replayed.n_fft == 8
+    assert replayed.window == "hamming"
+    assert replayed.operation_history == [
+        {"operation": "wandas.audio.fft", "version": 1, "params": {"n_fft": 8, "window": "hamming"}}
+    ]
+    _assert_frame_contract(replayed, source)
+    assert replayed.lineage.operation.version == 1
+    assert direct_v2.operation_history[-1]["version"] == 2
+    _assert_source_unchanged(source, values)
+
+
+def test_released_welch_v1_payload_preserves_odd_final_positive_bin() -> None:
+    """A literal schema-2 payload preserves v1's odd-size Welch endpoint."""
+    time = np.arange(5, dtype=float)
+    values = (1.25 + 2.0 * np.cos(2 * np.pi * time / 5) + 3.0 * np.cos(4 * np.pi * time / 5))[None, :]
+    source = _source(values, offset=1.5)
+    direct_v2 = source.welch(n_fft=5, hop_length=5, win_length=5, window="boxcar", average="mean")
+    direct_v2_values = channel_first_values(direct_v2)
+
+    released_payload = {
+        "schema": "wandas.recipe",
+        "version": 2,
+        "inputs": [{"id": "input-0", "name": "signal", "kind": "frame"}],
+        "nodes": [
+            {
+                "id": "node-0",
+                "operation": "wandas.audio.welch",
+                "version": 1,
+                "inputs": ["input-0"],
+                "params": {
+                    "$type": "map",
+                    "entries": [
+                        ["average", "mean"],
+                        ["hop_length", 5],
+                        ["n_fft", 5],
+                        ["win_length", 5],
+                        ["window", "boxcar"],
+                    ],
+                },
+            }
+        ],
+        "output": "node-0",
+    }
+
+    plan = RecipePlan.from_dict(released_payload)
+    with (
+        patch.object(DaArray, "compute", autospec=True) as compute,
+        patch.object(Welch, "_process", side_effect=AssertionError("Recipe v1 invoked current Welch")),
+    ):
+        replayed = plan.apply({"signal": source})
+        compute.assert_not_called()
+
+    expected_v1 = _welch_oracle(
+        values,
+        n_fft=5,
+        win_length=5,
+        hop_length=5,
+        window="boxcar",
+        detrend="constant",
+        legacy_scaling=True,
+    )
+    expected_v2 = _welch_oracle(
+        values,
+        n_fft=5,
+        win_length=5,
+        hop_length=5,
+        window="boxcar",
+        detrend="constant",
+        legacy_scaling=False,
+    )
+    np.testing.assert_allclose(channel_first_values(replayed), expected_v1)
+    np.testing.assert_allclose(direct_v2_values, expected_v2)
+    assert np.isclose(expected_v1[0, 0], 0.0)
+    assert np.isclose(expected_v1[0, 1], expected_v2[0, 1])
+    assert not np.isclose(expected_v1[0, -1], expected_v2[0, -1])
+    assert isinstance(replayed, SpectralFrame)
+    assert isinstance(replayed._data, DaArray)
+    assert replayed._data.shape == (1, 3)
+    assert replayed._data.dtype == np.dtype(np.float64)
+    assert replayed.n_fft == 5
+    assert replayed.window == "boxcar"
+    assert replayed.operation_history == [
+        {
+            "operation": "wandas.audio.welch",
+            "version": 1,
+            "params": {"n_fft": 5, "hop_length": 5, "win_length": 5, "window": "boxcar", "average": "mean"},
+        }
+    ]
+    _assert_frame_contract(replayed, source)
+    assert replayed.lineage.operation.version == 1
+    assert direct_v2.operation_history[-1]["version"] == 2
+    _assert_source_unchanged(source, values)
+
+
+def test_welch_oracle_checks_dc_internal_and_even_nyquist_bins() -> None:
+    """The corrected Welch rule preserves DC/Nyquist and scales interior bins."""
+    time = np.arange(6, dtype=float)
+    values = (
+        1.25 + 2.0 * np.cos(2 * np.pi * time / 6) + 1.5 * np.cos(4 * np.pi * time / 6) + 3.0 * np.cos(np.pi * time)
+    )[None, :]
+    operation = Welch(
+        _SAMPLING_RATE,
+        n_fft=6,
+        hop_length=6,
+        win_length=6,
+        window="boxcar",
+        detrend=None,  # ty: ignore[invalid-argument-type]
+    )
+    result = operation._process(values)
+    expected = _welch_oracle(
+        values,
+        n_fft=6,
+        win_length=6,
+        hop_length=6,
+        window="boxcar",
+        detrend=None,
+        legacy_scaling=False,
+    )
+    np.testing.assert_allclose(result, expected)
+    assert np.isclose(result[0, 0], 1.25)
+    assert np.isclose(result[0, 1], 2.0)
+    assert np.isclose(result[0, 2], 1.5)
+    assert np.isclose(result[0, -1], 3.0)
+
+
+def test_released_cepstrum_v1_payload_replays_legacy_window_before_padding() -> None:
+    """A literal schema-2 payload preserves the released short-input cepstrum."""
+    values = np.array([[1.0, 2.0, 3.0], [2.0, 1.0, 4.0]], dtype=np.float64)
+    source = _source(values, offset=2.5)
+    direct_v2 = source.cepstrum(n_fft=8, window="hamming", floor=_FLOOR)
+    direct_v2_values = channel_first_values(direct_v2)
+
+    released_payload = {
+        "schema": "wandas.recipe",
+        "version": 2,
+        "inputs": [{"id": "input-0", "name": "signal", "kind": "frame"}],
+        "nodes": [
+            {
+                "id": "node-0",
+                "operation": "wandas.audio.cepstrum",
+                "version": 1,
+                "inputs": ["input-0"],
+                "params": {
+                    "$type": "map",
+                    "entries": [
+                        ["floor", {"$type": "number", "data": "3eb0c6f7a0b5ed8d", "kind": "python-float"}],
+                        ["n_fft", 8],
+                        ["window", "hamming"],
+                    ],
+                },
+            }
+        ],
+        "output": "node-0",
+    }
+
+    plan = RecipePlan.from_dict(released_payload)
+    with (
+        patch.object(DaArray, "compute", autospec=True) as compute,
+        patch.object(Cepstrum, "_process", side_effect=AssertionError("Recipe v1 invoked current Cepstrum")),
+    ):
+        replayed = plan.apply({"signal": source})
+        compute.assert_not_called()
+
+    expected_v1 = _cepstrum_oracle(
+        values,
+        n_fft=8,
+        window="hamming",
+        floor=_FLOOR,
+        pad_before_window=False,
+    )
+    expected_v2 = _cepstrum_oracle(
+        values,
+        n_fft=8,
+        window="hamming",
+        floor=_FLOOR,
+        pad_before_window=True,
+    )
+    np.testing.assert_allclose(channel_first_values(replayed), expected_v1)
+    np.testing.assert_allclose(direct_v2_values, expected_v2)
+    assert not np.allclose(expected_v1, expected_v2)
+    assert isinstance(replayed, CepstralFrame)
+    assert isinstance(replayed._data, DaArray)
+    assert replayed._data.shape == (2, 8)
+    assert replayed._data.dtype == np.dtype(np.float64)
+    assert replayed.n_fft == 8
+    assert replayed.window == "hamming"
+    assert replayed.operation_history == [
+        {
+            "operation": "wandas.audio.cepstrum",
+            "version": 1,
+            "params": {"n_fft": 8, "window": "hamming", "floor": _FLOOR},
+        }
+    ]
+    _assert_frame_contract(replayed, source)
+    assert replayed.lineage.operation.version == 1
+    assert direct_v2.operation_history[-1]["version"] == 2
+
+
+def test_public_fft_v2_recipe_roundtrip_is_lazy_and_preserves_frame_contract() -> None:
+    """Public FFT extraction serializes version 2 and replays it end to end."""
+    source = _source(np.array([[1.0, 2.0, 3.0], [2.0, 1.0, 4.0]], dtype=np.float64))
+    with patch.object(DaArray, "compute", autospec=True) as compute:
+        direct = source.fft(n_fft=8, window="hamming")
+        plan = RecipePlan.from_frame(direct, input_names=("signal",))
+        payload = plan.to_dict()
+        loaded = RecipePlan.from_dict(json.loads(json.dumps(payload, allow_nan=False)))
+        replayed = loaded.apply({"signal": source})
+        compute.assert_not_called()
+
+    assert payload["nodes"][0]["version"] == 2
+    assert loaded.to_dict() == payload
+    assert [(node.operation, node.version) for node in loaded.nodes] == [("wandas.audio.fft", 2)]
+    np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(direct))
+    _assert_frame_contract(direct, source)
+    _assert_frame_contract(replayed, source)
+    assert direct.lineage is not None and direct.lineage.operation is not None
+    assert replayed.lineage is not None and replayed.lineage.operation is not None
+    assert direct.lineage.operation.version == replayed.lineage.operation.version == 2
+    _assert_source_unchanged(source, np.array([[1.0, 2.0, 3.0], [2.0, 1.0, 4.0]], dtype=np.float64))
+
+
+def test_public_welch_v2_recipe_roundtrip_is_lazy_and_preserves_frame_contract() -> None:
+    """Public Welch extraction serializes version 2 and replays it end to end."""
+    time = np.arange(5, dtype=float)
+    values = (1.25 + 2.0 * np.cos(2 * np.pi * time / 5) + 3.0 * np.cos(4 * np.pi * time / 5))[None, :]
+    source = _source(values, offset=1.5)
+    with patch.object(DaArray, "compute", autospec=True) as compute:
+        direct = source.welch(n_fft=5, hop_length=5, win_length=5, window="boxcar", average="mean")
+        plan = RecipePlan.from_frame(direct, input_names=("signal",))
+        payload = plan.to_dict()
+        loaded = RecipePlan.from_dict(json.loads(json.dumps(payload, allow_nan=False)))
+        replayed = loaded.apply({"signal": source})
+        compute.assert_not_called()
+
+    assert payload["nodes"][0]["version"] == 2
+    assert loaded.to_dict() == payload
+    assert [(node.operation, node.version) for node in loaded.nodes] == [("wandas.audio.welch", 2)]
+    np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(direct))
+    _assert_frame_contract(direct, source)
+    _assert_frame_contract(replayed, source)
+    assert direct.lineage is not None and direct.lineage.operation is not None
+    assert replayed.lineage is not None and replayed.lineage.operation is not None
+    assert direct.lineage.operation.version == replayed.lineage.operation.version == 2
+    _assert_source_unchanged(source, values)
+
+
+def test_public_cepstrum_v2_recipe_roundtrip_is_lazy_and_preserves_frame_contract() -> None:
+    """Public Cepstrum extraction serializes version 2 and replays it end to end."""
+    source = _source(np.array([[1.0, 2.0, 3.0], [2.0, 1.0, 4.0]], dtype=np.float64), offset=2.5)
+    with patch.object(DaArray, "compute", autospec=True) as compute:
+        direct = source.cepstrum(n_fft=8, window="hamming", floor=_FLOOR)
+        plan = RecipePlan.from_frame(direct, input_names=("signal",))
+        payload = plan.to_dict()
+        loaded = RecipePlan.from_dict(json.loads(json.dumps(payload, allow_nan=False)))
+        replayed = loaded.apply({"signal": source})
+        compute.assert_not_called()
+
+    assert payload["nodes"][0]["version"] == 2
+    assert loaded.to_dict() == payload
+    assert [(node.operation, node.version) for node in loaded.nodes] == [("wandas.audio.cepstrum", 2)]
+    np.testing.assert_allclose(channel_first_values(replayed), channel_first_values(direct))
+    assert direct.operation_history[-1]["params"]["floor"] == _FLOOR
+    assert replayed.operation_history[-1]["params"]["floor"] == _FLOOR
+    _assert_frame_contract(direct, source)
+    _assert_frame_contract(replayed, source)
+    assert direct.lineage is not None and direct.lineage.operation is not None
+    assert replayed.lineage is not None and replayed.lineage.operation is not None
+    assert direct.lineage.operation.version == replayed.lineage.operation.version == 2
+    _assert_source_unchanged(source, np.array([[1.0, 2.0, 3.0], [2.0, 1.0, 4.0]], dtype=np.float64))
+
+
+def test_default_registry_contains_v1_and_v2_for_all_spectral_recipe_operations() -> None:
+    """The immutable default registry exposes both persisted meanings."""
+    registry = default_recipe_registry()
+    for operation_id in (
+        "wandas.audio.fft",
+        "wandas.audio.welch",
+        "wandas.audio.cepstrum",
+    ):
+        assert registry.require(operation_id, 1).version == 1
+        assert registry.require(operation_id, 2).version == 2
+
+    for private_name in ("_recipe_fft_v1", "_recipe_welch_v1", "_recipe_cepstrum_v1"):
+        with pytest.raises(ValueError, match="Unknown operation type"):
+            get_operation(private_name)

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -340,10 +340,9 @@ class ChannelTransformMixin:
         """Replay the released Recipe v1 Welch scaling contract."""
         from wandas.processing.spectral import _RecipeWelchV1
 
-        resolved_n_fft = cast(int, n_fft or win_length)
         operation = _RecipeWelchV1(
             self.sampling_rate,
-            n_fft=resolved_n_fft,
+            n_fft=n_fft,
             hop_length=hop_length,
             win_length=win_length,
             window=window,

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -124,7 +124,7 @@ class ChannelTransformMixin:
             previous=self._as_base_frame,
         )
 
-    @recipe_operation("wandas.audio.cepstrum")
+    @recipe_operation("wandas.audio.cepstrum", version=2)
     def cepstrum(
         self: TransformFrameProtocol,
         n_fft: int | None = None,
@@ -156,7 +156,6 @@ class ChannelTransformMixin:
             >>> cepstrum = frame.cepstrum(n_fft=2048, window="hann")
             >>> envelope = cepstrum.lifter(0.002).to_spectral_envelope()
         """
-        from wandas.frames.cepstral import CepstralFrame
         from wandas.processing import Cepstrum, create_operation
 
         if np.issubdtype(self._effective_data.dtype, np.complexfloating):
@@ -176,6 +175,30 @@ class ChannelTransformMixin:
                 floor=floor,
             ),
         )
+        return cast(Any, self)._cepstrum_with_operation(operation)
+
+    @recipe_operation("wandas.audio.cepstrum", version=1)
+    def _cepstrum_recipe_v1(
+        self: TransformFrameProtocol,
+        n_fft: int | None = None,
+        window: str = "hann",
+        floor: float = 1e-12,
+    ) -> "CepstralFrame":
+        """Replay the released Recipe v1 cepstrum preparation contract."""
+        from wandas.processing.cepstral import _RecipeCepstrumV1
+
+        operation = _RecipeCepstrumV1(
+            self.sampling_rate,
+            n_fft=n_fft,
+            window=window,
+            floor=floor,
+        )
+        return cast(Any, self)._cepstrum_with_operation(operation)
+
+    def _cepstrum_with_operation(self: TransformFrameProtocol, operation: Any) -> "CepstralFrame":
+        """Build a CepstralFrame for the public or released Recipe operation."""
+        from wandas.frames.cepstral import CepstralFrame
+
         cepstrum_data = operation.process(self._effective_data)
         resolved_n_fft = int(cepstrum_data.shape[-1])
         return CepstralFrame(
@@ -192,7 +215,7 @@ class ChannelTransformMixin:
             lineage=cast(Any, self)._required_semantic_lineage(),
         )
 
-    @recipe_operation("wandas.audio.fft")
+    @recipe_operation("wandas.audio.fft", version=2)
     def fft(self: TransformFrameProtocol, n_fft: int | None = None, window: str = "hann") -> "SpectralFrame":
         """Calculate a one-sided peak-amplitude FFT spectrum.
 
@@ -210,7 +233,6 @@ class ChannelTransformMixin:
         Returns:
             A lazy SpectralFrame containing complex peak-amplitude values.
         """
-        from wandas.frames.spectral import SpectralFrame
         from wandas.processing import FFT, create_operation
 
         _n_fft = int(self._effective_data.shape[-1]) if n_fft is None else n_fft
@@ -221,27 +243,47 @@ class ChannelTransformMixin:
         # Create operation instance
         operation = create_operation(operation_name, self.sampling_rate, **params)
         operation = cast("FFT", operation)
-        # Apply processing to data
+        return cast(Any, self)._fft_with_operation(operation, n_fft=_n_fft)
+
+    @recipe_operation("wandas.audio.fft", version=1)
+    def _fft_recipe_v1(
+        self: TransformFrameProtocol,
+        n_fft: int | None = None,
+        window: str = "hann",
+    ) -> "SpectralFrame":
+        """Replay the released Recipe v1 FFT preparation contract."""
+        from wandas.processing.spectral import _RecipeFFTV1
+
+        _n_fft = int(self._effective_data.shape[-1]) if n_fft is None else n_fft
+        operation = _RecipeFFTV1(self.sampling_rate, n_fft=_n_fft, window=window)
+        return cast(Any, self)._fft_with_operation(operation, n_fft=_n_fft)
+
+    def _fft_with_operation(
+        self: TransformFrameProtocol,
+        operation: Any,
+        *,
+        n_fft: int,
+    ) -> "SpectralFrame":
+        """Build a SpectralFrame for the public or released Recipe operation."""
+        from wandas.frames.spectral import SpectralFrame
+
         spectrum_data = operation.process(self._effective_data)
-
-        logger.debug(f"Created new SpectralFrame with operation {operation_name} added to graph")
-
-        lineage = cast(Any, self)._required_semantic_lineage()
+        logger.debug("Created new SpectralFrame with FFT operation added to graph")
         return SpectralFrame(
             data=spectrum_data,
             sampling_rate=self.sampling_rate,
-            n_fft=_n_fft,
+            n_fft=n_fft,
             window=operation.window,
             label=f"Spectrum of {self.label}",
             metadata=self.metadata,
             channel_metadata=cast(Any, self)._metadata_after_analysis(),
             channel_ids=cast(Any, self)._channel_ids,
             source_time_offset=cast(Any, self).source_time_offset,
-            lineage=lineage,
+            lineage=cast(Any, self)._required_semantic_lineage(),
             previous=self._as_base_frame,
         )
 
-    @recipe_operation("wandas.audio.welch")
+    @recipe_operation("wandas.audio.welch", version=2)
     def welch(
         self: TransformFrameProtocol,
         n_fft: int = 2048,
@@ -269,7 +311,6 @@ class ChannelTransformMixin:
         Returns:
             A lazy SpectralFrame containing real peak-amplitude values.
         """
-        from wandas.frames.spectral import SpectralFrame
         from wandas.processing import Welch, create_operation
 
         params = {
@@ -285,12 +326,37 @@ class ChannelTransformMixin:
         # Create operation instance
         operation = create_operation(operation_name, self.sampling_rate, **params)
         operation = cast("Welch", operation)
-        # Apply processing to data
+        return cast(Any, self)._welch_with_operation(operation)
+
+    @recipe_operation("wandas.audio.welch", version=1)
+    def _welch_recipe_v1(
+        self: TransformFrameProtocol,
+        n_fft: int = 2048,
+        hop_length: int | None = None,
+        win_length: int | None = None,
+        window: str = "hann",
+        average: str = "mean",
+    ) -> "SpectralFrame":
+        """Replay the released Recipe v1 Welch scaling contract."""
+        from wandas.processing.spectral import _RecipeWelchV1
+
+        resolved_n_fft = cast(int, n_fft or win_length)
+        operation = _RecipeWelchV1(
+            self.sampling_rate,
+            n_fft=resolved_n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            average=average,
+        )
+        return cast(Any, self)._welch_with_operation(operation)
+
+    def _welch_with_operation(self: TransformFrameProtocol, operation: Any) -> "SpectralFrame":
+        """Build a SpectralFrame for the public or released Recipe operation."""
+        from wandas.frames.spectral import SpectralFrame
+
         spectrum_data = operation.process(self._effective_data)
-
-        logger.debug(f"Created new SpectralFrame with operation {operation_name} added to graph")
-
-        lineage = cast(Any, self)._required_semantic_lineage()
+        logger.debug("Created new SpectralFrame with Welch operation added to graph")
         return SpectralFrame(
             data=spectrum_data,
             sampling_rate=self.sampling_rate,
@@ -301,7 +367,7 @@ class ChannelTransformMixin:
             channel_metadata=cast(Any, self)._metadata_after_analysis(),
             channel_ids=cast(Any, self)._channel_ids,
             source_time_offset=cast(Any, self).source_time_offset,
-            lineage=lineage,
+            lineage=cast(Any, self)._required_semantic_lineage(),
             previous=self._as_base_frame,
         )
 

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -58,6 +58,17 @@ def _build_cross_channel_source_time_offsets(source_time_offset: Any) -> Any:
     return np.asarray(result, dtype=float)
 
 
+def _validate_real_cepstrum_input(data: Any) -> None:
+    """Reject complex channel data before constructing a cepstrum operation."""
+    if np.issubdtype(data.dtype, np.complexfloating):
+        raise TypeError(
+            "Cepstrum analysis requires real-valued input\n"
+            f"  Got: {data.dtype}\n"
+            "  Expected: real time-domain samples\n"
+            "Apply cepstrum() to a real ChannelFrame."
+        )
+
+
 class ChannelTransformMixin:
     """Mixin providing methods related to frequency transformations.
 
@@ -158,13 +169,7 @@ class ChannelTransformMixin:
         """
         from wandas.processing import Cepstrum, create_operation
 
-        if np.issubdtype(self._effective_data.dtype, np.complexfloating):
-            raise TypeError(
-                "Cepstrum analysis requires real-valued input\n"
-                f"  Got: {self._effective_data.dtype}\n"
-                "  Expected: real time-domain samples\n"
-                "Apply cepstrum() to a real ChannelFrame."
-            )
+        _validate_real_cepstrum_input(self._effective_data)
         operation = cast(
             "Cepstrum",
             create_operation(
@@ -185,6 +190,7 @@ class ChannelTransformMixin:
         floor: float = 1e-12,
     ) -> "CepstralFrame":
         """Replay the released Recipe v1 cepstrum preparation contract."""
+        _validate_real_cepstrum_input(self._effective_data)
         from wandas.processing.cepstral import _RecipeCepstrumV1
 
         operation = _RecipeCepstrumV1(
@@ -340,9 +346,11 @@ class ChannelTransformMixin:
         """Replay the released Recipe v1 Welch scaling contract."""
         from wandas.processing.spectral import _RecipeWelchV1
 
+        # Released v1 captured raw n_fft but executed the public truthy fallback.
+        resolved_n_fft = cast(int, n_fft or win_length)
         operation = _RecipeWelchV1(
             self.sampling_rate,
-            n_fft=n_fft,
+            n_fft=resolved_n_fft,
             hop_length=hop_length,
             win_length=win_length,
             window=window,

--- a/wandas/processing/cepstral.py
+++ b/wandas/processing/cepstral.py
@@ -200,6 +200,43 @@ class Cepstrum(AudioOperation[NDArrayReal, NDArrayReal]):
         return np.asarray(np.fft.irfft(log_magnitude, n=n_fft, axis=-1), dtype=np.float64)
 
 
+class _RecipeCepstrumV1(Cepstrum):
+    """Released Recipe v1 cepstrum padding and windowing contract."""
+
+    name = "_recipe_cepstrum_v1"
+    _display = "cepstrum Recipe v1"
+
+    def _process(self, data: NDArrayReal) -> NDArrayReal:
+        """Apply the released window-before-zero-padding preparation order."""
+        if np.iscomplexobj(data):
+            raise TypeError(
+                "Cepstrum analysis requires real-valued input\n"
+                f"  Got: {np.asarray(data).dtype}\n"
+                "  Expected: real time-domain samples\n"
+                "Use ChannelFrame time-domain data as the input."
+            )
+        n_fft = _resolve_fft_size(self.n_fft, int(data.shape[-1]))
+        analysis = np.asarray(data[..., :n_fft], dtype=np.float64)
+        window_values = get_window(self.window, analysis.shape[-1])
+        window_gain = float(np.sum(window_values))
+        if not np.isfinite(window_gain) or window_gain == 0:
+            raise ValueError(
+                "Invalid window gain for cepstrum\n"
+                f"  Window: {self.window!r}\n"
+                f"  Gain: {window_gain}\n"
+                "Use a window with a finite non-zero coherent gain."
+            )
+        spectrum = np.fft.rfft(analysis * window_values, n=n_fft, axis=-1)
+        normalized_spectrum = _normalize_rfft_amplitude(
+            spectrum,
+            n_fft=n_fft,
+            window_gain=window_gain,
+        )
+        magnitude = np.abs(normalized_spectrum)
+        log_magnitude = np.log(np.maximum(magnitude, self.floor))
+        return np.asarray(np.fft.irfft(log_magnitude, n=n_fft, axis=-1), dtype=np.float64)
+
+
 class SpectrogramCepstrum(AudioOperation[NDArrayComplex, NDArrayReal]):
     """Calculate a real cepstrum independently at every STFT time frame.
 

--- a/wandas/processing/spectral.py
+++ b/wandas/processing/spectral.py
@@ -285,6 +285,30 @@ class FFT(AudioOperation[NDArrayReal, NDArrayComplex]):
         )
 
 
+class _RecipeFFTV1(FFT):
+    """Released Recipe v1 FFT padding and windowing contract."""
+
+    name = "_recipe_fft_v1"
+    _display = "FFT Recipe v1"
+
+    def _process(self, x: NDArrayReal) -> NDArrayComplex:
+        """Apply the released window-before-zero-padding preparation order."""
+        n_fft = self.n_fft
+        if n_fft is not None and x.shape[-1] > n_fft:
+            x = x[..., :n_fft]
+
+        win = get_window(self.window, x.shape[-1])
+        x = x * win
+        fft_size = int(x.shape[-1]) if n_fft is None else n_fft
+        result: NDArrayComplex = np.fft.rfft(x, n=fft_size, axis=-1)
+        scaling_factor = np.sum(win)
+        return _normalize_rfft_amplitude(
+            result,
+            n_fft=fft_size,
+            window_gain=float(scaling_factor),
+        )
+
+
 class IFFT(AudioOperation[NDArrayComplex, NDArrayReal]):
     """Inverse of Wandas' one-sided peak-amplitude FFT normalization.
 
@@ -808,6 +832,34 @@ class Welch(AudioOperation[NDArrayReal, NDArrayReal]):
         result[_rfft_positive_frequency_bins(result.ndim, n_fft=self.n_fft, axis=-1)] *= np.sqrt(2)
 
         return result
+
+
+class _RecipeWelchV1(Welch):
+    """Released Recipe v1 Welch positive-frequency scaling contract."""
+
+    name = "_recipe_welch_v1"
+    _display = "Welch Recipe v1"
+
+    def _process(self, x: NDArrayReal) -> NDArrayReal:
+        """Apply the released ``1:-1`` scaling, including its odd-size endpoint."""
+        from scipy import signal as ss
+
+        if not isinstance(x, np.ndarray):
+            raise ValueError("Welch operation requires a numpy ndarray, but received a non-ndarray.")
+
+        _, result = ss.welch(
+            x,
+            nperseg=self.win_length,
+            noverlap=self.noverlap,
+            nfft=self.n_fft,
+            window=self.window,
+            average=self.average,
+            detrend=self.detrend,
+            scaling="spectrum",
+        )
+        result = np.sqrt(result)
+        result[..., 1:-1] *= np.sqrt(2)
+        return np.array(result)
 
 
 class _NOctBase(AudioOperation[NDArrayReal, NDArrayReal]):

--- a/wandas/processing/spectral.py
+++ b/wandas/processing/spectral.py
@@ -859,7 +859,7 @@ class _RecipeWelchV1(Welch):
         )
         result = np.sqrt(result)
         result[..., 1:-1] *= np.sqrt(2)
-        return np.array(result)
+        return result
 
 
 class _NOctBase(AudioOperation[NDArrayReal, NDArrayReal]):


### PR DESCRIPTION
Closes #397
Related #391

## Summary

This PR publishes the corrected FFT, Welch, and Cepstrum Recipe meaning as version 2 while preserving the released schema-2 Recipe version 1 meanings for replay.

- `ChannelFrame.fft()`, `ChannelFrame.welch()`, and `ChannelFrame.cepstrum()` now emit Recipe v2.
- Private operation-local v1 handlers replay the released numerical contracts.
- Frame construction remains shared between public and replay paths, preserving metadata, provenance, lineage, operation history, and Dask laziness.
- The public non-Recipe numerical results remain unchanged.

## v1 and v2 meanings

- FFT and Cepstrum v1 apply the window to the available input samples and then zero-pad on the FFT side when `n_fft` exceeds the input length. V2 applies truncate/pad first, then applies the `n_fft`-length window.
- Welch v1 applies the historical `1:-1` positive-bin scaling, which leaves the last positive-frequency bin unscaled for odd `n_fft`. V2 uses the corrected parity-aware rule: DC and even-`n_fft` Nyquist are unscaled, and every interior positive bin is scaled.
- FFT/Cepstrum retain their existing normalization, floor, real-cepstrum definition, dtype, shape, and public signatures.

## Fixed v1 payloads and independent oracles

`tests/pipeline/test_spectral_recipe_versions.py` contains literal schema-2 payloads for all three operation IDs:

- FFT v1: `n_fft=8`, Hamming window, short two-channel input.
- Welch v1: odd `n_fft=5`, boxcar window, with assertions covering DC, interior positive bins, and the odd final positive bin; an independent even-`n_fft=6` oracle covers Nyquist.
- Cepstrum v1: `n_fft=8`, Hamming window, fixed serialized `floor=1e-6`, short two-channel input.

Expected values are calculated independently with NumPy/SciPy window, FFT, inverse FFT, and Welch formulas. They are not generated from Recipe extraction, decorators, `to_params()`, or the current production helpers. Tests prove each v1/v2 pair is numerically distinguishable and that fixed-payload load/apply uses the private v1 handler without calling the current operation implementation or Dask `compute()`.

The same test module covers public v2 extraction, `RecipePlan.from_frame()`, dictionary and JSON round trips, load/apply, registry coexistence, history version, concrete Frame type, shape/dtype, sampling rate, `n_fft`, window/floor, channel metadata, IDs/order, source offsets, `previous`, lineage, input immutability, and laziness. A focused guard test also covers all four lines reported by Codecov: Cepstrum v1 complex-input and zero-gain validation, FFT v1 truncation, and Welch v1 non-NumPy input rejection.

## Compatibility judgment and scope

This is a serialized-meaning compatibility fix: released v1 payloads must continue to reproduce their released values, while newly recorded Recipes explicitly select the corrected v2 meaning. Existing public method signatures and ordinary direct numerical results are unchanged.

The central Recipe model, compiler, serializer, loader, executor, validator, registry infrastructure, and operation-name dispatch were not changed. Compatibility kernels and replay decorators are kept in the owning spectral operations and Frame orchestration. IFFT, #400, #401, #402, and #406 are out of scope.

## Validation

- Focused tests: `9 passed` for the updated spectral Recipe module
- `uv run pytest -q`: `3042 passed, 3 skipped, 136 warnings`
- `uv run ruff check wandas tests scripts`: passed
- `uv run ruff format --check wandas tests scripts`: passed
- `uv run ty check wandas tests scripts`: passed
- `uv run python scripts/check_public_docstrings.py`: passed on the original implementation head
- `uv run mkdocs build --strict -f docs/mkdocs.yml`: passed on the original implementation head
- `git diff --check`: passed

The scalability benchmark was not run: the repository benchmark exercises `RemoveDC`, not the changed FFT/Welch/Cepstrum or Recipe paths, so it would not provide representative evidence. The change preserves the existing lazy Dask boundary and adds no dependency.

## Residual risks

The v1/v2 numerical differences are intentional for short tapered FFT/Cepstrum inputs and odd-`n_fft` Welch endpoints. Existing persisted v1 payloads are covered by fixed fixtures; future Recipe versions remain subject to explicit compatibility tests.

## Review result

Two earlier review-agent attempts and a final fixed-head read-only review attempt did not return before timeout. No agent findings are being represented as approval. The main-agent fixed-head audit found no actionable issue: the central Recipe diff is empty, fixed payloads and independent oracles pass, v1/v2 registry entries coexist, private v1 kernels are not exposed through the normal operation factory, and all validation gates pass.

Do not merge this PR.