### PR TITLE
test: add independent ISTFT numerical oracle

### DIFF
--- a/tests/frames/test_spectrogram_frame_istft_oracle.py
+++ b/tests/frames/test_spectrogram_frame_istft_oracle.py
@@ -1,0 +1,176 @@
+"""Independent numerical and provenance contracts for SpectrogramFrame ISTFT."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+from unittest import mock
+
+import dask.array as da
+import numpy as np
+import pytest
+from dask.array.core import Array as DaArray
+
+from tests.processing.test_istft_independent_oracle import (
+    _CASES,
+    _make_independent_oracle,
+    _OracleCase,
+)
+from wandas.core.metadata import ChannelCalibration, ChannelMetadata
+from wandas.frames.channel import ChannelFrame
+from wandas.frames.spectrogram import SpectrogramFrame
+from wandas.processing.semantic import source_lineage
+
+_FRAME_SAMPLING_RATE = 8_000.0
+_SOURCE_HISTORY = [{"operation": "fixture.independent_istft", "version": 1, "params": {}}]
+
+
+def _frame_metadata(case: _OracleCase) -> tuple[dict[str, Any], list[ChannelMetadata], list[str], np.ndarray]:
+    """Build metadata that makes ownership and channel alignment observable."""
+
+    channels = [
+        ChannelMetadata(
+            label=f"oracle-{index}",
+            calibration=ChannelCalibration(
+                factor=1.0 + 0.25 * index,
+                unit="Pa",
+                ref=2e-5 * (index + 1),
+            ),
+            extra={"sensor": f"sensor-{index}", "case": case.window},
+        )
+        for index in range(case.channels)
+    ]
+    channel_ids = [f"oracle-id-{index}" for index in range(case.channels)]
+    source_time_offset = np.asarray(
+        [0.125 + 0.75 * index for index in range(case.channels)],
+        dtype=np.float64,
+    )
+    metadata = {
+        "recording": "independent-istft-oracle",
+        "analysis": {"fft": case.n_fft, "hop": case.hop_length},
+    }
+    return metadata, channels, channel_ids, source_time_offset
+
+
+def _channel_metadata_snapshot(frame: SpectrogramFrame | ChannelFrame) -> list[tuple[Any, ...]]:
+    """Return a value snapshot of public channel metadata fields."""
+
+    return [
+        (
+            channel.label,
+            channel.unit,
+            channel.ref,
+            channel.calibration,
+            channel.extra.copy(),
+        )
+        for channel in frame._channel_metadata
+    ]
+
+
+@pytest.mark.parametrize(
+    ("case", "channels"),
+    [
+        (_CASES[0], 1),
+        (_CASES[1], 2),
+        (_CASES[2], 1),
+        (_CASES[3], 2),
+    ],
+)
+def test_spectrogram_frame_public_istft_matches_independent_oracle(
+    case: _OracleCase,
+    channels: int,
+) -> None:
+    """Both public inverse paths preserve full values and public mono shape."""
+
+    case = replace(case, channels=channels)
+    scipy_sft, scipy_domain, normalized_wandas = _make_independent_oracle(case)
+    expected_raw = scipy_sft.istft(scipy_domain)
+    metadata, channel_metadata, channel_ids, source_time_offset = _frame_metadata(case)
+    input_lineage = source_lineage(_SOURCE_HISTORY)
+    input_snapshot = normalized_wandas.copy()
+
+    frame = SpectrogramFrame(
+        data=da.from_array(
+            normalized_wandas.copy(),
+            chunks=(1, normalized_wandas.shape[1], normalized_wandas.shape[2]),
+        ),
+        sampling_rate=_FRAME_SAMPLING_RATE,
+        n_fft=case.n_fft,
+        hop_length=case.hop_length,
+        win_length=case.win_length,
+        window=case.window,
+        label="independent-oracle",
+        metadata=metadata,
+        channel_metadata=channel_metadata,
+        channel_ids=channel_ids,
+        source_time_offset=source_time_offset,
+        lineage=input_lineage,
+    )
+    input_history = frame.operation_history
+    input_metadata = frame.metadata
+    input_channel_metadata = _channel_metadata_snapshot(frame)
+
+    assert isinstance(frame._data, DaArray)
+    assert frame._data.shape == normalized_wandas.shape
+    assert frame.shape == (
+        (normalized_wandas.shape[1], normalized_wandas.shape[2]) if channels == 1 else normalized_wandas.shape
+    )
+
+    with mock.patch.object(DaArray, "compute") as compute:
+        actual_istft = frame.istft()
+        actual_to_channel = frame.to_channel_frame()
+        compute.assert_not_called()
+
+    for actual in (actual_istft, actual_to_channel):
+        assert isinstance(actual, ChannelFrame)
+        assert isinstance(actual._data, DaArray)
+        assert actual._data.shape == expected_raw.shape
+        assert actual._data.dtype == np.dtype(np.float64)
+        assert actual.previous is frame
+        assert actual.sampling_rate == _FRAME_SAMPLING_RATE
+        assert actual.label == "istft(independent-oracle)"
+        assert actual.labels == frame.labels
+        assert actual._channel_ids == channel_ids
+        np.testing.assert_array_equal(actual.source_time_offset, source_time_offset)
+        assert actual.metadata == metadata
+        assert actual.lineage.inputs == (frame.lineage,)
+        assert actual.lineage.operation is not None
+        assert actual.lineage.operation.operation_id == "wandas.spectrogram.to_channel_frame"
+        assert actual.operation_history == [
+            *_SOURCE_HISTORY,
+            {"operation": "wandas.spectrogram.to_channel_frame", "version": 1, "params": {}},
+        ]
+        assert _channel_metadata_snapshot(actual) == input_channel_metadata
+        for source_channel, output_channel in zip(frame.channels, actual.channels, strict=True):
+            assert output_channel.unit == source_channel.unit
+            assert output_channel.ref == source_channel.ref
+            assert output_channel.calibration == source_channel.calibration
+            assert output_channel.extra == source_channel.extra
+
+        # The internal tensor is the direct SciPy oracle. Public data also applies
+        # the preserved per-channel calibration factor and hides mono's axis.
+        np.testing.assert_allclose(actual._data.compute(), expected_raw, rtol=2e-12, atol=2e-12)
+        calibration_factors = np.asarray(
+            [channel.calibration.factor for channel in channel_metadata],
+            dtype=np.float64,
+        )
+        expected_public = expected_raw * calibration_factors[:, None]
+        public_data = actual.data
+        if channels == 1:
+            assert public_data.shape == expected_public.shape[1:]
+            np.testing.assert_allclose(public_data, expected_public[0], rtol=2e-12, atol=2e-12)
+        else:
+            assert public_data.shape == expected_public.shape
+            np.testing.assert_allclose(public_data, expected_public, rtol=2e-12, atol=2e-12)
+
+    assert actual_istft is not actual_to_channel
+    np.testing.assert_allclose(actual_istft._data.compute(), actual_to_channel._data.compute(), rtol=0.0, atol=0.0)
+
+    # Constructing either public result must not alter the source Frame or its
+    # caller-owned values, metadata, offsets, or semantic provenance.
+    np.testing.assert_array_equal(frame._data.compute(), input_snapshot)
+    assert frame.metadata == input_metadata
+    assert frame.operation_history == input_history
+    assert frame.lineage is input_lineage
+    assert _channel_metadata_snapshot(frame) == input_channel_metadata
+    np.testing.assert_array_equal(frame.source_time_offset, source_time_offset)

--- a/tests/frames/test_spectrogram_frame_istft_oracle.py
+++ b/tests/frames/test_spectrogram_frame_istft_oracle.py
@@ -11,8 +11,9 @@ import numpy as np
 import pytest
 from dask.array.core import Array as DaArray
 
-from tests.processing.test_istft_independent_oracle import (
+from tests.processing.istft_oracle_fixtures import (
     _CASES,
+    _SAMPLING_RATE,
     _make_independent_oracle,
     _OracleCase,
 )
@@ -21,7 +22,6 @@ from wandas.frames.channel import ChannelFrame
 from wandas.frames.spectrogram import SpectrogramFrame
 from wandas.processing.semantic import source_lineage
 
-_FRAME_SAMPLING_RATE = 8_000.0
 _SOURCE_HISTORY = [{"operation": "fixture.independent_istft", "version": 1, "params": {}}]
 
 
@@ -94,7 +94,7 @@ def test_spectrogram_frame_public_istft_matches_independent_oracle(
             normalized_wandas.copy(),
             chunks=(1, normalized_wandas.shape[1], normalized_wandas.shape[2]),
         ),
-        sampling_rate=_FRAME_SAMPLING_RATE,
+        sampling_rate=_SAMPLING_RATE,
         n_fft=case.n_fft,
         hop_length=case.hop_length,
         win_length=case.win_length,
@@ -127,7 +127,7 @@ def test_spectrogram_frame_public_istft_matches_independent_oracle(
         assert actual._data.shape == expected_raw.shape
         assert actual._data.dtype == np.dtype(np.float64)
         assert actual.previous is frame
-        assert actual.sampling_rate == _FRAME_SAMPLING_RATE
+        assert actual.sampling_rate == _SAMPLING_RATE
         assert actual.label == "istft(independent-oracle)"
         assert actual.labels == frame.labels
         assert actual._channel_ids == channel_ids

--- a/tests/processing/istft_oracle_fixtures.py
+++ b/tests/processing/istft_oracle_fixtures.py
@@ -1,0 +1,82 @@
+"""Independent SciPy-domain fixtures shared by ISTFT contract tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.signal import ShortTimeFFT
+from scipy.signal.windows import get_window
+
+_SAMPLING_RATE = 8_000.0
+
+
+@dataclass(frozen=True)
+class _OracleCase:
+    """Small, invertible ShortTimeFFT configuration used by the oracle."""
+
+    n_fft: int
+    win_length: int
+    hop_length: int
+    window: str
+    n_frames: int = 5
+    channels: int = 1
+
+
+_CASES = (
+    _OracleCase(n_fft=16, win_length=16, hop_length=8, window="boxcar"),
+    _OracleCase(n_fft=16, win_length=12, hop_length=5, window="hann"),
+    _OracleCase(n_fft=15, win_length=15, hop_length=7, window="hann"),
+    _OracleCase(n_fft=15, win_length=11, hop_length=4, window="boxcar"),
+)
+
+
+def _make_independent_oracle(
+    case: _OracleCase,
+) -> tuple[ShortTimeFFT, np.ndarray, np.ndarray]:
+    """Build a SciPy-domain spectrum and its independent Wandas input form.
+
+    ``domain_spectrogram`` is the direct one-sided complex value consumed by
+    ``ShortTimeFFT.istft``.  It deliberately contains DC, interior bins, and an
+    endpoint bin.  Channel-dependent gain and phase make channel mixing visible.
+
+    The final array is converted to Wandas' stored peak-amplitude convention by
+    the explicit one-sided rule: for an even FFT only ``1:-1`` is doubled, while
+    for an odd FFT every positive-frequency bin ``1:`` is doubled.
+    """
+
+    scipy_sft = ShortTimeFFT(
+        win=np.asarray(get_window(case.window, case.win_length), dtype=np.float64),
+        hop=case.hop_length,
+        fs=_SAMPLING_RATE,
+        fft_mode="onesided",
+        mfft=case.n_fft,
+        scale_to="magnitude",
+    )
+    if not scipy_sft.invertible:
+        raise AssertionError(f"Oracle configuration is not invertible: {case!r}")
+
+    n_frequency_bins = case.n_fft // 2 + 1
+    channel_index = np.arange(case.channels, dtype=np.float64)[:, None, None]
+    frequency_index = np.arange(n_frequency_bins, dtype=np.float64)[None, :, None]
+    time_index = np.arange(case.n_frames, dtype=np.float64)[None, None, :]
+
+    channel_gain = 1.0 + 0.31 * channel_index
+    amplitude = channel_gain * (0.35 + 0.11 * frequency_index) * (1.0 + 0.07 * time_index)
+    phase = 0.17 * frequency_index + 0.31 * time_index + 0.43 * channel_index
+    domain_spectrogram = np.asarray(amplitude * np.exp(1j * phase), dtype=np.complex128)
+
+    # Real endpoint values are valid for a real-valued inverse and ensure that
+    # the even Nyquist endpoint is distinguishable from an odd final bin.
+    frame_values = np.arange(case.n_frames, dtype=np.float64)
+    domain_spectrogram[:, 0, :] = channel_gain[:, 0, 0, None] * (0.95 + 0.13 * frame_values)[None, :]
+    if case.n_fft % 2 == 0:
+        domain_spectrogram[:, -1, :] = channel_gain[:, 0, 0, None] * (0.65 + 0.09 * frame_values)[None, :]
+
+    normalized_wandas = domain_spectrogram.copy()
+    if case.n_fft % 2 == 0:
+        normalized_wandas[:, 1:-1, :] *= 2.0
+    else:
+        normalized_wandas[:, 1:, :] *= 2.0
+
+    return scipy_sft, domain_spectrogram, normalized_wandas

