### PR TITLE
fix(frames): align spectral property shapes

### DIFF
--- a/docs/src/release-notes/v0.6.3.md
+++ b/docs/src/release-notes/v0.6.3.md
@@ -11,6 +11,8 @@ Wandas 0.6.3 makes N-octave synthesis use the authoritative FFT size stored by
 - [Issue #397](https://github.com/kasahart/wandas/issues/397) (parent [#391](https://github.com/kasahart/wandas/issues/391)):
   preserve released Recipe v1 replay and emit Recipe v2 for the corrected
   `wandas.audio.fft`, `wandas.audio.welch`, and `wandas.audio.cepstrum` calls.
+- [Issue #400](https://github.com/kasahart/wandas/issues/400) (parent [#391](https://github.com/kasahart/wandas/issues/391)):
+  make materialized spectral properties follow the public `Frame.data` channel-axis shape.
 
 ## Compatibility
 
@@ -23,3 +25,4 @@ it cannot distinguish adjacent odd and even FFT sizes.
 | `wandas.processing.NOctSynthesis` constructor | Stable user surface | None | Pass the positive source `n_fft`; `SpectralFrame.noct_synthesis()` supplies it automatically. | 0.6.3 | Numerical-correctness exception approved by [Issue #398](https://github.com/kasahart/wandas/issues/398). |
 | `wandas.spectral.noct_synthesis` Recipe v1 | Serialized operation version | None | Existing v1 payloads replay through the legacy meaning; new public calls emit version 2. | 0.6.3 | Persisted numerical meaning is kept separate from the corrected current behavior; [Issue #398](https://github.com/kasahart/wandas/issues/398). |
 | `wandas.audio.fft`, `wandas.audio.welch`, and `wandas.audio.cepstrum` Recipe v1 | Serialized operation versions | None | Existing v1 payloads replay through the released meaning; new public calls emit version 2. | 0.6.3 | Persisted numerical meaning is kept separate from the corrected current behavior; [Issue #397](https://github.com/kasahart/wandas/issues/397), parent [#391](https://github.com/kasahart/wandas/issues/391). |
+| `SpectralFrame` and `SpectrogramFrame` spectral NumPy properties | Public return shape | None | Single-channel properties follow `frame.data` without a leading singleton channel axis; multi-channel properties retain the channel axis. Numerical definitions are unchanged. | 0.6.3 | Public shape consistency correction; [Issue #400](https://github.com/kasahart/wandas/issues/400), parent [#391](https://github.com/kasahart/wandas/issues/391). |

--- a/tests/frames/test_spectral_property_shapes.py
+++ b/tests/frames/test_spectral_property_shapes.py
@@ -68,12 +68,15 @@ def _manual_spectral(
     *,
     refs: list[float] | None = None,
     factors: list[float] | None = None,
+    complex64: bool = False,
 ) -> SpectralFrame:
     """Create a manually constructed spectral frame."""
     values = _spectral_values(n_channels)
     refs = refs or [1.0] * n_channels
     metadata = _metadata(refs, factors)
     data = values if n_channels > 1 else values[0]
+    if complex64:
+        data = data.astype(np.complex64)
     return SpectralFrame(
         data=da.from_array(data, chunks=(1, -1) if n_channels > 1 else (-1,)),
         sampling_rate=_SAMPLING_RATE,
@@ -90,12 +93,15 @@ def _manual_spectrogram(
     *,
     refs: list[float] | None = None,
     factors: list[float] | None = None,
+    complex64: bool = False,
 ) -> SpectrogramFrame:
     """Create a manually constructed spectrogram frame."""
     values = _spectrogram_values(n_channels)
     refs = refs or [1.0] * n_channels
     metadata = _metadata(refs, factors)
     data = values if n_channels > 1 else values[0]
+    if complex64:
+        data = data.astype(np.complex64)
     return SpectrogramFrame(
         data=da.from_array(data, chunks=(1, -1, -1) if n_channels > 1 else (-1, -1)),
         sampling_rate=_SAMPLING_RATE,
@@ -255,7 +261,11 @@ def test_db_floor_and_calibration_are_preserved() -> None:
 
 
 def test_public_shape_level_conversion_rejects_invalid_metadata_broadcast() -> None:
-    """Reject empty metadata and channel-count mismatches instead of guessing a shape."""
+    """Preserve empty levels while rejecting non-empty channel mismatches."""
+    empty_level = spectral_properties_mixin._ref_weighted_db_public_shape(np.ones((0, _N_FREQ)), [])
+    assert empty_level.shape == (0, _N_FREQ)
+    assert empty_level.size == 0
+
     with pytest.raises(ValueError, match="requires channel metadata"):
         spectral_properties_mixin._ref_weighted_db_public_shape(np.ones(_N_FREQ), [])
 
@@ -293,6 +303,54 @@ def test_a_weighting_rejects_a_frequency_axis_mismatch(monkeypatch: pytest.Monke
     monkeypatch.setattr(spectral_properties_mixin, "a_weighting_db", short_a_weighting)
     with pytest.raises(ValueError, match="frequency axis"):
         _manual_spectral(1).dBA
+
+
+@pytest.mark.parametrize("frame_factory", [_manual_spectral, _manual_spectrogram])
+def test_single_channel_float32_db_retains_historical_float64_promotion(
+    frame_factory: Callable[..., SpectralFrame | SpectrogramFrame],
+) -> None:
+    """Removing the public axis does not change the old reference promotion."""
+    frame = frame_factory(1, complex64=True)
+
+    assert frame.data.dtype == np.dtype(np.complex64)
+    assert frame.dB.dtype == np.dtype(np.float64)
+    assert frame.dBA.dtype == np.dtype(np.float64)
+
+
+def test_zero_channel_spectral_levels_preserve_empty_public_shapes() -> None:
+    """Empty FFT and STFT outputs retain their shape for dB and dBA."""
+    source = ChannelFrame.from_numpy(np.empty((0, 32)), _SAMPLING_RATE)
+    frames = (
+        source.fft(n_fft=_N_FFT, window="boxcar"),
+        source.stft(n_fft=_N_FFT, hop_length=4, win_length=_N_FFT, window="boxcar"),
+    )
+
+    for frame in frames:
+        assert frame.data.size == 0
+        assert frame.dB.shape == frame.data.shape
+        assert frame.dBA.shape == frame.data.shape
+        assert frame.dB.size == 0
+        assert frame.dBA.size == 0
+
+
+class _SpectralPropertiesHost(spectral_properties_mixin.SpectralPropertiesMixin):
+    """Minimal host implementing the mixin's documented attributes."""
+
+    data: np.ndarray
+    _data: da.Array
+    _channel_metadata: list[ChannelMetadata]
+    freqs: np.ndarray
+
+
+def test_spectral_properties_mixin_dba_uses_documented_data_contract() -> None:
+    """A host implementing the documented mixin attributes needs no private suffix."""
+    host = _SpectralPropertiesHost()
+    host.data = np.ones(_N_FREQ)
+    host._data = da.ones((1, _N_FREQ), chunks=(1, _N_FREQ))
+    host._channel_metadata = _metadata([1.0])
+    host.freqs = np.arange(_N_FREQ, dtype=float)
+
+    assert host.dBA.shape == (_N_FREQ,)
 
 
 @pytest.mark.parametrize("n_channels", [1, 2])

--- a/tests/frames/test_spectral_property_shapes.py
+++ b/tests/frames/test_spectral_property_shapes.py
@@ -24,7 +24,6 @@ from wandas.frames.channel import ChannelFrame
 from wandas.frames.spectral import SpectralFrame
 from wandas.frames.spectrogram import SpectrogramFrame
 from wandas.pipeline import RecipePlan
-from wandas.processing.weighting import a_weighting_db
 from wandas.utils.util import DB_FLOOR
 
 _SAMPLING_RATE = 8.0
@@ -138,6 +137,15 @@ def _expected_levels(
     return magnitude, level, magnitude**2
 
 
+def _independent_a_weighting_db(frequencies: np.ndarray) -> np.ndarray:
+    """Evaluate the standard A-weighting expression independently of Wandas."""
+    f = np.asarray(frequencies, dtype=float)
+    f2 = f**2
+    ra = (12194.0**2 * f2**2) / ((f2 + 20.6**2) * np.sqrt((f2 + 107.7**2) * (f2 + 737.9**2)) * (f2 + 12194.0**2))
+    with np.errstate(divide="ignore", invalid="ignore"):
+        return 20.0 * np.log10(ra) + 2.0
+
+
 def _public_shape(values: np.ndarray, n_channels: int) -> np.ndarray:
     """Remove the analytical singleton channel axis like ``Frame.data``."""
     return values[0] if n_channels == 1 else values
@@ -173,7 +181,7 @@ def test_manual_spectral_properties_match_public_data_shape_and_values(n_channel
     np.testing.assert_allclose(values["power"], _public_shape(power, n_channels))
     np.testing.assert_allclose(values["dB"], _public_shape(level, n_channels))
 
-    weights = a_weighting_db(frame.freqs, min_db=None)
+    weights = _independent_a_weighting_db(frame.freqs)
     np.testing.assert_allclose(values["dBA"], _public_shape(level + weights, n_channels))
 
     assert frame.metadata == before_metadata
@@ -210,7 +218,7 @@ def test_manual_spectrogram_properties_match_public_data_shape_and_values(n_chan
     np.testing.assert_allclose(values["power"], _public_shape(power, n_channels))
     np.testing.assert_allclose(values["dB"], _public_shape(level, n_channels))
 
-    weights = a_weighting_db(frame.freqs, min_db=None)
+    weights = _independent_a_weighting_db(frame.freqs)
     expected_weights = weights.reshape((_N_FREQ, 1)) if n_channels == 1 else weights.reshape((1, _N_FREQ, 1))
     np.testing.assert_allclose(values["dBA"], _public_shape(level + expected_weights, n_channels))
 

--- a/tests/frames/test_spectral_property_shapes.py
+++ b/tests/frames/test_spectral_property_shapes.py
@@ -1,0 +1,453 @@
+"""Public shape and broadcast contracts for spectral NumPy properties."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import cast
+
+import dask.array as da
+import matplotlib
+import numpy as np
+import pytest
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+
+import wandas as wd
+import wandas.frames.mixins.spectral_properties_mixin as spectral_properties_mixin
+from wandas.core.metadata import ChannelCalibration, ChannelMetadata
+from wandas.frames.channel import ChannelFrame
+from wandas.frames.spectral import SpectralFrame
+from wandas.frames.spectrogram import SpectrogramFrame
+from wandas.pipeline import RecipePlan
+from wandas.processing.weighting import a_weighting_db
+from wandas.utils.util import DB_FLOOR
+
+_SAMPLING_RATE = 8.0
+_N_FFT = 8
+_N_FREQ = _N_FFT // 2 + 1
+_N_TIME = 3
+
+
+def _metadata(refs: list[float], factors: list[float] | None = None) -> list[ChannelMetadata]:
+    """Build deterministic channel metadata with independent references."""
+    factors = factors or [1.0] * len(refs)
+    return [
+        ChannelMetadata(
+            label=f"channel-{index}",
+            calibration=ChannelCalibration(factor=factor, ref=ref),
+        )
+        for index, (ref, factor) in enumerate(zip(refs, factors, strict=True))
+    ]
+
+
+def _spectral_values(n_channels: int = 2) -> np.ndarray:
+    """Return a deterministic spectrum with nontrivial phases and a zero bin."""
+    values = np.array(
+        [
+            [0.0 + 0.0j, 1.0 + 1.0j, -2.0 + 0.5j, 3.0 - 1.0j, -1.0 - 2.0j],
+            [0.0 + 0.0j, 1.0 + 1.0j, -2.0 + 0.5j, 3.0 - 1.0j, -1.0 - 2.0j],
+        ],
+        dtype=np.complex128,
+    )
+    return values[:n_channels]
+
+
+def _spectrogram_values(n_channels: int = 2) -> np.ndarray:
+    """Return a deterministic complex spectrogram with a frequency gradient."""
+    base = _spectral_values(2)
+    values = np.stack([base + (time * 0.25) for time in range(_N_TIME)], axis=-1)
+    return values[:n_channels]
+
+
+def _manual_spectral(
+    n_channels: int = 2,
+    *,
+    refs: list[float] | None = None,
+    factors: list[float] | None = None,
+) -> SpectralFrame:
+    """Create a manually constructed spectral frame."""
+    values = _spectral_values(n_channels)
+    refs = refs or [1.0] * n_channels
+    metadata = _metadata(refs, factors)
+    data = values if n_channels > 1 else values[0]
+    return SpectralFrame(
+        data=da.from_array(data, chunks=(1, -1) if n_channels > 1 else (-1,)),
+        sampling_rate=_SAMPLING_RATE,
+        n_fft=_N_FFT,
+        window="boxcar",
+        label="manual-spectrum",
+        metadata={"recording": {"take": "shape-contract"}},
+        channel_metadata=metadata,
+    )
+
+
+def _manual_spectrogram(
+    n_channels: int = 2,
+    *,
+    refs: list[float] | None = None,
+    factors: list[float] | None = None,
+) -> SpectrogramFrame:
+    """Create a manually constructed spectrogram frame."""
+    values = _spectrogram_values(n_channels)
+    refs = refs or [1.0] * n_channels
+    metadata = _metadata(refs, factors)
+    data = values if n_channels > 1 else values[0]
+    return SpectrogramFrame(
+        data=da.from_array(data, chunks=(1, -1, -1) if n_channels > 1 else (-1, -1)),
+        sampling_rate=_SAMPLING_RATE,
+        n_fft=_N_FFT,
+        hop_length=2,
+        win_length=_N_FFT,
+        window="boxcar",
+        label="manual-spectrogram",
+        metadata={"recording": {"take": "shape-contract"}},
+        channel_metadata=metadata,
+    )
+
+
+def _property_values(frame: SpectralFrame | SpectrogramFrame) -> dict[str, np.ndarray]:
+    """Materialize every public spectral property covered by the contract."""
+    values = {
+        "data": frame.data,
+        "magnitude": frame.magnitude,
+        "phase": frame.phase,
+        "power": frame.power,
+        "dB": frame.dB,
+        "dBA": frame.dBA,
+    }
+    if isinstance(frame, SpectralFrame):
+        values["unwrapped_phase"] = frame.unwrapped_phase
+    return values
+
+
+def _expected_levels(
+    raw_values: np.ndarray,
+    refs: list[float],
+    factors: list[float],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Calculate calibrated magnitude, dB, and power independently."""
+    calibrated = raw_values * np.asarray(factors, dtype=float).reshape((len(factors),) + (1,) * (raw_values.ndim - 1))
+    magnitude = np.abs(calibrated)
+    reference = np.asarray(refs, dtype=float).reshape((len(refs),) + (1,) * (raw_values.ndim - 1))
+    level = 20 * np.log10(np.maximum(magnitude / reference, DB_FLOOR))
+    return magnitude, level, magnitude**2
+
+
+def _public_shape(values: np.ndarray, n_channels: int) -> np.ndarray:
+    """Remove the analytical singleton channel axis like ``Frame.data``."""
+    return values[0] if n_channels == 1 else values
+
+
+@pytest.mark.parametrize("n_channels", [1, 2])
+def test_manual_spectral_properties_match_public_data_shape_and_values(n_channels: int) -> None:
+    """All SpectralFrame properties follow data and retain their definitions."""
+    refs = [1.0, 2.0][:n_channels]
+    factors = [2.0, 0.5][:n_channels]
+    frame = _manual_spectral(n_channels, refs=refs, factors=factors)
+    assert isinstance(frame._data, da.Array)
+    initial_chunks = frame._data.chunks
+    before_data = frame._compute().copy()
+    before_metadata = frame.metadata
+    before_history = frame.operation_history
+
+    values = _property_values(frame)
+    public_values = _spectral_values(n_channels)
+    magnitude, level, power = _expected_levels(public_values, refs, factors)
+
+    expected_shapes = [_N_FREQ] if n_channels == 1 else [n_channels, _N_FREQ]
+    for name, value in values.items():
+        assert value.shape == tuple(expected_shapes), name
+    np.testing.assert_allclose(
+        values["data"], _public_shape(magnitude * np.exp(1j * np.angle(public_values)), n_channels)
+    )
+    np.testing.assert_allclose(values["magnitude"], _public_shape(magnitude, n_channels))
+    np.testing.assert_allclose(values["phase"], _public_shape(np.angle(public_values), n_channels))
+    np.testing.assert_allclose(
+        values["unwrapped_phase"], _public_shape(np.unwrap(np.angle(public_values), axis=-1), n_channels)
+    )
+    np.testing.assert_allclose(values["power"], _public_shape(power, n_channels))
+    np.testing.assert_allclose(values["dB"], _public_shape(level, n_channels))
+
+    weights = a_weighting_db(frame.freqs, min_db=None)
+    np.testing.assert_allclose(values["dBA"], _public_shape(level + weights, n_channels))
+
+    assert frame.metadata == before_metadata
+    assert frame.operation_history == before_history
+    assert isinstance(frame._data, da.Array)
+    assert frame._data.chunks == initial_chunks
+    np.testing.assert_array_equal(frame._compute(), before_data)
+
+
+@pytest.mark.parametrize("n_channels", [1, 2])
+def test_manual_spectrogram_properties_match_public_data_shape_and_values(n_channels: int) -> None:
+    """All SpectrogramFrame properties follow data and retain their definitions."""
+    refs = [1.0, 2.0][:n_channels]
+    factors = [2.0, 0.5][:n_channels]
+    frame = _manual_spectrogram(n_channels, refs=refs, factors=factors)
+    assert isinstance(frame._data, da.Array)
+    initial_chunks = frame._data.chunks
+    before_data = frame._compute().copy()
+    before_metadata = frame.metadata
+    before_history = frame.operation_history
+
+    values = _property_values(frame)
+    public_values = _spectrogram_values(n_channels)
+    magnitude, level, power = _expected_levels(public_values, refs, factors)
+
+    expected_shape = [_N_FREQ, _N_TIME] if n_channels == 1 else [n_channels, _N_FREQ, _N_TIME]
+    for name, value in values.items():
+        assert value.shape == tuple(expected_shape), name
+    np.testing.assert_allclose(
+        values["data"], _public_shape(magnitude * np.exp(1j * np.angle(public_values)), n_channels)
+    )
+    np.testing.assert_allclose(values["magnitude"], _public_shape(magnitude, n_channels))
+    np.testing.assert_allclose(values["phase"], _public_shape(np.angle(public_values), n_channels))
+    np.testing.assert_allclose(values["power"], _public_shape(power, n_channels))
+    np.testing.assert_allclose(values["dB"], _public_shape(level, n_channels))
+
+    weights = a_weighting_db(frame.freqs, min_db=None)
+    expected_weights = weights.reshape((_N_FREQ, 1)) if n_channels == 1 else weights.reshape((1, _N_FREQ, 1))
+    np.testing.assert_allclose(values["dBA"], _public_shape(level + expected_weights, n_channels))
+
+    assert frame.metadata == before_metadata
+    assert frame.operation_history == before_history
+    assert isinstance(frame._data, da.Array)
+    assert frame._data.chunks == initial_chunks
+    np.testing.assert_array_equal(frame._compute(), before_data)
+
+
+@pytest.mark.parametrize("frame_factory", [_manual_spectral, _manual_spectrogram])
+def test_db_reference_broadcast_is_channel_specific(
+    frame_factory: Callable[..., SpectralFrame | SpectrogramFrame],
+) -> None:
+    """Different references affect only their corresponding public channel."""
+    frame = frame_factory(2, refs=[1.0, 2.0])
+    values = frame.data
+    if isinstance(frame, SpectralFrame):
+        expected_difference = np.full((_N_FREQ,), -20 * np.log10(2.0))
+    else:
+        expected_difference = np.full((_N_FREQ, _N_TIME), -20 * np.log10(2.0))
+
+    assert frame.dB.shape == values.shape
+    np.testing.assert_allclose(frame.dB[1][1:] - frame.dB[0][1:], expected_difference[1:])
+
+
+def test_db_floor_and_calibration_are_preserved() -> None:
+    """Public shape normalization does not change calibration or the dB floor."""
+    frame = _manual_spectral(1, refs=[4.0], factors=[2.0])
+    expected = 20 * np.log10(np.maximum(np.abs(_spectral_values(1)[0]) * 2.0 / 4.0, DB_FLOOR))
+
+    np.testing.assert_allclose(frame.dB, expected)
+    assert frame.dB[0] == pytest.approx(20 * np.log10(DB_FLOOR))
+
+
+def test_a_weighting_uses_frequency_axis_for_every_public_rank(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Distinct synthetic weights prove that dBA broadcasts over frequency."""
+    weights = np.linspace(-12.0, 12.0, _N_FREQ)
+
+    def fake_a_weighting(frequencies: np.ndarray, min_db: float | None = None) -> np.ndarray:
+        assert frequencies.shape == (_N_FREQ,)
+        return weights.copy()
+
+    monkeypatch.setattr(spectral_properties_mixin, "a_weighting_db", fake_a_weighting)
+    for frame in (_manual_spectral(1), _manual_spectral(2), _manual_spectrogram(1), _manual_spectrogram(2)):
+        delta = frame.dBA - frame.dB
+        if isinstance(frame, SpectralFrame):
+            expected = weights if frame.n_channels == 1 else weights.reshape((1, _N_FREQ))
+        else:
+            expected = weights.reshape((_N_FREQ, 1)) if frame.n_channels == 1 else weights.reshape((1, _N_FREQ, 1))
+        np.testing.assert_allclose(delta, np.broadcast_to(expected, delta.shape))
+
+
+@pytest.mark.parametrize("n_channels", [1, 2])
+def test_fft_and_welch_public_paths_follow_property_shape_contract(n_channels: int) -> None:
+    """FFT and Welch domain transitions expose the same property ranks as data."""
+    samples = np.arange(32.0)
+    source_values = np.vstack([samples, samples + 1.0])[:n_channels]
+    source = ChannelFrame.from_numpy(source_values if n_channels > 1 else source_values[0], _SAMPLING_RATE)
+
+    for frame in (
+        source.fft(n_fft=_N_FFT, window="boxcar"),
+        source.welch(n_fft=_N_FFT, hop_length=4, win_length=_N_FFT, window="boxcar"),
+    ):
+        values = _property_values(frame)
+        expected_shape = [_N_FREQ] if n_channels == 1 else [n_channels, _N_FREQ]
+        assert frame.data.shape == tuple(expected_shape)
+        assert all(value.shape == frame.data.shape for value in values.values())
+
+    fft_frame = source.fft(n_fft=_N_FFT, window="boxcar")
+    expected_fft = np.fft.rfft(source_values, n=_N_FFT, axis=-1)
+    expected_fft[..., 1:-1] *= 2.0
+    expected_fft /= _N_FFT
+    expected_fft = _public_shape(expected_fft, n_channels)
+    np.testing.assert_allclose(fft_frame.data, expected_fft)
+
+    from scipy import signal
+
+    _, expected_welch = signal.welch(
+        source_values,
+        nperseg=_N_FFT,
+        noverlap=4,
+        nfft=_N_FFT,
+        window="boxcar",
+        average="mean",
+        detrend="constant",
+        scaling="spectrum",
+        axis=-1,
+    )
+    expected_welch = np.sqrt(expected_welch)
+    expected_welch[..., 1:-1] *= np.sqrt(2.0)
+    expected_welch = _public_shape(expected_welch, n_channels)
+    welch_frame = source.welch(n_fft=_N_FFT, hop_length=4, win_length=_N_FFT, window="boxcar")
+    np.testing.assert_allclose(welch_frame.data, expected_welch)
+
+
+@pytest.mark.parametrize("n_channels", [1, 2])
+def test_stft_public_path_follow_property_shape_contract(n_channels: int) -> None:
+    """STFT domain transitions expose the same property ranks as data."""
+    samples = np.arange(32.0)
+    source_values = np.vstack([samples, samples + 1.0])[:n_channels]
+    source = ChannelFrame.from_numpy(source_values if n_channels > 1 else source_values[0], _SAMPLING_RATE)
+    frame = source.stft(n_fft=_N_FFT, hop_length=4, win_length=_N_FFT, window="boxcar")
+
+    values = _property_values(frame)
+    expected_shape = [_N_FREQ, frame.n_frames] if n_channels == 1 else [n_channels, _N_FREQ, frame.n_frames]
+    assert frame.data.shape == tuple(expected_shape)
+    assert all(value.shape == frame.data.shape for value in values.values())
+
+    from scipy.signal import ShortTimeFFT
+    from scipy.signal.windows import get_window
+
+    short_time_fft = ShortTimeFFT(
+        win=get_window("boxcar", _N_FFT),
+        hop=4,
+        fs=_SAMPLING_RATE,
+        mfft=_N_FFT,
+        scale_to="magnitude",
+    )
+    expected_stft = np.asarray(short_time_fft.stft(source_values))
+    expected_stft[..., 1:-1, :] *= 2.0
+    expected_stft = _public_shape(expected_stft, n_channels)
+    np.testing.assert_allclose(frame.data, expected_stft)
+
+
+@pytest.mark.parametrize("n_channels", [1, 2])
+def test_recipe_roundtrip_preserves_spectral_property_shapes(n_channels: int) -> None:
+    """Recipe extraction and replay preserve the public property contract."""
+    samples = np.arange(32.0)
+    source_values = np.vstack([samples, samples + 1.0])[:n_channels]
+    source = ChannelFrame.from_numpy(source_values if n_channels > 1 else source_values[0], _SAMPLING_RATE)
+    processed_frames = (
+        source.fft(n_fft=_N_FFT, window="boxcar"),
+        source.welch(n_fft=_N_FFT, hop_length=4, win_length=_N_FFT, window="boxcar"),
+        source.stft(n_fft=_N_FFT, hop_length=4, win_length=_N_FFT, window="boxcar"),
+    )
+
+    for processed in processed_frames:
+        plan = RecipePlan.from_frame(processed)
+        loaded = RecipePlan.from_dict(json.loads(json.dumps(plan.to_dict())))
+        replayed = cast(SpectralFrame | SpectrogramFrame, loaded.apply({"input_0": source}))
+
+        assert isinstance(replayed._data, da.Array)
+        assert replayed.data.shape == processed.data.shape
+        assert all(value.shape == replayed.data.shape for value in _property_values(replayed).values())
+        np.testing.assert_allclose(replayed.data, processed.data)
+
+
+@pytest.mark.parametrize("n_channels", [1, 2])
+@pytest.mark.parametrize("frame_factory", [_manual_spectral, _manual_spectrogram])
+def test_wdf_roundtrip_preserves_spectral_property_shapes(
+    frame_factory: Callable[..., SpectralFrame | SpectrogramFrame],
+    n_channels: int,
+    tmp_path: Path,
+) -> None:
+    """WDF persists internal storage and restores the same public properties."""
+    frame = frame_factory(n_channels)
+    path = tmp_path / f"{type(frame).__name__}-{n_channels}.wdf"
+    frame.save(path)
+    loaded = cast(SpectralFrame | SpectrogramFrame, wd.load(path))
+
+    assert type(loaded) is type(frame)
+    assert loaded._xr.dims == frame._xr.dims
+    for name, value in _property_values(frame).items():
+        loaded_value = _property_values(loaded)[name]
+        assert loaded_value.shape == value.shape, name
+        np.testing.assert_allclose(loaded_value, value)
+
+
+def _as_axes(result: Axes | Iterator[Axes]) -> list[Axes]:
+    """Normalize a plot result for assertions without changing plotting code."""
+    if isinstance(result, Axes):
+        return [result]
+    return list(result)
+
+
+def _assert_line_values(axis: Axes, frequencies: np.ndarray, expected: np.ndarray) -> None:
+    """Verify both axes and values for a plotted spectral line."""
+    assert len(axis.lines) == 1
+    line = axis.lines[0]
+    np.testing.assert_allclose(np.asarray(line.get_xdata()), frequencies)
+    np.testing.assert_allclose(np.asarray(line.get_ydata()), expected)
+
+
+def _assert_mesh_values(axis: Axes, expected: np.ndarray) -> None:
+    """Verify the materialized values in a plotted spectrogram mesh."""
+    assert len(axis.collections) == 1
+    np.testing.assert_allclose(np.asarray(axis.collections[0].get_array()), expected)
+
+
+def test_plotting_restores_channel_rank_at_the_boundary() -> None:
+    """Frequency, matrix, and spectrogram plots accept squeezed public properties."""
+    spectral_single = _manual_spectral(1)
+    spectral_multi = _manual_spectral(2)
+    spectrogram_single = _manual_spectrogram(1)
+    spectrogram_multi = _manual_spectrogram(2)
+
+    try:
+        single_axes = _as_axes(spectral_single.plot(overlay=False, Aw=False))
+        assert len(single_axes) == 1
+        _assert_line_values(single_axes[0], spectral_single.freqs, spectral_single.dB)
+
+        multi_axes = _as_axes(spectral_multi.plot(overlay=False, Aw=True))
+        assert len(multi_axes) == 2
+        assert [len(axis.lines) for axis in multi_axes] == [1, 1]
+        for axis, expected in zip(multi_axes, spectral_multi.dBA, strict=True):
+            _assert_line_values(axis, spectral_multi.freqs, expected)
+
+        overlay_axis = spectral_multi.plot(overlay=True, Aw=False)
+        assert isinstance(overlay_axis, Axes)
+        assert len(overlay_axis.lines) == 2
+        for line, expected in zip(overlay_axis.lines, spectral_multi.dB, strict=True):
+            np.testing.assert_allclose(np.asarray(line.get_xdata()), spectral_multi.freqs)
+            np.testing.assert_allclose(np.asarray(line.get_ydata()), expected)
+
+        caller_axis = plt.subplots()[1]
+        assert spectral_single.plot(ax=caller_axis, Aw=True) is caller_axis
+        _assert_line_values(caller_axis, spectral_single.freqs, spectral_single.dBA)
+
+        matrix_axes = _as_axes(spectral_single.plot(plot_type="matrix", overlay=False, Aw=True))
+        assert len(matrix_axes) == 1
+        _assert_line_values(matrix_axes[0], spectral_single.freqs, spectral_single.dBA)
+
+        single_spectrogram_axes = _as_axes(spectrogram_single.plot(Aw=False))
+        single_data_axes = [axis for axis in single_spectrogram_axes if axis.get_xlabel() == "Time [s]"]
+        assert len(single_data_axes) == 1
+        _assert_mesh_values(single_data_axes[0], spectrogram_single.dB)
+
+        caller_spectrogram_axis = plt.subplots()[1]
+        assert spectrogram_single.plot(ax=caller_spectrogram_axis, Aw=True) is caller_spectrogram_axis
+        _assert_mesh_values(caller_spectrogram_axis, spectrogram_single.dBA)
+
+        multi_spectrogram_axes = _as_axes(spectrogram_multi.plot(Aw=True))
+        multi_data_axes = [axis for axis in multi_spectrogram_axes if axis.get_xlabel() == "Time [s]"]
+        assert len(multi_data_axes) == 2
+        assert all(len(axis.collections) == 1 for axis in multi_data_axes)
+        for axis, expected in zip(multi_data_axes, spectrogram_multi.dBA, strict=True):
+            _assert_mesh_values(axis, expected)
+    finally:
+        plt.close("all")

--- a/tests/frames/test_spectral_property_shapes.py
+++ b/tests/frames/test_spectral_property_shapes.py
@@ -254,6 +254,18 @@ def test_db_floor_and_calibration_are_preserved() -> None:
     assert frame.dB[0] == pytest.approx(20 * np.log10(DB_FLOOR))
 
 
+def test_public_shape_level_conversion_rejects_invalid_metadata_broadcast() -> None:
+    """Reject empty metadata and channel-count mismatches instead of guessing a shape."""
+    with pytest.raises(ValueError, match="requires channel metadata"):
+        spectral_properties_mixin._ref_weighted_db_public_shape(np.ones(_N_FREQ), [])
+
+    with pytest.raises(ValueError, match="does not match channel metadata"):
+        spectral_properties_mixin._ref_weighted_db_public_shape(
+            np.ones((1, _N_FREQ)),
+            _metadata([1.0, 2.0]),
+        )
+
+
 def test_a_weighting_uses_frequency_axis_for_every_public_rank(monkeypatch: pytest.MonkeyPatch) -> None:
     """Distinct synthetic weights prove that dBA broadcasts over frequency."""
     weights = np.linspace(-12.0, 12.0, _N_FREQ)
@@ -270,6 +282,17 @@ def test_a_weighting_uses_frequency_axis_for_every_public_rank(monkeypatch: pyte
         else:
             expected = weights.reshape((_N_FREQ, 1)) if frame.n_channels == 1 else weights.reshape((1, _N_FREQ, 1))
         np.testing.assert_allclose(delta, np.broadcast_to(expected, delta.shape))
+
+
+def test_a_weighting_rejects_a_frequency_axis_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reject weights whose length cannot be aligned to the public frequency axis."""
+
+    def short_a_weighting(frequencies: np.ndarray, min_db: float | None = None) -> np.ndarray:
+        return np.zeros(frequencies.size - 1)
+
+    monkeypatch.setattr(spectral_properties_mixin, "a_weighting_db", short_a_weighting)
+    with pytest.raises(ValueError, match="frequency axis"):
+        _manual_spectral(1).dBA
 
 
 @pytest.mark.parametrize("n_channels", [1, 2])

--- a/wandas/frames/mixins/spectral_properties_mixin.py
+++ b/wandas/frames/mixins/spectral_properties_mixin.py
@@ -1,18 +1,51 @@
 """Mixin providing common spectral properties (magnitude, phase, power, dB, dBA).
 
 These properties are shared between SpectralFrame (2D) and SpectrogramFrame (3D).
-Broadcasting differences are handled via ``_data.ndim``.
+Broadcasting follows the materialized public ``data`` shape.
 """
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 
 import numpy as np
 
 from wandas.processing.weighting import a_weighting_db
 from wandas.utils.types import NDArrayReal
-from wandas.utils.util import ref_weighted_dB
+from wandas.utils.util import DB_FLOOR
+
+
+def _ref_weighted_db_public_shape(
+    data: NDArrayReal,
+    channel_metadata: Sequence[Any],
+) -> NDArrayReal:
+    """Convert amplitudes to dB using the materialized public shape.
+
+    Spectral properties follow ``Frame.data``: a single channel has no leading
+    channel axis, while multiple channels retain it.  The older utility
+    ``ref_weighted_dB`` is intentionally left unchanged because ``NOctFrame``
+    uses its internal channel-first rank contract.
+    """
+    channel_count = len(channel_metadata)
+    if channel_count == 0:
+        raise ValueError("Spectral level conversion requires channel metadata")
+
+    if channel_count == 1:
+        reference: float | NDArrayReal = float(channel_metadata[0].ref)
+    else:
+        if data.ndim == 0 or data.shape[0] != channel_count:
+            raise ValueError(
+                "Spectral level data shape does not match channel metadata\n"
+                f"  Data shape: {data.shape}\n"
+                f"  Channels: {channel_count}"
+            )
+        reference = np.asarray([channel.ref for channel in channel_metadata], dtype=float).reshape(
+            (channel_count,) + (1,) * (data.ndim - 1)
+        )
+
+    result: NDArrayReal = 20 * np.log10(np.maximum(data / reference, DB_FLOOR))
+    return result
 
 
 class SpectralPropertiesMixin:
@@ -21,6 +54,12 @@ class SpectralPropertiesMixin:
     Host classes must provide ``data`` (computed array),
     ``_data`` (Dask array), ``_channel_metadata``, and ``freqs``.
     The operation that created the host defines the stored quantity and unit.
+
+    NumPy properties use the same channel-axis convention as ``data``: a
+    single-channel ``SpectralFrame`` returns ``(frequency,)`` and a
+    single-channel ``SpectrogramFrame`` returns ``(frequency, time)``; multiple
+    channels retain a leading channel axis. Plotting restores that axis only at
+    its boundary when it needs channel-first input.
     """
 
     # -- read-only properties reused by SpectralFrame & SpectrogramFrame --
@@ -52,7 +91,7 @@ class SpectralPropertiesMixin:
         an amplitude level.
         """
         mag: NDArrayReal = np.abs(self.data)
-        return ref_weighted_dB(mag, self._channel_metadata, self._data.ndim)
+        return _ref_weighted_db_public_shape(mag, self._channel_metadata)
 
     @property
     def dBA(self: Any) -> NDArrayReal:  # noqa: N802
@@ -61,11 +100,16 @@ class SpectralPropertiesMixin:
         For the canonical FFT, STFT, and Welch amplitude quantities, this is
         an A-weighted amplitude level.
         """
+        level: NDArrayReal = self.dB
         weighted: NDArrayReal = a_weighting_db(frequencies=self.freqs, min_db=None)
-        if self._data.ndim == 3:
-            # SpectrogramFrame: broadcast over time axis
-            result: NDArrayReal = self.dB + weighted[:, np.newaxis]
-            return result
-        # SpectralFrame: weighted is already (freq,), broadcasts over (channels, freq)
-        result = self.dB + weighted
+        frequency_axis = level.ndim - 2 if self._xarray_dim_suffix[-1:] == ("time",) else level.ndim - 1
+        if level.shape[frequency_axis] != weighted.shape[0]:
+            raise ValueError(
+                "A-weighting frequency axis does not match spectral data\n"
+                f"  Data shape: {level.shape}\n"
+                f"  Frequencies: {weighted.shape[0]}"
+            )
+        weight_shape = [1] * level.ndim
+        weight_shape[frequency_axis] = weighted.shape[0]
+        result: NDArrayReal = level + weighted.reshape(weight_shape)
         return result

--- a/wandas/frames/mixins/spectral_properties_mixin.py
+++ b/wandas/frames/mixins/spectral_properties_mixin.py
@@ -11,9 +11,8 @@ from typing import Any
 
 import numpy as np
 
-from wandas.processing.weighting import a_weighting_db
+from wandas.processing.weighting import _reference_level_db, a_weighting_db
 from wandas.utils.types import NDArrayReal
-from wandas.utils.util import DB_FLOOR
 
 
 def _ref_weighted_db_public_shape(
@@ -29,10 +28,13 @@ def _ref_weighted_db_public_shape(
     """
     channel_count = len(channel_metadata)
     if channel_count == 0:
-        raise ValueError("Spectral level conversion requires channel metadata")
+        if data.size:
+            raise ValueError("Spectral level conversion requires channel metadata")
+        return _reference_level_db(data, np.asarray(1.0, dtype=float))
 
     if channel_count == 1:
-        reference: float | NDArrayReal = float(channel_metadata[0].ref)
+        # Keep the historical float64 promotion while returning the public shape.
+        reference: NDArrayReal = np.asarray(channel_metadata[0].ref, dtype=float)
     else:
         if data.ndim == 0 or data.shape[0] != channel_count:
             raise ValueError(
@@ -44,8 +46,7 @@ def _ref_weighted_db_public_shape(
             (channel_count,) + (1,) * (data.ndim - 1)
         )
 
-    result: NDArrayReal = 20 * np.log10(np.maximum(data / reference, DB_FLOOR))
-    return result
+    return _reference_level_db(data, reference)
 
 
 class SpectralPropertiesMixin:
@@ -59,7 +60,9 @@ class SpectralPropertiesMixin:
     single-channel ``SpectralFrame`` returns ``(frequency,)`` and a
     single-channel ``SpectrogramFrame`` returns ``(frequency, time)``; multiple
     channels retain a leading channel axis. Plotting restores that axis only at
-    its boundary when it needs channel-first input.
+    its boundary when it needs channel-first input. ``dBA`` uses the documented
+    internal ``_data.ndim`` (2 for spectra, 3 for spectrograms) to locate the
+    public frequency axis.
     """
 
     # -- read-only properties reused by SpectralFrame & SpectrogramFrame --
@@ -102,7 +105,7 @@ class SpectralPropertiesMixin:
         """
         level: NDArrayReal = self.dB
         weighted: NDArrayReal = a_weighting_db(frequencies=self.freqs, min_db=None)
-        frequency_axis = level.ndim - 2 if self._xarray_dim_suffix[-1:] == ("time",) else level.ndim - 1
+        frequency_axis = level.ndim - 2 if self._data.ndim == 3 else level.ndim - 1
         if level.shape[frequency_axis] != weighted.shape[0]:
             raise ValueError(
                 "A-weighting frequency axis does not match spectral data\n"

--- a/wandas/processing/weighting.py
+++ b/wandas/processing/weighting.py
@@ -36,6 +36,14 @@ from numpy import pi
 from scipy.signal import bilinear_zpk, freqs, sosfilt, zpk2sos, zpk2tf
 
 from wandas.utils.types import NDArrayReal
+from wandas.utils.util import DB_FLOOR
+
+
+def _reference_level_db(data: NDArrayReal, reference: NDArrayReal) -> NDArrayReal:
+    """Compute amplitude level for a caller-provided, broadcastable reference."""
+    reference_array = np.asarray(reference, dtype=float)
+    result: NDArrayReal = 20.0 * np.log10(np.maximum(data / reference_array, DB_FLOOR))
+    return result
 
 
 def a_weighting_db(frequencies: NDArrayReal, min_db: float | None = -45.0) -> NDArrayReal:

--- a/wandas/utils/util.py
+++ b/wandas/utils/util.py
@@ -47,8 +47,9 @@ def ref_weighted_dB(
     ref = np.array([ch.ref for ch in channel_metadata])
     extra_dims = ndim - 1
     ref_shape = ref.reshape((-1,) + (1,) * extra_dims)
-    level: NDArrayReal = 20 * np.log10(np.maximum(data / ref_shape, DB_FLOOR))
-    return level
+    from wandas.processing.weighting import _reference_level_db
+
+    return _reference_level_db(data, ref_shape)
 
 
 def _normalize_sampling_rate(sampling_rate: object, param_name: str = "sampling_rate") -> float:


### PR DESCRIPTION
Closes #400
Related #391

## Summary

Unify the public NumPy property shapes of `SpectralFrame` and `SpectrogramFrame` with `frame.data`. The numerical definitions and values are unchanged.

| Frame / public property | Before: single channel | After: single channel | Multi-channel |
| --- | --- | --- | --- |
| `SpectralFrame` magnitude, phase, unwrapped_phase, power | `(frequency,)` | `(frequency,)` | `(channel, frequency)` |
| `SpectralFrame` dB, dBA | `(1, frequency)` | `(frequency,)` | `(channel, frequency)` |
| `SpectrogramFrame` magnitude, phase, power | `(frequency, time)` | `(frequency, time)` | `(channel, frequency, time)` |
| `SpectrogramFrame` dB, dBA | `(1, frequency, time)` | `(frequency, time)` | `(channel, frequency, time)` |

## Design

The root cause was that `magnitude`, `phase`, and `power` already used materialized `self.data`, while `dB` used the internal `self._data.ndim` when broadcasting references. That reintroduced a singleton channel axis for single-channel frames.

The public-shape helper now owns only reference alignment:

- single-channel public data uses a scalar-shaped reference without adding an axis;
- multi-channel public data uses `(channel, 1, ...)` reference broadcasting;
- valid zero-channel frames return empty level arrays, while non-empty data without channel metadata remains rejected;
- the historical float64 promotion for single-channel float32 spectra is preserved.

The actual reference division, floor, and logarithm are delegated to the shared numerical kernel in `wandas/processing/weighting.py`; `ref_weighted_dB()` uses the same kernel. This keeps numerical algorithms out of the Frame layer without changing the `NOctFrame` contract.

A-weighting is reshaped explicitly onto the frequency axis: the final axis for `SpectralFrame`, and the penultimate axis for `SpectrogramFrame`, based on the documented internal rank. The mixin no longer requires the private `_xarray_dim_suffix` attribute. The existing plotting boundary helpers restore channel-first rank only for plotting.

The generic Recipe infrastructure, BaseFrame constructors, internal Dask channel-first storage, WDF schema, FFT/Welch/STFT processing, and public signatures were not changed.

## Tests and validation

The focused coverage includes:

- manual single-/multi-channel SpectralFrame and SpectrogramFrame shape/value checks for all affected properties;
- independent NumPy FFT, SciPy Welch, SciPy ShortTimeFFT, and analytical A-weighting oracles;
- per-channel reference, calibration, dB floor, metadata/history/input immutability, and Dask/chunk invariants;
- zero-channel output, float32-to-float64 compatibility, documented mixin host, invalid metadata, and A-weighting-axis validation;
- FFT/Welch/STFT public paths;
- frequency/matrix/spectrogram plotting, A-weighting, overlay, and caller-provided Axes with plotted x/y/mesh values;
- Recipe JSON round-trip and WDF round-trip property shapes;
- existing NOctFrame, xarray/DataFrame, DescribePlot, and plotting regressions through the full suite.

Results at final head `9c23741e`:

- `uv run pytest -q`: **3117 passed, 3 skipped**
- `uv run ruff check wandas tests scripts learning-path`: passed
- `uv run ruff format --check wandas tests scripts learning-path`: passed
- `uv run ty check wandas tests scripts learning-path`: passed
- `uv run python scripts/check_public_docstrings.py`: passed
- `uv run marimo check --strict learning-path/*.py`: passed
- `uv run mkdocs build --strict -f docs/mkdocs.yml`: passed
- `git diff --check`: passed
- focused spectral/NOctFrame regression tests: **137 passed**
- post-push GitHub CI Gate, all OS test matrices, Pyodide, documentation, lint/type, wheel smoke, Release Drafter, and Codecov patch coverage: **passed**

## Compatibility

This is a public-shape compatibility correction. Single-channel spectral properties now consistently follow the already-public `frame.data` contract; multi-channel shapes and all numerical definitions are preserved. The release note records the shape correction. No WDF or Recipe schema/version change is needed because persisted internal tensors and operation meanings are unchanged.

## Review follow-up

The review feedback was addressed in `9c23741e`:

- shared the dB conversion kernel with `wandas/processing`;
- preserved zero-channel empty outputs and fail-closed metadata validation;
- preserved historical float64 dB/dBA promotion for complex64 mono data;
- removed the undeclared `_xarray_dim_suffix` mixin dependency and documented the host contract.

An independent fixed-head review against `9c23741e` was **approve-equivalent** with no major or actionable findings. It also confirmed the NOctFrame, plotting, Dask, metadata, Recipe, WDF, and scope boundaries.

## Residual risk

The repository's existing test/documentation runs still emit non-failing font and other warnings, and three existing tests remain skipped. No known Issue #400-specific risk remains.