### PR TITLE
Define independent CSD and transfer-function contracts

### DIFF
--- a/docs/src/explanation/spectral-numerical-contracts.md
+++ b/docs/src/explanation/spectral-numerical-contracts.md
@@ -52,6 +52,13 @@ source-time offsets, and numerical fixtures use this same order. The source-time
 offset is the input-role offset because the input signal is the reference for a
 cross quantity or transfer denominator.
 
+The public CSD and coherence declarations are Recipe version 2 because their
+labels now spell out `(output, input)`. Recipe version 1 remains available for
+replay with the released reversed labels; its CSD/coherence numeric array is
+unchanged. Transfer version 1 likewise remains replay-only for its released
+output-axis denominator, while version 2 is the canonical input-denominator
+contract.
+
 ### Cross-spectrum / CSD
 
 `ChannelFrame.csd()` stores the complex one-sided quantity returned by the

--- a/docs/src/explanation/spectral-numerical-contracts.md
+++ b/docs/src/explanation/spectral-numerical-contracts.md
@@ -118,10 +118,15 @@ denominator remains a finite, potentially large gain. Non-finite inputs and
 results remain non-finite and are not clipped. Diagnostics, when added by a
 caller, must identify the affected input pair and frequency bin.
 
-A-weighting is unsupported for CSD and transfer quantities because there is no
-unambiguous generic choice of which channel(s) to weight or how many times to
-apply the weighting. Requests must fail explicitly rather than silently
-altering a pairwise value.
+A-weighting is unsupported for typed CSD and transfer quantities because there
+is no unambiguous generic choice of which channel(s) to weight or how many
+times to apply the weighting. The architecture-neutral
+`reject_pairwise_a_weighting()` helper is the enforcement hook for those
+consumers; requests must fail explicitly rather than silently altering a
+pairwise value. #401 intentionally does not route the current generic
+`SpectralFrame.dBA` or plot `Aw` paths through operation-history quantity
+inference. Those legacy paths remain unchanged until #406 supplies typed
+dispatch and enforces this rejection at the public pairwise API boundary.
 
 Issue #406 owns the typed plotting implementation. Its frequency and matrix
 projections should use linear `abs(P_out_in)` for CSD and linear

--- a/docs/src/explanation/spectral-numerical-contracts.md
+++ b/docs/src/explanation/spectral-numerical-contracts.md
@@ -30,6 +30,107 @@ Each channel's `channel_ref` comes from its calibration metadata. For example,
 For the amplitude results above, `dBA` adds the IEC 61672 A-weighting curve to
 that amplitude level; it does not change the underlying stored amplitude.
 
+## Pairwise spectral contracts
+
+The pairwise contracts below are the mathematical authority for the dedicated
+`CoherenceFrame`, `CrossSpectralFrame`, and `TransferFunctionFrame` planned in
+issue #406. The current generic `SpectralFrame` is not a semantic owner for
+these quantities; its amplitude `dB`, `dBA`, and `ifft` behavior must not be
+used to infer or render CSD or transfer meaning.
+
+### Ordered channel pairs
+
+For `n_channels` input channels, every pair uses output-major, input-minor
+ordering:
+
+```text
+pair_index = output_index * n_channels + input_index
+```
+
+The pair at that index is always `(output, input)`. Pair labels, role metadata,
+source-time offsets, and numerical fixtures use this same order. The source-time
+offset is the input-role offset because the input signal is the reference for a
+cross quantity or transfer denominator.
+
+### Cross-spectrum / CSD
+
+`ChannelFrame.csd()` stores the complex one-sided quantity returned by the
+SciPy-domain definition
+
+```python
+P_out_in = scipy.signal.csd(
+    x=input_signal,
+    y=output_signal,
+    ...,
+)[1]
+```
+
+Therefore `P_out_in` is conceptually `conj(X_input) * X_output`. Its phase is
+`angle(P_out_in)` in radians and its magnitude is `abs(P_out_in)`.
+
+| Scaling | Stored unit | Pair reference | Explicit level |
+| --- | --- | --- | --- |
+| `spectrum` | `input_unit * output_unit` | `input_ref * output_ref` | `10 * log10(abs(P_out_in) / pair_reference)` |
+| `density` | `input_unit * output_unit / Hz` | `input_ref * output_ref / Hz` (numeric reference per 1 Hz) | `10 * log10(abs(P_out_in) / pair_reference)` |
+
+For an auto-spectrum, the reference is the square of the channel amplitude
+reference, so the CSD power level equals the corresponding amplitude level:
+`10 * log10(abs(P) / ref**2) == 20 * log10(amplitude / ref)`. CSD must not use
+the generic amplitude `20 * log10` rule for cross values.
+
+### Transfer function
+
+The stored quantity is the complex ordered transfer ratio
+
+```python
+H_out_in = P_out_in / P_in_in
+```
+
+where `P_out_in` is the CSD above and `P_in_in` is the input auto-spectrum from
+`scipy.signal.welch(input_signal, ...)`, using the same spectral configuration.
+`H[output, input]` therefore means the response observed on `output` for the
+signal on `input`. Its magnitude is `abs(H_out_in)` and its phase is
+`angle(H_out_in)` in radians.
+
+| Quantity | Contract |
+| --- | --- |
+| Unit | `output_unit / input_unit` (`1` when the physical units are equal) |
+| Reference ratio | `output_ref / input_ref` |
+| Transfer level | `20 * log10(abs(H_out_in) / (output_ref / input_ref))` |
+| Same unit and same reference | Ordinary gain level `20 * log10(abs(H_out_in))` |
+
+For unlike units the result is a unit ratio, not a dimensionless gain. Its
+level is still defined only relative to the explicit output/input reference
+ratio.
+
+### Pairwise edge cases and plotting handoff
+
+An exact zero input auto-spectrum is not silently floored or regularized:
+the corresponding transfer value is complex NaN. A nonzero near-zero
+denominator remains a finite, potentially large gain. Non-finite inputs and
+results remain non-finite and are not clipped. Diagnostics, when added by a
+caller, must identify the affected input pair and frequency bin.
+
+A-weighting is unsupported for CSD and transfer quantities because there is no
+unambiguous generic choice of which channel(s) to weight or how many times to
+apply the weighting. Requests must fail explicitly rather than silently
+altering a pairwise value.
+
+Issue #406 owns the typed plotting implementation. Its frequency and matrix
+projections should use linear `abs(P_out_in)` for CSD and linear
+`abs(H_out_in)` for transfer by default, with unit-aware labels. Explicit phase
+views show radians. Explicit level views use the CSD `10 * log10` rule or the
+transfer `20 * log10` rule, respectively; A-weighting remains unsupported.
+
+The planned #406 property handoff is intentionally quantity-specific: a
+`CrossSpectralFrame` exposes raw complex `data`, `magnitude`, `phase`, and an
+explicit CSD `level_db`; a `TransferFunctionFrame` exposes raw complex `data`,
+`gain`, `phase`, `gain_db` for the ordinary same-unit gain case, and
+`transfer_level_db` for the explicit output/input reference ratio (including
+unlike units). Pair roles, `scaling`, derived unit, and reference remain typed
+Frame state. These names are a contract handoff for #406, not properties added
+to the current generic `SpectralFrame`.
+
 ## FFT inverse guarantee
 
 `SpectralFrame.ifft()` inverts Wandas' one-sided amplitude normalization. For a