--- a/tests/processing/test_istft_independent_oracle.py
+++ b/tests/processing/test_istft_independent_oracle.py
@@ -1,0 +1,223 @@
+"""Independent numerical contracts for the public ISTFT operation.
+
+The spectra in this module are authored in SciPy's magnitude-scaled domain.  No
+Wandas forward transform or spectral normalization helper is involved in making
+the expected values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+import dask.array as da
+import numpy as np
+import pytest
+from dask.array.core import Array as DaArray
+from scipy.signal import ShortTimeFFT
+from scipy.signal.windows import get_window
+
+from wandas.processing import ISTFT
+
+_SAMPLING_RATE = 8_000.0
+
+
+@dataclass(frozen=True)
+class _OracleCase:
+    """Small, invertible ShortTimeFFT configuration used by the oracle."""
+
+    n_fft: int
+    win_length: int
+    hop_length: int
+    window: str
+    n_frames: int = 5
+    channels: int = 1
+
+
+_CASES = (
+    _OracleCase(n_fft=16, win_length=16, hop_length=8, window="boxcar"),
+    _OracleCase(n_fft=16, win_length=12, hop_length=5, window="hann"),
+    _OracleCase(n_fft=15, win_length=15, hop_length=7, window="hann"),
+    _OracleCase(n_fft=15, win_length=11, hop_length=4, window="boxcar"),
+)
+
+
+def _make_independent_oracle(
+    case: _OracleCase,
+) -> tuple[ShortTimeFFT, np.ndarray, np.ndarray]:
+    """Build a SciPy-domain spectrum and its independent Wandas input form.
+
+    ``domain_spectrogram`` is the direct one-sided complex value consumed by
+    ``ShortTimeFFT.istft``.  It deliberately contains DC, interior bins, and an
+    endpoint bin.  Channel-dependent gain and phase make channel mixing visible.
+
+    The final array is converted to Wandas' stored peak-amplitude convention by
+    the explicit one-sided rule: for an even FFT only ``1:-1`` is doubled, while
+    for an odd FFT every positive-frequency bin ``1:`` is doubled.
+    """
+
+    scipy_sft = ShortTimeFFT(
+        win=np.asarray(get_window(case.window, case.win_length), dtype=np.float64),
+        hop=case.hop_length,
+        fs=_SAMPLING_RATE,
+        fft_mode="onesided",
+        mfft=case.n_fft,
+        scale_to="magnitude",
+    )
+    if not scipy_sft.invertible:
+        raise AssertionError(f"Oracle configuration is not invertible: {case!r}")
+
+    n_frequency_bins = case.n_fft // 2 + 1
+    channel_index = np.arange(case.channels, dtype=np.float64)[:, None, None]
+    frequency_index = np.arange(n_frequency_bins, dtype=np.float64)[None, :, None]
+    time_index = np.arange(case.n_frames, dtype=np.float64)[None, None, :]
+
+    channel_gain = 1.0 + 0.31 * channel_index
+    amplitude = channel_gain * (0.35 + 0.11 * frequency_index) * (1.0 + 0.07 * time_index)
+    phase = 0.17 * frequency_index + 0.31 * time_index + 0.43 * channel_index
+    domain_spectrogram = np.asarray(amplitude * np.exp(1j * phase), dtype=np.complex128)
+
+    # Real endpoint values are valid for a real-valued inverse and ensure that
+    # the even Nyquist endpoint is distinguishable from an odd final bin.
+    frame_values = np.arange(case.n_frames, dtype=np.float64)
+    domain_spectrogram[:, 0, :] = channel_gain[:, 0, 0, None] * (0.95 + 0.13 * frame_values)[None, :]
+    if case.n_fft % 2 == 0:
+        domain_spectrogram[:, -1, :] = channel_gain[:, 0, 0, None] * (0.65 + 0.09 * frame_values)[None, :]
+
+    normalized_wandas = domain_spectrogram.copy()
+    if case.n_fft % 2 == 0:
+        normalized_wandas[:, 1:-1, :] *= 2.0
+    else:
+        normalized_wandas[:, 1:, :] *= 2.0
+
+    return scipy_sft, domain_spectrogram, normalized_wandas
+
+
+def _as_dask_input(values: np.ndarray) -> DaArray:
+    """Create the channel-first lazy input required by ``ISTFT.process``."""
+
+    return da.from_array(
+        values.copy(),
+        chunks=(1, values.shape[1], values.shape[2]),
+    )
+
+
+@pytest.mark.parametrize("case", _CASES)
+@pytest.mark.parametrize("channels", [1, 2])
+def test_istft_process_matches_independent_scipy_oracle(
+    case: _OracleCase,
+    channels: int,
+) -> None:
+    """ISTFT reconstructs the complete SciPy-domain inverse for mono/multi data."""
+
+    case = replace(case, channels=channels)
+    scipy_sft, scipy_domain, normalized_wandas = _make_independent_oracle(case)
+    expected = scipy_sft.istft(scipy_domain)
+    input_snapshot = normalized_wandas.copy()
+    lazy_input = _as_dask_input(normalized_wandas)
+
+    operation = ISTFT(
+        sampling_rate=_SAMPLING_RATE,
+        n_fft=case.n_fft,
+        hop_length=case.hop_length,
+        win_length=case.win_length,
+        window=case.window,
+    )
+    actual_lazy = operation.process(lazy_input)
+
+    assert isinstance(actual_lazy, DaArray)
+    assert actual_lazy.shape == expected.shape
+    assert actual_lazy.shape == operation.calculate_output_shape(lazy_input.shape)
+    assert actual_lazy.dtype == np.dtype(np.float64)
+    assert operation.length is None
+    assert operation.calculate_output_dtype(lazy_input.dtype) == np.dtype(np.float64)
+
+    actual = actual_lazy.compute()
+    np.testing.assert_allclose(actual, expected, rtol=2e-12, atol=2e-12)
+    np.testing.assert_array_equal(lazy_input.compute(), input_snapshot)
+    np.testing.assert_array_equal(normalized_wandas, input_snapshot)
+
+
+@pytest.mark.parametrize("case", _CASES)
+@pytest.mark.parametrize("channels", [1, 2])
+def test_istft_process_trims_only_at_the_operation_boundary(
+    case: _OracleCase,
+    channels: int,
+) -> None:
+    """An explicit operation length trims SciPy's full independent output."""
+
+    case = replace(case, channels=channels)
+    scipy_sft, scipy_domain, normalized_wandas = _make_independent_oracle(case)
+    expected_full = scipy_sft.istft(scipy_domain)
+    length = expected_full.shape[-1] - 3
+    expected = expected_full[..., :length]
+
+    operation = ISTFT(
+        sampling_rate=_SAMPLING_RATE,
+        n_fft=case.n_fft,
+        hop_length=case.hop_length,
+        win_length=case.win_length,
+        window=case.window,
+        length=length,
+    )
+    lazy_input = _as_dask_input(normalized_wandas)
+    actual_lazy = operation.process(lazy_input)
+
+    assert isinstance(actual_lazy, DaArray)
+    assert actual_lazy.shape == expected.shape
+    assert actual_lazy.shape == operation.calculate_output_shape(lazy_input.shape)
+    assert actual_lazy.dtype == np.dtype(np.float64)
+    np.testing.assert_allclose(actual_lazy.compute(), expected, rtol=2e-12, atol=2e-12)
+
+
+@pytest.mark.parametrize("case", _CASES)
+def test_independent_fixture_is_sensitive_to_istft_contract_mutations(case: _OracleCase) -> None:
+    """The fixture rejects scaling, endpoint, placement, phase, and gain mutations."""
+
+    case = replace(case, channels=2)
+    scipy_sft, scipy_domain, normalized_wandas = _make_independent_oracle(case)
+    expected = scipy_sft.istft(scipy_domain)
+    positive_bins = (
+        (slice(None), slice(1, -1), slice(None))
+        if case.n_fft % 2 == 0
+        else (
+            slice(None),
+            slice(1, None),
+            slice(None),
+        )
+    )
+
+    missing_peak_factor = scipy_domain.copy()
+    double_peak_factor = normalized_wandas.copy()
+    double_peak_factor[positive_bins] *= 2.0
+    double_denormalization = normalized_wandas.copy()
+    double_denormalization[positive_bins] /= 2.0
+
+    wrong_endpoint_parity = normalized_wandas.copy()
+    if case.n_fft % 2 == 0:
+        wrong_endpoint_parity[:, -1, :] *= 2.0
+    else:
+        wrong_endpoint_parity[:, -1, :] /= 2.0
+
+    mutations = {
+        "missing positive-frequency factor": missing_peak_factor,
+        "positive-frequency factor applied twice": double_peak_factor,
+        "positive-frequency bin divided twice": double_denormalization,
+        "wrong endpoint parity": wrong_endpoint_parity,
+        "frequency-bin shift": np.roll(normalized_wandas, 1, axis=1),
+        "discarded complex phase": np.abs(normalized_wandas).astype(np.complex128),
+        "wrong overall gain": normalized_wandas * 1.25,
+    }
+
+    for description, mutated_input in mutations.items():
+        actual = (
+            ISTFT(
+                sampling_rate=_SAMPLING_RATE,
+                n_fft=case.n_fft,
+                hop_length=case.hop_length,
+                win_length=case.win_length,
+                window=case.window,
+            )
+            .process(_as_dask_input(mutated_input))
+            .compute()
+        )
+        assert not np.allclose(actual, expected, rtol=2e-12, atol=2e-12), description

