### PR TITLE
fix(ci): close routing and validation gaps

### DIFF
--- a/.github/workflows/full-compatibility.yml
+++ b/.github/workflows/full-compatibility.yml
@@ -66,15 +66,23 @@ jobs:
             case "$requested_ref" in
               refs/heads/*)
                 query_refs=("$requested_ref")
+                expected_refs=("$requested_ref")
                 ;;
               refs/tags/*)
                 query_refs=("$requested_ref" "${requested_ref}^{}")
+                expected_refs=("$requested_ref" "${requested_ref}^{}")
                 ;;
               refs/*)
                 query_refs=("$requested_ref")
+                expected_refs=("$requested_ref")
                 ;;
               *)
                 query_refs=(
+                  "refs/heads/$requested_ref"
+                  "refs/tags/$requested_ref"
+                  "refs/tags/$requested_ref^{}"
+                )
+                expected_refs=(
                   "refs/heads/$requested_ref"
                   "refs/tags/$requested_ref"
                   "refs/tags/$requested_ref^{}"
@@ -91,6 +99,14 @@ jobs:
             tag_candidates=()
             while read -r candidate_sha candidate_ref; do
               [[ "$candidate_sha" =~ ^[0-9a-fA-F]{40}$ ]] || continue
+              candidate_is_expected=false
+              for expected_ref in "${expected_refs[@]}"; do
+                if [[ "$candidate_ref" == "$expected_ref" ]]; then
+                  candidate_is_expected=true
+                  break
+                fi
+              done
+              [[ "$candidate_is_expected" == true ]] || continue
               case "$candidate_ref" in
                 refs/heads/*) branch_candidates+=("$candidate_sha") ;;
                 *"^{}") peeled_tag_candidates+=("$candidate_sha") ;;

--- a/.github/workflows/full-compatibility.yml
+++ b/.github/workflows/full-compatibility.yml
@@ -90,11 +90,25 @@ jobs:
               esac
             done <<< "$remote_matches"
 
-            candidates=("${branch_candidates[@]}")
-            candidates+=("${peeled_tag_candidates[@]}")
-            if ((${#candidates[@]} == 0)); then
-              candidates+=("${tag_candidates[@]}")
-            fi
+            candidates=()
+            case "$requested_ref" in
+              refs/heads/*)
+                candidates=("${branch_candidates[@]}")
+                ;;
+              refs/tags/*)
+                candidates=("${peeled_tag_candidates[@]}")
+                if ((${#candidates[@]} == 0)); then
+                  candidates+=("${tag_candidates[@]}")
+                fi
+                ;;
+              *)
+                candidates=("${branch_candidates[@]}")
+                candidates+=("${peeled_tag_candidates[@]}")
+                if ((${#peeled_tag_candidates[@]} == 0)); then
+                  candidates+=("${tag_candidates[@]}")
+                fi
+                ;;
+            esac
             if ((${#candidates[@]} == 0)); then
               echo "Requested ref is missing or ambiguous: $requested_ref" >&2
               exit 1

--- a/.github/workflows/full-compatibility.yml
+++ b/.github/workflows/full-compatibility.yml
@@ -20,15 +20,114 @@ permissions:
   contents: read
 
 jobs:
+  resolve-ref:
+    name: Resolve validation ref
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      resolved_sha: ${{ steps.resolve.outputs.resolved_sha }}
+    steps:
+      - name: チェックアウト (ref解決用)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: requested refをimmutable SHAへ解決
+        id: resolve
+        shell: bash
+        env:
+          REQUESTED_REF: ${{ inputs.ref || github.sha }}
+        run: |
+          set -euo pipefail
+
+          requested_ref="$REQUESTED_REF"
+          if [[ -z "$requested_ref" || "$requested_ref" =~ [[:space:]] ]]; then
+            echo "Requested ref is empty or contains whitespace." >&2
+            exit 1
+          fi
+          echo "Requested ref: $requested_ref"
+
+          resolved_sha=""
+          if [[ "$requested_ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            if git cat-file -e "${requested_ref}^{commit}" 2>/dev/null; then
+              resolved_sha="$(git rev-parse --verify "${requested_ref}^{commit}")"
+            fi
+          else
+            remote_matches=""
+            case "$requested_ref" in
+              refs/heads/*)
+                query_refs=("$requested_ref")
+                ;;
+              refs/tags/*)
+                query_refs=("$requested_ref" "${requested_ref}^{}")
+                ;;
+              refs/*)
+                query_refs=("$requested_ref")
+                ;;
+              *)
+                query_refs=(
+                  "refs/heads/$requested_ref"
+                  "refs/tags/$requested_ref"
+                  "refs/tags/$requested_ref^{}"
+                )
+                ;;
+            esac
+            if ! remote_matches="$(git ls-remote origin "${query_refs[@]}")"; then
+              echo "Unable to resolve requested ref: $requested_ref" >&2
+              exit 1
+            fi
+
+            branch_candidates=()
+            peeled_tag_candidates=()
+            tag_candidates=()
+            while read -r candidate_sha candidate_ref; do
+              [[ "$candidate_sha" =~ ^[0-9a-fA-F]{40}$ ]] || continue
+              case "$candidate_ref" in
+                refs/heads/*) branch_candidates+=("$candidate_sha") ;;
+                *"^{}") peeled_tag_candidates+=("$candidate_sha") ;;
+                refs/tags/*) tag_candidates+=("$candidate_sha") ;;
+              esac
+            done <<< "$remote_matches"
+
+            candidates=("${branch_candidates[@]}")
+            candidates+=("${peeled_tag_candidates[@]}")
+            if ((${#candidates[@]} == 0)); then
+              candidates+=("${tag_candidates[@]}")
+            fi
+            if ((${#candidates[@]} == 0)); then
+              echo "Requested ref is missing or ambiguous: $requested_ref" >&2
+              exit 1
+            fi
+            mapfile -t unique_candidates < <(printf '%s\n' "${candidates[@]}" | sort -u)
+            if ((${#unique_candidates[@]} != 1)); then
+              echo "Requested ref is missing or ambiguous: $requested_ref" >&2
+              exit 1
+            fi
+            resolved_sha="${unique_candidates[0]}"
+          fi
+
+          if [[ ! "$resolved_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Requested ref did not resolve to a commit SHA: $requested_ref" >&2
+            exit 1
+          fi
+          if ! git cat-file -e "${resolved_sha}^{commit}" 2>/dev/null; then
+            echo "Resolved SHA is not a commit available in the full checkout: $resolved_sha" >&2
+            exit 1
+          fi
+          echo "Resolved SHA: $resolved_sha"
+          printf 'resolved_sha=%s\n' "$resolved_sha" >>"$GITHUB_OUTPUT"
+
   lint:
     name: Lint and Type Check
+    needs: resolve-ref
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: チェックアウト
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ needs['resolve-ref'].outputs.resolved_sha }}
 
       - name: uv をセットアップ
         uses: astral-sh/setup-uv@v5
@@ -53,13 +152,14 @@ jobs:
 
   docs:
     name: Build Documentation
+    needs: resolve-ref
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: チェックアウト
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ needs['resolve-ref'].outputs.resolved_sha }}
 
       - name: uv をセットアップ
         uses: astral-sh/setup-uv@v5
@@ -84,13 +184,14 @@ jobs:
 
   core-install-smoke:
     name: Core-only wheel install smoke
+    needs: resolve-ref
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: チェックアウト
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ needs['resolve-ref'].outputs.resolved_sha }}
 
       - name: uv をセットアップ
         uses: astral-sh/setup-uv@v5
@@ -156,13 +257,14 @@ jobs:
 
   pyodide:
     name: Pyodide 314.0.3
+    needs: resolve-ref
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: チェックアウト
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ needs['resolve-ref'].outputs.resolved_sha }}
 
       - name: uv をセットアップ
         uses: astral-sh/setup-uv@v5
@@ -188,6 +290,7 @@ jobs:
 
   native-test:
     name: Test on ${{ matrix.os }} / Python ${{ matrix.python-version }}
+    needs: resolve-ref
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
@@ -228,7 +331,7 @@ jobs:
       - name: チェックアウト
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ needs['resolve-ref'].outputs.resolved_sha }}
 
       - name: uv をインストール
         uses: astral-sh/setup-uv@v5
@@ -260,11 +363,13 @@ jobs:
   full-gate:
     name: Full Compatibility Gate
     if: always()
-    needs: [lint, docs, core-install-smoke, pyodide, native-test]
+    needs: [resolve-ref, lint, docs, core-install-smoke, pyodide, native-test]
     runs-on: ubuntu-latest
     steps:
       - name: 完全互換性チェックの結果を検証
         env:
+          RESOLVE_RESULT: ${{ needs['resolve-ref'].result }}
+          RESOLVED_SHA: ${{ needs['resolve-ref'].outputs.resolved_sha }}
           LINT_RESULT: ${{ needs.lint.result }}
           DOCS_RESULT: ${{ needs.docs.result }}
           WHEEL_RESULT: ${{ needs['core-install-smoke'].result }}
@@ -273,6 +378,15 @@ jobs:
         shell: bash
         run: |
           set -u
+          if [[ "$RESOLVE_RESULT" != "success" ]]; then
+            echo "Ref resolver did not succeed: $RESOLVE_RESULT" >&2
+            exit 1
+          fi
+          if [[ ! "$RESOLVED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Ref resolver produced an invalid SHA: $RESOLVED_SHA" >&2
+            exit 1
+          fi
+
           failed_checks=()
           for check in \
             "lint:$LINT_RESULT" \

--- a/.github/workflows/full-compatibility.yml
+++ b/.github/workflows/full-compatibility.yml
@@ -50,10 +50,18 @@ jobs:
 
           resolved_sha=""
           if [[ "$requested_ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            if ! git fetch --no-tags --depth=1 origin "$requested_ref"; then
+              echo "Unable to fetch requested commit SHA: $requested_ref" >&2
+              exit 1
+            fi
             if git cat-file -e "${requested_ref}^{commit}" 2>/dev/null; then
               resolved_sha="$(git rev-parse --verify "${requested_ref}^{commit}")"
             fi
           else
+            if ! git check-ref-format --allow-onelevel "$requested_ref" >/dev/null 2>&1; then
+              echo "Requested ref is not a valid literal Git ref name: $requested_ref" >&2
+              exit 1
+            fi
             remote_matches=""
             case "$requested_ref" in
               refs/heads/*)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,12 @@ wandas = { workspace = true }
 
 [tool.ruff]
 line-length = 120
-include = ["wandas/**/*.py", "tests/**/*.py"]
+include = [
+    "wandas/**/*.py",
+    "tests/**/*.py",
+    "scripts/**/*.py",
+    "learning-path/**/*.py",
+]
 # 共通のruff設定はここにまとめる
 
 [tool.ruff.lint]