--- a/tests/frames/test_channel_transform.py
+++ b/tests/frames/test_channel_transform.py
@@ -462,7 +462,7 @@ class TestChannelTransform:
 
     @pytest.mark.parametrize(
         ("method_name", "expected_version"),
-        [("coherence", 1), ("csd", 1), ("transfer_function", 2)],
+        [("coherence", 2), ("csd", 2), ("transfer_function", 2)],
     )
     def test_cross_channel_default_params_operation_lineage_matches_history(
         self,

--- a/tests/frames/test_channel_transform.py
+++ b/tests/frames/test_channel_transform.py
@@ -460,8 +460,15 @@ class TestChannelTransform:
 
         np.testing.assert_array_equal(csd_frame.source_time_offset, np.array([0.0, 5.0, 0.0, 5.0]))
 
-    @pytest.mark.parametrize("method_name", ["coherence", "csd", "transfer_function"])
-    def test_cross_channel_default_params_operation_lineage_matches_history(self, method_name: str) -> None:
+    @pytest.mark.parametrize(
+        ("method_name", "expected_version"),
+        [("coherence", 1), ("csd", 1), ("transfer_function", 2)],
+    )
+    def test_cross_channel_default_params_operation_lineage_matches_history(
+        self,
+        method_name: str,
+        expected_version: int,
+    ) -> None:
         cf = ChannelFrame.from_numpy(_DATA, _SAMPLE_RATE, metadata={"recording": "fixture"})
 
         result = getattr(cf, method_name)()
@@ -473,25 +480,25 @@ class TestChannelTransform:
         operation_id = f"wandas.audio.{method_name}"
         assert result.lineage.operation.operation_id == operation_id
         operation_record = result.operation_history[-1]
-        assert operation_record == {"operation": operation_id, "version": 1, "params": {}}
+        assert operation_record == {"operation": operation_id, "version": expected_version, "params": {}}
         assert not set(operation_record["params"]).intersection(result.metadata)
 
     @pytest.mark.parametrize(
         ("method_name", "expected_labels"),
         [
-            ("csd", ["csd(left, left)", "csd(right, left)", "csd(left, right)", "csd(right, right)"]),
+            ("csd", ["csd(left, left)", "csd(left, right)", "csd(right, left)", "csd(right, right)"]),
             (
                 "coherence",
                 [
                     "$\\gamma_{left, left}$",
-                    "$\\gamma_{right, left}$",
                     "$\\gamma_{left, right}$",
+                    "$\\gamma_{right, left}$",
                     "$\\gamma_{right, right}$",
                 ],
             ),
             (
                 "transfer_function",
-                ["$H_{left, left}$", "$H_{right, left}$", "$H_{left, right}$", "$H_{right, right}$"],
+                ["$H_{left, left}$", "$H_{left, right}$", "$H_{right, left}$", "$H_{right, right}$"],
             ),
         ],
     )
@@ -555,12 +562,16 @@ class TestChannelTransform:
         idx_100hz = np.argmin(np.abs(freq_bins - 100))
         idx_200hz = np.argmin(np.abs(freq_bins - 200))
 
-        # 入力から出力への伝達関数（インデックス1は入力->出力）
+        # 入力から出力への伝達関数は output-major/input-minor の index 2。
         # 主要周波数でのゲインがほぼ正確かチェック
-        h_in_to_out = tf_data[1]
+        h_in_to_out = tf_data[2]
         # rtol=0.2: Welch PSD estimation variance in transfer function
         assert np.isclose(np.abs(h_in_to_out[idx_100hz]), 2.0, rtol=0.2)
         assert np.isclose(np.abs(h_in_to_out[idx_200hz]), 1.5, rtol=0.2)
+
+        # 逆向きの pair は入力PSDを分母にするため、おおむね逆数になる。
+        h_out_to_in = tf_data[1]
+        assert np.isclose(np.abs(h_out_to_in[idx_100hz]), 0.5, rtol=0.2)
 
         # 自己伝達関数は約1.0になるはず
         assert np.isclose(np.abs(tf_data[0, idx_100hz]), 1.0, rtol=0.2)  # 入力->入力
@@ -575,8 +586,8 @@ class TestChannelTransform:
 
         expected_pairs = [
             f"$H_{{{ch0_label}, {ch0_label}}}$",
-            f"$H_{{{ch0_label}, {ch1_label}}}$",
             f"$H_{{{ch1_label}, {ch0_label}}}$",
+            f"$H_{{{ch0_label}, {ch1_label}}}$",
             f"$H_{{{ch1_label}, {ch1_label}}}$",
         ]
 

--- a/tests/pipeline/test_spectral_recipe_versions.py
+++ b/tests/pipeline/test_spectral_recipe_versions.py
@@ -10,6 +10,7 @@ import dask.array as da
 import numpy as np
 import pytest
 from dask.array.core import Array as DaArray
+from scipy.signal import csd as scipy_csd
 from scipy.signal import get_window
 from scipy.signal import welch as scipy_welch
 
@@ -22,18 +23,23 @@ from wandas.pipeline import RecipePlan, default_recipe_registry
 from wandas.pipeline.errors import RecipeExecutionError
 from wandas.processing import get_operation
 from wandas.processing.cepstral import Cepstrum, _RecipeCepstrumV1
-from wandas.processing.spectral import FFT, Welch, _RecipeFFTV1, _RecipeWelchV1
+from wandas.processing.spectral import FFT, TransferFunction, Welch, _RecipeFFTV1, _RecipeWelchV1
 
 _SAMPLING_RATE = 8_000
 _FLOOR = 1e-6
 
 
-def _source(values: np.ndarray, *, offset: float = 0.25) -> ChannelFrame:
+def _source(
+    values: np.ndarray,
+    *,
+    offset: float = 0.25,
+    sampling_rate: float = _SAMPLING_RATE,
+) -> ChannelFrame:
     """Build a lazy source with stable channel and recording metadata."""
     channel_count = values.shape[0]
     return ChannelFrame(
         data=da.from_array(values, chunks=(1, -1)),
-        sampling_rate=_SAMPLING_RATE,
+        sampling_rate=sampling_rate,
         label="recipe-source",
         metadata={"recording": {"take": "A"}},
         channel_metadata=[
@@ -375,6 +381,105 @@ def test_welch_oracle_checks_dc_internal_and_even_nyquist_bins() -> None:
     assert np.isclose(result[0, -1], 3.0)
 
 
+def test_transfer_function_recipe_v1_preserves_legacy_denominator_and_v2_corrects_it() -> None:
+    """A literal Recipe v1 payload keeps the released output-axis denominator."""
+    sampling_rate = 256.0
+    time = np.arange(256, dtype=float) / sampling_rate
+    values = np.stack(
+        [
+            np.sin(2 * np.pi * 16 * time) + 0.2 * np.cos(2 * np.pi * 40 * time),
+            2.75 * np.sin(2 * np.pi * 16 * time + 0.4) + 0.1 * np.cos(2 * np.pi * 40 * time),
+            0.35 * np.cos(2 * np.pi * 40 * time - 0.7) + 0.05 * np.sin(2 * np.pi * 16 * time),
+        ]
+    )
+    source = _source(values, offset=0.75, sampling_rate=sampling_rate)
+    params = {
+        "n_fft": 32,
+        "hop_length": 16,
+        "win_length": 32,
+        "window": "boxcar",
+        "detrend": "constant",
+        "scaling": "spectrum",
+        "average": "mean",
+    }
+    direct_v2 = source.transfer_function(**params)
+
+    released_payload = {
+        "schema": "wandas.recipe",
+        "version": 2,
+        "inputs": [{"id": "input-0", "name": "signal", "kind": "frame"}],
+        "nodes": [
+            {
+                "id": "node-0",
+                "operation": "wandas.audio.transfer_function",
+                "version": 1,
+                "inputs": ["input-0"],
+                "params": {
+                    "$type": "map",
+                    "entries": [
+                        ["average", "mean"],
+                        ["detrend", "constant"],
+                        ["hop_length", 16],
+                        ["n_fft", 32],
+                        ["scaling", "spectrum"],
+                        ["win_length", 32],
+                        ["window", "boxcar"],
+                    ],
+                },
+            }
+        ],
+        "output": "node-0",
+    }
+
+    with (
+        patch.object(DaArray, "compute", autospec=True) as compute,
+        patch.object(TransferFunction, "_process", side_effect=AssertionError("Recipe v1 invoked current TF")),
+    ):
+        replayed = RecipePlan.from_dict(released_payload).apply({"signal": source})
+        compute.assert_not_called()
+
+    def scipy_transfer(denominator_role: str) -> np.ndarray:
+        rows = []
+        for output_index in range(values.shape[0]):
+            for input_index in range(values.shape[0]):
+                _, cross = scipy_csd(
+                    values[input_index],
+                    values[output_index],
+                    fs=sampling_rate,
+                    nperseg=32,
+                    noverlap=16,
+                    nfft=32,
+                    window="boxcar",
+                    detrend="constant",
+                    scaling="spectrum",
+                    average="mean",
+                )
+                denominator_index = output_index if denominator_role == "output" else input_index
+                _, power = scipy_welch(
+                    values[denominator_index],
+                    fs=sampling_rate,
+                    nperseg=32,
+                    noverlap=16,
+                    nfft=32,
+                    window="boxcar",
+                    detrend="constant",
+                    scaling="spectrum",
+                    average="mean",
+                )
+                rows.append(cross / power)
+        return np.stack(rows)
+
+    expected_v1 = scipy_transfer("output")
+    expected_v2 = scipy_transfer("input")
+    np.testing.assert_allclose(channel_first_values(replayed), expected_v1, rtol=1e-12, atol=1e-12, equal_nan=True)
+    np.testing.assert_allclose(channel_first_values(direct_v2), expected_v2, rtol=1e-12, atol=1e-12, equal_nan=True)
+    assert not np.allclose(expected_v1, expected_v2, equal_nan=True)
+    assert replayed.operation_history[-1]["version"] == 1
+    assert direct_v2.operation_history[-1]["version"] == 2
+    assert isinstance(replayed._data, DaArray)
+    _assert_source_unchanged(source, values)
+
+
 def test_released_cepstrum_v1_payload_replays_legacy_window_before_padding() -> None:
     """A literal schema-2 payload preserves the released short-input cepstrum."""
     values = np.array([[1.0, 2.0, 3.0], [2.0, 1.0, 4.0]], dtype=np.float64)
@@ -534,10 +639,16 @@ def test_default_registry_contains_v1_and_v2_for_all_spectral_recipe_operations(
         "wandas.audio.fft",
         "wandas.audio.welch",
         "wandas.audio.cepstrum",
+        "wandas.audio.transfer_function",
     ):
         assert registry.require(operation_id, 1).version == 1
         assert registry.require(operation_id, 2).version == 2
 
-    for private_name in ("_recipe_fft_v1", "_recipe_welch_v1", "_recipe_cepstrum_v1"):
+    for private_name in (
+        "_recipe_fft_v1",
+        "_recipe_welch_v1",
+        "_recipe_cepstrum_v1",
+        "_recipe_transfer_function_v1",
+    ):
         with pytest.raises(ValueError, match="Unknown operation type"):
             get_operation(private_name)

--- a/tests/pipeline/test_spectral_recipe_versions.py
+++ b/tests/pipeline/test_spectral_recipe_versions.py
@@ -642,6 +642,104 @@ def test_public_cepstrum_v2_recipe_roundtrip_is_lazy_and_preserves_frame_contrac
     _assert_source_unchanged(source, np.array([[1.0, 2.0, 3.0], [2.0, 1.0, 4.0]], dtype=np.float64))
 
 
+@pytest.mark.parametrize(
+    ("operation_id", "method_name", "v1_labels", "v2_labels", "params"),
+    [
+        (
+            "wandas.audio.coherence",
+            "coherence",
+            [
+                r"$\gamma_{channel-0, channel-0}$",
+                r"$\gamma_{channel-1, channel-0}$",
+                r"$\gamma_{channel-0, channel-1}$",
+                r"$\gamma_{channel-1, channel-1}$",
+            ],
+            [
+                r"$\gamma_{channel-0, channel-0}$",
+                r"$\gamma_{channel-0, channel-1}$",
+                r"$\gamma_{channel-1, channel-0}$",
+                r"$\gamma_{channel-1, channel-1}$",
+            ],
+            {"n_fft": 32, "hop_length": 16, "win_length": 32, "window": "boxcar"},
+        ),
+        (
+            "wandas.audio.csd",
+            "csd",
+            [
+                "csd(channel-0, channel-0)",
+                "csd(channel-1, channel-0)",
+                "csd(channel-0, channel-1)",
+                "csd(channel-1, channel-1)",
+            ],
+            [
+                "csd(channel-0, channel-0)",
+                "csd(channel-0, channel-1)",
+                "csd(channel-1, channel-0)",
+                "csd(channel-1, channel-1)",
+            ],
+            {
+                "n_fft": 32,
+                "hop_length": 16,
+                "win_length": 32,
+                "window": "boxcar",
+                "scaling": "spectrum",
+            },
+        ),
+    ],
+)
+def test_pairwise_recipe_v1_preserves_released_label_order(
+    operation_id: str,
+    method_name: str,
+    v1_labels: list[str],
+    v2_labels: list[str],
+    params: dict[str, Any],
+) -> None:
+    """Schema-2 v1 replay keeps historical labels while v2 is canonical."""
+    sample_index = np.arange(256)
+    values = np.array(
+        [
+            np.sin(2 * np.pi * sample_index / 16),
+            1.5 * np.sin(2 * np.pi * sample_index / 16 + 0.3),
+        ],
+        dtype=float,
+    )
+    source = _source(values, sampling_rate=256.0)
+    direct_v2 = getattr(source, method_name)(**params)
+    released_payload = {
+        "schema": "wandas.recipe",
+        "version": 2,
+        "inputs": [{"id": "input-0", "name": "signal", "kind": "frame"}],
+        "nodes": [
+            {
+                "id": "node-0",
+                "operation": operation_id,
+                "version": 1,
+                "inputs": ["input-0"],
+                "params": {
+                    "$type": "map",
+                    "entries": [[name, value] for name, value in sorted(params.items())],
+                },
+            }
+        ],
+        "output": "node-0",
+    }
+
+    replayed = RecipePlan.from_dict(released_payload).apply({"signal": source})
+
+    np.testing.assert_allclose(
+        channel_first_values(replayed),
+        channel_first_values(direct_v2),
+        rtol=1e-12,
+        atol=1e-12,
+        equal_nan=True,
+    )
+    assert replayed.labels == v1_labels
+    assert direct_v2.labels == v2_labels
+    assert replayed.operation_history[-1]["version"] == 1
+    assert direct_v2.operation_history[-1]["version"] == 2
+    _assert_source_unchanged(source, values)
+
+
 def test_default_registry_contains_v1_and_v2_for_all_spectral_recipe_operations() -> None:
     """The immutable default registry exposes both persisted meanings."""
     registry = default_recipe_registry()
@@ -649,6 +747,8 @@ def test_default_registry_contains_v1_and_v2_for_all_spectral_recipe_operations(
         "wandas.audio.fft",
         "wandas.audio.welch",
         "wandas.audio.cepstrum",
+        "wandas.audio.coherence",
+        "wandas.audio.csd",
         "wandas.audio.transfer_function",
     ):
         assert registry.require(operation_id, 1).version == 1
@@ -658,6 +758,8 @@ def test_default_registry_contains_v1_and_v2_for_all_spectral_recipe_operations(
         "_recipe_fft_v1",
         "_recipe_welch_v1",
         "_recipe_cepstrum_v1",
+        "_coherence_recipe_v1",
+        "_csd_recipe_v1",
         "_recipe_transfer_function_v1",
     ):
         with pytest.raises(ValueError, match="Unknown operation type"):

--- a/tests/pipeline/test_spectral_recipe_versions.py
+++ b/tests/pipeline/test_spectral_recipe_versions.py
@@ -476,6 +476,16 @@ def test_transfer_function_recipe_v1_preserves_legacy_denominator_and_v2_correct
     assert not np.allclose(expected_v1, expected_v2, equal_nan=True)
     assert replayed.operation_history[-1]["version"] == 1
     assert direct_v2.operation_history[-1]["version"] == 2
+    assert replayed.labels == [
+        f"$H_{{{values_input}, {values_output}}}$"
+        for values_output in ("channel-0", "channel-1", "channel-2")
+        for values_input in ("channel-0", "channel-1", "channel-2")
+    ]
+    assert direct_v2.labels == [
+        f"$H_{{{values_output}, {values_input}}}$"
+        for values_output in ("channel-0", "channel-1", "channel-2")
+        for values_input in ("channel-0", "channel-1", "channel-2")
+    ]
     assert isinstance(replayed._data, DaArray)
     _assert_source_unchanged(source, values)
 

--- a/tests/processing/test_pairwise_spectral_contracts.py
+++ b/tests/processing/test_pairwise_spectral_contracts.py
@@ -441,6 +441,29 @@ def test_pairwise_operation_matches_independent_scipy_pairs(
     np.testing.assert_array_equal(input_data.compute(), input_snapshot)
 
 
+def test_transfer_operation_marks_exact_zero_input_psd_as_complex_nan() -> None:
+    """The operation applies the explicit zero-denominator policy per input pair."""
+    time = np.arange(128, dtype=float) / _SAMPLING_RATE
+    signals = np.stack([np.zeros_like(time), np.sin(2.0 * np.pi * 16.0 * time)])
+
+    actual = run_operation_eager(
+        _make_operation(
+            "transfer_function",
+            scaling="spectrum",
+            n_fft=32,
+            win_length=32,
+            hop_length=16,
+            window="boxcar",
+        ),
+        signals,
+    )
+
+    # Pair indices 0 and 2 have input_index=0 and therefore an exact zero PSD.
+    assert np.isnan(actual[[0, 2]].real).all()
+    assert np.isnan(actual[[0, 2]].imag).all()
+    assert np.isfinite(actual[[1, 3]]).all()
+
+
 def test_csd_oracle_preserves_complex_conjugate_relation_for_ordered_pairs() -> None:
     fixture = _make_fixture(3)
     matrix = _scipy_csd_matrix(

--- a/tests/processing/test_pairwise_spectral_contracts.py
+++ b/tests/processing/test_pairwise_spectral_contracts.py
@@ -334,6 +334,12 @@ def test_transfer_ratio_handles_zero_and_near_zero_denominators_without_flooring
     assert np.isfinite(result[:, 0, 1]).all()
     assert np.isnan(result[:, 1, 1].real).all()
     assert np.isnan(result[:, 1, 1].imag).all()
+    nonfinite_denominator = transfer_function_ratio(
+        np.ones((1, 1, 1), dtype=np.complex128),
+        np.array([[np.inf]], dtype=np.float64),
+    )
+    assert np.isnan(nonfinite_denominator.real).all()
+    assert np.isnan(nonfinite_denominator.imag).all()
     np.testing.assert_array_equal(cross, cross_before)
     np.testing.assert_array_equal(input_power, power_before)
 

--- a/tests/processing/test_pairwise_spectral_contracts.py
+++ b/tests/processing/test_pairwise_spectral_contracts.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal, cast
 from unittest.mock import patch
 
 import dask.array as da
@@ -21,9 +21,12 @@ from wandas.processing.spectral_contracts import (
     DerivedSpectralDomain,
     OrderedSpectralPair,
     SpectralChannelRole,
+    as_output_input_pairs,
     csd_level,
+    derive_coherence_domain,
     derive_csd_domain,
     derive_transfer_domain,
+    flatten_output_input_pairs,
     flatten_pair_index,
     reject_pairwise_a_weighting,
     transfer_function_ratio,
@@ -271,6 +274,79 @@ def test_spectral_roles_and_pairs_are_immutable_and_carry_physical_domains() -> 
         role.unit = "mV"  # ty: ignore[invalid-assignment]
     with pytest.raises((AttributeError, TypeError)):
         pair.input = role  # ty: ignore[invalid-assignment]
+
+
+def test_pairwise_contract_validation_edges_are_explicit() -> None:
+    """Pure contract values reject malformed roles, domains, and pair arrays."""
+    role = SpectralChannelRole(index=0, label="source", unit="Pa", reference=1.0)
+
+    for invalid_index in (True, 1.5, "0"):
+        with pytest.raises(TypeError, match="integer index"):
+            SpectralChannelRole(
+                index=cast(Any, invalid_index),
+                label="source",
+                unit="Pa",
+                reference=1.0,
+            )
+    with pytest.raises(TypeError, match="Channel label"):
+        SpectralChannelRole(index=0, label=cast(Any, 1), unit="Pa", reference=1.0)
+    with pytest.raises(TypeError, match="Channel unit"):
+        SpectralChannelRole(index=0, label="source", unit=cast(Any, 1), reference=1.0)
+    for invalid_reference in (True, "1"):
+        with pytest.raises(TypeError, match="positive finite"):
+            SpectralChannelRole(index=0, label="source", unit="Pa", reference=cast(Any, invalid_reference))
+    for invalid_reference in (0.0, -1.0, np.inf, np.nan):
+        with pytest.raises(ValueError, match="positive finite"):
+            SpectralChannelRole(index=0, label="source", unit="Pa", reference=invalid_reference)
+
+    with pytest.raises(ValueError, match="Channel count"):
+        OrderedSpectralPair(output=role, input=role, n_channels=0)
+    with pytest.raises(TypeError, match="requires SpectralChannelRole"):
+        OrderedSpectralPair(output=cast(Any, object()), input=role, n_channels=1)
+    out_of_range = SpectralChannelRole(index=1, label="output", unit="Pa", reference=1.0)
+    with pytest.raises(ValueError, match="Output channel index"):
+        OrderedSpectralPair(output=out_of_range, input=role, n_channels=1)
+    with pytest.raises(ValueError, match="Input channel index"):
+        OrderedSpectralPair(output=role, input=out_of_range, n_channels=1)
+    with pytest.raises(TypeError, match="Derived spectral unit"):
+        DerivedSpectralDomain(unit=cast(Any, 1), reference=1.0)
+
+    with pytest.raises(ValueError, match="Channel count"):
+        flatten_pair_index(0, 0, 0)
+    with pytest.raises(ValueError, match="Output channel index"):
+        flatten_pair_index(1, 0, 1)
+    with pytest.raises(ValueError, match="Input channel index"):
+        flatten_pair_index(0, 1, 1)
+
+    fixture = _make_fixture(3)
+    pair = _pair(fixture, output_index=1, input_index=0)
+    with pytest.raises(ValueError, match="scaling"):
+        derive_csd_domain(pair, "invalid")
+    assert derive_coherence_domain() == DerivedSpectralDomain(unit="1", reference=1.0)
+
+    output_only = OrderedSpectralPair(
+        output=SpectralChannelRole(index=0, label="output", unit="V", reference=2.0),
+        input=SpectralChannelRole(index=1, label="input", unit="", reference=4.0),
+        n_channels=2,
+    )
+    input_only = OrderedSpectralPair(
+        output=SpectralChannelRole(index=0, label="output", unit="", reference=2.0),
+        input=SpectralChannelRole(index=1, label="input", unit="V", reference=4.0),
+        n_channels=2,
+    )
+    assert derive_transfer_domain(output_only).unit == "V"
+    assert derive_transfer_domain(input_only).unit == "1/V"
+
+    with pytest.raises(ValueError, match="output and input axes"):
+        transfer_function_ratio(np.ones(2, dtype=np.complex128), np.ones(1))
+    with pytest.raises(ValueError, match="omit only the output axis"):
+        transfer_function_ratio(np.ones((2, 2, 3), dtype=np.complex128), np.ones((2, 3, 1)))
+    with pytest.raises(ValueError, match="one value per input channel"):
+        transfer_function_ratio(np.ones((2, 2, 3), dtype=np.complex128), np.ones((1, 3)))
+    with pytest.raises(ValueError, match="equal input and output axes"):
+        as_output_input_pairs(np.ones((2, 3, 4)))
+    with pytest.raises(ValueError, match="equal output and input axes"):
+        flatten_output_input_pairs(np.ones((2, 3, 4)))
 
 
 def test_derived_csd_domain_distinguishes_same_units_and_scaling() -> None:

--- a/tests/processing/test_pairwise_spectral_contracts.py
+++ b/tests/processing/test_pairwise_spectral_contracts.py
@@ -1,0 +1,562 @@
+"""Independent numerical and semantic contracts for pairwise spectra."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+from unittest.mock import patch
+
+import dask.array as da
+import numpy as np
+import pytest
+from dask.array.core import Array as DaArray
+from scipy import signal as ss
+
+from tests.frame_helpers import channel_first_values
+from tests.processing_helpers import run_operation_eager
+from wandas.frames.channel import ChannelFrame
+from wandas.frames.spectral import SpectralFrame
+from wandas.processing.spectral import CSD, TransferFunction
+from wandas.processing.spectral_contracts import (
+    DerivedSpectralDomain,
+    OrderedSpectralPair,
+    SpectralChannelRole,
+    csd_level,
+    derive_csd_domain,
+    derive_transfer_domain,
+    flatten_pair_index,
+    reject_pairwise_a_weighting,
+    transfer_function_ratio,
+    transfer_level,
+)
+
+_SAMPLING_RATE = 256.0
+_N_SAMPLES = 512
+_WINDOW = "hann"
+_DETREND = "constant"
+_AVERAGE = "mean"
+_SCALINGS = ("spectrum", "density")
+_WINDOWS = ("boxcar", "hann")
+_FFT_CONFIGS = ((32, 32, 16), (64, 32, 16))
+
+SpectralScaling = Literal["spectrum", "density"]
+
+
+@dataclass(frozen=True)
+class _OracleFixture:
+    """Physical signals and channel domains owned entirely by this test."""
+
+    signals: np.ndarray
+    labels: tuple[str, ...]
+    units: tuple[str, ...]
+    references: tuple[float, ...]
+
+    @property
+    def n_channels(self) -> int:
+        return self.signals.shape[0]
+
+
+def _make_fixture(n_channels: int) -> _OracleFixture:
+    """Build distinct delayed/gained channels without using Wandas helpers."""
+    if n_channels not in (2, 3):
+        raise ValueError("The independent fixture supports two or three channels")
+
+    time = np.arange(_N_SAMPLES, dtype=float) / _SAMPLING_RATE
+    rng = np.random.default_rng(402_110)
+    reference = (
+        0.15
+        + 1.1 * np.sin(2.0 * np.pi * 16.0 * time + 0.37)
+        + 0.45 * np.cos(2.0 * np.pi * 40.0 * time - 0.19)
+        + 0.02 * rng.standard_normal(_N_SAMPLES)
+    )
+    positive_delay = 2.25 * np.roll(reference, 3)
+    negative_delay = 0.65 * np.roll(reference, -2)
+
+    all_signals = np.stack([reference, positive_delay, negative_delay]).astype(np.float64)
+    return _OracleFixture(
+        signals=all_signals[:n_channels].copy(),
+        labels=("reference", "positive-delay", "negative-delay")[:n_channels],
+        units=("V", "Pa", "V")[:n_channels],
+        references=(2.0, 5.0, 3.0)[:n_channels],
+    )
+
+
+def _scipy_csd_matrix(
+    signals: np.ndarray,
+    *,
+    scaling: SpectralScaling,
+    n_fft: int,
+    win_length: int,
+    hop_length: int,
+    window: str,
+) -> np.ndarray:
+    """Compute each output/input CSD pair independently with SciPy."""
+    return np.asarray(
+        [
+            [
+                ss.csd(
+                    x=signals[input_index],
+                    y=signals[output_index],
+                    fs=_SAMPLING_RATE,
+                    nperseg=win_length,
+                    noverlap=win_length - hop_length,
+                    nfft=n_fft,
+                    window=window,
+                    detrend=_DETREND,
+                    scaling=scaling,
+                    average=_AVERAGE,
+                )[1]
+                for input_index in range(signals.shape[0])
+            ]
+            for output_index in range(signals.shape[0])
+        ]
+    )
+
+
+def _scipy_power_matrix(
+    signals: np.ndarray,
+    *,
+    scaling: SpectralScaling,
+    n_fft: int,
+    win_length: int,
+    hop_length: int,
+    window: str,
+) -> np.ndarray:
+    """Compute the input auto-spectrum independently for every channel."""
+    return np.asarray(
+        [
+            ss.welch(
+                x=signals[input_index],
+                fs=_SAMPLING_RATE,
+                nperseg=win_length,
+                noverlap=win_length - hop_length,
+                nfft=n_fft,
+                window=window,
+                detrend=_DETREND,
+                scaling=scaling,
+                average=_AVERAGE,
+            )[1]
+            for input_index in range(signals.shape[0])
+        ]
+    )
+
+
+def _scipy_transfer_matrix(
+    signals: np.ndarray,
+    *,
+    scaling: SpectralScaling,
+    n_fft: int,
+    win_length: int,
+    hop_length: int,
+    window: str,
+) -> np.ndarray:
+    """Compute H[output, input] from independent SciPy pair calls."""
+    return np.asarray(
+        [
+            [
+                ss.csd(
+                    x=signals[input_index],
+                    y=signals[output_index],
+                    fs=_SAMPLING_RATE,
+                    nperseg=win_length,
+                    noverlap=win_length - hop_length,
+                    nfft=n_fft,
+                    window=window,
+                    detrend=_DETREND,
+                    scaling=scaling,
+                    average=_AVERAGE,
+                )[1]
+                / ss.welch(
+                    x=signals[input_index],
+                    fs=_SAMPLING_RATE,
+                    nperseg=win_length,
+                    noverlap=win_length - hop_length,
+                    nfft=n_fft,
+                    window=window,
+                    detrend=_DETREND,
+                    scaling=scaling,
+                    average=_AVERAGE,
+                )[1]
+                for input_index in range(signals.shape[0])
+            ]
+            for output_index in range(signals.shape[0])
+        ]
+    )
+
+
+def _flatten_pair_matrix(matrix: np.ndarray) -> np.ndarray:
+    """Flatten an oracle matrix by explicit output-major/input-minor iteration."""
+    return np.stack(
+        [
+            matrix[output_index][input_index]
+            for output_index in range(matrix.shape[0])
+            for input_index in range(matrix.shape[1])
+        ]
+    )
+
+
+def _make_operation(
+    operation_name: str,
+    *,
+    scaling: SpectralScaling,
+    n_fft: int,
+    win_length: int,
+    hop_length: int,
+    window: str,
+) -> CSD | TransferFunction:
+    operation_type: type[CSD] | type[TransferFunction]
+    if operation_name == "csd":
+        operation_type = CSD
+    elif operation_name == "transfer_function":
+        operation_type = TransferFunction
+    else:
+        raise AssertionError(f"Unexpected pairwise operation: {operation_name}")
+    return operation_type(
+        _SAMPLING_RATE,
+        n_fft=n_fft,
+        win_length=win_length,
+        hop_length=hop_length,
+        window=window,
+        detrend=_DETREND,
+        scaling=scaling,
+        average=_AVERAGE,
+    )
+
+
+def _roles(fixture: _OracleFixture) -> tuple[SpectralChannelRole, ...]:
+    return tuple(
+        SpectralChannelRole(
+            index=index,
+            label=fixture.labels[index],
+            unit=fixture.units[index],
+            reference=fixture.references[index],
+        )
+        for index in range(fixture.n_channels)
+    )
+
+
+def _pair(fixture: _OracleFixture, output_index: int, input_index: int) -> OrderedSpectralPair:
+    roles = _roles(fixture)
+    return OrderedSpectralPair(
+        output=roles[output_index],
+        input=roles[input_index],
+        n_channels=fixture.n_channels,
+    )
+
+
+@pytest.mark.parametrize("n_channels", [2, 3], ids=lambda value: f"{value}ch")
+@pytest.mark.parametrize("output_index,input_index", [(0, 1), (1, 0)], ids=["out0-in1", "out1-in0"])
+def test_ordered_pair_contract_uses_output_major_indices(n_channels: int, output_index: int, input_index: int) -> None:
+    fixture = _make_fixture(n_channels)
+    pair = _pair(fixture, output_index, input_index)
+
+    assert pair.output.index == output_index
+    assert pair.input.index == input_index
+    assert pair.pair_index == output_index * n_channels + input_index
+    assert flatten_pair_index(output_index, input_index, n_channels) == pair.pair_index
+
+
+def test_spectral_roles_and_pairs_are_immutable_and_carry_physical_domains() -> None:
+    fixture = _make_fixture(3)
+    role = _roles(fixture)[1]
+    pair = _pair(fixture, 1, 0)
+
+    assert role.label == "positive-delay"
+    assert role.unit == "Pa"
+    assert role.reference == 5.0
+    assert pair.output == role
+    assert pair.input.index == 0
+
+    with pytest.raises((AttributeError, TypeError)):
+        role.unit = "mV"  # ty: ignore[invalid-assignment]
+    with pytest.raises((AttributeError, TypeError)):
+        pair.input = role  # ty: ignore[invalid-assignment]
+
+
+def test_derived_csd_domain_distinguishes_same_units_and_scaling() -> None:
+    fixture = _make_fixture(3)
+    different_units = _pair(fixture, output_index=1, input_index=0)
+    same_units = _pair(fixture, output_index=2, input_index=0)
+
+    spectrum = derive_csd_domain(different_units, "spectrum")
+    density = derive_csd_domain(different_units, "density")
+    same_unit_spectrum = derive_csd_domain(same_units, "spectrum")
+
+    assert isinstance(spectrum, DerivedSpectralDomain)
+    assert spectrum.unit == "V*Pa"
+    assert spectrum.reference == 10.0
+    assert density.unit == "V*Pa/Hz"
+    assert density.reference == spectrum.reference
+    assert same_unit_spectrum.unit == "V*V"
+    assert same_unit_spectrum.reference == 6.0
+
+
+def test_derived_transfer_domain_is_output_over_input() -> None:
+    fixture = _make_fixture(3)
+    different_units = derive_transfer_domain(_pair(fixture, output_index=1, input_index=0))
+    same_units = derive_transfer_domain(_pair(fixture, output_index=2, input_index=0))
+
+    assert different_units.unit == "Pa/V"
+    assert different_units.reference == 2.5
+    assert same_units.unit == "1"
+    assert same_units.reference == 1.5
+
+
+def test_pairwise_levels_use_quantity_appropriate_logarithms() -> None:
+    values = np.array([1.0 + 0.0j, 2.0 + 2.0j, 10.0 - 5.0j])
+    reference = 2.0
+
+    np.testing.assert_allclose(csd_level(values, reference), 10.0 * np.log10(np.abs(values) / reference))
+    np.testing.assert_allclose(transfer_level(values, reference), 20.0 * np.log10(np.abs(values) / reference))
+
+
+def test_pairwise_a_weighting_is_explicitly_rejected() -> None:
+    assert reject_pairwise_a_weighting(False) is None
+    with pytest.raises(ValueError, match="A-weighting"):
+        reject_pairwise_a_weighting(True)
+
+
+def test_transfer_ratio_handles_zero_and_near_zero_denominators_without_flooring() -> None:
+    cross = np.array(
+        [
+            [[2.0 + 1.0j, 3.0 - 4.0j], [5.0 + 2.0j, 7.0 - 1.0j]],
+            [[11.0 - 3.0j, 13.0 + 2.0j], [17.0 + 1.0j, 19.0 - 5.0j]],
+        ]
+    )
+    input_power = np.array([[2.0, 1.0e-12], [4.0, 0.0]])
+    cross_before = cross.copy()
+    power_before = input_power.copy()
+
+    result = transfer_function_ratio(cross, input_power)
+
+    np.testing.assert_allclose(result[:, 0, 0], cross[:, 0, 0] / 2.0)
+    np.testing.assert_allclose(result[:, 1, 0], cross[:, 1, 0] / 4.0)
+    assert np.isfinite(result[:, 0, 1]).all()
+    assert np.isnan(result[:, 1, 1].real).all()
+    assert np.isnan(result[:, 1, 1].imag).all()
+    np.testing.assert_array_equal(cross, cross_before)
+    np.testing.assert_array_equal(input_power, power_before)
+
+
+@pytest.mark.parametrize("scaling", _SCALINGS)
+def test_scipy_transfer_ratio_cancels_common_spectrum_density_scaling(scaling: SpectralScaling) -> None:
+    fixture = _make_fixture(3)
+    cross = _scipy_csd_matrix(
+        fixture.signals,
+        scaling=scaling,
+        n_fft=64,
+        win_length=32,
+        hop_length=16,
+        window=_WINDOW,
+    )
+    power = _scipy_power_matrix(
+        fixture.signals,
+        scaling=scaling,
+        n_fft=64,
+        win_length=32,
+        hop_length=16,
+        window=_WINDOW,
+    )
+    expected = _scipy_transfer_matrix(
+        fixture.signals,
+        scaling=scaling,
+        n_fft=64,
+        win_length=32,
+        hop_length=16,
+        window=_WINDOW,
+    )
+
+    actual = transfer_function_ratio(cross, power)
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-12, atol=1e-12, equal_nan=True)
+
+
+@pytest.mark.parametrize("n_channels", [2, 3], ids=lambda value: f"{value}ch")
+@pytest.mark.parametrize("operation_name", ["csd", "transfer_function"])
+@pytest.mark.parametrize("scaling", _SCALINGS)
+@pytest.mark.parametrize("window", _WINDOWS)
+@pytest.mark.parametrize(
+    "n_fft,win_length,hop_length",
+    _FFT_CONFIGS,
+    ids=["full-window-half-hop", "zero-padded-half-window"],
+)
+def test_pairwise_operation_matches_independent_scipy_pairs(
+    n_channels: int,
+    operation_name: str,
+    scaling: SpectralScaling,
+    window: str,
+    n_fft: int,
+    win_length: int,
+    hop_length: int,
+) -> None:
+    fixture = _make_fixture(n_channels)
+    if operation_name == "csd":
+        expected_matrix = _scipy_csd_matrix(
+            fixture.signals,
+            scaling=scaling,
+            n_fft=n_fft,
+            win_length=win_length,
+            hop_length=hop_length,
+            window=window,
+        )
+    else:
+        expected_matrix = _scipy_transfer_matrix(
+            fixture.signals,
+            scaling=scaling,
+            n_fft=n_fft,
+            win_length=win_length,
+            hop_length=hop_length,
+            window=window,
+        )
+    expected = _flatten_pair_matrix(expected_matrix)
+
+    operation = _make_operation(
+        operation_name,
+        scaling=scaling,
+        n_fft=n_fft,
+        win_length=win_length,
+        hop_length=hop_length,
+        window=window,
+    )
+    input_data = da.from_array(fixture.signals, chunks=(1, -1))
+    input_snapshot = fixture.signals.copy()
+    with patch.object(DaArray, "compute") as compute:
+        result = operation.process(input_data)
+        compute.assert_not_called()
+
+    expected_shape = (n_channels * n_channels, n_fft // 2 + 1)
+    assert result.shape == expected_shape
+    assert operation.calculate_output_shape(input_data.shape) == expected_shape
+    assert np.dtype(result.dtype) == np.dtype(np.complex128)
+    assert np.dtype(operation.calculate_output_dtype(input_data.dtype)) == np.dtype(np.complex128)
+
+    actual = result.compute()
+    np.testing.assert_allclose(actual, expected, rtol=1e-9, atol=1e-11, equal_nan=True)
+    np.testing.assert_array_equal(input_data.compute(), input_snapshot)
+
+
+def test_csd_oracle_preserves_complex_conjugate_relation_for_ordered_pairs() -> None:
+    fixture = _make_fixture(3)
+    matrix = _scipy_csd_matrix(
+        fixture.signals,
+        scaling="spectrum",
+        n_fft=64,
+        win_length=32,
+        hop_length=16,
+        window="boxcar",
+    )
+    actual = run_operation_eager(
+        CSD(
+            _SAMPLING_RATE,
+            n_fft=64,
+            win_length=32,
+            hop_length=16,
+            window="boxcar",
+            scaling="spectrum",
+            average=_AVERAGE,
+        ),
+        fixture.signals,
+    )
+
+    for output_index in range(fixture.n_channels):
+        for input_index in range(output_index):
+            np.testing.assert_allclose(matrix[output_index][input_index], np.conj(matrix[input_index][output_index]))
+    np.testing.assert_allclose(actual, _flatten_pair_matrix(matrix), rtol=1e-9, atol=1e-11)
+
+
+def test_transfer_oracle_covers_known_gain_signed_delay_and_inverse_pairs() -> None:
+    fixture = _make_fixture(3)
+    matrix = _scipy_transfer_matrix(
+        fixture.signals,
+        scaling="spectrum",
+        n_fft=64,
+        win_length=32,
+        hop_length=16,
+        window="boxcar",
+    )
+    frequencies = np.fft.rfftfreq(64, 1.0 / _SAMPLING_RATE)
+    tone_bins = [int(np.flatnonzero(np.isclose(frequencies, frequency))[0]) for frequency in (16.0, 40.0)]
+
+    for output_index, gain, delay in ((1, 2.25, 3), (2, 0.65, -2)):
+        expected_phase = gain * np.exp(-2j * np.pi * frequencies * delay / _SAMPLING_RATE)
+        np.testing.assert_allclose(matrix[output_index][0][tone_bins], expected_phase[tone_bins], rtol=1e-3, atol=1e-3)
+        np.testing.assert_allclose(
+            matrix[output_index][0][tone_bins] * matrix[0][output_index][tone_bins],
+            1.0,
+            rtol=1e-4,
+            atol=1e-4,
+        )
+
+    flattened = _flatten_pair_matrix(matrix)
+    assert not np.allclose(flattened[1], flattened[2])
+    assert not np.allclose(flattened[3], flattened[6])
+
+
+@pytest.mark.parametrize(
+    ("operation_name", "scaling"),
+    [("csd", "density"), ("transfer_function", "spectrum")],
+)
+def test_public_channel_pairwise_route_matches_independent_pairs(
+    operation_name: str,
+    scaling: SpectralScaling,
+) -> None:
+    """The current public route preserves the contract before #406 typed Frames."""
+    fixture = _make_fixture(3)
+    frame = ChannelFrame.from_numpy(fixture.signals, _SAMPLING_RATE, ch_labels=list(fixture.labels))
+    frame = frame.with_source_time_offset([0.25, 0.5, 0.75])
+
+    if operation_name == "csd":
+        expected_matrix = _scipy_csd_matrix(
+            fixture.signals,
+            scaling=scaling,
+            n_fft=64,
+            win_length=32,
+            hop_length=16,
+            window="hann",
+        )
+        expected_operation_version = 1
+    else:
+        expected_matrix = _scipy_transfer_matrix(
+            fixture.signals,
+            scaling=scaling,
+            n_fft=64,
+            win_length=32,
+            hop_length=16,
+            window="hann",
+        )
+        expected_operation_version = 2
+
+    with patch.object(DaArray, "compute") as compute:
+        result = getattr(frame, operation_name)(
+            n_fft=64,
+            win_length=32,
+            hop_length=16,
+            window="hann",
+            scaling=scaling,
+        )
+        compute.assert_not_called()
+
+    assert isinstance(result, SpectralFrame)
+    assert isinstance(result._data, DaArray)
+    assert result.previous is frame
+    assert result.sampling_rate == _SAMPLING_RATE
+    assert result.operation_history[-1]["version"] == expected_operation_version
+    np.testing.assert_array_equal(result.source_time_offset, np.array([0.25, 0.5, 0.75] * 3))
+    np.testing.assert_allclose(
+        channel_first_values(result),
+        _flatten_pair_matrix(expected_matrix),
+        rtol=1e-9,
+        atol=1e-11,
+        equal_nan=True,
+    )
+    expected_labels = [
+        (
+            f"csd({fixture.labels[output_index]}, {fixture.labels[input_index]})"
+            if operation_name == "csd"
+            else f"$H_{{{fixture.labels[output_index]}, {fixture.labels[input_index]}}}$"
+        )
+        for output_index in range(fixture.n_channels)
+        for input_index in range(fixture.n_channels)
+    ]
+    assert result.labels == expected_labels
+    np.testing.assert_array_equal(channel_first_values(frame), fixture.signals)

--- a/tests/processing/test_pairwise_spectral_contracts.py
+++ b/tests/processing/test_pairwise_spectral_contracts.py
@@ -543,7 +543,7 @@ def test_public_channel_pairwise_route_matches_independent_pairs(
             hop_length=16,
             window="hann",
         )
-        expected_operation_version = 1
+        expected_operation_version = 2
     else:
         expected_matrix = _scipy_transfer_matrix(
             fixture.signals,

--- a/tests/processing/test_pairwise_spectral_contracts.py
+++ b/tests/processing/test_pairwise_spectral_contracts.py
@@ -420,6 +420,163 @@ def test_transfer_ratio_handles_zero_and_near_zero_denominators_without_flooring
     np.testing.assert_array_equal(input_power, power_before)
 
 
+def test_transfer_function_distinguishes_input_output_roles_and_denominator_axis() -> None:
+    sampling_rate = 8.0
+
+    input_signal = np.array(
+        [1.0, 0.0, -1.0, 0.0, 1.0, 0.0, -1.0, 0.0],
+        dtype=np.float64,
+    )
+    output_signal = np.array(
+        [0.0, 2.0, 0.0, -2.0, 0.0, 2.0, 0.0, -2.0],
+        dtype=np.float64,
+    )
+    signals = np.stack([input_signal, output_signal])
+
+    n_fft = 8
+    win_length = 8
+    hop_length = 8
+    window = "boxcar"
+    detrend = "constant"
+    scaling = "spectrum"
+    average = "mean"
+    bin_index = 2
+    frequency = 2.0
+
+    h_00_index = flatten_pair_index(0, 0, 2)
+    h_01_index = flatten_pair_index(0, 1, 2)
+    h_10_index = flatten_pair_index(1, 0, 2)
+    h_11_index = flatten_pair_index(1, 1, 2)
+
+    operation = TransferFunction(
+        sampling_rate,
+        n_fft=n_fft,
+        win_length=win_length,
+        hop_length=hop_length,
+        window=window,
+        detrend=detrend,
+        scaling=scaling,
+        average=average,
+    )
+    actual = run_operation_eager(operation, signals)
+
+    expected = np.array(
+        [
+            1.0 + 0.0j,  # H[0, 0]
+            0.0 + 0.5j,  # H[0, 1]
+            0.0 - 2.0j,  # H[1, 0]
+            1.0 + 0.0j,  # H[1, 1]
+        ],
+        dtype=np.complex128,
+    )
+    np.testing.assert_allclose(
+        actual[:, bin_index],
+        expected,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        actual[[h_00_index, h_11_index], bin_index],
+        [1.0 + 0.0j, 1.0 + 0.0j],
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+    assert not np.isclose(
+        actual[h_01_index, bin_index],
+        actual[h_10_index, bin_index],
+    )
+    np.testing.assert_allclose(
+        actual[h_01_index, bin_index],
+        0.0 + 0.5j,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        actual[h_10_index, bin_index],
+        0.0 - 2.0j,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+    wrong_untransposed_flatten = np.array(
+        [
+            1.0 + 0.0j,
+            0.0 - 2.0j,
+            0.0 + 0.5j,
+            1.0 + 0.0j,
+        ],
+        dtype=np.complex128,
+    )
+    assert not np.allclose(
+        actual[:, bin_index],
+        wrong_untransposed_flatten,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+    wrong_output_denominator = np.array(
+        [
+            1.0 + 0.0j,
+            0.0 + 2.0j,
+            0.0 - 0.5j,
+            1.0 + 0.0j,
+        ],
+        dtype=np.complex128,
+    )
+    assert not np.allclose(
+        actual[:, bin_index],
+        wrong_output_denominator,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    assert not np.isclose(actual[h_01_index, bin_index], 0.0 + 2.0j)
+    assert not np.isclose(actual[h_10_index, bin_index], 0.0 - 0.5j)
+
+    scipy_params = {
+        "fs": sampling_rate,
+        "nperseg": win_length,
+        "noverlap": 0,
+        "nfft": n_fft,
+        "window": window,
+        "detrend": detrend,
+        "scaling": scaling,
+        "average": average,
+    }
+    frequencies, cross_10 = ss.csd(
+        x=input_signal,
+        y=output_signal,
+        **scipy_params,
+    )
+    _, power_00 = ss.welch(
+        x=input_signal,
+        **scipy_params,
+    )
+    _, cross_01 = ss.csd(
+        x=output_signal,
+        y=input_signal,
+        **scipy_params,
+    )
+    _, power_11 = ss.welch(
+        x=output_signal,
+        **scipy_params,
+    )
+
+    np.testing.assert_allclose(frequencies[bin_index], frequency)
+    np.testing.assert_allclose(power_00[bin_index], 0.5)
+    np.testing.assert_allclose(power_11[bin_index], 2.0)
+    np.testing.assert_allclose(cross_10[bin_index], -1.0j)
+    np.testing.assert_allclose(cross_01[bin_index], 1.0j)
+    np.testing.assert_allclose(
+        cross_10[bin_index] / power_00[bin_index],
+        -2.0j,
+    )
+    np.testing.assert_allclose(
+        cross_01[bin_index] / power_11[bin_index],
+        0.5j,
+    )
+
+
 @pytest.mark.parametrize("scaling", _SCALINGS)
 def test_scipy_transfer_ratio_cancels_common_spectrum_density_scaling(scaling: SpectralScaling) -> None:
     fixture = _make_fixture(3)

--- a/tests/processing/test_spectral_operations.py
+++ b/tests/processing/test_spectral_operations.py
@@ -1586,24 +1586,28 @@ class TestCSDOperation:
         assert operation.average == "median"
 
     def test_content_matches_scipy_csd(self) -> None:
-        """CSD matches ``scipy.signal.csd`` at float precision."""
+        """CSD matches independent SciPy calls for each ordered pair."""
         signal = _cross_spectral_pair()
         result = run_operation_eager(_csd_operation(), signal)
 
-        _, scipy_csd = ss.csd(
-            x=signal[:, np.newaxis, :],
-            y=signal[np.newaxis, :, :],
-            fs=_SR,
-            nperseg=_PAIRWISE_WINDOW_LENGTH,
-            noverlap=_PAIRWISE_WINDOW_LENGTH - _PAIRWISE_HOP_LENGTH,
-            nfft=_PAIRWISE_N_FFT,
-            window=_PAIRWISE_WINDOW,
-            detrend=_PAIRWISE_DETREND,
-            scaling=_PAIRWISE_SCALING,
-            average=_PAIRWISE_AVERAGE,
+        expected = np.stack(
+            [
+                ss.csd(
+                    x=signal[input_index],
+                    y=signal[output_index],
+                    fs=_SR,
+                    nperseg=_PAIRWISE_WINDOW_LENGTH,
+                    noverlap=_PAIRWISE_WINDOW_LENGTH - _PAIRWISE_HOP_LENGTH,
+                    nfft=_PAIRWISE_N_FFT,
+                    window=_PAIRWISE_WINDOW,
+                    detrend=_PAIRWISE_DETREND,
+                    scaling=_PAIRWISE_SCALING,
+                    average=_PAIRWISE_AVERAGE,
+                )[1]
+                for output_index in range(signal.shape[0])
+                for input_index in range(signal.shape[0])
+            ]
         )
-        expected = scipy_csd.transpose(1, 0, 2).reshape(-1, scipy_csd.shape[-1])
-        # rtol=1e-6: wrapper equivalence with scipy.signal.csd.
         np.testing.assert_allclose(result, expected, rtol=1e-6)
 
     def test_auto_spectrum_peaks_at_signal_frequency(self) -> None:
@@ -1647,44 +1651,45 @@ class TestTransferFunctionOperation:
         signal_bin = np.argmin(np.abs(frequency_bins - 1000))
 
         # rtol=0.2: deterministic noise and spectral leakage around the target bin.
-        np.testing.assert_allclose(np.abs(result[1, signal_bin]), 2.0, rtol=0.2)
+        np.testing.assert_allclose(np.abs(result[2, signal_bin]), 2.0, rtol=0.2)
         np.testing.assert_allclose(np.abs(result[0, signal_bin]), 1.0, rtol=0.2)
         np.testing.assert_allclose(np.abs(result[3, signal_bin]), 1.0, rtol=0.2)
-        np.testing.assert_allclose(np.abs(result[2, signal_bin]), 0.5, rtol=0.2)
+        np.testing.assert_allclose(np.abs(result[1, signal_bin]), 0.5, rtol=0.2)
 
     def test_content_matches_scipy_csd_welch_ratio(self) -> None:
-        """Transfer function matches a direct SciPy CSD/PSD ratio."""
+        """Transfer function matches independent SciPy CSD/PSD pair ratios."""
         signal = _transfer_pair()
         result = run_operation_eager(_transfer_function_operation(), signal)
 
-        _, cross_spectrum = ss.csd(
-            x=signal[:, np.newaxis, :],
-            y=signal[np.newaxis, :, :],
-            fs=_SR,
-            nperseg=_PAIRWISE_WINDOW_LENGTH,
-            noverlap=_PAIRWISE_WINDOW_LENGTH - _PAIRWISE_HOP_LENGTH,
-            nfft=_PAIRWISE_N_FFT,
-            window=_PAIRWISE_WINDOW,
-            detrend=_PAIRWISE_DETREND,
-            scaling=_PAIRWISE_SCALING,
-            average=_PAIRWISE_AVERAGE,
-            axis=-1,
+        expected = np.stack(
+            [
+                ss.csd(
+                    x=signal[input_index],
+                    y=signal[output_index],
+                    fs=_SR,
+                    nperseg=_PAIRWISE_WINDOW_LENGTH,
+                    noverlap=_PAIRWISE_WINDOW_LENGTH - _PAIRWISE_HOP_LENGTH,
+                    nfft=_PAIRWISE_N_FFT,
+                    window=_PAIRWISE_WINDOW,
+                    detrend=_PAIRWISE_DETREND,
+                    scaling=_PAIRWISE_SCALING,
+                    average=_PAIRWISE_AVERAGE,
+                )[1]
+                / ss.welch(
+                    signal[input_index],
+                    fs=_SR,
+                    nperseg=_PAIRWISE_WINDOW_LENGTH,
+                    noverlap=_PAIRWISE_WINDOW_LENGTH - _PAIRWISE_HOP_LENGTH,
+                    nfft=_PAIRWISE_N_FFT,
+                    window=_PAIRWISE_WINDOW,
+                    detrend=_PAIRWISE_DETREND,
+                    scaling=_PAIRWISE_SCALING,
+                    average=_PAIRWISE_AVERAGE,
+                )[1]
+                for output_index in range(signal.shape[0])
+                for input_index in range(signal.shape[0])
+            ]
         )
-        _, power_spectrum = ss.welch(
-            x=signal,
-            fs=_SR,
-            nperseg=_PAIRWISE_WINDOW_LENGTH,
-            noverlap=_PAIRWISE_WINDOW_LENGTH - _PAIRWISE_HOP_LENGTH,
-            nfft=_PAIRWISE_N_FFT,
-            window=_PAIRWISE_WINDOW,
-            detrend=_PAIRWISE_DETREND,
-            scaling=_PAIRWISE_SCALING,
-            average=_PAIRWISE_AVERAGE,
-            axis=-1,
-        )
-        transfer = cross_spectrum / power_spectrum[np.newaxis, :, :]
-        expected = transfer.transpose(1, 0, 2).reshape(-1, transfer.shape[-1])
-        # rtol=1e-6: wrapper equivalence with the same SciPy algorithms.
         np.testing.assert_allclose(result, expected, rtol=1e-6)
 
 

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -508,7 +508,7 @@ class ChannelTransformMixin:
             previous=self._as_base_frame,
         )
 
-    @recipe_operation("wandas.audio.coherence")
+    @recipe_operation("wandas.audio.coherence", version=2)
     def coherence(
         self: TransformFrameProtocol,
         n_fft: int = 2048,
@@ -541,7 +541,28 @@ class ChannelTransformMixin:
             detrend=detrend,
         )
 
-    @recipe_operation("wandas.audio.csd")
+    @recipe_operation("wandas.audio.coherence", version=1)
+    def _coherence_recipe_v1(
+        self: TransformFrameProtocol,
+        n_fft: int = 2048,
+        hop_length: int | None = None,
+        win_length: int | None = None,
+        window: str = "hann",
+        detrend: str = "constant",
+    ) -> "SpectralFrame":
+        """Replay the released coherence pair-label order."""
+        return self._cross_channel_spectral_transform(
+            "coherence",
+            "Coherence of",
+            "$\\gamma_{{{in_label}, {out_label}}}$",
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            detrend=detrend,
+        )
+
+    @recipe_operation("wandas.audio.csd", version=2)
     def csd(
         self: TransformFrameProtocol,
         n_fft: int = 2048,
@@ -571,6 +592,31 @@ class ChannelTransformMixin:
             "csd",
             "CSD of",
             "csd({out_label}, {in_label})",
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            detrend=detrend,
+            scaling=scaling,
+            average=average,
+        )
+
+    @recipe_operation("wandas.audio.csd", version=1)
+    def _csd_recipe_v1(
+        self: TransformFrameProtocol,
+        n_fft: int = 2048,
+        hop_length: int | None = None,
+        win_length: int | None = None,
+        window: str = "hann",
+        detrend: str = "constant",
+        scaling: str = "spectrum",
+        average: str = "mean",
+    ) -> "SpectralFrame":
+        """Replay the released CSD pair-label order."""
+        return self._cross_channel_spectral_transform(
+            "csd",
+            "CSD of",
+            "csd({in_label}, {out_label})",
             n_fft=n_fft,
             hop_length=hop_length,
             win_length=win_length,

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -652,7 +652,7 @@ class ChannelTransformMixin:
         return self._cross_channel_spectral_transform(
             "transfer_function",
             "Transfer function of",
-            "$H_{{{out_label}, {in_label}}}$",
+            "$H_{{{in_label}, {out_label}}}$",
             operation_override=operation,
             n_fft=n_fft,
             hop_length=hop_length,

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -27,7 +27,7 @@ def _build_cross_channel_metadata(
     operation_name: str,
     label_template: str,
 ) -> list[Any]:
-    """Build channel metadata for cross-channel operations (coherence, csd, tf).
+    """Build channel metadata for cross-channel spectral operations.
 
     Args:
         channel_metadata: list. Input channel metadata list.
@@ -86,6 +86,7 @@ class ChannelTransformMixin:
         operation_name: str,
         label_prefix: str,
         label_template: str,
+        operation_override: Any | None = None,
         **params: Any,
     ) -> "SpectralFrame":
         """Shared implementation for cross-channel spectral transforms.
@@ -98,16 +99,16 @@ class ChannelTransformMixin:
 
         logger.debug(f"Applying operation={operation_name} with params={params} (lazy)")
 
-        operation = create_operation(operation_name, self.sampling_rate, **params)
+        operation = (
+            operation_override
+            if operation_override is not None
+            else create_operation(operation_name, self.sampling_rate, **params)
+        )
         result_data = operation.process(self._effective_data)
 
         logger.debug(f"Created new SpectralFrame with operation {operation_name} added to graph")
 
-        channel_metadata = _build_cross_channel_metadata(
-            self._channel_metadata,
-            operation_name,
-            label_template,
-        )
+        channel_metadata = _build_cross_channel_metadata(self._channel_metadata, operation_name, label_template)
 
         operation_params = operation.to_params()
         n_fft = operation_params["n_fft"]
@@ -534,7 +535,7 @@ class ChannelTransformMixin:
         return self._cross_channel_spectral_transform(
             "coherence",
             "Coherence of",
-            "$\\gamma_{{{in_label}, {out_label}}}$",
+            "$\\gamma_{{{out_label}, {in_label}}}$",
             n_fft=n_fft,
             hop_length=hop_length,
             win_length=win_length,
@@ -571,7 +572,7 @@ class ChannelTransformMixin:
         return self._cross_channel_spectral_transform(
             "csd",
             "CSD of",
-            "csd({in_label}, {out_label})",
+            "csd({out_label}, {in_label})",
             n_fft=n_fft,
             hop_length=hop_length,
             win_length=win_length,
@@ -581,7 +582,7 @@ class ChannelTransformMixin:
             average=average,
         )
 
-    @recipe_operation("wandas.audio.transfer_function")
+    @recipe_operation("wandas.audio.transfer_function", version=2)
     def transfer_function(
         self: TransformFrameProtocol,
         n_fft: int = 2048,
@@ -614,7 +615,45 @@ class ChannelTransformMixin:
         return self._cross_channel_spectral_transform(
             "transfer_function",
             "Transfer function of",
-            "$H_{{{in_label}, {out_label}}}$",
+            "$H_{{{out_label}, {in_label}}}$",
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            detrend=detrend,
+            scaling=scaling,
+            average=average,
+        )
+
+    @recipe_operation("wandas.audio.transfer_function", version=1)
+    def _transfer_function_recipe_v1(
+        self: TransformFrameProtocol,
+        n_fft: int = 2048,
+        hop_length: int | None = None,
+        win_length: int | None = None,
+        window: str = "hann",
+        detrend: str = "constant",
+        scaling: str = "spectrum",
+        average: str = "mean",
+    ) -> "SpectralFrame":
+        """Replay the released transfer-function denominator contract."""
+        from wandas.processing.spectral import _RecipeTransferFunctionV1
+
+        operation = _RecipeTransferFunctionV1(
+            self.sampling_rate,
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            detrend=detrend,
+            scaling=scaling,
+            average=average,
+        )
+        return self._cross_channel_spectral_transform(
+            "transfer_function",
+            "Transfer function of",
+            "$H_{{{out_label}, {in_label}}}$",
+            operation_override=operation,
             n_fft=n_fft,
             hop_length=hop_length,
             win_length=win_length,

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -24,14 +24,12 @@ logger = logging.getLogger(__name__)
 
 def _build_cross_channel_metadata(
     channel_metadata: list[Any],
-    operation_name: str,
     label_template: str,
 ) -> list[Any]:
     """Build channel metadata for cross-channel spectral operations.
 
     Args:
         channel_metadata: list. Input channel metadata list.
-        operation_name: str. Operation name for the metadata dict key.
         label_template: str. Format string with ``{in_label}`` and ``{out_label}`` placeholders.
     """
     from wandas.core.metadata import ChannelMetadata
@@ -108,7 +106,7 @@ class ChannelTransformMixin:
 
         logger.debug(f"Created new SpectralFrame with operation {operation_name} added to graph")
 
-        channel_metadata = _build_cross_channel_metadata(self._channel_metadata, operation_name, label_template)
+        channel_metadata = _build_cross_channel_metadata(self._channel_metadata, label_template)
 
         operation_params = operation.to_params()
         n_fft = operation_params["n_fft"]

--- a/wandas/frames/mixins/protocols.py
+++ b/wandas/frames/mixins/protocols.py
@@ -150,6 +150,7 @@ class TransformFrameProtocol(BaseFrameProtocol, Protocol):
         operation_name: str,
         label_prefix: str,
         label_template: str,
+        operation_override: Any | None = None,
         **params: Any,
     ) -> SpectralFrame: ...
 

--- a/wandas/processing/spectral.py
+++ b/wandas/processing/spectral.py
@@ -9,6 +9,11 @@ from scipy.signal import ShortTimeFFT
 from scipy.signal.windows import get_window
 
 from wandas.processing.base import AudioOperation, ChannelIndependentAudioOperation, register_operation
+from wandas.processing.spectral_contracts import (
+    as_output_input_pairs,
+    flatten_output_input_pairs,
+    transfer_function_ratio,
+)
 from wandas.utils.optional_imports import require_mosqito_center_freq, require_mosqito_sound_level_meter
 from wandas.utils.types import NDArrayComplex, NDArrayReal
 
@@ -1187,8 +1192,8 @@ class Coherence(_CrossSpectralBase):
             detrend=self.detrend,
         )
 
-        # Reshape result to (n_channels * n_channels, n_freqs)
-        result: NDArrayReal = coh.transpose(1, 0, 2).reshape(-1, coh.shape[-1])
+        # SciPy returns (input, output, frequency); expose output-major pairs.
+        result: NDArrayReal = flatten_output_input_pairs(as_output_input_pairs(coh))
 
         logger.debug(f"Coherence estimation applied, result shape: {result.shape}")
         return result
@@ -1263,8 +1268,8 @@ class CSD(_ScaledCrossSpectralBase):
             average=self.average,
         )
 
-        # Reshape result to (n_channels * n_channels, n_freqs)
-        result: NDArrayComplex = csd_result.transpose(1, 0, 2).reshape(-1, csd_result.shape[-1])
+        # SciPy returns (input, output, frequency); expose output-major pairs.
+        result: NDArrayComplex = flatten_output_input_pairs(as_output_input_pairs(csd_result))
 
         logger.debug(f"CSD estimation applied, result shape: {result.shape}")
         return result
@@ -1296,7 +1301,7 @@ class TransferFunction(_ScaledCrossSpectralBase):
             average=self.average,
             axis=-1,
         )
-        # p_yx shape: (num_channels, num_channels, num_frequencies)
+        # p_yx shape: (input, output, frequency)
 
         # Calculate power spectral density for each channel
         _f, p_xx = ss.welch(
@@ -1313,12 +1318,59 @@ class TransferFunction(_ScaledCrossSpectralBase):
         )
         # p_xx shape: (num_channels, num_frequencies)
 
-        # Calculate transfer function H(f) = P_yx / P_xx
-        h_f = p_yx / p_xx[np.newaxis, :, :]
-        result: NDArrayComplex = h_f.transpose(1, 0, 2).reshape(-1, h_f.shape[-1])
+        # Calculate H[output, input] = P_out_in / P_in_in. Exact zero
+        # denominators remain complex NaN; nonzero near-zero bins are untouched.
+        h_f = transfer_function_ratio(as_output_input_pairs(p_yx), p_xx)
+        result: NDArrayComplex = flatten_output_input_pairs(h_f)
 
         logger.debug(f"Transfer function estimation applied, result shape: {result.shape}")
         return result
+
+
+class _RecipeTransferFunctionV1(TransferFunction):
+    """Released Recipe v1 transfer denominator contract.
+
+    Recipe v1 exposed output-major pair labels but divided each cross-spectrum
+    by the PSD selected from the output axis.  Keep that numerical behavior
+    available only for replay; the public operation uses
+    :class:`TransferFunction` above and divides by the input PSD.
+    """
+
+    name = "_recipe_transfer_function_v1"
+    _display = "H Recipe v1"
+
+    def _process(self, x: NDArrayReal) -> NDArrayComplex:
+        """Reproduce the released output-axis broadcast exactly."""
+        logger.debug(f"Applying Recipe v1 transfer function to array with shape: {x.shape}")
+        from scipy import signal as ss
+
+        _f, p_yx = ss.csd(
+            x=x[:, np.newaxis, :],
+            y=x[np.newaxis, :, :],
+            fs=self.sampling_rate,
+            nperseg=self.win_length,
+            noverlap=self.noverlap,
+            nfft=self.n_fft,
+            window=self.window,
+            detrend=self.detrend,
+            scaling=self.scaling,
+            average=self.average,
+            axis=-1,
+        )
+        _f, p_xx = ss.welch(
+            x=x,
+            fs=self.sampling_rate,
+            nperseg=self.win_length,
+            noverlap=self.noverlap,
+            nfft=self.n_fft,
+            window=self.window,
+            detrend=self.detrend,
+            scaling=self.scaling,
+            average=self.average,
+            axis=-1,
+        )
+        h_f = p_yx / p_xx[np.newaxis, :, :]
+        return h_f.transpose(1, 0, 2).reshape(-1, h_f.shape[-1])
 
 
 # Register all operations

--- a/wandas/processing/spectral_contracts.py
+++ b/wandas/processing/spectral_contracts.py
@@ -210,7 +210,9 @@ def transfer_function_ratio(
         np.nan + 1j * np.nan,
         dtype=np.result_type(cross.dtype, np.complex64),
     )
-    valid = np.broadcast_to(denominator != 0, cross.shape)
+    # Non-finite denominator values are undefined rather than a reason to let
+    # IEEE division silently turn ``cross / inf`` into a plausible zero.
+    valid = np.broadcast_to((denominator != 0) & np.isfinite(denominator), cross.shape)
     with np.errstate(divide="ignore", invalid="ignore"):
         np.divide(cross, denominator, out=result, where=valid)
     return result

--- a/wandas/processing/spectral_contracts.py
+++ b/wandas/processing/spectral_contracts.py
@@ -1,0 +1,251 @@
+"""Architecture-neutral contracts for ordered pairwise spectra.
+
+The concrete Frame types for pairwise quantities are tracked separately in
+Issue #406.  This module owns only immutable channel roles, pair ordering,
+derived linear-domain metadata, level formulas, and transfer-ratio edge-case
+handling so those rules can be shared without making ``SpectralFrame`` infer a
+quantity from lineage or display labels.
+"""
+
+from __future__ import annotations
+
+import numbers
+from dataclasses import dataclass
+from typing import Literal, cast
+
+import numpy as np
+
+from wandas.utils.types import NDArrayComplex, NDArrayReal
+
+SpectralScaling = Literal["spectrum", "density"]
+
+
+def _normalize_index(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, numbers.Integral):
+        raise TypeError(f"{name} must be an integer index")
+    return int(value)
+
+
+def _normalize_reference(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        raise TypeError(f"{name} must be a positive finite number")
+    reference = float(value)
+    if not np.isfinite(reference) or reference <= 0:
+        raise ValueError(f"{name} must be a positive finite number")
+    return reference
+
+
+@dataclass(frozen=True, slots=True)
+class SpectralChannelRole:
+    """Immutable channel identity used by a pairwise spectral quantity."""
+
+    index: int
+    label: str
+    unit: str
+    reference: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "index", _normalize_index(self.index, name="Channel index"))
+        if not isinstance(self.label, str):
+            raise TypeError("Channel label must be a string")
+        if not isinstance(self.unit, str):
+            raise TypeError("Channel unit must be a string")
+        object.__setattr__(self, "unit", self.unit.strip())
+        object.__setattr__(
+            self,
+            "reference",
+            _normalize_reference(self.reference, name="Channel reference"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OrderedSpectralPair:
+    """Output/input channel roles with the canonical flattened index."""
+
+    output: SpectralChannelRole
+    input: SpectralChannelRole
+    n_channels: int
+
+    def __post_init__(self) -> None:
+        n_channels = _normalize_index(self.n_channels, name="Channel count")
+        if n_channels <= 0:
+            raise ValueError("Channel count must be positive")
+        if not isinstance(self.output, SpectralChannelRole) or not isinstance(self.input, SpectralChannelRole):
+            raise TypeError("OrderedSpectralPair requires SpectralChannelRole values")
+        if not 0 <= self.output.index < n_channels:
+            raise ValueError("Output channel index is outside the channel count")
+        if not 0 <= self.input.index < n_channels:
+            raise ValueError("Input channel index is outside the channel count")
+        object.__setattr__(self, "n_channels", n_channels)
+
+    @property
+    def pair_index(self) -> int:
+        """Return ``output_index * n_channels + input_index``."""
+        return flatten_pair_index(self.output.index, self.input.index, self.n_channels)
+
+
+@dataclass(frozen=True, slots=True)
+class DerivedSpectralDomain:
+    """Linear unit and numeric reference for a derived spectral quantity."""
+
+    unit: str
+    reference: float
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.unit, str):
+            raise TypeError("Derived spectral unit must be a string")
+        object.__setattr__(self, "unit", self.unit.strip())
+        object.__setattr__(
+            self,
+            "reference",
+            _normalize_reference(self.reference, name="Derived spectral reference"),
+        )
+
+
+def flatten_pair_index(output_index: int, input_index: int, n_channels: int) -> int:
+    """Return the canonical output-major/input-minor flattened pair index."""
+    n = _normalize_index(n_channels, name="Channel count")
+    output = _normalize_index(output_index, name="Output channel index")
+    input_ = _normalize_index(input_index, name="Input channel index")
+    if n <= 0:
+        raise ValueError("Channel count must be positive")
+    if not 0 <= output < n:
+        raise ValueError("Output channel index is outside the channel count")
+    if not 0 <= input_ < n:
+        raise ValueError("Input channel index is outside the channel count")
+    return output * n + input_
+
+
+def _product_unit(input_unit: str, output_unit: str) -> str:
+    factors = [unit for unit in (input_unit, output_unit) if unit]
+    return "*".join(factors) or "1"
+
+
+def _validate_scaling(scaling: str) -> SpectralScaling:
+    if scaling == "spectrum" or scaling == "density":
+        return cast(SpectralScaling, scaling)
+    raise ValueError("CSD scaling must be 'spectrum' or 'density'")
+
+
+def derive_csd_domain(pair: OrderedSpectralPair, scaling: str) -> DerivedSpectralDomain:
+    """Derive CSD unit/reference from ``input * output`` and scaling."""
+    mode = _validate_scaling(scaling)
+    unit = _product_unit(pair.input.unit, pair.output.unit)
+    if mode == "density":
+        unit = f"{unit}/Hz"
+    return DerivedSpectralDomain(
+        unit=unit,
+        reference=pair.input.reference * pair.output.reference,
+    )
+
+
+def derive_coherence_domain() -> DerivedSpectralDomain:
+    """Return the dimensionless domain of magnitude-squared coherence."""
+    return DerivedSpectralDomain(unit="1", reference=1.0)
+
+
+def derive_transfer_domain(pair: OrderedSpectralPair) -> DerivedSpectralDomain:
+    """Derive transfer unit/reference as output divided by input."""
+    output_unit = pair.output.unit
+    input_unit = pair.input.unit
+    if not output_unit and not input_unit or output_unit == input_unit:
+        unit = "1"
+    elif not input_unit:
+        unit = output_unit
+    elif not output_unit:
+        unit = f"1/{input_unit}"
+    else:
+        unit = f"{output_unit}/{input_unit}"
+    return DerivedSpectralDomain(
+        unit=unit,
+        reference=pair.output.reference / pair.input.reference,
+    )
+
+
+def csd_level(value: NDArrayComplex, reference: float) -> NDArrayReal:
+    """Return CSD level as ``10 * log10(abs(value) / reference)``."""
+    normalized_reference = _normalize_reference(reference, name="CSD level reference")
+    with np.errstate(divide="ignore", invalid="ignore"):
+        return np.asarray(10.0 * np.log10(np.abs(value) / normalized_reference))
+
+
+def transfer_level(value: NDArrayComplex, reference: float) -> NDArrayReal:
+    """Return transfer level as ``20 * log10(abs(value) / reference)``."""
+    normalized_reference = _normalize_reference(reference, name="Transfer level reference")
+    with np.errstate(divide="ignore", invalid="ignore"):
+        return np.asarray(20.0 * np.log10(np.abs(value) / normalized_reference))
+
+
+def reject_pairwise_a_weighting(enabled: bool) -> None:
+    """Reject A-weighting for CSD and transfer quantities explicitly."""
+    if enabled:
+        raise ValueError(
+            "A-weighting is unsupported for CSD and transfer-function quantities. "
+            "Use a dedicated quantity-aware projection instead."
+        )
+
+
+def transfer_function_ratio(
+    cross_spectrum: NDArrayComplex,
+    input_power: NDArrayReal,
+) -> NDArrayComplex:
+    """Divide ``H[output, input]`` by the matching input auto-spectrum.
+
+    The cross-spectrum must have shape ``(output, input, ...)`` and the power
+    array must have shape ``(input, ...)``. Exact zero denominator bins remain
+    complex NaN; nonzero near-zero bins are not floored or clipped.
+    """
+    cross = np.asarray(cross_spectrum)
+    power = np.asarray(input_power)
+    if cross.ndim < 2:
+        raise ValueError("Cross-spectrum must have output and input axes")
+    if power.ndim != cross.ndim - 1:
+        raise ValueError("Input power must omit only the output axis")
+    if cross.shape[1] != power.shape[0] or cross.shape[2:] != power.shape[1:]:
+        raise ValueError("Transfer denominator must have one value per input channel and matching trailing axes")
+
+    denominator = power[np.newaxis, ...]
+    result = np.full(
+        cross.shape,
+        np.nan + 1j * np.nan,
+        dtype=np.result_type(cross.dtype, np.complex64),
+    )
+    valid = np.broadcast_to(denominator != 0, cross.shape)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        np.divide(cross, denominator, out=result, where=valid)
+    return result
+
+
+def as_output_input_pairs(input_output_values: np.ndarray) -> np.ndarray:
+    """Transpose a square ``(input, output, ...)`` matrix to ``(output, input, ...)``."""
+    values = np.asarray(input_output_values)
+    if values.ndim < 2 or values.shape[0] != values.shape[1]:
+        raise ValueError("Pairwise matrix must have equal input and output axes")
+    return np.swapaxes(values, 0, 1)
+
+
+def flatten_output_input_pairs(output_input_values: np.ndarray) -> np.ndarray:
+    """Flatten an ``(output, input, ...)`` matrix in canonical pair order."""
+    values = np.asarray(output_input_values)
+    if values.ndim < 2 or values.shape[0] != values.shape[1]:
+        raise ValueError("Pairwise matrix must have equal output and input axes")
+    n_channels = values.shape[0]
+    return values.reshape((n_channels * n_channels, *values.shape[2:]))
+
+
+__all__ = [
+    "DerivedSpectralDomain",
+    "OrderedSpectralPair",
+    "SpectralChannelRole",
+    "SpectralScaling",
+    "as_output_input_pairs",
+    "csd_level",
+    "derive_coherence_domain",
+    "derive_csd_domain",
+    "derive_transfer_domain",
+    "flatten_output_input_pairs",
+    "flatten_pair_index",
+    "reject_pairwise_a_weighting",
+    "transfer_function_ratio",
+    "transfer_level",
+]


### PR DESCRIPTION
Closes #401

Related #391
Related #406
Follow-up to PR #382 and PR #405; also builds on PR #403, PR #417, and PR #418

## Summary

This PR makes #401 contract-only and proves the CSD/Transfer Function numerical meaning with independent SciPy-domain expectations. The Issue body now separates #401 from #406:

- #401 owns mathematics, units, references, levels, phase, ordered pairs, zero/A-weighting policy, independent numerical oracles, and the canonical contract document.
- #406 owns dedicated CoherenceFrame/CrossSpectralFrame/TransferFunctionFrame types, quantity-specific public properties, typed plotting, WDF, Recipe type preservation, and removal of operation-history inference.

PR #405's fragile exact-prose spectral tests are already absent from main; no wording test, document scanner, or governance infrastructure is added here.

## Canonical pair order

All current flattened pair results use output-major/input-minor order:

~~~text
pair_index = output_index * n_channels + input_index
~~~

The pair is H[output, input] or P_out_in. Current public labels and input-side source offsets use this order for the corrected public path.

## CSD contract

| Aspect | Contract |
| --- | --- |
| Stored value | P_out_in = scipy.signal.csd(x=input_signal, y=output_signal, ...)[1] = conceptually conj(X_input) * X_output |
| spectrum unit | input_unit * output_unit |
| density unit | input_unit * output_unit / Hz |
| reference | input_ref * output_ref, with the density reference expressed per Hz |
| magnitude / phase | abs(P_out_in); angle(P_out_in) in radians |
| explicit level | 10 * log10(abs(P_out_in) / pair_reference) |
| A-weighting | Unsupported because generic input/output weighting is ambiguous |

The independent fixture covers two and three channels, spectrum and density scaling, boxcar and Hann windows, same/different unit domains, auto/cross spectra, non-trivial complex phase, conjugate pairs, and stable pair order.

## Transfer Function contract

| Aspect | Contract |
| --- | --- |
| Stored value | H_out_in = P_out_in / P_in_in |
| numerator | Per-pair scipy.signal.csd(input_signal, output_signal, ...)[1] |
| denominator | Per-pair scipy.signal.welch(input_signal, ...)[1] |
| unit | output_unit / input_unit |
| reference | output_ref / input_ref |
| magnitude / phase | abs(H_out_in); angle(H_out_in) in radians |
| explicit level | 20 * log10(abs(H_out_in) / (output_ref / input_ref)) |
| same unit/reference | Ordinary gain level 20 * log10(abs(H)) |
| A-weighting | Unsupported |

The fixture combines multiple tones, noise, positive/negative delays, distinct gains, and three-channel forward/inverse pairs. Expected values call SciPy csd and welch independently for every output/input pair; they do not copy the production broadcast, transpose, or flatten expression. This makes wrong one-sided factors, bin/pair placement, conjugation/phase, gain, or denominator axis observable.

## Denominator audit and Recipe decision

The audit found a real released numerical defect in the current TransferFunction implementation: SciPy returns the CSD matrix as (input, output, frequency), but the old code divided by p_xx[np.newaxis, :, :], selecting the output axis after the final transpose. The independent contract requires the input PSD for H[output, input].

The public TransferFunction operation now uses an explicit output/input conversion and an input-axis denominator with exact-zero/non-finite handling. Because this changes released numerical meaning, TransferFunction is version 2. A literal schema-2 payload continues to replay the old output-axis denominator through a private Recipe v1 operation; v1 and v2 are numerically distinguishable in tests. CSD and coherence now publish corrected output/input labels as version 2 while dedicated v1 handlers preserve the released reversed labels; their numeric arrays are unchanged. No central Recipe model/compiler/serializer/executor branch was added.

Exact zero and non-finite denominators return complex NaN; nonzero near-zero denominators are not floored, clipped, or regularized. Non-finite numerator/result behavior remains visible.

## Layers and handoff

- Operation layer: Dask-lazy channel-first processing, stable shape/dtype, independent SciPy comparisons, input immutability, two/three-channel pair coverage.
- Current public Frame route: existing generic SpectralFrame remains the temporary runtime container; public CSD/Transfer calls are checked for independent values, labels, offsets, lineage, previous, shape, dtype, sampling rate, and laziness. No temporary quantity inference or generic dB/dBA behavior was added.
- Canonical documentation: docs/src/explanation/spectral-numerical-contracts.md records stored values, pair order, units, scaling, references, phase, levels, A-weighting, zero policy, plotting projections, and the planned #406 properties: CrossSpectralFrame data/magnitude/phase/level_db and TransferFunctionFrame data/gain/phase/gain_db/transfer_level_db.
- Plotting handoff to #406: linear abs(P_out_in) or abs(H_out_in) by default, radians for explicit phase, 10-log CSD levels, 20-log transfer levels, unit-aware labels, and no A-weighting. No typed plotting or operation-history detector changes are included.

## Production changes

Production code changes are limited to the architecture-neutral pair contract helpers, the canonical CSD/Transfer pair-axis conversion, the corrected input-PSD denominator, and the versioned replay adapters required by the discovered compatibility contracts: CSD/coherence v1 label preservation and TransferFunction v1 denominator preservation. No dedicated Frame type, WDF schema, generic quantity enum, or operation-history quantity inference was added.

## Validation

- Focused pairwise/frame/Recipe suite: 258 passed on the final implementation head.
- Full pytest: 3202 passed, 3 skipped; 2 pre-existing failures remain in learning-path contracts outside this diff (temporary-cwd fixture lookup and an existing .compute() token finding in learning-path/06_skill_validation.py).
- uv run ruff check wandas tests scripts learning-path: passed.
- uv run ruff format --check wandas tests scripts learning-path: passed.
- uv run ty check wandas tests scripts learning-path: passed.
- uv run python scripts/check_public_docstrings.py: passed.
- uv run marimo check --strict learning-path/*.py: passed.
- uv run mkdocs build --strict -f docs/mkdocs.yml: passed (existing unlisted-page and font warnings only).
- `coverage report`: `wandas/processing/spectral_contracts.py` is now 100% covered; the Codecov patch report should refresh from this test-only follow-up.
- git diff --check: passed.

## Independent review

A separate read-only fixed-head review approved commit b03741ad against latest main a1b9a02f and found no blocking issues across pair order, independent SciPy oracles, CSD/Transfer math, units/references, levels, phase, zero policy, A-weighting, Recipe v1/v2 behavior, and the #406 boundary. It recorded one nonblocking note: `reject_pairwise_a_weighting()` is intentionally a handoff helper rather than a route through the current generic `SpectralFrame.dBA`/plot `Aw` paths; the final head afaa9214 adds the canonical-document clarification that #406 typed dispatch must enforce the rejection. The final head d4b7c28e adds only contract-validation tests after that review; production behavior is unchanged. Copilot's review covered 9/9 files and its two actionable threads are resolved (the first cleanup in c9e3100a and the Recipe compatibility fix in b03741ad). No merge is authorized by this PR.

## Residual risks

- #406 must implement the typed Frame/property/plot/WDF migration without reintroducing quantity inference or changing the documented formulas.
- Existing generic SpectralFrame amplitude properties are intentionally not repurposed in this PR; callers need the #406 typed API for quantity-specific level/plot behavior.
- The full suite's two learning-path failures are unrelated baseline/environment issues and should be resolved separately.