--- a/tests/processing/test_istft_independent_oracle.py
+++ b/tests/processing/test_istft_independent_oracle.py
@@ -7,89 +7,20 @@ the expected values.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import replace
 
 import dask.array as da
 import numpy as np
 import pytest
 from dask.array.core import Array as DaArray
-from scipy.signal import ShortTimeFFT
-from scipy.signal.windows import get_window
 
-from wandas.processing import ISTFT
-
-_SAMPLING_RATE = 8_000.0
-
-
-@dataclass(frozen=True)
-class _OracleCase:
-    """Small, invertible ShortTimeFFT configuration used by the oracle."""
-
-    n_fft: int
-    win_length: int
-    hop_length: int
-    window: str
-    n_frames: int = 5
-    channels: int = 1
-
-
-_CASES = (
-    _OracleCase(n_fft=16, win_length=16, hop_length=8, window="boxcar"),
-    _OracleCase(n_fft=16, win_length=12, hop_length=5, window="hann"),
-    _OracleCase(n_fft=15, win_length=15, hop_length=7, window="hann"),
-    _OracleCase(n_fft=15, win_length=11, hop_length=4, window="boxcar"),
+from tests.processing.istft_oracle_fixtures import (
+    _CASES,
+    _SAMPLING_RATE,
+    _make_independent_oracle,
+    _OracleCase,
 )
-
-
-def _make_independent_oracle(
-    case: _OracleCase,
-) -> tuple[ShortTimeFFT, np.ndarray, np.ndarray]:
-    """Build a SciPy-domain spectrum and its independent Wandas input form.
-
-    ``domain_spectrogram`` is the direct one-sided complex value consumed by
-    ``ShortTimeFFT.istft``.  It deliberately contains DC, interior bins, and an
-    endpoint bin.  Channel-dependent gain and phase make channel mixing visible.
-
-    The final array is converted to Wandas' stored peak-amplitude convention by
-    the explicit one-sided rule: for an even FFT only ``1:-1`` is doubled, while
-    for an odd FFT every positive-frequency bin ``1:`` is doubled.
-    """
-
-    scipy_sft = ShortTimeFFT(
-        win=np.asarray(get_window(case.window, case.win_length), dtype=np.float64),
-        hop=case.hop_length,
-        fs=_SAMPLING_RATE,
-        fft_mode="onesided",
-        mfft=case.n_fft,
-        scale_to="magnitude",
-    )
-    if not scipy_sft.invertible:
-        raise AssertionError(f"Oracle configuration is not invertible: {case!r}")
-
-    n_frequency_bins = case.n_fft // 2 + 1
-    channel_index = np.arange(case.channels, dtype=np.float64)[:, None, None]
-    frequency_index = np.arange(n_frequency_bins, dtype=np.float64)[None, :, None]
-    time_index = np.arange(case.n_frames, dtype=np.float64)[None, None, :]
-
-    channel_gain = 1.0 + 0.31 * channel_index
-    amplitude = channel_gain * (0.35 + 0.11 * frequency_index) * (1.0 + 0.07 * time_index)
-    phase = 0.17 * frequency_index + 0.31 * time_index + 0.43 * channel_index
-    domain_spectrogram = np.asarray(amplitude * np.exp(1j * phase), dtype=np.complex128)
-
-    # Real endpoint values are valid for a real-valued inverse and ensure that
-    # the even Nyquist endpoint is distinguishable from an odd final bin.
-    frame_values = np.arange(case.n_frames, dtype=np.float64)
-    domain_spectrogram[:, 0, :] = channel_gain[:, 0, 0, None] * (0.95 + 0.13 * frame_values)[None, :]
-    if case.n_fft % 2 == 0:
-        domain_spectrogram[:, -1, :] = channel_gain[:, 0, 0, None] * (0.65 + 0.09 * frame_values)[None, :]
-
-    normalized_wandas = domain_spectrogram.copy()
-    if case.n_fft % 2 == 0:
-        normalized_wandas[:, 1:-1, :] *= 2.0
-    else:
-        normalized_wandas[:, 1:, :] *= 2.0
-
-    return scipy_sft, domain_spectrogram, normalized_wandas
+from wandas.processing import ISTFT
 
 
 def _as_dask_input(values: np.ndarray) -> DaArray:
@@ -190,7 +121,8 @@ def test_independent_fixture_is_sensitive_to_istft_contract_mutations(case: _Ora
     double_peak_factor = normalized_wandas.copy()
     double_peak_factor[positive_bins] *= 2.0
     double_denormalization = normalized_wandas.copy()
-    double_denormalization[positive_bins] /= 2.0
+    # Applying the inverse peak-amplitude factor twice changes 2*D to D/2.
+    double_denormalization[positive_bins] /= 4.0
 
     wrong_endpoint_parity = normalized_wandas.copy()
     if case.n_fft % 2 == 0:


### PR DESCRIPTION
Closes #402
Related #391
Follow-up to PR #382 and PR #405
Follow-up context: PR #417

## Summary

Add an independent numerical ISTFT oracle without changing production code or the public API. The oracle directly authors one-sided complex SciPy-domain spectrograms and compares SciPy's inverse with Wandas ISTFT.

PR #405 already removed the fragile exact spectral-prose test and related editorial/documentation checks. This PR does not restore that test and adds no crawler, scanner, governance infrastructure, duplicate contract page, or documentation changes.

## Independent oracle

The shared test fixture in `tests/processing/istft_oracle_fixtures.py` constructs a fresh `scipy.signal.ShortTimeFFT(scale_to="magnitude", fft_mode="onesided")` and a complex one-sided spectrogram directly. It includes:

- DC, interior positive-frequency bins, and the even-`n_fft` Nyquist bin;
- the odd-`n_fft` final positive-frequency bin;
- five time frames;
- non-trivial real and imaginary values from known per-bin phase;
- channel-specific gain and phase for mono and multi-channel cases.

The expected value is always:

```python
expected = scipy_sft.istft(scipy_domain_spectrogram)
```

The fixture never calls Wandas STFT, `ChannelFrame.stft()`, Wandas normalization helpers, private ISTFT helpers, or Wandas output to create an expected value.

The test-only conversion to Wandas' stored peak-amplitude convention is explicit:

```python
normalized = scipy_domain.copy()

# even n_fft: DC and Nyquist unchanged; interior positive bins doubled
normalized[:, 1:-1, :] *= 2.0

# odd n_fft: DC unchanged; every positive bin, including the final bin, doubled
normalized[:, 1:, :] *= 2.0
```

Thus Wandas ISTFT receives the normalized input, while the SciPy oracle receives the original SciPy-domain values; denormalization is not applied twice to the expected side.

## Coverage

Operation-layer tests cover:

- even and odd `n_fft` (16 and 15);
- boxcar and Hann windows;
- full-window and shorter-window configurations with distinct hops;
- mono and multi-channel channel-first Dask inputs;
- `length=None` full output and explicit Operation `length` trimming;
- lazy Dask graph construction, input immutability, output dtype, `calculate_output_shape()`, and computed shape;
- complete SciPy output boundaries, without discarding edge samples.

Mutation-sensitive assertions show that the fixture rejects missing or repeated one-sided factors, double positive-bin denormalization, wrong even/odd endpoint handling, a frequency-bin shift, discarded complex phase, and incorrect overall gain.

Public Frame tests construct `SpectrogramFrame` directly from the independent normalized spectrogram and verify both `frame.istft()` and `frame.to_channel_frame()`. They cover the concrete `ChannelFrame` type, public mono/multi shapes, internal channel-first shapes, sampling rate, labels, IDs, unit/reference/calibration/extra, frame metadata, source-time offsets, `previous`, lineage, derived operation history, input immutability, and lazy construction.

Explicit `length` is tested only at the Operation layer because `SpectrogramFrame.istft()` is currently the no-argument alias of `to_channel_frame()`. This PR intentionally does not add a public Frame `length` parameter; that API extension should be a separate issue if needed.

## Audit and scope

The remaining spectral self-reference was audited narrowly:

- existing STFT-to-SciPy, FFT, Welch, and related numerical tests already use independent or analytical references;
- the existing STFT → ISTFT round-trip remains as a coupling test, but is no longer the ISTFT numerical oracle;
- existing shape, metadata, alias, lineage, Recipe, and WDF tests assert those contracts rather than numerical truth and were left unchanged;
- the remaining STFT-derived ISTFT shape/round-trip tests are not duplicated as independent numerical claims.

No production code, Recipe schema/version, WDF schema, dependency, public signature, or user documentation was changed.

## Validation

Base commit: `6ed7279a374ff3dcaa875ca00dd32525cf8d9a6b` (latest `main` after PR #417).

- Independent oracle tests: **24 passed**
- Related spectral/Frame/lazy metadata/Recipe/WDF tests: **441 passed**
- `uv run ruff check wandas tests scripts learning-path`: passed
- `uv run ruff format --check wandas tests scripts learning-path`: passed
- `uv run ty check wandas tests scripts learning-path`: passed
- `uv run python scripts/check_public_docstrings.py`: passed
- `uv run marimo check --strict learning-path/*.py`: passed
- `uv run mkdocs build --strict -f docs/mkdocs.yml`: passed
- `git diff --check`: passed

The local `uv run pytest -q` completed with **3149 passed, 3 skipped, and 2 failures**. Both failures are outside this diff and come from the pre-existing ignored local `learning-path/06_skill_validation.py`: its temporary-directory fixture path and its `.compute()` token are picked up by existing learning-path tests. The tracked PR diff contains three test-only files, including the shared oracle fixture; the affected ignored file is not staged or pushed.

## Independent review

A separate review agent reviewed fixed head `6f56e0f62952063e61dc45641205838f8c231592` against the Issue #402 acceptance criteria and returned **approve-equivalent with no actionable findings**. It confirmed oracle independence, parity-aware endpoints, mutation sensitivity, Operation and public Frame coverage, lazy/metadata/lineage preservation, no PR #405 prose-test revival, and no production/scope changes.

The subsequent GitHub review feedback was addressed by moving shared fixture construction out of a `test_*.py` module and making the double-denormalization mutation distinct (`2*D` becomes `D/2` via two inverse factors).

## Residual risk

The only local residual risk is the unrelated ignored learning-path artifact described above. The test-only change does not alter runtime ISTFT behavior; its purpose is to make future one-sided scaling, endpoint, bin placement, phase, gain, boundary, or trim regressions fail independently.