--- a/scripts/ci_route.py
+++ b/scripts/ci_route.py
@@ -28,9 +28,16 @@ _ROOT_CONFIG_FILES = frozenset(
 )
 _PACKAGING_SCRIPT_NAMES = frozenset({"build.py", "package.py", "test_installation.py"})
 _KNOWN_SCRIPT_PATHS = frozenset({"scripts/check_public_docstrings.py", "scripts/ci_route.py"})
+# Keep these inputs aligned with the files copied by run_pyodide_tests.mjs.
+_PYODIDE_HARNESS_INPUTS = frozenset({"tests/__init__.py", "tests/frame_helpers.py"})
+_PYODIDE_SCRIPT_PATHS = frozenset(
+    {"scripts/test_pyodide.sh", "scripts/run_pyodide_tests.py", "scripts/run_pyodide_tests.mjs"}
+)
 _PYODIDE_PATH_PREFIXES = (
+    "examples/pyodide/",
     "scripts/pyodide/",
     "tests/pyodide/",
+    "tests/core/",
     "docs/src/how-to/pyodide",
 )
 
@@ -66,11 +73,7 @@ def _is_test_related_script(path: str) -> bool:
 
 
 def _is_pyodide_path(path: str) -> bool:
-    return path.startswith(_PYODIDE_PATH_PREFIXES) or path in {
-        "scripts/test_pyodide.sh",
-        "scripts/run_pyodide_tests.py",
-        "scripts/run_pyodide_tests.mjs",
-    }
+    return path.startswith(_PYODIDE_PATH_PREFIXES) or path in _PYODIDE_HARNESS_INPUTS or path in _PYODIDE_SCRIPT_PATHS
 
 
 def _is_known_path(path: str) -> bool:

--- a/tests/test_ci_route.py
+++ b/tests/test_ci_route.py
@@ -315,6 +315,12 @@ def test_full_resolver_rejects_ambiguous_bare_branch_and_tag(tmp_path: Path) -> 
         capture_output=True,
         text=True,
     )
+    subprocess.run(
+        ["git", "-C", str(source), "push", "origin", "HEAD:refs/heads/nested/refs/heads/missing"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
     subprocess.run(["git", "clone", str(remote), str(clone)], check=True, capture_output=True, text=True)
 
     result = subprocess.run(
@@ -342,6 +348,19 @@ def test_full_resolver_rejects_ambiguous_bare_branch_and_tag(tmp_path: Path) -> 
 
     assert glob_result.returncode != 0
     assert "valid literal" in glob_result.stderr.lower()
+
+    suffix_result = subprocess.run(
+        ["bash"],
+        input=_resolver_script(),
+        cwd=clone,
+        text=True,
+        capture_output=True,
+        check=False,
+        env={**os.environ, "REQUESTED_REF": "missing", "GITHUB_OUTPUT": str(output)},
+    )
+
+    assert suffix_result.returncode != 0
+    assert "missing or ambiguous" in suffix_result.stderr.lower()
 
 
 def test_release_publish_waits_for_full_compatibility() -> None:

--- a/tests/test_ci_route.py
+++ b/tests/test_ci_route.py
@@ -259,6 +259,8 @@ def test_full_lane_preserves_the_ten_environment_compatibility_matrix() -> None:
     assert resolver_checkout["with"]["fetch-depth"] == "0"
     assert resolver_step["env"]["REQUESTED_REF"] == "${{ inputs.ref || github.sha }}"
     assert "git ls-remote origin" in resolver_step["run"]
+    assert "git fetch --no-tags --depth=1 origin" in resolver_step["run"]
+    assert "git check-ref-format --allow-onelevel" in resolver_step["run"]
     assert "Resolved SHA:" in resolver_step["run"]
     assert workflow["jobs"]["full-gate"]["needs"] == ["resolve-ref", *FULL_VALIDATION_JOBS]
     for job_name in FULL_VALIDATION_JOBS:
@@ -327,6 +329,19 @@ def test_full_resolver_rejects_ambiguous_bare_branch_and_tag(tmp_path: Path) -> 
 
     assert result.returncode != 0
     assert "ambiguous" in result.stderr.lower()
+
+    glob_result = subprocess.run(
+        ["bash"],
+        input=_resolver_script(),
+        cwd=clone,
+        text=True,
+        capture_output=True,
+        check=False,
+        env={**os.environ, "REQUESTED_REF": "collision*", "GITHUB_OUTPUT": str(output)},
+    )
+
+    assert glob_result.returncode != 0
+    assert "valid literal" in glob_result.stderr.lower()
 
 
 def test_release_publish_waits_for_full_compatibility() -> None:

--- a/tests/test_ci_route.py
+++ b/tests/test_ci_route.py
@@ -14,6 +14,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 BASH_GATE_ONLY = pytest.mark.skipif(os.name == "nt", reason="CI Gate runs Bash on ubuntu-latest")
 REQUIRED_OUTPUT_NAMES = ("NATIVE_REQUIRED", "LINT_REQUIRED", "DOCS_REQUIRED", "WHEEL_REQUIRED", "PYODIDE_REQUIRED")
 RESULT_NAMES = ("NATIVE_RESULT", "LINT_RESULT", "DOCS_RESULT", "WHEEL_RESULT", "PYODIDE_RESULT")
+FULL_VALIDATION_JOBS = ("lint", "docs", "core-install-smoke", "pyodide", "native-test")
 
 
 def _workflow(name: str) -> dict[str, Any]:
@@ -30,6 +31,15 @@ def _decision(**selected: bool) -> dict[str, bool]:
 def _gate_script() -> str:
     workflow = _workflow("ci.yml")
     steps = workflow["jobs"]["ci-gate"]["steps"]
+    assert len(steps) == 1
+    script = steps[0]["run"]
+    assert isinstance(script, str)
+    return script
+
+
+def _full_gate_script() -> str:
+    workflow = _workflow("full-compatibility.yml")
+    steps = workflow["jobs"]["full-gate"]["steps"]
     assert len(steps) == 1
     script = steps[0]["run"]
     assert isinstance(script, str)
@@ -55,6 +65,26 @@ def _run_gate(
     return subprocess.run(
         ["bash"],
         input=_gate_script(),
+        text=True,
+        capture_output=True,
+        check=False,
+        env={**os.environ, **environment},
+    )
+
+
+def _run_full_gate(
+    *,
+    resolve_result: str = "success",
+    resolved_sha: str = "a" * 40,
+) -> subprocess.CompletedProcess[str]:
+    environment = {
+        "RESOLVE_RESULT": resolve_result,
+        "RESOLVED_SHA": resolved_sha,
+        **dict.fromkeys(RESULT_NAMES, "success"),
+    }
+    return subprocess.run(
+        ["bash"],
+        input=_full_gate_script(),
         text=True,
         capture_output=True,
         check=False,
@@ -111,6 +141,32 @@ def test_product_and_configuration_paths_select_required_checks() -> None:
 )
 def test_pyodide_guide_example_and_harness_select_pyodide(path: str) -> None:
     assert classify_paths([path])["pyodide"] is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "tests/core/test_base_frame.py",
+        "tests/frame_helpers.py",
+        "tests/__init__.py",
+        "tests/pyodide/test_wav_smoke.py",
+    ],
+)
+def test_pyodide_harness_inputs_select_pyodide(path: str) -> None:
+    assert classify_paths([path])["pyodide"] is True
+
+
+def test_unrelated_test_changes_do_not_select_pyodide() -> None:
+    assert classify_paths(["tests/io/test_wav_io.py"]) == _decision(native=True, lint=True)
+
+
+def test_path_routing_uses_the_union_of_all_changed_paths() -> None:
+    assert classify_paths(["tests/core/test_base_frame.py", "docs/src/contributing.md"]) == _decision(
+        native=True,
+        lint=True,
+        docs=True,
+        pyodide=True,
+    )
 
 
 def test_workflow_changes_select_every_check() -> None:
@@ -174,6 +230,9 @@ def test_documentation_job_runs_contract_tests_without_coverage() -> None:
 def test_full_lane_preserves_the_ten_environment_compatibility_matrix() -> None:
     workflow = _workflow("full-compatibility.yml")
     matrix = workflow["jobs"]["native-test"]["strategy"]["matrix"]["include"]
+    resolver = workflow["jobs"]["resolve-ref"]
+    resolver_step = next(step for step in resolver["steps"] if step.get("id") == "resolve")
+    resolver_checkout = next(step for step in resolver["steps"] if step.get("uses") == "actions/checkout@v4")
 
     assert len(matrix) == 10
     assert {(item["os"], item["python-version"]) for item in matrix} == {
@@ -186,12 +245,23 @@ def test_full_lane_preserves_the_ten_environment_compatibility_matrix() -> None:
     assert "workflow_dispatch" in workflow["on"]
     assert "workflow_call" in workflow["on"]
     assert workflow["jobs"]["full-gate"]["if"] == "always()"
-    for job_name in ("lint", "docs", "core-install-smoke", "pyodide", "native-test"):
+    assert resolver["outputs"]["resolved_sha"] == "${{ steps.resolve.outputs.resolved_sha }}"
+    assert resolver_checkout["with"]["ref"] == "${{ github.sha }}"
+    assert resolver_checkout["with"]["fetch-depth"] == "0"
+    assert resolver_step["env"]["REQUESTED_REF"] == "${{ inputs.ref || github.sha }}"
+    assert "git ls-remote origin" in resolver_step["run"]
+    assert "Resolved SHA:" in resolver_step["run"]
+    assert workflow["jobs"]["full-gate"]["needs"] == ["resolve-ref", *FULL_VALIDATION_JOBS]
+    for job_name in FULL_VALIDATION_JOBS:
+        assert workflow["jobs"][job_name]["needs"] == "resolve-ref"
         checkout_steps = [
             step for step in workflow["jobs"][job_name]["steps"] if step.get("uses") == "actions/checkout@v4"
         ]
         assert len(checkout_steps) == 1
-        assert checkout_steps[0]["with"]["ref"] == "${{ inputs.ref || github.ref }}"
+        checkout_ref = checkout_steps[0]["with"]["ref"]
+        assert checkout_ref == "${{ needs['resolve-ref'].outputs.resolved_sha }}"
+        assert "inputs.ref" not in checkout_ref
+        assert "github.ref" not in checkout_ref
 
 
 def test_release_publish_waits_for_full_compatibility() -> None:
@@ -211,6 +281,19 @@ def test_release_publish_waits_for_full_compatibility() -> None:
     installation_checkout = [step for step in installation_job["steps"] if step.get("uses") == "actions/checkout@v4"]
     assert len(installation_checkout) == 1
     assert installation_checkout[0]["with"]["ref"] == "${{ github.sha }}"
+    assert installation_job["needs"] == "build"
+
+
+@pytest.mark.parametrize(
+    ("resolve_result", "resolved_sha"),
+    [("failure", ""), ("success", ""), ("success", "not-a-sha")],
+)
+@BASH_GATE_ONLY
+def test_full_gate_rejects_resolver_failure_or_invalid_sha(resolve_result: str, resolved_sha: str) -> None:
+    result = _run_full_gate(resolve_result=resolve_result, resolved_sha=resolved_sha)
+
+    assert result.returncode != 0
+    assert "resolver" in result.stderr.lower()
 
 
 @BASH_GATE_ONLY

--- a/tests/test_ci_route.py
+++ b/tests/test_ci_route.py
@@ -1,7 +1,6 @@
 """Contract tests for CI path routing and validation lanes."""
 
 import os
-import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -274,7 +273,7 @@ def test_full_lane_preserves_the_ten_environment_compatibility_matrix() -> None:
         assert "github.ref" not in checkout_ref
 
 
-@pytest.mark.skipif(shutil.which("git") is None, reason="git is required for resolver contract test")
+@BASH_GATE_ONLY
 def test_full_resolver_rejects_ambiguous_bare_branch_and_tag(tmp_path: Path) -> None:
     remote = tmp_path / "remote.git"
     source = tmp_path / "source"

--- a/tests/test_ci_route.py
+++ b/tests/test_ci_route.py
@@ -1,6 +1,7 @@
 """Contract tests for CI path routing and validation lanes."""
 
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -42,6 +43,15 @@ def _full_gate_script() -> str:
     steps = workflow["jobs"]["full-gate"]["steps"]
     assert len(steps) == 1
     script = steps[0]["run"]
+    assert isinstance(script, str)
+    return script
+
+
+def _resolver_script() -> str:
+    workflow = _workflow("full-compatibility.yml")
+    resolver = workflow["jobs"]["resolve-ref"]
+    step = next(step for step in resolver["steps"] if step.get("id") == "resolve")
+    script = step["run"]
     assert isinstance(script, str)
     return script
 
@@ -262,6 +272,62 @@ def test_full_lane_preserves_the_ten_environment_compatibility_matrix() -> None:
         assert checkout_ref == "${{ needs['resolve-ref'].outputs.resolved_sha }}"
         assert "inputs.ref" not in checkout_ref
         assert "github.ref" not in checkout_ref
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is required for resolver contract test")
+def test_full_resolver_rejects_ambiguous_bare_branch_and_tag(tmp_path: Path) -> None:
+    remote = tmp_path / "remote.git"
+    source = tmp_path / "source"
+    clone = tmp_path / "clone"
+    output = tmp_path / "github-output"
+
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "init", "--initial-branch", "main", str(source)], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(source), "config", "user.email", "ci@example.invalid"], check=True)
+    subprocess.run(["git", "-C", str(source), "config", "user.name", "CI contract test"], check=True)
+    (source / "state.txt").write_text("branch\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(source), "add", "state.txt"], check=True)
+    subprocess.run(
+        ["git", "-C", str(source), "commit", "-m", "branch target"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(["git", "-C", str(source), "remote", "add", "origin", str(remote)], check=True)
+    subprocess.run(
+        ["git", "-C", str(source), "push", "origin", "HEAD:refs/heads/collision"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    (source / "state.txt").write_text("tag\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(source), "commit", "-am", "tag target"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(["git", "-C", str(source), "tag", "collision"], check=True)
+    subprocess.run(
+        ["git", "-C", str(source), "push", "origin", "refs/tags/collision"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(["git", "clone", str(remote), str(clone)], check=True, capture_output=True, text=True)
+
+    result = subprocess.run(
+        ["bash"],
+        input=_resolver_script(),
+        cwd=clone,
+        text=True,
+        capture_output=True,
+        check=False,
+        env={**os.environ, "REQUESTED_REF": "collision", "GITHUB_OUTPUT": str(output)},
+    )
+
+    assert result.returncode != 0
+    assert "ambiguous" in result.stderr.lower()
 
 
 def test_release_publish_waits_for_full_compatibility() -> None:


### PR DESCRIPTION
Related #411
Follow-up to #413

## What this follow-up fixes

PR #413's three post-merge findings are addressed:

1. Pyodide routing now covers every repository input consumed by the harness: `tests/core/**`, `tests/pyodide/**`, `tests/__init__.py`, `tests/frame_helpers.py`, `scripts/test_pyodide.sh`, `scripts/run_pyodide_tests.py`, `scripts/run_pyodide_tests.mjs`, `scripts/pyodide/**`, `examples/pyodide/**`, the Pyodide guide, and existing `wandas/**`/configuration/workflow inputs. Ordinary test changes such as `tests/io/test_wav_io.py` do not select Pyodide; unknown and empty path lists select all checks fail-closed.

2. Ruff's canonical `pyproject.toml` include now covers `wandas/**/*.py`, `tests/**/*.py`, `scripts/**/*.py`, and `learning-path/**/*.py`. `uv run ruff check --show-files` discovered 205 files, including `scripts/ci_route.py`, `scripts/check_public_docstrings.py`, `learning-path/01_getting_started.py`, `learning-path/06_reusable_pipeline_recipes.py`, `wandas/__init__.py`, and `tests/test_ci_route.py`.

3. Full Compatibility has one `resolve-ref` job. It resolves `inputs.ref || github.sha` once to a validated immutable 40-character commit SHA, logs requested/resolved values, and publishes `resolved_sha`. Lint, docs, wheel, Pyodide, and all 10 native jobs depend on it and checkout that exact output. Scheduled runs use the triggering `github.sha`; manual and reusable runs resolve the requested ref. Explicit SHAs are fetched before commit validation, literal ref syntax is checked before `git ls-remote`, and returned refs must match the requested branch/tag exactly. Missing, invalid, non-commit, ambiguous, suffix-matching, and bare branch/tag-collision refs fail closed. `cd.yml` already passes release `github.sha` to Full Compatibility and uses the same release SHA for build/install, while publish requires compatibility and installation success.

## Validation

- `uv run pytest tests/test_ci_route.py -q`: 60 passed, including deterministic branch/tag collision, glob rejection, and suffix-match rejection tests
- `uv run pytest tests/docs -q`: 34 passed in the tracked repository configuration; PR docs job runs it with `--no-cov` and installs docs + test groups
- `uv run pytest -q`: 3092 passed, 3 skipped
- Ruff check/format, `ty check wandas tests scripts learning-path`, public-docstring check, Marimo strict, and MkDocs strict: passed for tracked repository files
- All 7 GitHub Actions YAML files parsed with a safe YAML loader; resolver shell passed `bash -n` and resolved the current main SHA
- PR CI at the previous head passed docs contract, Pyodide, lint, wheel, native Ubuntu 3.10/3.14, Windows 3.14, and `CI Gate`; the current head reruns the same checks after exact-ref validation
- `actionlint` is not installed locally; this is the remaining local tooling limitation

Known warnings: existing Matplotlib Japanese glyph warnings, expected MkDocs nav warnings for pages outside nav, and the isolated router test's no-coverage warning. An unrelated untracked `learning-path/06_skill_validation.py` remains preserved and is not part of this PR.

## Review scope

- Latest fixed head: `f2db8f2bf0c5bcf23b1b94ae1ff9f8f7c121a385`
- Fixed-head review findings were addressed: bare branch/tag collision, explicit SHA fetching, ref-glob rejection, and exact remote-ref matching. The Bash-only resolver contract test is skipped on Windows because the resolver runs on Ubuntu.
- No changes to #415, production signal processing, public APIs, Recipe schema, supported Python/OS matrix, or coverage contract. PR #415 was not updated, rebased, or merged by this work.
- Existing fail-closed `CI Gate` behavior and required `CI Gate` branch protection are preserved and contract-tested.

## Post-merge verification

- PR #416 merge commit: `38cfcd4875e95639db08df791f95c0dd3d0016ea`
- Full Compatibility: https://github.com/kasahart/wandas/actions/runs/30729300338 — all resolver, lint, docs, wheel, Pyodide, Ubuntu/Windows Python 3.10–3.14, and Gate jobs passed; resolved SHA was `38cfcd4875e95639db08df791f95c0dd3d0016ea`
- Main CI: https://github.com/kasahart/wandas/actions/runs/30729291732 — `CI Gate` passed
- Main branch protection ruleset was rechecked unchanged; required status check is `CI Gate` only
- PR #413's three review threads were replied to and resolved; unresolved threads: 0
- Issue #411 completion was reported and the issue was closed as `completed`: https://github.com/kasahart/wandas/issues/411