### PR TITLE
feat: split pairwise spectral quantities into dedicated Frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,10 @@ Read WDF with `wd.load()`, not `wd.read()`. `read_wav()`, `read_csv()`, and `fro
 ## Core Objects
 
 - `ChannelFrame`: multichannel waveform or sensor data in the time domain.
-- `SpectralFrame`: FFT, Welch, coherence, CSD, and transfer-function results.
+- `SpectralFrame`: FFT, Welch, and other amplitude-spectrum results.
+- `CoherenceFrame`: dimensionless magnitude-squared coherence with typed output/input pairs.
+- `CrossSpectralFrame`: complex cross-spectral values with quantity-specific phase and level views.
+- `TransferFunctionFrame`: complex output/input transfer values, including truthful Recipe v1 state.
 - `SpectrogramFrame`: STFT and other time-frequency data.
 - `NOctFrame`: octave and fractional-octave spectra.
 - `ChannelFrameDataset`: a lazy collection for loading and preprocessing recordings from a folder.

--- a/docs/src/api/frames.md
+++ b/docs/src/api/frames.md
@@ -10,6 +10,12 @@ frequency-domain, time-frequency, cepstral, octave-band, and roughness results.
 
 ::: wandas.frames.spectral.SpectralFrame
 
+::: wandas.frames.pairwise.CoherenceFrame
+
+::: wandas.frames.pairwise.CrossSpectralFrame
+
+::: wandas.frames.pairwise.TransferFunctionFrame
+
 ::: wandas.frames.spectrogram.SpectrogramFrame
 
 ::: wandas.frames.cepstral.CepstralFrame

--- a/docs/src/explanation/spectral-numerical-contracts.md
+++ b/docs/src/explanation/spectral-numerical-contracts.md
@@ -33,10 +33,10 @@ that amplitude level; it does not change the underlying stored amplitude.
 ## Pairwise spectral contracts
 
 The pairwise contracts below are the mathematical authority for the dedicated
-`CoherenceFrame`, `CrossSpectralFrame`, and `TransferFunctionFrame` planned in
-issue #406. The current generic `SpectralFrame` is not a semantic owner for
-these quantities; its amplitude `dB`, `dBA`, and `ifft` behavior must not be
-used to infer or render CSD or transfer meaning.
+`CoherenceFrame`, `CrossSpectralFrame`, and `TransferFunctionFrame`.
+The generic `SpectralFrame` is not a semantic owner for these quantities; its
+amplitude `dB`, `dBA`, and `ifft` behavior must not be used to infer or render
+CSD or transfer meaning.
 
 ### Ordered channel pairs
 
@@ -118,30 +118,31 @@ denominator remains a finite, potentially large gain. Non-finite inputs and
 results remain non-finite and are not clipped. Diagnostics, when added by a
 caller, must identify the affected input pair and frequency bin.
 
-A-weighting is unsupported for typed CSD and transfer quantities because there
-is no unambiguous generic choice of which channel(s) to weight or how many
-times to apply the weighting. The architecture-neutral
+A-weighting is unsupported for typed coherence, CSD, and transfer quantities
+because there is no unambiguous generic choice of which channel(s) to weight or
+how many times to apply the weighting. The architecture-neutral
 `reject_pairwise_a_weighting()` helper is the enforcement hook for those
 consumers; requests must fail explicitly rather than silently altering a
 pairwise value. #401 intentionally does not route the current generic
-`SpectralFrame.dBA` or plot `Aw` paths through operation-history quantity
-inference. Those legacy paths remain unchanged until #406 supplies typed
-dispatch and enforces this rejection at the public pairwise API boundary.
+Generic `SpectralFrame.dBA` and its amplitude plot `Aw` path remain available
+for amplitude spectra. Dedicated pairwise Frames reject `Aw` at their typed
+plot boundary; no operation-history quantity inference is used.
 
-Issue #406 owns the typed plotting implementation. Its frequency and matrix
-projections should use linear `abs(P_out_in)` for CSD and linear
+The dedicated Frames own the typed plotting implementation. Their frequency
+and matrix projections use linear `abs(P_out_in)` for CSD and linear
 `abs(H_out_in)` for transfer by default, with unit-aware labels. Explicit phase
 views show radians. Explicit level views use the CSD `10 * log10` rule or the
 transfer `20 * log10` rule, respectively; A-weighting remains unsupported.
 
-The planned #406 property handoff is intentionally quantity-specific: a
-`CrossSpectralFrame` exposes raw complex `data`, `magnitude`, `phase`, and an
-explicit CSD `level_db`; a `TransferFunctionFrame` exposes raw complex `data`,
-`gain`, `phase`, `gain_db` for the ordinary same-unit gain case, and
-`transfer_level_db` for the explicit output/input reference ratio (including
-unlike units). Pair roles, `scaling`, derived unit, and reference remain typed
-Frame state. These names are a contract handoff for #406, not properties added
-to the current generic `SpectralFrame`.
+The property surface is intentionally quantity-specific: a `CoherenceFrame`
+exposes raw `data` and `coherence`; a `CrossSpectralFrame` exposes raw complex
+`data`, `magnitude`, `phase`, and an explicit CSD `level_db`; a
+`TransferFunctionFrame` exposes raw complex `data`, `gain`, `phase`, `gain_db`
+for the ordinary same-unit gain case, and `transfer_level_db` for the explicit
+output/input reference ratio (including unlike units). Pair roles, `scaling`,
+derived unit, reference, and the Transfer v1 denominator definition remain
+typed Frame state. These properties are not added to the generic
+`SpectralFrame`.
 
 ## FFT inverse guarantee
 

--- a/docs/src/release-notes/v0.6.3.md
+++ b/docs/src/release-notes/v0.6.3.md
@@ -13,6 +13,11 @@ Wandas 0.6.3 makes N-octave synthesis use the authoritative FFT size stored by
   `wandas.audio.fft`, `wandas.audio.welch`, and `wandas.audio.cepstrum` calls.
 - [Issue #400](https://github.com/kasahart/wandas/issues/400) (parent [#391](https://github.com/kasahart/wandas/issues/391)):
   make materialized spectral properties follow the public `Frame.data` channel-axis shape.
+- [Issue #406](https://github.com/kasahart/wandas/issues/406) (follow-up to
+  [#401](https://github.com/kasahart/wandas/issues/401) / [PR #419](https://github.com/kasahart/wandas/pull/419)):
+  route coherence, CSD, and transfer-function results to dedicated typed
+  Frames. The mathematical definitions and migration details are maintained
+  in the [spectral numerical contracts](../explanation/spectral-numerical-contracts.md).
 
 ## Compatibility
 
@@ -26,3 +31,4 @@ it cannot distinguish adjacent odd and even FFT sizes.
 | `wandas.spectral.noct_synthesis` Recipe v1 | Serialized operation version | None | Existing v1 payloads replay through the legacy meaning; new public calls emit version 2. | 0.6.3 | Persisted numerical meaning is kept separate from the corrected current behavior; [Issue #398](https://github.com/kasahart/wandas/issues/398). |
 | `wandas.audio.fft`, `wandas.audio.welch`, and `wandas.audio.cepstrum` Recipe v1 | Serialized operation versions | None | Existing v1 payloads replay through the released meaning; new public calls emit version 2. | 0.6.3 | Persisted numerical meaning is kept separate from the corrected current behavior; [Issue #397](https://github.com/kasahart/wandas/issues/397), parent [#391](https://github.com/kasahart/wandas/issues/391). |
 | `SpectralFrame` and `SpectrogramFrame` spectral NumPy properties | Public return shape | None | Single-channel properties follow `frame.data` without a leading singleton channel axis; multi-channel properties retain the channel axis. Numerical definitions are unchanged. | 0.6.3 | Public shape consistency correction; [Issue #400](https://github.com/kasahart/wandas/issues/400), parent [#391](https://github.com/kasahart/wandas/issues/391). |
+| `ChannelFrame.coherence()`, `.csd()`, and `.transfer_function()` | Public result type and WDF frame type | None | Use `CoherenceFrame`, `CrossSpectralFrame`, and `TransferFunctionFrame`; existing Recipe v1 payloads keep their recorded display/denominator contracts, while new calls emit v2. | 0.6.3 | Quantity meaning is represented by exact Frame type and typed pair state; [Issue #406](https://github.com/kasahart/wandas/issues/406). |

--- a/tests/frames/test_channel_transform.py
+++ b/tests/frames/test_channel_transform.py
@@ -8,6 +8,7 @@ from dask.array.core import Array as DaArray
 
 from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
+from wandas.frames.mixins.channel_transform_mixin import _cross_channel_spectral_transform
 from wandas.frames.noct import NOctFrame
 from wandas.frames.pairwise import CoherenceFrame, CrossSpectralFrame, TransferFunctionFrame
 from wandas.frames.spectral import SpectralFrame
@@ -755,7 +756,7 @@ class TestChannelTransform:
             )
 
 
-# --- Tests for _cross_channel_spectral_transform n_fft validation (lines 91, 96) ---
+# --- Tests for pairwise Operation property validation ---
 
 
 def test_cross_channel_spectral_transform_n_fft_not_int():
@@ -767,7 +768,9 @@ def test_cross_channel_spectral_transform_n_fft_not_int():
 
     mock_op = MagicMock()
     mock_op.process.return_value = _da_from_array(np.random.default_rng(42).random((3, 513)), chunks=(3, 513))
-    mock_op.to_params.return_value = {"n_fft": "not_an_int", "window": "hann"}
+    mock_op.n_fft = "not_an_int"
+    mock_op.window = "hann"
+    mock_op.to_params.side_effect = AssertionError("pairwise builder must use typed Operation properties")
 
     with patch("wandas.processing.create_operation", return_value=mock_op):
         with pytest.raises(TypeError, match="must provide a positive integer n_fft"):
@@ -783,7 +786,9 @@ def test_cross_channel_spectral_transform_n_fft_non_positive():
 
     mock_op = MagicMock()
     mock_op.process.return_value = _da_from_array(np.random.default_rng(42).random((3, 513)), chunks=(3, 513))
-    mock_op.to_params.return_value = {"n_fft": 0, "window": "hann"}
+    mock_op.n_fft = 0
+    mock_op.window = "hann"
+    mock_op.to_params.side_effect = AssertionError("pairwise builder must use typed Operation properties")
 
     with patch("wandas.processing.create_operation", return_value=mock_op):
         with pytest.raises(ValueError, match="must provide a positive integer n_fft"):
@@ -800,10 +805,14 @@ def test_cross_channel_spectral_transform_rejects_invalid_transfer_scaling_from_
         np.ones((4, 257), dtype=np.complex128),
         chunks=(4, 257),
     )
-    mock_op.to_params.return_value = {"n_fft": 512, "window": "hann", "scaling": "invalid"}
+    mock_op.n_fft = 512
+    mock_op.window = "hann"
+    mock_op.scaling = "invalid"
+    mock_op.to_params.side_effect = AssertionError("pairwise builder must use typed Operation properties")
 
     with semantic_lineage(cf.lineage), pytest.raises(ValueError, match="valid scaling mode"):
-        cf._cross_channel_spectral_transform(
+        _cross_channel_spectral_transform(
+            cf,
             "transfer_function",
             "Transfer function of",
             "$H_{{{out_label}, {in_label}}}$",

--- a/tests/frames/test_channel_transform.py
+++ b/tests/frames/test_channel_transform.py
@@ -788,3 +788,27 @@ def test_cross_channel_spectral_transform_n_fft_non_positive():
     with patch("wandas.processing.create_operation", return_value=mock_op):
         with pytest.raises(ValueError, match="must provide a positive integer n_fft"):
             cf.coherence()
+
+
+def test_cross_channel_spectral_transform_rejects_invalid_transfer_scaling_from_operation() -> None:
+    """A malformed transfer operation cannot bypass the dedicated Frame contract."""
+    from wandas.processing.semantic import semantic_lineage
+
+    cf = ChannelFrame.from_numpy(np.random.default_rng(42).random((2, 1024)), sampling_rate=1000)
+    mock_op = mock.MagicMock()
+    mock_op.process.return_value = _da_from_array(
+        np.ones((4, 257), dtype=np.complex128),
+        chunks=(4, 257),
+    )
+    mock_op.to_params.return_value = {"n_fft": 512, "window": "hann", "scaling": "invalid"}
+
+    with semantic_lineage(cf.lineage), pytest.raises(ValueError, match="valid scaling mode"):
+        cf._cross_channel_spectral_transform(
+            "transfer_function",
+            "Transfer function of",
+            "$H_{{{out_label}, {in_label}}}$",
+            TransferFunctionFrame,
+            "transfer",
+            operation_override=mock_op,
+            scaling="invalid",
+        )

--- a/tests/frames/test_channel_transform.py
+++ b/tests/frames/test_channel_transform.py
@@ -9,6 +9,7 @@ from dask.array.core import Array as DaArray
 from tests.frame_helpers import channel_first_values
 from wandas.frames.channel import ChannelFrame
 from wandas.frames.noct import NOctFrame
+from wandas.frames.pairwise import CoherenceFrame, CrossSpectralFrame, TransferFunctionFrame
 from wandas.frames.spectral import SpectralFrame
 from wandas.frames.spectrogram import SpectrogramFrame
 
@@ -407,6 +408,7 @@ class TestChannelTransform:
 
         # ChannelFrameメソッドを使用してCSDを計算
         csd_frame = cf.csd(n_fft=n_fft, win_length=win_length, hop_length=hop_length, window="hamming")
+        assert type(csd_frame) is CrossSpectralFrame
         np.testing.assert_array_equal(csd_frame.source_time_offset, np.array([3.5, 3.5, 3.5, 3.5]))
         assert csd_frame.lineage.operation is not None
         assert csd_frame.lineage.operation.operation_id == "wandas.audio.csd"
@@ -473,6 +475,12 @@ class TestChannelTransform:
 
         result = getattr(cf, method_name)()
 
+        expected_type = {
+            "coherence": CoherenceFrame,
+            "csd": CrossSpectralFrame,
+            "transfer_function": TransferFunctionFrame,
+        }[method_name]
+        assert type(result) is expected_type
         assert result.n_fft == 2048
         assert result.window == "hann"
         assert result.metadata == {"recording": "fixture"}
@@ -517,6 +525,13 @@ class TestChannelTransform:
         transform = getattr(cf, method_name)
         result = transform(n_fft=512, win_length=256, hop_length=128)
 
+        expected_type = {
+            "coherence": CoherenceFrame,
+            "csd": CrossSpectralFrame,
+            "transfer_function": TransferFunctionFrame,
+        }[method_name]
+        assert type(result) is expected_type
+
         assert result.labels == expected_labels
         np.testing.assert_array_equal(result.source_time_offset, np.array([1.0, 9.0, 1.0, 9.0]))
 
@@ -550,6 +565,7 @@ class TestChannelTransform:
 
         # ChannelFrameメソッドを使用して伝達関数を計算
         tf_frame = cf.transfer_function(n_fft=n_fft, win_length=win_length, hop_length=hop_length, window="hamming")
+        assert type(tf_frame) is TransferFunctionFrame
 
         # 実際のデータを取得するために計算
         tf_data = channel_first_values(tf_frame)
@@ -586,13 +602,12 @@ class TestChannelTransform:
 
         expected_pairs = [
             f"$H_{{{ch0_label}, {ch0_label}}}$",
-            f"$H_{{{ch1_label}, {ch0_label}}}$",
             f"$H_{{{ch0_label}, {ch1_label}}}$",
+            f"$H_{{{ch1_label}, {ch0_label}}}$",
             f"$H_{{{ch1_label}, {ch1_label}}}$",
         ]
 
-        for pair in expected_pairs:
-            assert pair in ch_pairs
+        assert ch_pairs == expected_pairs
 
     def test_coherence(self) -> None:
         """コヒーレンスメソッドのテスト"""
@@ -617,6 +632,7 @@ class TestChannelTransform:
 
         # ChannelFrameメソッドを使用してコヒーレンスを計算
         coherence_frame = cf.coherence(n_fft=n_fft, win_length=win_length, hop_length=hop_length, window="hamming")
+        assert type(coherence_frame) is CoherenceFrame
         assert coherence_frame.lineage.operation is not None
         assert coherence_frame.lineage.operation.operation_id == "wandas.audio.coherence"
 

--- a/tests/frames/test_pairwise_frames.py
+++ b/tests/frames/test_pairwise_frames.py
@@ -531,6 +531,15 @@ def test_pairwise_state_helpers_reject_malformed_identity_and_domains() -> None:
     altered_record = replace(records[3], pair=altered_pair, row_id="pair:duplicate-source:duplicate-source")
     with pytest.raises(ValueError, match="source channel IDs must be unique"):
         _normalize_pair_state((records[0], altered_record), data_rows=2, source_channel_ids=None)
+    inconsistent_role = replace(records[1].pair.input, unit="A", reference=999.0)
+    inconsistent_pair = replace(records[1].pair, input=inconsistent_role)
+    inconsistent_record = replace(records[1], pair=inconsistent_pair)
+    with pytest.raises(ValueError, match="inconsistent source channel roles"):
+        _normalize_pair_state(
+            (records[0], inconsistent_record, records[2]),
+            data_rows=3,
+            source_channel_ids=None,
+        )
     with pytest.raises(ValueError, match="count must match"):
         _normalize_pair_state(records, data_rows=4, source_channel_ids=["only"])
     with pytest.raises(ValueError, match="Source channel IDs must be unique"):

--- a/tests/frames/test_pairwise_frames.py
+++ b/tests/frames/test_pairwise_frames.py
@@ -1,0 +1,416 @@
+"""Public contracts for dedicated flattened pairwise spectral Frames."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from dask.array.core import Array as DaArray
+from scipy import signal as ss
+
+import wandas as wd
+from tests.frame_helpers import channel_first_values
+from tests.pairwise_test_helpers import expected_pair_indices, make_pairwise_source
+from tests.processing.test_pairwise_spectral_contracts import (
+    _flatten_pair_matrix,
+    _make_fixture,
+    _scipy_csd_matrix,
+    _scipy_transfer_matrix,
+)
+from wandas.core.base_frame import BaseFrame
+from wandas.core.metadata import ChannelCalibration, ChannelMetadata
+from wandas.frames.pairwise import CoherenceFrame, CrossSpectralFrame, TransferFunctionFrame
+from wandas.frames.spectral import SpectralFrame
+from wandas.processing.spectral_contracts import csd_level, transfer_level
+
+_N_FFT = 32
+_WINDOW = "hann"
+_HOP_LENGTH = 16
+_WIN_LENGTH = 32
+
+
+def _pairwise_frames() -> tuple[CoherenceFrame, CrossSpectralFrame, TransferFunctionFrame]:
+    source = make_pairwise_source()
+    return (
+        source.coherence(n_fft=_N_FFT, win_length=_WIN_LENGTH, hop_length=_HOP_LENGTH, window=_WINDOW),
+        source.csd(
+            n_fft=_N_FFT,
+            win_length=_WIN_LENGTH,
+            hop_length=_HOP_LENGTH,
+            window=_WINDOW,
+            scaling="density",
+        ),
+        source.transfer_function(
+            n_fft=_N_FFT,
+            win_length=_WIN_LENGTH,
+            hop_length=_HOP_LENGTH,
+            window=_WINDOW,
+            scaling="spectrum",
+        ),
+    )
+
+
+def test_public_pairwise_operations_return_exact_dedicated_types_and_stay_lazy() -> None:
+    source = make_pairwise_source(n_channels=3)
+    source_values = channel_first_values(source).copy()
+
+    with patch.object(DaArray, "compute", autospec=True) as compute:
+        coherence = source.coherence(n_fft=_N_FFT, win_length=_WIN_LENGTH, hop_length=_HOP_LENGTH)
+        csd = source.csd(
+            n_fft=_N_FFT,
+            win_length=_WIN_LENGTH,
+            hop_length=_HOP_LENGTH,
+            scaling="density",
+        )
+        transfer = source.transfer_function(
+            n_fft=_N_FFT,
+            win_length=_WIN_LENGTH,
+            hop_length=_HOP_LENGTH,
+            scaling="spectrum",
+        )
+        compute.assert_not_called()
+
+    assert type(coherence) is CoherenceFrame
+    assert type(csd) is CrossSpectralFrame
+    assert type(transfer) is TransferFunctionFrame
+    assert all(isinstance(frame, BaseFrame) for frame in (coherence, csd, transfer))
+    assert all(not isinstance(frame, SpectralFrame) for frame in (coherence, csd, transfer))
+    assert all(isinstance(frame._data, DaArray) for frame in (coherence, csd, transfer))
+    assert all(frame._data.shape == (9, _N_FFT // 2 + 1) for frame in (coherence, csd, transfer))
+    assert coherence.sampling_rate == csd.sampling_rate == transfer.sampling_rate == source.sampling_rate
+    assert coherence.n_fft == csd.n_fft == transfer.n_fft == _N_FFT
+    assert coherence.window == csd.window == transfer.window == _WINDOW
+    assert csd.scaling == "density"
+    assert transfer.scaling == "spectrum"
+    assert transfer.denominator_role == "input"
+    assert transfer.definition == "canonical_input_denominator"
+
+    expected_offsets = np.tile(source.source_time_offset, source.n_channels)
+    for frame in (coherence, csd, transfer):
+        assert frame.previous is source
+        assert frame.metadata == source.metadata
+        np.testing.assert_array_equal(frame.source_time_offset, expected_offsets)
+        assert frame.operation_history[-1]["version"] == 2
+        assert frame.lineage.operation is not None
+        assert frame.lineage.operation.operation_id.startswith("wandas.audio.")
+    np.testing.assert_array_equal(channel_first_values(source), source_values)
+
+
+@pytest.mark.parametrize("operation_name", ["fft", "welch"])
+def test_ordinary_fft_and_welch_spectral_frame_amplitude_contract_regresses(
+    operation_name: str,
+) -> None:
+    source = make_pairwise_source(n_channels=1)
+    result = getattr(source, operation_name)(n_fft=_N_FFT, window="boxcar")
+
+    assert type(result) is SpectralFrame
+    assert all(hasattr(result, name) for name in ("magnitude", "power", "dB", "dBA", "ifft"))
+    assert np.asarray(result.dB).shape == np.asarray(result.data).shape
+
+
+def test_pair_state_is_output_major_input_minor_and_has_opaque_source_identity() -> None:
+    source = make_pairwise_source(n_channels=3)
+    frame = source.csd(n_fft=_N_FFT, win_length=_WIN_LENGTH, hop_length=_HOP_LENGTH, scaling="density")
+
+    assert frame.n_pairs == 9
+    assert frame.n_source_channels == 3
+    assert frame.source_channel_ids == tuple(source._channel_ids)
+    assert tuple((pair.output.index, pair.input.index) for pair in frame.ordered_pairs) == expected_pair_indices(3)
+    assert [pair.pair_index for pair in frame.pairs] == list(range(9))
+    assert all(record.pair is pair for record, pair in zip(frame.pair_state, frame.pairs, strict=True))
+    assert all(
+        record.row_id == channel_id for record, channel_id in zip(frame.pair_state, frame._channel_ids, strict=True)
+    )
+    assert frame.pair_row_index(2, 1) == 7
+    assert frame.pair_row_index("source-id-2", "source-id-1") == 7
+    with pytest.raises(KeyError, match="display labels are not pair identity"):
+        frame.pair_row_index("source-2", "source-1")
+
+    assert frame.labels == [f"csd(source-{output}, source-{input_})" for output, input_ in expected_pair_indices(3)]
+    assert frame.channels[0].extra == {
+        "output": {"sensor": "S0"},
+        "input": {"sensor": "S0"},
+    }
+    assert frame.channels[1].extra == {
+        "output": {"sensor": "S0"},
+        "input": {"sensor": "S1"},
+    }
+    assert [record.domain.unit for record in frame.pair_state] == [
+        "V*V/Hz",
+        "Pa*V/Hz",
+        "V*V/Hz",
+        "V*Pa/Hz",
+        "Pa*Pa/Hz",
+        "V*Pa/Hz",
+        "V*V/Hz",
+        "Pa*V/Hz",
+        "V*V/Hz",
+    ]
+
+
+@pytest.mark.parametrize("frame", _pairwise_frames(), ids=lambda value: type(value).__name__)
+def test_dedicated_frames_do_not_expose_generic_amplitude_apis(frame: BaseFrame[Any]) -> None:
+    forbidden = {"dB", "dBA", "power", "ifft", "noct_synthesis"}
+    for name in forbidden:
+        assert not hasattr(frame, name), f"{type(frame).__name__} unexpectedly exposes {name}"
+
+    if type(frame) is CoherenceFrame:
+        assert hasattr(frame, "coherence")
+        assert not hasattr(frame, "magnitude")
+    elif type(frame) is CrossSpectralFrame:
+        assert all(hasattr(frame, name) for name in ("magnitude", "phase", "level_db"))
+        assert not hasattr(frame, "gain")
+    else:
+        assert all(
+            isinstance(getattr(type(frame), name), property)
+            for name in ("gain", "phase", "gain_db", "transfer_level_db")
+        )
+        assert not hasattr(frame, "magnitude")
+
+
+def test_properties_preserve_public_shape_and_typed_state() -> None:
+    coherence, csd, transfer = _pairwise_frames()
+    assert np.asarray(coherence.coherence).shape == np.asarray(coherence.data).shape
+    assert np.asarray(csd.magnitude).shape == np.asarray(csd.data).shape
+    assert np.asarray(csd.phase).shape == np.asarray(csd.data).shape
+    assert np.asarray(csd.level_db).shape == np.asarray(csd.data).shape
+    assert np.asarray(transfer.gain).shape == np.asarray(transfer.data).shape
+    assert np.asarray(transfer.phase).shape == np.asarray(transfer.data).shape
+    assert np.asarray(transfer.transfer_level_db).shape == np.asarray(transfer.data).shape
+    assert all(
+        record.pair.output.index == pair.output.index for record, pair in zip(csd.pair_state, csd.pairs, strict=True)
+    )
+
+
+def test_pair_selection_frequency_slice_and_annotation_copies_keep_concrete_type_and_state() -> None:
+    source = make_pairwise_source(n_channels=3)
+    frame = source.transfer_function(n_fft=_N_FFT, win_length=_WIN_LENGTH, hop_length=_HOP_LENGTH)
+
+    selected = frame.select_pair("source-id-2", "source-id-0")
+    assert type(selected) is TransferFunctionFrame
+    assert selected.n_pairs == 1
+    assert selected.pairs[0].pair_index == 6
+    assert selected.pair_state[0] == frame.pair_state[6]
+    assert selected.pair_row_index(2, 0) == 0
+    np.testing.assert_array_equal(selected.source_time_offset, np.array([source.source_time_offset[0]]))
+    assert np.asarray(selected.data).shape == (_N_FFT // 2 + 1,)
+
+    subset = frame.select_pairs([8, 0, 4])
+    assert type(subset) is TransferFunctionFrame
+    assert subset.pairs == tuple(frame.pairs[index] for index in (8, 0, 4))
+    assert subset.pair_state == tuple(frame.pair_state[index] for index in (8, 0, 4))
+    assert subset._channel_ids == [frame._channel_ids[index] for index in (8, 0, 4)]
+
+    sliced = frame[:, 2:10]
+    assert type(sliced) is TransferFunctionFrame
+    assert sliced.pair_state == frame.pair_state
+    assert sliced.source_channel_ids == frame.source_channel_ids
+    assert sliced._data.shape == (frame.n_pairs, 8)
+
+    annotated = selected.with_label("selected").with_metadata({"review": "pairwise"})
+    annotated = annotated.with_channel_extra(0, {"display": "kept"})
+    renamed = annotated.rename_channels({0: "renamed pair"})
+    assert type(renamed) is TransferFunctionFrame
+    assert renamed.label == "selected"
+    assert renamed.metadata["review"] == "pairwise"
+    assert renamed.channels[0].extra["display"] == "kept"
+    assert renamed.labels == ["renamed pair"]
+    assert renamed.pair_state == selected.pair_state
+    assert renamed.source_channel_ids == selected.source_channel_ids
+    assert list(renamed)[0].pair_state == renamed.pair_state[:1]
+
+
+@pytest.mark.parametrize(
+    ("values", "error", "message"),
+    [
+        (np.full((1, 5), 1.1), ValueError, "between 0 and 1"),
+        (np.full((1, 5), -0.1), ValueError, "between 0 and 1"),
+        (np.full((1, 5), np.inf), ValueError, "infinity"),
+        (np.ones((1, 5, 1)), ValueError, "data rank"),
+        (np.ones((1, 4)), ValueError, "frequency bin count"),
+        (np.ones((1, 5), dtype=np.complex128), TypeError, "real numeric dtype"),
+    ],
+)
+def test_coherence_direct_constructor_rejects_invalid_domain_values(
+    values: np.ndarray[Any, Any], error: type[Exception], message: str
+) -> None:
+    source = make_pairwise_source()
+    valid = source.coherence(n_fft=8, win_length=8, hop_length=4, window="boxcar").pair_state[:1]
+    with pytest.raises(error, match=message):
+        CoherenceFrame(
+            values,
+            source.sampling_rate,
+            n_fft=8,
+            window="boxcar",
+            pair_state=valid,
+            source_channel_ids=source._channel_ids,
+        )
+
+
+def test_coherence_direct_constructor_preserves_undefined_nan_bins() -> None:
+    source = make_pairwise_source()
+    valid = source.coherence(n_fft=8, win_length=8, hop_length=4, window="boxcar").pair_state[:1]
+    frame = CoherenceFrame(
+        np.array([[0.0, np.nan, 1.0, 0.5, 0.25]]),
+        source.sampling_rate,
+        n_fft=8,
+        window="boxcar",
+        pair_state=valid,
+        source_channel_ids=source._channel_ids,
+    )
+    values = np.asarray(frame.coherence)
+    assert values.shape == (5,)
+    assert np.isnan(values[1])
+    np.testing.assert_allclose(values[[0, 2, 3, 4]], [0.0, 1.0, 0.5, 0.25])
+
+
+def test_csd_properties_use_complex_magnitude_phase_and_ten_log_level() -> None:
+    frame = make_pairwise_source().csd(
+        n_fft=_N_FFT,
+        win_length=_WIN_LENGTH,
+        hop_length=_HOP_LENGTH,
+        scaling="density",
+    )
+    raw = channel_first_values(frame)
+    expected_level = np.stack(
+        [csd_level(row, record.domain.reference) for row, record in zip(raw, frame.pair_state, strict=True)]
+    )
+    np.testing.assert_allclose(frame.magnitude, np.abs(raw))
+    np.testing.assert_allclose(frame.phase, np.angle(raw))
+    np.testing.assert_allclose(frame.level_db, expected_level, equal_nan=True)
+    assert all(record.domain.unit.endswith("/Hz") for record in frame.pair_state)
+
+
+def test_transfer_properties_use_twenty_log_gain_and_references_without_flooring() -> None:
+    unlike = make_pairwise_source().transfer_function(
+        n_fft=_N_FFT,
+        win_length=_WIN_LENGTH,
+        hop_length=_HOP_LENGTH,
+        scaling="spectrum",
+    )
+    raw = channel_first_values(unlike)
+    with pytest.raises(ValueError, match="dimensionless|Select a same-unit pair"):
+        _ = unlike.gain_db
+    expected_level = np.stack(
+        [transfer_level(row, record.domain.reference) for row, record in zip(raw, unlike.pair_state, strict=True)]
+    )
+    np.testing.assert_allclose(unlike.gain, np.abs(raw))
+    np.testing.assert_allclose(unlike.phase, np.angle(raw))
+    np.testing.assert_allclose(unlike.transfer_level_db, expected_level, equal_nan=True)
+
+    same_unit = make_pairwise_source(units=("V", "V"), references=(2.0, 5.0)).transfer_function(
+        n_fft=_N_FFT,
+        win_length=_WIN_LENGTH,
+        hop_length=_HOP_LENGTH,
+        scaling="spectrum",
+    )
+    same_raw = channel_first_values(same_unit)
+    np.testing.assert_allclose(
+        same_unit.gain_db,
+        20.0 * np.log10(np.abs(same_raw)),
+        equal_nan=True,
+    )
+
+    direct = TransferFunctionFrame(
+        data=np.array([[0.0 + 0.0j, 1.0e-12 + 0.0j, np.nan + 0.0j]]),
+        sampling_rate=8.0,
+        n_fft=4,
+        window="boxcar",
+        scaling="spectrum",
+        pair_state=same_unit.pair_state[:1],
+        source_channel_ids=same_unit.source_channel_ids,
+    )
+    assert np.isneginf(direct.gain_db[0])
+    assert direct.gain_db[1] < -200.0
+    assert np.isnan(direct.gain_db[2])
+    with pytest.raises(AttributeError):
+        direct.denominator_role = "output"  # ty: ignore[invalid-assignment]
+    with pytest.raises(AttributeError):
+        direct.scaling = "density"  # ty: ignore[invalid-assignment]
+
+
+def test_pairwise_direct_constructor_rejects_reapplied_calibration_and_validates_lists() -> None:
+    source = make_pairwise_source(n_channels=2)
+    valid = source.coherence(n_fft=8, win_length=8, hop_length=4, window="boxcar")
+    with pytest.raises(ValueError, match="calibration.*1.0|must not be reapplied"):
+        CoherenceFrame(
+            [[0.5] * 5] * 4,
+            source.sampling_rate,
+            n_fft=8,
+            window="boxcar",
+            pair_state=valid.pair_state,
+            source_channel_ids=source._channel_ids,
+            channel_metadata=[
+                ChannelMetadata(
+                    label=record.display_label,
+                    calibration=ChannelCalibration(factor=2.0, unit="1", ref=1.0),
+                )
+                for record in valid.pair_state
+            ],
+        )
+
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        CoherenceFrame(
+            [[1.1] * 5] * 4,
+            source.sampling_rate,
+            n_fft=8,
+            window="boxcar",
+            pair_state=valid.pair_state,
+            source_channel_ids=source._channel_ids,
+        )
+
+
+@pytest.mark.parametrize("frame", _pairwise_frames(), ids=lambda value: type(value).__name__)
+def test_pairwise_arithmetic_and_a_weighting_are_explicitly_rejected(frame: BaseFrame[Any]) -> None:
+    with pytest.raises(TypeError, match="Arithmetic is undefined"):
+        _ = frame + 1.0
+    with pytest.raises(ValueError, match="A-weighting"):
+        frame.plot(Aw=True)
+
+
+def test_public_pairwise_values_match_reused_independent_scipy_oracles() -> None:
+    fixture = _make_fixture(3)
+    source = wd.ChannelFrame.from_numpy(
+        fixture.signals,
+        256.0,
+        ch_labels=list(fixture.labels),
+    )
+    params: dict[str, Any] = {"n_fft": 64, "win_length": 32, "hop_length": 16, "window": "hann"}
+    expected_csd = _flatten_pair_matrix(_scipy_csd_matrix(fixture.signals, scaling="density", **params))
+    expected_transfer = _flatten_pair_matrix(_scipy_transfer_matrix(fixture.signals, scaling="spectrum", **params))
+    actual_csd = source.csd(**params, scaling="density")
+    actual_transfer = source.transfer_function(**params, scaling="spectrum")
+    np.testing.assert_allclose(channel_first_values(actual_csd), expected_csd, rtol=1e-9, atol=1e-11, equal_nan=True)
+    np.testing.assert_allclose(
+        channel_first_values(actual_transfer),
+        expected_transfer,
+        rtol=1e-9,
+        atol=1e-11,
+        equal_nan=True,
+    )
+
+    coherence_expected = np.stack(
+        [
+            ss.coherence(
+                fixture.signals[input_index],
+                fixture.signals[output_index],
+                fs=256.0,
+                nperseg=32,
+                noverlap=16,
+                nfft=64,
+                window="hann",
+                detrend="constant",
+            )[1]
+            for output_index, input_index in expected_pair_indices(3)
+        ]
+    )
+    actual_coherence = source.coherence(**params)
+    np.testing.assert_allclose(
+        channel_first_values(actual_coherence),
+        coherence_expected,
+        rtol=1e-9,
+        atol=1e-11,
+        equal_nan=True,
+    )

--- a/tests/frames/test_pairwise_frames.py
+++ b/tests/frames/test_pairwise_frames.py
@@ -27,6 +27,7 @@ from wandas.core.metadata import ChannelCalibration, ChannelMetadata
 from wandas.frames.pairwise import (
     CoherenceFrame,
     CrossSpectralFrame,
+    PairwiseSpectralFrame,
     SpectralPairState,
     TransferFunctionFrame,
     _expected_pair_domain,
@@ -726,6 +727,20 @@ def test_public_pairwise_constructors_expose_complete_typed_signatures(frame_typ
         assert "scaling" in parameters
     if frame_type is TransferFunctionFrame:
         assert "denominator_role" in parameters
+
+
+@pytest.mark.parametrize("frame", _pairwise_frames(), ids=lambda value: type(value).__name__)
+def test_pairwise_fft_state_is_immutable(frame: PairwiseSpectralFrame) -> None:
+    original_n_fft = frame.n_fft
+    original_window = frame.window
+
+    with pytest.raises(AttributeError):
+        frame.n_fft = original_n_fft + 1  # ty: ignore[invalid-assignment]
+    with pytest.raises(AttributeError):
+        frame.window = "boxcar"  # ty: ignore[invalid-assignment]
+
+    assert frame.n_fft == original_n_fft
+    assert frame.window == original_window
 
 
 @pytest.mark.parametrize("frame", _pairwise_frames(), ids=lambda value: type(value).__name__)

--- a/tests/frames/test_pairwise_frames.py
+++ b/tests/frames/test_pairwise_frames.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any
+from dataclasses import replace
+from typing import Any, cast
 from unittest.mock import patch
 
+import dask.array as da
 import numpy as np
 import pytest
 from dask.array.core import Array as DaArray
@@ -21,9 +23,18 @@ from tests.processing.test_pairwise_spectral_contracts import (
 )
 from wandas.core.base_frame import BaseFrame
 from wandas.core.metadata import ChannelCalibration, ChannelMetadata
-from wandas.frames.pairwise import CoherenceFrame, CrossSpectralFrame, TransferFunctionFrame
+from wandas.frames.pairwise import (
+    CoherenceFrame,
+    CrossSpectralFrame,
+    SpectralPairState,
+    TransferFunctionFrame,
+    _expected_pair_domain,
+    _metadata_for_pair_state,
+    _normalize_pair_state,
+    build_pair_state,
+)
 from wandas.frames.spectral import SpectralFrame
-from wandas.processing.spectral_contracts import csd_level, transfer_level
+from wandas.processing.spectral_contracts import DerivedSpectralDomain, csd_level, transfer_level
 
 _N_FFT = 32
 _WINDOW = "hann"
@@ -241,7 +252,7 @@ def test_coherence_direct_constructor_rejects_invalid_domain_values(
     with pytest.raises(error, match=message):
         CoherenceFrame(
             values,
-            source.sampling_rate,
+            sampling_rate=source.sampling_rate,
             n_fft=8,
             window="boxcar",
             pair_state=valid,
@@ -337,7 +348,7 @@ def test_pairwise_direct_constructor_rejects_reapplied_calibration_and_validates
     with pytest.raises(ValueError, match="calibration.*1.0|must not be reapplied"):
         CoherenceFrame(
             [[0.5] * 5] * 4,
-            source.sampling_rate,
+            sampling_rate=source.sampling_rate,
             n_fft=8,
             window="boxcar",
             pair_state=valid.pair_state,
@@ -354,12 +365,274 @@ def test_pairwise_direct_constructor_rejects_reapplied_calibration_and_validates
     with pytest.raises(ValueError, match="between 0 and 1"):
         CoherenceFrame(
             [[1.1] * 5] * 4,
-            source.sampling_rate,
+            sampling_rate=source.sampling_rate,
             n_fft=8,
             window="boxcar",
             pair_state=valid.pair_state,
             source_channel_ids=source._channel_ids,
         )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error", "message"),
+    [
+        ({"n_fft": True}, TypeError, "positive integer"),
+        ({"n_fft": 0}, ValueError, "positive integer"),
+        ({"window": ""}, TypeError, "non-blank string"),
+        ({"frequency_indices": "bins"}, TypeError, "ordered sequence"),
+        ({"frequency_indices": []}, ValueError, "at least one"),
+        ({"frequency_indices": [0.5]}, TypeError, "integer bin"),
+        ({"frequency_indices": [5]}, ValueError, "outside"),
+        ({"frequency_indices": [0, 0]}, ValueError, "duplicate"),
+    ],
+)
+def test_pairwise_direct_constructor_rejects_invalid_scalar_and_frequency_state(
+    kwargs: dict[str, Any], error: type[Exception], message: str
+) -> None:
+    source = make_pairwise_source(n_channels=2)
+    valid = source.coherence(n_fft=8, win_length=8, hop_length=4, window="boxcar")
+    constructor = {
+        "data": np.ones((4, 5)),
+        "sampling_rate": source.sampling_rate,
+        "n_fft": 8,
+        "window": "boxcar",
+        "pair_state": valid.pair_state,
+        "source_channel_ids": source._channel_ids,
+    }
+    constructor.update(kwargs)
+
+    with pytest.raises(error, match=message):
+        CoherenceFrame(**constructor)
+
+
+def test_pairwise_direct_constructor_accepts_one_dimensional_rows_and_rejects_complex_coherence() -> None:
+    source = make_pairwise_source(n_channels=2)
+    valid = source.coherence(n_fft=8, win_length=8, hop_length=4, window="boxcar")
+    row = CoherenceFrame(
+        np.ones(5),
+        source.sampling_rate,
+        n_fft=8,
+        window="boxcar",
+        pair_state=valid.pair_state[:1],
+        source_channel_ids=source._channel_ids,
+    )
+    assert row._data.shape == (1, 5)
+    assert row.data.shape == (5,)
+
+    with pytest.raises(TypeError, match="real numeric dtype"):
+        CoherenceFrame(
+            da.from_array(np.ones((1, 5), dtype=np.complex128), chunks=(1, 5)),
+            source.sampling_rate,
+            n_fft=8,
+            window="boxcar",
+            pair_state=valid.pair_state[:1],
+            source_channel_ids=source._channel_ids,
+        )
+
+    with pytest.raises(TypeError, match="complex numeric dtype"):
+        CrossSpectralFrame(
+            data=np.ones((1, 5)),
+            sampling_rate=source.sampling_rate,
+            n_fft=8,
+            window="boxcar",
+            scaling="density",
+            pair_state=valid.pair_state[:1],
+            source_channel_ids=source._channel_ids,
+        )
+
+
+def test_pairwise_state_helpers_reject_malformed_identity_and_domains() -> None:
+    source = make_pairwise_source(n_channels=2)
+    frame = source.csd(n_fft=8, win_length=8, hop_length=4, window="boxcar", scaling="density")
+    records = frame.pair_state
+
+    with pytest.raises(TypeError, match="SpectralPairState"):
+        SpectralPairState(
+            pair=cast(Any, object()),
+            domain=records[0].domain,
+            row_id="row",
+            display_label="label",
+        )
+    with pytest.raises(TypeError, match="DerivedSpectralDomain"):
+        SpectralPairState(
+            pair=records[0].pair,
+            domain=cast(Any, object()),
+            row_id="row",
+            display_label="label",
+        )
+
+    with pytest.raises(ValueError, match="equal lengths"):
+        build_pair_state(source.channels.to_list(), source._channel_ids[:1], quantity="coherence", label_template="x")
+    with pytest.raises(ValueError, match="unique"):
+        build_pair_state(
+            source.channels.to_list(),
+            [source._channel_ids[0], source._channel_ids[0]],
+            quantity="coherence",
+            label_template="x",
+        )
+    with pytest.raises(ValueError, match="scaling mode"):
+        build_pair_state(source.channels.to_list(), source._channel_ids, quantity="csd", label_template="x")
+    with pytest.raises(ValueError, match="cover every pair role"):
+        _metadata_for_pair_state((records[1],), source.channels.to_list()[:1])
+
+    with pytest.raises(TypeError, match="ordered sequence"):
+        _normalize_pair_state(cast(Any, "not-state"), data_rows=4, source_channel_ids=source._channel_ids)
+    with pytest.raises(ValueError, match="row count"):
+        _normalize_pair_state(records[:1], data_rows=4, source_channel_ids=source._channel_ids)
+    with pytest.raises(TypeError, match="only SpectralPairState"):
+        _normalize_pair_state((cast(Any, object()),) * 4, data_rows=4, source_channel_ids=source._channel_ids)
+    with pytest.raises(ValueError, match="duplicate output/input"):
+        _normalize_pair_state(
+            (records[0], records[0], records[2], records[3]),
+            data_rows=4,
+            source_channel_ids=source._channel_ids,
+        )
+    duplicate_row_id = replace(records[1], row_id=records[0].row_id)
+    with pytest.raises(ValueError, match="duplicate row IDs"):
+        _normalize_pair_state(
+            (records[0], duplicate_row_id, records[2], records[3]),
+            data_rows=4,
+            source_channel_ids=source._channel_ids,
+        )
+
+    three_channel = make_pairwise_source(n_channels=3).csd(n_fft=8, win_length=8, hop_length=4, window="boxcar")
+    with pytest.raises(ValueError, match="one source channel count"):
+        _normalize_pair_state((records[0], three_channel.pair_state[1]), data_rows=2, source_channel_ids=None)
+    assert _normalize_pair_state((), data_rows=0, source_channel_ids=None) == ((), ())
+    with pytest.raises(ValueError, match="every source channel"):
+        _normalize_pair_state((records[0],), data_rows=1, source_channel_ids=None)
+
+    altered_role = replace(records[3].pair.output, channel_id=records[0].pair.output.channel_id)
+    altered_pair = replace(records[3].pair, output=altered_role, input=altered_role)
+    altered_record = replace(records[3], pair=altered_pair, row_id="pair:duplicate-source:duplicate-source")
+    with pytest.raises(ValueError, match="source channel IDs must be unique"):
+        _normalize_pair_state((records[0], altered_record), data_rows=2, source_channel_ids=None)
+    with pytest.raises(ValueError, match="count must match"):
+        _normalize_pair_state(records, data_rows=4, source_channel_ids=["only"])
+    with pytest.raises(ValueError, match="Source channel IDs must be unique"):
+        _normalize_pair_state(records, data_rows=4, source_channel_ids=["same", "same"])
+    with pytest.raises(ValueError, match="role channel IDs"):
+        _normalize_pair_state(records, data_rows=4, source_channel_ids=["other", source._channel_ids[1]])
+    with pytest.raises(ValueError, match="CSD pair state"):
+        _expected_pair_domain(records[0], quantity="csd", scaling=None, denominator_role="input")
+
+
+def test_pairwise_constructor_rejects_typed_domain_and_channel_id_mismatches() -> None:
+    source = make_pairwise_source(n_channels=2)
+    frame = source.csd(n_fft=8, win_length=8, hop_length=4, window="boxcar", scaling="density")
+    with pytest.raises(ValueError, match="scaling"):
+        CrossSpectralFrame(
+            data=frame._data,
+            sampling_rate=source.sampling_rate,
+            n_fft=8,
+            window="boxcar",
+            scaling=cast(Any, "invalid"),
+            pair_state=frame.pair_state,
+            source_channel_ids=source._channel_ids,
+        )
+    with pytest.raises(ValueError, match="scaling"):
+        TransferFunctionFrame(
+            data=frame._data,
+            sampling_rate=source.sampling_rate,
+            n_fft=8,
+            window="boxcar",
+            scaling=cast(Any, "invalid"),
+            denominator_role="input",
+            pair_state=frame.pair_state,
+            source_channel_ids=source._channel_ids,
+        )
+    with pytest.raises(ValueError, match="denominator_role"):
+        TransferFunctionFrame(
+            data=frame._data,
+            sampling_rate=source.sampling_rate,
+            n_fft=8,
+            window="boxcar",
+            scaling="spectrum",
+            denominator_role=cast(Any, "invalid"),
+            pair_state=frame.pair_state,
+            source_channel_ids=source._channel_ids,
+        )
+    bad_record = replace(frame.pair_state[0], domain=DerivedSpectralDomain(unit="wrong", reference=1.0))
+    records = (bad_record, *frame.pair_state[1:])
+    with pytest.raises(ValueError, match="pair domain"):
+        CrossSpectralFrame(
+            data=frame._data,
+            sampling_rate=source.sampling_rate,
+            n_fft=8,
+            window="boxcar",
+            scaling="density",
+            pair_state=records,
+            source_channel_ids=source._channel_ids,
+        )
+    with pytest.raises(ValueError, match="count must match"):
+        CrossSpectralFrame(
+            data=frame._data,
+            sampling_rate=source.sampling_rate,
+            n_fft=8,
+            window="boxcar",
+            scaling="density",
+            pair_state=frame.pair_state,
+            source_channel_ids=source._channel_ids,
+            channel_ids=["one"],
+        )
+    with pytest.raises(ValueError, match="channel IDs must be unique"):
+        CrossSpectralFrame(
+            data=frame._data,
+            sampling_rate=source.sampling_rate,
+            n_fft=8,
+            window="boxcar",
+            scaling="density",
+            pair_state=frame.pair_state,
+            source_channel_ids=source._channel_ids,
+            channel_ids=["same"] * frame.n_pairs,
+        )
+
+
+def test_pairwise_selection_and_reconstruction_errors_are_actionable() -> None:
+    frame = make_pairwise_source(n_channels=2).transfer_function(
+        n_fft=8, win_length=8, hop_length=4, window="boxcar", scaling="spectrum"
+    )
+    assert frame.pair_domains == tuple(record.domain for record in frame.pair_state)
+    assert frame.get_pair(-1) == frame.pair_at(-1)
+    for invalid in (True, 1.5):
+        with pytest.raises(TypeError, match="row index"):
+            frame.pair_at(cast(Any, invalid))
+    with pytest.raises(IndexError, match="out of range"):
+        frame.pair_at(99)
+
+    selected = frame.select_pair(0, 0)
+    with pytest.raises(KeyError, match="not selected"):
+        selected.pair_row_index(0, 1)
+    with pytest.raises(TypeError, match="selector"):
+        frame.pair_row_index(cast(Any, 1.5), 0)
+    assert frame.pair_row_index(-1, 0) == 2
+    with pytest.raises(IndexError, match="source channel index"):
+        frame.pair_row_index(99, 0)
+    with pytest.raises(KeyError, match="Unknown"):
+        frame.pair_row_index("missing", 0)
+
+    with pytest.raises(TypeError, match="ordered sequence"):
+        frame.select_pairs(cast(Any, "rows"))
+    with pytest.raises(TypeError, match="integer indices"):
+        frame.select_pairs([True])
+    with pytest.raises(IndexError, match="out of range"):
+        frame.select_pairs([99])
+    with pytest.raises(ValueError, match="empty pair"):
+        frame.select_pairs([])
+    assert frame.select_pairs([-1]).pair_at(0) == frame.pair_at(-1)
+
+    with pytest.raises(ValueError, match="Invalid key length"):
+        frame[(slice(None), slice(None), slice(None))]
+    with pytest.raises(ValueError, match="Only slice selectors"):
+        frame[(slice(None), [0])]
+    with pytest.raises(ValueError, match="unknown row IDs"):
+        frame._create_new_instance(frame._data, channel_ids=["unknown"])
+    assert frame.to_dataframe().index.name == "frequency"
+    assert frame._supports_base_reverse_scalar_op()
+    with pytest.raises(TypeError, match="Arithmetic is undefined"):
+        _ = 1.0 + frame
+    with pytest.raises(TypeError, match="Arithmetic is undefined"):
+        np.add(frame, 1.0)
 
 
 @pytest.mark.parametrize("frame", _pairwise_frames(), ids=lambda value: type(value).__name__)

--- a/tests/frames/test_pairwise_frames.py
+++ b/tests/frames/test_pairwise_frames.py
@@ -277,6 +277,30 @@ def test_coherence_direct_constructor_preserves_undefined_nan_bins() -> None:
     np.testing.assert_allclose(values[[0, 2, 3, 4]], [0.0, 1.0, 0.5, 0.25])
 
 
+def test_coherence_float32_validation_allows_only_dtype_scale_rounding() -> None:
+    source = make_pairwise_source()
+    valid = source.coherence(n_fft=8, win_length=8, hop_length=4, window="boxcar").pair_state[:1]
+    rounded = CoherenceFrame(
+        np.full((1, 5), np.float32(1.0000001), dtype=np.float32),
+        source.sampling_rate,
+        n_fft=8,
+        window="boxcar",
+        pair_state=valid,
+        source_channel_ids=source._channel_ids,
+    )
+    np.testing.assert_allclose(np.asarray(rounded.coherence), np.float32(1.0000001))
+
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        CoherenceFrame(
+            np.full((1, 5), np.float32(1.00001), dtype=np.float32),
+            source.sampling_rate,
+            n_fft=8,
+            window="boxcar",
+            pair_state=valid,
+            source_channel_ids=source._channel_ids,
+        )
+
+
 def test_csd_properties_use_complex_magnitude_phase_and_ten_log_level() -> None:
     frame = make_pairwise_source().csd(
         n_fft=_N_FFT,
@@ -585,6 +609,35 @@ def test_pairwise_constructor_rejects_typed_domain_and_channel_id_mismatches() -
             pair_state=frame.pair_state,
             source_channel_ids=source._channel_ids,
             channel_ids=["same"] * frame.n_pairs,
+        )
+    with pytest.raises(ValueError, match="typed pair row IDs"):
+        CrossSpectralFrame(
+            data=frame._data,
+            sampling_rate=source.sampling_rate,
+            n_fft=8,
+            window="boxcar",
+            scaling="density",
+            pair_state=frame.pair_state,
+            source_channel_ids=source._channel_ids,
+            channel_ids=[f"arbitrary-{index}" for index in range(frame.n_pairs)],
+        )
+    mismatched_metadata = [
+        ChannelMetadata(
+            label=record.display_label,
+            calibration=ChannelCalibration(factor=1.0, unit="wrong", ref=1.0),
+        )
+        for record in frame.pair_state
+    ]
+    with pytest.raises(ValueError, match="typed pair domain"):
+        CrossSpectralFrame(
+            data=frame._data,
+            sampling_rate=source.sampling_rate,
+            n_fft=8,
+            window="boxcar",
+            scaling="density",
+            pair_state=frame.pair_state,
+            source_channel_ids=source._channel_ids,
+            channel_metadata=mismatched_metadata,
         )
 
 

--- a/tests/frames/test_pairwise_frames.py
+++ b/tests/frames/test_pairwise_frames.py
@@ -562,6 +562,8 @@ def test_pairwise_state_helpers_reject_malformed_identity_and_domains() -> None:
         _normalize_pair_state(records, data_rows=4, source_channel_ids=["only"])
     with pytest.raises(ValueError, match="Source channel IDs must be unique"):
         _normalize_pair_state(records, data_rows=4, source_channel_ids=["same", "same"])
+    with pytest.raises(TypeError, match="non-blank"):
+        _normalize_pair_state(records, data_rows=4, source_channel_ids=[" ", source._channel_ids[1]])
     with pytest.raises(ValueError, match="role channel IDs"):
         _normalize_pair_state(records, data_rows=4, source_channel_ids=["other", source._channel_ids[1]])
     with pytest.raises(ValueError, match="CSD pair state"):
@@ -733,6 +735,12 @@ def test_private_pairwise_base_is_not_a_public_module_export() -> None:
     import wandas.frames.pairwise as pairwise_module
 
     assert "PairwiseSpectralFrame" not in pairwise_module.__all__
+    assert inspect.isabstract(PairwiseSpectralFrame)
+    frame = _pairwise_frames()[0]
+    with pytest.raises(NotImplementedError):
+        PairwiseSpectralFrame._plot_frequency_values(frame, view=None, Aw=False)
+    with pytest.raises(NotImplementedError):
+        PairwiseSpectralFrame._plot_ylabel(frame, view=None, Aw=False)
 
 
 @pytest.mark.parametrize("frame", _pairwise_frames(), ids=lambda value: type(value).__name__)

--- a/tests/frames/test_pairwise_frames.py
+++ b/tests/frames/test_pairwise_frames.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from dataclasses import replace
 from typing import Any, cast
 from unittest.mock import patch
@@ -220,6 +221,12 @@ def test_pair_selection_frequency_slice_and_annotation_copies_keep_concrete_type
     assert sliced.source_channel_ids == frame.source_channel_ids
     assert sliced._data.shape == (frame.n_pairs, 8)
 
+    reversed_frequency = frame[:, ::-1]
+    assert type(reversed_frequency) is TransferFunctionFrame
+    assert reversed_frequency.pair_state == frame.pair_state
+    assert reversed_frequency._frequency_indices == tuple(reversed(frame._frequency_indices))
+    np.testing.assert_array_equal(reversed_frequency.freqs, frame.freqs[::-1])
+
     annotated = selected.with_label("selected").with_metadata({"review": "pairwise"})
     annotated = annotated.with_channel_extra(0, {"display": "kept"})
     renamed = annotated.rename_channels({0: "renamed pair"})
@@ -371,7 +378,7 @@ def test_pairwise_direct_constructor_rejects_reapplied_calibration_and_validates
     valid = source.coherence(n_fft=8, win_length=8, hop_length=4, window="boxcar")
     with pytest.raises(ValueError, match="calibration.*1.0|must not be reapplied"):
         CoherenceFrame(
-            [[0.5] * 5] * 4,
+            cast(Any, [[0.5] * 5] * 4),
             sampling_rate=source.sampling_rate,
             n_fft=8,
             window="boxcar",
@@ -388,12 +395,22 @@ def test_pairwise_direct_constructor_rejects_reapplied_calibration_and_validates
 
     with pytest.raises(ValueError, match="between 0 and 1"):
         CoherenceFrame(
-            [[1.1] * 5] * 4,
+            cast(Any, [[1.1] * 5] * 4),
             sampling_rate=source.sampling_rate,
             n_fft=8,
             window="boxcar",
             pair_state=valid.pair_state,
             source_channel_ids=source._channel_ids,
+        )
+
+    with pytest.raises(ValueError, match="at least one selected pair"):
+        CoherenceFrame(
+            np.empty((0, 5)),
+            sampling_rate=source.sampling_rate,
+            n_fft=8,
+            window="boxcar",
+            pair_state=(),
+            source_channel_ids=(),
         )
 
 
@@ -426,7 +443,7 @@ def test_pairwise_direct_constructor_rejects_invalid_scalar_and_frequency_state(
     constructor.update(kwargs)
 
     with pytest.raises(error, match=message):
-        CoherenceFrame(**constructor)
+        CoherenceFrame(**cast(Any, constructor))
 
 
 def test_pairwise_direct_constructor_accepts_one_dimensional_rows_and_rejects_complex_coherence() -> None:
@@ -695,6 +712,20 @@ def test_pairwise_selection_and_reconstruction_errors_are_actionable() -> None:
         _ = 1.0 + frame
     with pytest.raises(TypeError, match="Arithmetic is undefined"):
         np.add(frame, 1.0)
+
+
+@pytest.mark.parametrize("frame_type", [CoherenceFrame, CrossSpectralFrame, TransferFunctionFrame])
+def test_public_pairwise_constructors_expose_complete_typed_signatures(frame_type: type[BaseFrame[Any]]) -> None:
+    parameters = inspect.signature(frame_type).parameters
+    assert not any(
+        parameter.kind in {inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD}
+        for parameter in parameters.values()
+    )
+    assert {"data", "sampling_rate", "n_fft", "window", "pair_state"} <= set(parameters)
+    if frame_type is not CoherenceFrame:
+        assert "scaling" in parameters
+    if frame_type is TransferFunctionFrame:
+        assert "denominator_role" in parameters
 
 
 @pytest.mark.parametrize("frame", _pairwise_frames(), ids=lambda value: type(value).__name__)

--- a/tests/frames/test_pairwise_frames.py
+++ b/tests/frames/test_pairwise_frames.py
@@ -729,6 +729,12 @@ def test_public_pairwise_constructors_expose_complete_typed_signatures(frame_typ
         assert "denominator_role" in parameters
 
 
+def test_private_pairwise_base_is_not_a_public_module_export() -> None:
+    import wandas.frames.pairwise as pairwise_module
+
+    assert "PairwiseSpectralFrame" not in pairwise_module.__all__
+
+
 @pytest.mark.parametrize("frame", _pairwise_frames(), ids=lambda value: type(value).__name__)
 def test_pairwise_fft_state_is_immutable(frame: PairwiseSpectralFrame) -> None:
     original_n_fft = frame.n_fft

--- a/tests/io/test_wdf_io.py
+++ b/tests/io/test_wdf_io.py
@@ -88,6 +88,75 @@ def _typed_frames() -> list[BaseFrame[Any]]:
     ]
 
 
+@pytest.mark.parametrize(
+    "source_ids",
+    [
+        ("a:b", "a", "b:c", "c"),
+        ("a", " a ", "b:c", "c"),
+    ],
+)
+def test_pairwise_source_ids_are_opaque_and_survive_wdf_roundtrip(source_ids: tuple[str, ...], tmp_path: Path) -> None:
+    data = da.from_array(np.arange(4 * 32, dtype=float).reshape(4, 32), chunks=(1, -1))
+    metadata = [
+        ChannelMetadata(
+            label=f"source-{index}",
+            calibration=ChannelCalibration(factor=1.0, unit="V", ref=1.0),
+        )
+        for index in range(4)
+    ]
+    source = ChannelFrame(
+        data=data,
+        sampling_rate=32.0,
+        channel_metadata=metadata,
+        channel_ids=list(source_ids),
+    )
+    frame = source.csd(n_fft=8, win_length=8, hop_length=4, window="boxcar", scaling="density")
+
+    assert frame.source_channel_ids == source_ids
+    assert len({record.row_id for record in frame.pair_state}) == frame.n_pairs
+    assert frame.pair_row_index(source_ids[0], source_ids[3]) == 3
+    assert frame.pair_row_index(source_ids[1], source_ids[2]) == 6
+    assert frame.pair_state[0].pair.output.channel_id == source_ids[0]
+    assert frame.pair_state[0].pair.input.channel_id == source_ids[0]
+
+    path = tmp_path / "opaque-source-ids.wdf"
+    frame.save(path)
+    loaded = cast(CrossSpectralFrame, wd.load(path))
+    assert type(loaded) is CrossSpectralFrame
+    assert loaded.source_channel_ids == source_ids
+    assert loaded.pair_state == frame.pair_state
+    np.testing.assert_allclose(channel_first_values(loaded), channel_first_values(frame), equal_nan=True)
+
+
+def test_public_pairwise_constructor_state_is_wdf_roundtrippable(tmp_path: Path) -> None:
+    source = make_pairwise_source(n_channels=2)
+    original = source.csd(n_fft=8, win_length=8, hop_length=4, window="boxcar", scaling="density")
+    constructed = CrossSpectralFrame(
+        data=original._data,
+        sampling_rate=original.sampling_rate,
+        n_fft=original.n_fft,
+        window=original.window,
+        frequency_indices=original._frequency_indices,
+        scaling=original.scaling,
+        pair_state=original.pair_state,
+        source_channel_ids=original.source_channel_ids,
+        label=original.label,
+        metadata=original.metadata,
+        channel_metadata=original.channels.to_list(),
+        channel_ids=original._channel_ids,
+        source_time_offset=original.source_time_offset,
+    )
+
+    path = tmp_path / "explicit-constructor.wdf"
+    constructed.save(path)
+    loaded = cast(CrossSpectralFrame, wd.load(path))
+    assert type(loaded) is CrossSpectralFrame
+    assert loaded.pair_state == constructed.pair_state
+    assert loaded._channel_ids == constructed._channel_ids
+    assert loaded.channels.to_list() == constructed.channels.to_list()
+    np.testing.assert_allclose(channel_first_values(loaded), channel_first_values(constructed), equal_nan=True)
+
+
 @pytest.mark.parametrize("frame", _typed_frames(), ids=lambda frame: type(frame).__name__)
 def test_wdf_roundtrips_all_exact_builtin_types(frame: BaseFrame[Any], tmp_path: Path) -> None:
     path = tmp_path / f"{type(frame).__name__}.wdf"
@@ -271,7 +340,7 @@ def _pairwise_constructor_state(frame: BaseFrame[Any]) -> dict[str, Any]:
         ),
         (
             "coherence",
-            lambda state: state["pairs"][0]["output"].update(source_id=" source-id-0"),
+            lambda state: state["pairs"][0]["output"].update(unit=" V"),
             "surrounding whitespace",
         ),
         ("coherence", lambda state: state["pairs"][0]["output"].update(label=1), "label"),

--- a/tests/io/test_wdf_io.py
+++ b/tests/io/test_wdf_io.py
@@ -15,11 +15,13 @@ import xarray as xr
 
 import wandas as wd
 from tests.frame_helpers import channel_first_values
+from tests.pairwise_test_helpers import make_pairwise_source
 from wandas.core.base_frame import BaseFrame
 from wandas.frames.cepstral import CepstralFrame
 from wandas.frames.cepstrogram import CepstrogramFrame
 from wandas.frames.channel import ChannelFrame
 from wandas.frames.noct import NOctFrame
+from wandas.frames.pairwise import CoherenceFrame, CrossSpectralFrame, TransferFunctionFrame
 from wandas.frames.roughness import RoughnessFrame
 from wandas.frames.spectral import SpectralFrame
 from wandas.frames.spectrogram import SpectrogramFrame
@@ -66,6 +68,21 @@ def _typed_frames() -> list[BaseFrame[Any]]:
             overlap=0.5,
             channel_metadata=[{"label": "mic", "unit": "asper"}],
         ),
+        make_pairwise_source(n_channels=2).coherence(n_fft=8, win_length=8, hop_length=4, window="boxcar"),
+        make_pairwise_source(n_channels=2).csd(
+            n_fft=8,
+            win_length=8,
+            hop_length=4,
+            window="boxcar",
+            scaling="density",
+        ),
+        make_pairwise_source(n_channels=2).transfer_function(
+            n_fft=8,
+            win_length=8,
+            hop_length=4,
+            window="boxcar",
+            scaling="spectrum",
+        ),
     ]
 
 
@@ -94,6 +111,135 @@ def test_wdf_roundtrips_all_exact_builtin_types(frame: BaseFrame[Any], tmp_path:
         np.testing.assert_array_equal(actual, expected) if isinstance(expected, np.ndarray) else assert_equal(
             actual, expected
         )
+
+
+@pytest.mark.parametrize(
+    ("method_name", "params", "expected_type"),
+    [
+        (
+            "coherence",
+            {"n_fft": 32, "win_length": 32, "hop_length": 16, "window": "boxcar"},
+            CoherenceFrame,
+        ),
+        (
+            "csd",
+            {"n_fft": 32, "win_length": 32, "hop_length": 16, "window": "boxcar", "scaling": "density"},
+            CrossSpectralFrame,
+        ),
+        (
+            "transfer_function",
+            {"n_fft": 32, "win_length": 32, "hop_length": 16, "window": "boxcar", "scaling": "spectrum"},
+            TransferFunctionFrame,
+        ),
+    ],
+)
+def test_wdf_roundtrips_pairwise_full_and_selected_subset(
+    method_name: str,
+    params: dict[str, Any],
+    expected_type: type[CoherenceFrame] | type[CrossSpectralFrame] | type[TransferFunctionFrame],
+    tmp_path: Path,
+) -> None:
+    source = make_pairwise_source(n_channels=3)
+    full = getattr(source, method_name)(**params)
+    subset = full.select_pairs([6, 0, 8])
+
+    for name, frame in (("full", full), ("subset", subset)):
+        path = tmp_path / f"{method_name}-{name}.wdf"
+        frame.save(path)
+        typed_frame = frame
+        loaded = cast(Any, wd.load(path))
+
+        assert type(loaded) is expected_type
+        assert loaded.n_pairs == typed_frame.n_pairs
+        assert loaded.n_source_channels == typed_frame.n_source_channels
+        assert loaded.source_channel_ids == typed_frame.source_channel_ids
+        assert loaded.pair_state == typed_frame.pair_state
+        np.testing.assert_allclose(channel_first_values(loaded), channel_first_values(frame), equal_nan=True)
+        assert loaded._get_additional_init_kwargs() == typed_frame._get_additional_init_kwargs()
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("n_fft", 0, "n_fft"),
+        ("window", "", "window"),
+        ("scaling", "invalid", "scaling"),
+        ("source_channel_count", 0, "source_channel_count"),
+    ],
+)
+def test_wdf_pairwise_codec_fails_closed_for_malformed_constructor_state(
+    field: str, value: Any, message: str, tmp_path: Path
+) -> None:
+    frame = make_pairwise_source(n_channels=2).csd(
+        n_fft=8,
+        win_length=8,
+        hop_length=4,
+        window="boxcar",
+        scaling="density",
+    )
+    path = tmp_path / f"malformed-{field}.wdf"
+    frame.save(path)
+
+    def mutate(dataset: xr.Dataset) -> None:
+        constructor = json.loads(dataset.attrs["constructor_json"])
+        constructor[field] = value
+        dataset.attrs["constructor_json"] = json.dumps(constructor, allow_nan=False, separators=(",", ":"))
+
+    _rewrite(path, mutate)
+    with pytest.raises(ValueError, match=message):
+        wd.load(path)
+
+
+def test_wdf_pairwise_codec_rejects_duplicate_pair_state(tmp_path: Path) -> None:
+    frame = make_pairwise_source(n_channels=2).coherence(n_fft=8, win_length=8, hop_length=4, window="boxcar")
+    path = tmp_path / "duplicate-pair.wdf"
+    frame.save(path)
+
+    def mutate(dataset: xr.Dataset) -> None:
+        constructor = json.loads(dataset.attrs["constructor_json"])
+        constructor["pairs"][1] = dict(constructor["pairs"][0])
+        dataset.attrs["constructor_json"] = json.dumps(constructor, allow_nan=False, separators=(",", ":"))
+
+    _rewrite(path, mutate)
+    with pytest.raises(ValueError, match="duplicate|Pair state"):
+        wd.load(path)
+
+
+@pytest.mark.parametrize("mutation", ["rank", "bins", "dtype"])
+def test_wdf_pairwise_codec_rejects_wrong_data_domain_shape_or_dtype(mutation: str, tmp_path: Path) -> None:
+    frame = make_pairwise_source(n_channels=2).csd(
+        n_fft=8,
+        win_length=8,
+        hop_length=4,
+        window="boxcar",
+        scaling="density",
+    )
+    path = tmp_path / f"wrong-data-{mutation}.wdf"
+    frame.save(path)
+
+    def mutate(dataset: xr.Dataset) -> None:
+        data = np.asarray(dataset["data"].values)
+        if mutation == "rank":
+            dataset["data"] = (("channel", "frequency", "extra"), data[..., None])
+        elif mutation == "bins":
+            dataset["data"] = (("channel", "frequency"), data[:, :-1])
+        else:
+            dataset["data"] = (("channel", "frequency"), np.asarray(data.real, dtype=np.float64))
+
+    _rewrite(path, mutate)
+    with pytest.raises(ValueError, match="rank|frequency bin|complex|dtype|data domain"):
+        wd.load(path)
+
+
+def test_old_spectral_wdf_type_is_not_inferred_as_a_dedicated_pairwise_frame(tmp_path: Path) -> None:
+    source = make_pairwise_source(n_channels=2)
+    legacy = source.fft(n_fft=8).with_metadata({"quantity": "coherence"})
+    path = tmp_path / "legacy-spectral.wdf"
+    legacy.save(path)
+
+    loaded = wd.load(path)
+    assert type(loaded) is SpectralFrame
+    assert not isinstance(loaded, (CoherenceFrame, CrossSpectralFrame, TransferFunctionFrame))
 
 
 def test_wdf_roundtrips_immutable_annotations_without_recipe_intent(tmp_path: Path) -> None:

--- a/tests/io/test_wdf_io.py
+++ b/tests/io/test_wdf_io.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 from collections.abc import Callable
 from pathlib import Path
@@ -17,6 +18,7 @@ import wandas as wd
 from tests.frame_helpers import channel_first_values
 from tests.pairwise_test_helpers import make_pairwise_source
 from wandas.core.base_frame import BaseFrame
+from wandas.core.metadata import ChannelCalibration, ChannelMetadata
 from wandas.frames.cepstral import CepstralFrame
 from wandas.frames.cepstrogram import CepstrogramFrame
 from wandas.frames.channel import ChannelFrame
@@ -203,6 +205,162 @@ def test_wdf_pairwise_codec_rejects_duplicate_pair_state(tmp_path: Path) -> None
     _rewrite(path, mutate)
     with pytest.raises(ValueError, match="duplicate|Pair state"):
         wd.load(path)
+
+
+def test_wdf_codec_validators_cover_non_pairwise_constructor_edges() -> None:
+    with pytest.raises(ValueError, match="JSON object"):
+        wdf_frames._require_fields(cast(Any, []), set(), "TestFrame")
+
+    with pytest.raises(ValueError, match="win_length"):
+        wdf_frames._validate_spectrogram_constructor_state(
+            {"n_fft": 8, "hop_length": 2, "win_length": 9, "window": "boxcar"},
+            da.zeros((1, 5, 2)),
+        )
+
+
+def _pairwise_codec_frame(quantity: str) -> BaseFrame[Any]:
+    source = make_pairwise_source(n_channels=2)
+    if quantity == "coherence":
+        return source.coherence(n_fft=8, win_length=8, hop_length=4, window="boxcar")
+    if quantity == "csd":
+        return source.csd(n_fft=8, win_length=8, hop_length=4, window="boxcar", scaling="density")
+    return source.transfer_function(n_fft=8, win_length=8, hop_length=4, window="boxcar", scaling="spectrum")
+
+
+def _pairwise_constructor_state(frame: BaseFrame[Any]) -> dict[str, Any]:
+    fields = {"scaling"} if type(frame) is CrossSpectralFrame else set()
+    if type(frame) is TransferFunctionFrame:
+        fields = {"scaling", "denominator_role", "definition"}
+    return wdf_frames._pairwise_state(frame, fields=fields)
+
+
+@pytest.mark.parametrize(
+    ("quantity", "mutation", "message"),
+    [
+        ("coherence", lambda state: state.update(source_channel_ids=["only"]), "source_channel_ids"),
+        (
+            "coherence",
+            lambda state: state.update(source_channel_ids=["same", "same"]),
+            "unique",
+        ),
+        ("coherence", lambda state: state.update(window=" boxcar"), "window"),
+        ("coherence", lambda state: state.update(frequency_indices=[]), "frequency_indices"),
+        (
+            "coherence",
+            lambda state: state["frequency_indices"].__setitem__(0, 5),
+            "frequency_indices",
+        ),
+        (
+            "coherence",
+            lambda state: state["frequency_indices"].__setitem__(1, state["frequency_indices"][0]),
+            "unique",
+        ),
+        ("coherence", lambda state: state.update(pairs={}), "pairs"),
+        ("coherence", lambda state: state["pairs"].__setitem__(0, "bad"), r"pairs\[0\]"),
+        ("coherence", lambda state: state["pairs"][0].update(output="bad"), "output"),
+        ("coherence", lambda state: state["pairs"][0]["output"].update(index=2), "index"),
+        (
+            "coherence",
+            lambda state: state["pairs"][0]["output"].update(source_id="wrong"),
+            "source_id",
+        ),
+        (
+            "coherence",
+            lambda state: state["pairs"][0]["output"].update(source_id=""),
+            "source_id",
+        ),
+        (
+            "coherence",
+            lambda state: state["pairs"][0]["output"].update(source_id=" source-id-0"),
+            "surrounding whitespace",
+        ),
+        ("coherence", lambda state: state["pairs"][0]["output"].update(label=1), "label"),
+        ("coherence", lambda state: state["pairs"][0]["output"].update(reference="bad"), "reference"),
+        ("coherence", lambda state: state["pairs"][0]["output"].update(reference=0), "reference"),
+        ("coherence", lambda state: state["pairs"][0].update(domain="bad"), "domain"),
+        (
+            "coherence",
+            lambda state: state["pairs"][0]["domain"].update(unit="wrong"),
+            "domain",
+        ),
+        (
+            "coherence",
+            lambda state: state["pairs"][0].update(row_id=state["pairs"][1]["row_id"]),
+            "row_id",
+        ),
+        ("coherence", lambda state: state["pairs"][0].update(pair_index=-1), "pair_index"),
+        ("coherence", lambda state: state["pairs"][0].update(pair_index=4), "pair_index"),
+        (
+            "coherence",
+            lambda state: state["pairs"][1].update(pair_index=state["pairs"][0]["pair_index"]),
+            "duplicate",
+        ),
+        ("coherence", lambda state: state["pairs"][0].update(pair_index=1), "pair_index"),
+        ("csd", lambda state: state.update(scaling="invalid"), "scaling"),
+        ("transfer", lambda state: state.update(denominator_role="invalid"), "denominator_role"),
+        ("transfer", lambda state: state.update(definition="wrong-definition"), "definition"),
+    ],
+)
+def test_wdf_pairwise_constructor_state_rejects_each_malformed_typed_field(
+    quantity: str, mutation: Callable[[dict[str, Any]], object], message: str
+) -> None:
+    frame = _pairwise_codec_frame(quantity)
+    state = copy.deepcopy(_pairwise_constructor_state(frame))
+    mutation(state)
+
+    with pytest.raises(ValueError, match=message):
+        wdf_frames._validated_pairwise_constructor_state(
+            state,
+            frame._data,
+            frame_type=type(frame).__name__,
+            quantity=cast(Any, quantity),
+        )
+
+
+def test_wdf_pairwise_constructor_state_rejects_too_many_pairs_and_common_metadata_mismatches() -> None:
+    frame = _pairwise_codec_frame("coherence")
+    state = _pairwise_constructor_state(frame)
+    too_many = copy.deepcopy(state)
+    too_many["pairs"].append(copy.deepcopy(too_many["pairs"][0]))
+    with pytest.raises(ValueError, match="at most"):
+        wdf_frames._validated_pairwise_constructor_state(
+            too_many,
+            da.zeros((5, 5)),
+            frame_type="CoherenceFrame",
+            quantity="coherence",
+        )
+
+    _, _, _, _, records, _, _ = wdf_frames._validated_pairwise_constructor_state(
+        state,
+        frame._data,
+        frame_type="CoherenceFrame",
+        quantity="coherence",
+    )
+    common = {
+        "channel_ids": [record.row_id for record in records],
+        "channel_metadata": frame.channels.to_list(),
+    }
+    common["channel_ids"] = ["wrong"]
+    with pytest.raises(ValueError, match="row identity"):
+        wdf_frames._validate_pairwise_common(common, records, frame_type="CoherenceFrame")
+
+    common["channel_ids"] = [record.row_id for record in records]
+    common["channel_metadata"] = []
+    with pytest.raises(ValueError, match="channel metadata"):
+        wdf_frames._validate_pairwise_common(common, records, frame_type="CoherenceFrame")
+
+    common["channel_metadata"] = ["not metadata"] * len(records)
+    with pytest.raises(ValueError, match="Expected: ChannelMetadata"):
+        wdf_frames._validate_pairwise_common(common, records, frame_type="CoherenceFrame")
+
+    metadata = frame.channels.to_list()
+    metadata[0] = ChannelMetadata(
+        label=metadata[0].label,
+        calibration=ChannelCalibration(factor=2.0, unit=metadata[0].unit, ref=metadata[0].ref),
+    )
+    common["channel_metadata"] = metadata
+    with pytest.raises(ValueError, match="unit/reference metadata"):
+        wdf_frames._validate_pairwise_common(common, records, frame_type="CoherenceFrame")
 
 
 @pytest.mark.parametrize("mutation", ["rank", "bins", "dtype"])

--- a/tests/pairwise_test_helpers.py
+++ b/tests/pairwise_test_helpers.py
@@ -1,0 +1,69 @@
+"""Shared deterministic fixtures for dedicated pairwise Frame tests."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import dask.array as da
+import numpy as np
+
+from wandas.core.metadata import ChannelCalibration, ChannelMetadata
+from wandas.frames.channel import ChannelFrame
+
+
+def make_pairwise_source(
+    *,
+    n_channels: int = 2,
+    sampling_rate: float = 256.0,
+    n_samples: int = 256,
+    units: Sequence[str] | None = None,
+    references: Sequence[float] | None = None,
+    calibration_factors: Sequence[float] | None = None,
+) -> ChannelFrame:
+    """Build a lazy multi-channel source with stable IDs and rich metadata."""
+    if n_channels < 1:
+        raise ValueError("n_channels must be positive")
+    time = np.arange(n_samples, dtype=float) / sampling_rate
+    signals = np.stack(
+        [
+            np.sin(2.0 * np.pi * 16.0 * time),
+            1.5 * np.sin(2.0 * np.pi * 16.0 * time + 0.31),
+            0.65 * np.cos(2.0 * np.pi * 40.0 * time - 0.22),
+        ][:n_channels]
+    )
+    labels = tuple(f"source-{index}" for index in range(n_channels))
+    source_ids = tuple(f"source-id-{index}" for index in range(n_channels))
+    normalized_units = tuple(units or ("V", "Pa", "V")[:n_channels])
+    normalized_references = tuple(references or (2.0, 5.0, 3.0)[:n_channels])
+    normalized_factors = tuple(calibration_factors or (1.0,) * n_channels)
+    if not (len(normalized_units) == len(normalized_references) == len(normalized_factors) == n_channels):
+        raise ValueError("units, references, and calibration_factors must match n_channels")
+
+    metadata = [
+        ChannelMetadata(
+            label=label,
+            calibration=ChannelCalibration(
+                factor=factor,
+                unit=unit,
+                ref=reference,
+            ),
+            extra={"sensor": f"S{index}"},
+        )
+        for index, (label, unit, reference, factor) in enumerate(
+            zip(labels, normalized_units, normalized_references, normalized_factors, strict=True)
+        )
+    ]
+    return ChannelFrame(
+        data=da.from_array(signals, chunks=(1, -1)),
+        sampling_rate=sampling_rate,
+        label="pairwise-source",
+        metadata={"recording": {"take": "pairwise"}},
+        channel_metadata=metadata,
+        channel_ids=list(source_ids),
+        source_time_offset=np.arange(n_channels, dtype=float) + 0.25,
+    )
+
+
+def expected_pair_indices(n_channels: int) -> tuple[tuple[int, int], ...]:
+    """Return canonical output-major/input-minor pair positions."""
+    return tuple((output_index, input_index) for output_index in range(n_channels) for input_index in range(n_channels))

--- a/tests/pipeline/test_spectral_recipe_versions.py
+++ b/tests/pipeline/test_spectral_recipe_versions.py
@@ -38,6 +38,8 @@ def _source(
     *,
     offset: float = 0.25,
     sampling_rate: float = _SAMPLING_RATE,
+    channel_ids: list[str] | None = None,
+    source_time_offset: np.ndarray | None = None,
 ) -> ChannelFrame:
     """Build a lazy source with stable channel and recording metadata."""
     channel_count = values.shape[0]
@@ -54,8 +56,12 @@ def _source(
             )
             for index in range(channel_count)
         ],
-        channel_ids=[f"channel-id-{index}" for index in range(channel_count)],
-        source_time_offset=np.arange(channel_count, dtype=float) + offset,
+        channel_ids=(
+            channel_ids if channel_ids is not None else [f"channel-id-{index}" for index in range(channel_count)]
+        ),
+        source_time_offset=(
+            source_time_offset if source_time_offset is not None else np.arange(channel_count, dtype=float) + offset
+        ),
     )
 
 
@@ -840,6 +846,55 @@ def test_public_pairwise_v2_recipe_roundtrip_rebuilds_exact_type_and_state(
     assert replayed.operation_history[-1]["version"] == 2
 
 
+def test_pair_selection_recipe_replays_opaque_source_selectors_after_reordering() -> None:
+    """A selected pair Recipe resolves source IDs on the replayed input Frame."""
+    values = np.stack(
+        [
+            np.sin(2.0 * np.pi * np.arange(256) / 16.0),
+            1.5 * np.sin(2.0 * np.pi * np.arange(256) / 16.0 + 0.3),
+            0.75 * np.cos(2.0 * np.pi * np.arange(256) / 32.0),
+        ]
+    )
+    source = _source(values, sampling_rate=256.0)
+    selected = source.csd(n_fft=32, hop_length=16, win_length=32, window="boxcar").select_pair(
+        "channel-id-1", "channel-id-0"
+    )
+
+    payload = RecipePlan.from_frame(selected, input_names=("signal",)).to_dict()
+    assert [node["operation"] for node in payload["nodes"]] == [
+        "wandas.audio.csd",
+        "wandas.frame.select_pair",
+    ]
+    assert payload["nodes"][-1]["params"] == {
+        "$type": "map",
+        "entries": [["input", "channel-id-0"], ["output", "channel-id-1"]],
+    }
+
+    reordered = _source(
+        values[[2, 0, 1]],
+        sampling_rate=256.0,
+        channel_ids=["channel-id-2", "channel-id-0", "channel-id-1"],
+        source_time_offset=np.array([2.25, 0.25, 1.25]),
+    )
+    replayed = RecipePlan.from_dict(json.loads(json.dumps(payload))).apply({"signal": reordered})
+
+    assert type(replayed) is CrossSpectralFrame
+    np.testing.assert_allclose(
+        channel_first_values(replayed),
+        channel_first_values(selected),
+        rtol=1e-12,
+        atol=1e-12,
+        equal_nan=True,
+    )
+    assert replayed.pairs[0].output.channel_id == "channel-id-1"
+    assert replayed.pairs[0].input.channel_id == "channel-id-0"
+    assert replayed.pairs[0].output.index == 2
+    assert replayed.pairs[0].input.index == 1
+    assert replayed.pairs[0].pair_index == 7
+    np.testing.assert_array_equal(replayed.source_time_offset, np.array([0.25]))
+    assert replayed.operation_history[-1]["operation"] == "wandas.frame.select_pair"
+
+
 def test_default_registry_contains_v1_and_v2_for_all_spectral_recipe_operations() -> None:
     """The immutable default registry exposes both persisted meanings."""
     registry = default_recipe_registry()
@@ -853,6 +908,7 @@ def test_default_registry_contains_v1_and_v2_for_all_spectral_recipe_operations(
     ):
         assert registry.require(operation_id, 1).version == 1
         assert registry.require(operation_id, 2).version == 2
+    assert registry.require("wandas.frame.select_pair", 1).version == 1
 
     for private_name in (
         "_recipe_fft_v1",

--- a/tests/pipeline/test_spectral_recipe_versions.py
+++ b/tests/pipeline/test_spectral_recipe_versions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -14,16 +15,19 @@ from scipy.signal import csd as scipy_csd
 from scipy.signal import get_window
 from scipy.signal import welch as scipy_welch
 
+import wandas as wd
 from tests.frame_helpers import channel_first_values
 from wandas.core.metadata import ChannelCalibration, ChannelMetadata
 from wandas.frames.cepstral import CepstralFrame
 from wandas.frames.channel import ChannelFrame
+from wandas.frames.pairwise import CoherenceFrame, CrossSpectralFrame, TransferFunctionFrame
 from wandas.frames.spectral import SpectralFrame
 from wandas.pipeline import RecipePlan, default_recipe_registry
 from wandas.pipeline.errors import RecipeExecutionError
 from wandas.processing import get_operation
 from wandas.processing.cepstral import Cepstrum, _RecipeCepstrumV1
 from wandas.processing.spectral import FFT, TransferFunction, Welch, _RecipeFFTV1, _RecipeWelchV1
+from wandas.processing.spectral_contracts import derive_transfer_domain
 
 _SAMPLING_RATE = 8_000
 _FLOOR = 1e-6
@@ -381,7 +385,7 @@ def test_welch_oracle_checks_dc_internal_and_even_nyquist_bins() -> None:
     assert np.isclose(result[0, -1], 3.0)
 
 
-def test_transfer_function_recipe_v1_preserves_legacy_denominator_and_v2_corrects_it() -> None:
+def test_transfer_function_recipe_v1_preserves_legacy_denominator_and_v2_corrects_it(tmp_path: Path) -> None:
     """A literal Recipe v1 payload keeps the released output-axis denominator."""
     sampling_rate = 256.0
     time = np.arange(256, dtype=float) / sampling_rate
@@ -438,6 +442,9 @@ def test_transfer_function_recipe_v1_preserves_legacy_denominator_and_v2_correct
         replayed = RecipePlan.from_dict(released_payload).apply({"signal": source})
         compute.assert_not_called()
 
+    assert type(replayed) is TransferFunctionFrame
+    assert type(direct_v2) is TransferFunctionFrame
+
     def scipy_transfer(denominator_role: str) -> np.ndarray:
         rows = []
         for output_index in range(values.shape[0]):
@@ -476,6 +483,12 @@ def test_transfer_function_recipe_v1_preserves_legacy_denominator_and_v2_correct
     assert not np.allclose(expected_v1, expected_v2, equal_nan=True)
     assert replayed.operation_history[-1]["version"] == 1
     assert direct_v2.operation_history[-1]["version"] == 2
+    assert replayed.denominator_role == "output"
+    assert replayed.definition == "legacy_output_denominator"
+    assert direct_v2.denominator_role == "input"
+    assert direct_v2.definition == "canonical_input_denominator"
+    assert all(record.domain == derive_transfer_domain(record.pair, "output") for record in replayed.pair_state)
+    assert all(record.domain == derive_transfer_domain(record.pair, "input") for record in direct_v2.pair_state)
     assert replayed.labels == [
         f"$H_{{{values_input}, {values_output}}}$"
         for values_output in ("channel-0", "channel-1", "channel-2")
@@ -487,6 +500,16 @@ def test_transfer_function_recipe_v1_preserves_legacy_denominator_and_v2_correct
         for values_input in ("channel-0", "channel-1", "channel-2")
     ]
     assert isinstance(replayed._data, DaArray)
+
+    path = tmp_path / "transfer-v1.wdf"
+    replayed.save(path)
+    loaded = wd.load(path)
+    assert type(loaded) is TransferFunctionFrame
+    assert loaded.denominator_role == "output"
+    assert loaded.definition == "legacy_output_denominator"
+    assert loaded.pair_state == replayed.pair_state
+    assert loaded.labels == replayed.labels
+    np.testing.assert_allclose(channel_first_values(loaded), expected_v1, equal_nan=True)
     _assert_source_unchanged(source, values)
 
 
@@ -726,6 +749,13 @@ def test_pairwise_recipe_v1_preserves_released_label_order(
 
     replayed = RecipePlan.from_dict(released_payload).apply({"signal": source})
 
+    expected_type = {
+        "wandas.audio.coherence": CoherenceFrame,
+        "wandas.audio.csd": CrossSpectralFrame,
+    }[operation_id]
+    assert type(replayed) is expected_type
+    assert type(direct_v2) is expected_type
+
     np.testing.assert_allclose(
         channel_first_values(replayed),
         channel_first_values(direct_v2),
@@ -737,7 +767,77 @@ def test_pairwise_recipe_v1_preserves_released_label_order(
     assert direct_v2.labels == v2_labels
     assert replayed.operation_history[-1]["version"] == 1
     assert direct_v2.operation_history[-1]["version"] == 2
+    assert [(pair.output.index, pair.input.index) for pair in replayed.pairs] == [
+        (0, 0),
+        (0, 1),
+        (1, 0),
+        (1, 1),
+    ]
+    assert [(record.pair, record.domain, record.row_id) for record in replayed.pair_state] == [
+        (record.pair, record.domain, record.row_id) for record in direct_v2.pair_state
+    ]
     _assert_source_unchanged(source, values)
+
+
+@pytest.mark.parametrize(
+    ("operation_name", "params", "expected_type"),
+    [
+        ("coherence", {"n_fft": 32, "hop_length": 16, "win_length": 32, "window": "boxcar"}, CoherenceFrame),
+        (
+            "csd",
+            {
+                "n_fft": 32,
+                "hop_length": 16,
+                "win_length": 32,
+                "window": "boxcar",
+                "scaling": "density",
+            },
+            CrossSpectralFrame,
+        ),
+        (
+            "transfer_function",
+            {
+                "n_fft": 32,
+                "hop_length": 16,
+                "win_length": 32,
+                "window": "boxcar",
+                "scaling": "spectrum",
+            },
+            TransferFunctionFrame,
+        ),
+    ],
+)
+def test_public_pairwise_v2_recipe_roundtrip_rebuilds_exact_type_and_state(
+    operation_name: str,
+    params: dict[str, Any],
+    expected_type: type[CoherenceFrame] | type[CrossSpectralFrame] | type[TransferFunctionFrame],
+) -> None:
+    values = np.stack(
+        [
+            np.sin(2.0 * np.pi * np.arange(256) / 16.0),
+            1.5 * np.sin(2.0 * np.pi * np.arange(256) / 16.0 + 0.3),
+        ]
+    )
+    source = _source(values, sampling_rate=256.0)
+    direct = getattr(source, operation_name)(**params)
+    payload = RecipePlan.from_frame(direct, input_names=("signal",)).to_dict()
+    serialized = json.loads(json.dumps(payload, allow_nan=False))
+    replayed = RecipePlan.from_dict(serialized).apply({"signal": source})
+
+    assert serialized == payload
+    assert type(direct) is expected_type
+    assert type(replayed) is expected_type
+    np.testing.assert_allclose(
+        channel_first_values(replayed),
+        channel_first_values(direct),
+        rtol=1e-12,
+        atol=1e-12,
+        equal_nan=True,
+    )
+    assert replayed.pair_state == direct.pair_state
+    assert replayed.source_channel_ids == direct.source_channel_ids
+    assert replayed.n_pairs == direct.n_pairs
+    assert replayed.operation_history[-1]["version"] == 2
 
 
 def test_default_registry_contains_v1_and_v2_for_all_spectral_recipe_operations() -> None:

--- a/tests/processing/test_pairwise_spectral_contracts.py
+++ b/tests/processing/test_pairwise_spectral_contracts.py
@@ -292,6 +292,9 @@ def test_pairwise_contract_validation_edges_are_explicit() -> None:
         SpectralChannelRole(index=0, label=cast(Any, 1), unit="Pa", reference=1.0)
     with pytest.raises(TypeError, match="Channel unit"):
         SpectralChannelRole(index=0, label="source", unit=cast(Any, 1), reference=1.0)
+    assert role.source_id == "c0"
+    with pytest.raises(TypeError, match="Channel id"):
+        SpectralChannelRole(index=0, label="source", unit="Pa", reference=1.0, channel_id=cast(Any, 1))
     for invalid_reference in (True, "1"):
         with pytest.raises(TypeError, match="positive finite"):
             SpectralChannelRole(index=0, label="source", unit="Pa", reference=cast(Any, invalid_reference))
@@ -322,6 +325,8 @@ def test_pairwise_contract_validation_edges_are_explicit() -> None:
     pair = _pair(fixture, output_index=1, input_index=0)
     with pytest.raises(ValueError, match="scaling"):
         derive_csd_domain(pair, "invalid")
+    with pytest.raises(ValueError, match="denominator role"):
+        derive_transfer_domain(pair, cast(Any, "invalid"))
     assert derive_coherence_domain() == DerivedSpectralDomain(unit="1", reference=1.0)
 
     output_only = OrderedSpectralPair(

--- a/tests/processing/test_pairwise_spectral_contracts.py
+++ b/tests/processing/test_pairwise_spectral_contracts.py
@@ -295,6 +295,8 @@ def test_pairwise_contract_validation_edges_are_explicit() -> None:
     assert role.source_id == "c0"
     with pytest.raises(TypeError, match="Channel id"):
         SpectralChannelRole(index=0, label="source", unit="Pa", reference=1.0, channel_id=cast(Any, 1))
+    with pytest.raises(ValueError, match="non-blank"):
+        SpectralChannelRole(index=0, label="source", unit="Pa", reference=1.0, channel_id=" ")
     for invalid_reference in (True, "1"):
         with pytest.raises(TypeError, match="positive finite"):
             SpectralChannelRole(index=0, label="source", unit="Pa", reference=cast(Any, invalid_reference))

--- a/tests/processing/test_pairwise_spectral_contracts.py
+++ b/tests/processing/test_pairwise_spectral_contracts.py
@@ -15,7 +15,7 @@ from scipy import signal as ss
 from tests.frame_helpers import channel_first_values
 from tests.processing_helpers import run_operation_eager
 from wandas.frames.channel import ChannelFrame
-from wandas.frames.spectral import SpectralFrame
+from wandas.frames.pairwise import CrossSpectralFrame, TransferFunctionFrame
 from wandas.processing.spectral import CSD, TransferFunction
 from wandas.processing.spectral_contracts import (
     DerivedSpectralDomain,
@@ -798,7 +798,8 @@ def test_public_channel_pairwise_route_matches_independent_pairs(
         )
         compute.assert_not_called()
 
-    assert isinstance(result, SpectralFrame)
+    expected_type = CrossSpectralFrame if operation_name == "csd" else TransferFunctionFrame
+    assert type(result) is expected_type
     assert isinstance(result._data, DaArray)
     assert result.previous is frame
     assert result.sampling_rate == _SAMPLING_RATE

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,6 +11,7 @@ from tests.frame_helpers import channel_first_values
 from wandas.frames.cepstrogram import CepstrogramFrame
 from wandas.frames.channel import ChannelFrame
 from wandas.frames.noct import NOctFrame
+from wandas.frames.pairwise import CoherenceFrame, CrossSpectralFrame, TransferFunctionFrame
 from wandas.frames.spectral import SpectralFrame
 from wandas.frames.spectrogram import SpectrogramFrame
 from wandas.utils.frame_dataset import ChannelFrameDataset
@@ -121,6 +122,9 @@ def test_top_level_all_is_curated_primary_api() -> None:
         "CepstrogramFrame",
         "SpectralFrame",
         "SpectrogramFrame",
+        "CoherenceFrame",
+        "CrossSpectralFrame",
+        "TransferFunctionFrame",
         "NOctFrame",
         "ChannelFrameDataset",
         "read",
@@ -147,6 +151,9 @@ def test_top_level_frame_classes_are_public() -> None:
     assert wandas.CepstrogramFrame is CepstrogramFrame
     assert wandas.SpectralFrame is SpectralFrame
     assert wandas.SpectrogramFrame is SpectrogramFrame
+    assert wandas.CoherenceFrame is CoherenceFrame
+    assert wandas.CrossSpectralFrame is CrossSpectralFrame
+    assert wandas.TransferFunctionFrame is TransferFunctionFrame
     assert wandas.NOctFrame is NOctFrame
     assert wandas.ChannelFrameDataset is ChannelFrameDataset
 
@@ -163,6 +170,9 @@ def test_frames_module_all_matches_documented_frames() -> None:
         "CepstrogramFrame",
         "SpectralFrame",
         "SpectrogramFrame",
+        "CoherenceFrame",
+        "CrossSpectralFrame",
+        "TransferFunctionFrame",
         "NOctFrame",
         "RoughnessFrame",
     ]
@@ -171,6 +181,9 @@ def test_frames_module_all_matches_documented_frames() -> None:
     assert frames.CepstrogramFrame is CepstrogramFrame
     assert frames.SpectralFrame is SpectralFrame
     assert frames.SpectrogramFrame is SpectrogramFrame
+    assert frames.CoherenceFrame is CoherenceFrame
+    assert frames.CrossSpectralFrame is CrossSpectralFrame
+    assert frames.TransferFunctionFrame is TransferFunctionFrame
     assert frames.NOctFrame is NOctFrame
     assert frames.RoughnessFrame is RoughnessFrame
 

--- a/tests/visualization/test_pairwise_plotting.py
+++ b/tests/visualization/test_pairwise_plotting.py
@@ -1,0 +1,157 @@
+"""Numeric plotting contracts for dedicated pairwise spectral Frames."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.axes import Axes
+
+from tests.frame_helpers import channel_first_values
+from tests.pairwise_test_helpers import make_pairwise_source
+from wandas.frames.pairwise import CoherenceFrame, CrossSpectralFrame, TransferFunctionFrame
+
+
+def _axes_list(result: Axes | Iterator[Axes]) -> list[Axes]:
+    return [result] if isinstance(result, Axes) else list(result)
+
+
+def test_csd_frequency_views_plot_exact_numeric_values_and_custom_axes() -> None:
+    frame = make_pairwise_source(n_channels=2).csd(
+        n_fft=32,
+        win_length=32,
+        hop_length=16,
+        window="boxcar",
+        scaling="density",
+    )
+    raw = channel_first_values(frame)
+    views = {
+        "magnitude": np.abs(raw),
+        "phase": np.angle(raw),
+        "level": np.asarray(frame.level_db),
+    }
+
+    for view, expected in views.items():
+        axes = _axes_list(frame.plot(view=view))
+        assert len(axes) == frame.n_pairs
+        assert all("CSD" in ax.get_ylabel() for ax in axes)
+        for ax, expected_row in zip(axes, expected, strict=True):
+            np.testing.assert_allclose(ax.lines[0].get_ydata(), expected_row, equal_nan=True)
+
+    figure, axis = plt.subplots()
+    result = frame.plot(
+        ax=axis,
+        overlay=True,
+        view="phase",
+        title="CSD phase",
+        xlabel="Custom frequency",
+        ylabel="Custom phase",
+        color="tab:red",
+    )
+    assert result is axis
+    assert axis.get_title() == "CSD phase"
+    assert axis.get_xlabel() == "Custom frequency"
+    assert axis.get_ylabel() == "Custom phase"
+    assert len(axis.lines) == frame.n_pairs
+    np.testing.assert_allclose(np.asarray(axis.lines[1].get_ydata()), np.asarray(np.angle(raw[1])), equal_nan=True)
+    plt.close(figure)
+
+
+def test_transfer_frequency_views_plot_gain_phase_and_both_level_definitions() -> None:
+    frame = make_pairwise_source(
+        n_channels=2,
+        units=("V", "V"),
+        references=(2.0, 5.0),
+    ).transfer_function(
+        n_fft=32,
+        win_length=32,
+        hop_length=16,
+        window="boxcar",
+        scaling="spectrum",
+    )
+    raw = channel_first_values(frame)
+    views = {
+        "gain": np.abs(raw),
+        "phase": np.angle(raw),
+        "gain_db": np.asarray(frame.gain_db),
+        "transfer_level_db": np.asarray(frame.transfer_level_db),
+    }
+
+    for view, expected in views.items():
+        axes = _axes_list(frame.plot(view=view))
+        assert len(axes) == frame.n_pairs
+        for ax, expected_row in zip(axes, expected, strict=True):
+            np.testing.assert_allclose(ax.lines[0].get_ydata(), expected_row, equal_nan=True)
+
+    assert frame.definition == "canonical_input_denominator"
+    assert all("Transfer" in ax.get_ylabel() for ax in _axes_list(frame.plot(view="gain")))
+
+
+def test_pairwise_matrix_plot_uses_typed_output_input_cells_and_leaves_sparse_cells_empty() -> None:
+    frame = make_pairwise_source(n_channels=3).csd(
+        n_fft=32,
+        win_length=32,
+        hop_length=16,
+        window="boxcar",
+        scaling="density",
+    )
+    subset = frame.select_pairs([6, 0, 8])
+    raw = channel_first_values(subset)
+    axes = _axes_list(subset.plot_matrix(view="magnitude"))
+
+    assert len(axes) == 9
+    for position, axis in enumerate(axes):
+        output_index, input_index = divmod(position, 3)
+        matching = [
+            row
+            for row, pair in enumerate(subset.pairs)
+            if (pair.output.index, pair.input.index) == (output_index, input_index)
+        ]
+        if matching:
+            assert len(axis.lines) == 1
+            np.testing.assert_allclose(
+                np.asarray(axis.lines[0].get_ydata()),
+                np.asarray(np.abs(raw[matching[0]])),
+                equal_nan=True,
+            )
+        else:
+            assert not axis.lines
+
+
+@pytest.mark.parametrize(
+    "frame",
+    [
+        make_pairwise_source().csd(n_fft=32, win_length=32, hop_length=16, window="boxcar", scaling="density"),
+        make_pairwise_source().transfer_function(
+            n_fft=32,
+            win_length=32,
+            hop_length=16,
+            window="boxcar",
+            scaling="spectrum",
+        ),
+    ],
+)
+def test_csd_and_transfer_plotting_rejects_a_weighting(frame: CrossSpectralFrame | TransferFunctionFrame) -> None:
+    with pytest.raises(ValueError, match="A-weighting"):
+        frame.plot(Aw=True)
+    with pytest.raises(ValueError, match="A-weighting"):
+        frame.plot_matrix(Aw=True)
+
+
+def test_coherence_plotting_is_typed_and_not_a_spectral_amplitude_view() -> None:
+    frame = make_pairwise_source(n_channels=2).coherence(
+        n_fft=32,
+        win_length=32,
+        hop_length=16,
+        window="boxcar",
+    )
+    assert type(frame) is CoherenceFrame
+    values = channel_first_values(frame)
+    axes = _axes_list(frame.plot())
+    assert all(axis.get_ylabel() == "Coherence" for axis in axes)
+    for axis, expected in zip(axes, values, strict=True):
+        np.testing.assert_allclose(axis.lines[0].get_ydata(), expected, equal_nan=True)
+    with pytest.raises(ValueError, match="A-weighting"):
+        frame.plot(Aw=True)

--- a/tests/visualization/test_pairwise_plotting.py
+++ b/tests/visualization/test_pairwise_plotting.py
@@ -227,6 +227,26 @@ def test_plot_dispatch_rejects_noncallable_and_incomplete_typed_hooks() -> None:
     with pytest.raises(TypeError, match="_matrix_plot_entries must be callable"):
         _typed_matrix_entries(BadMatrixHook(), view=None, aw=False)
 
+    class Shadowable:
+        @staticmethod
+        def _matrix_plot_entries(*, view: str | None, Aw: bool) -> tuple:  # noqa: N803
+            del view, Aw
+            return ()
+
+        @staticmethod
+        def _plot_frequency_values(*, view: str | None, Aw: bool) -> tuple[np.ndarray[Any, Any], str]:  # noqa: N803
+            del view, Aw
+            return np.array([0.0]), "Typed"
+
+    shadowable = Shadowable()
+    setattr(shadowable, "_matrix_plot_entries", object())
+    setattr(shadowable, "_plot_frequency_values", object())
+    assert _typed_matrix_entries(shadowable, view=None, aw=False) == ()
+    values = _typed_frequency_values(shadowable, view=None, aw=False)
+    assert values is not None
+    np.testing.assert_array_equal(values[0], [0.0])
+    assert values[1] == "Typed"
+
     class EntriesOnly:
         n_source_channels = 1
 

--- a/tests/visualization/test_pairwise_plotting.py
+++ b/tests/visualization/test_pairwise_plotting.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -12,6 +13,7 @@ from matplotlib.axes import Axes
 from tests.frame_helpers import channel_first_values
 from tests.pairwise_test_helpers import make_pairwise_source
 from wandas.frames.pairwise import CoherenceFrame, CrossSpectralFrame, TransferFunctionFrame
+from wandas.visualization.plotting import _typed_frequency_values, _typed_matrix_entries, create_operation
 
 
 def _axes_list(result: Axes | Iterator[Axes]) -> list[Axes]:
@@ -48,12 +50,17 @@ def test_csd_frequency_views_plot_exact_numeric_values_and_custom_axes() -> None
         title="CSD phase",
         xlabel="Custom frequency",
         ylabel="Custom phase",
+        alpha=0.5,
+        xlim=(0.0, 100.0),
+        ylim=(-4.0, 4.0),
         color="tab:red",
     )
     assert result is axis
     assert axis.get_title() == "CSD phase"
     assert axis.get_xlabel() == "Custom frequency"
     assert axis.get_ylabel() == "Custom phase"
+    assert axis.get_xlim() == (0.0, 100.0)
+    assert axis.get_ylim() == (-4.0, 4.0)
     assert len(axis.lines) == frame.n_pairs
     np.testing.assert_allclose(np.asarray(axis.lines[1].get_ydata()), np.asarray(np.angle(raw[1])), equal_nan=True)
     plt.close(figure)
@@ -155,3 +162,83 @@ def test_coherence_plotting_is_typed_and_not_a_spectral_amplitude_view() -> None
         np.testing.assert_allclose(axis.lines[0].get_ydata(), expected, equal_nan=True)
     with pytest.raises(ValueError, match="A-weighting"):
         frame.plot(Aw=True)
+
+
+def test_typed_plot_views_reject_unknown_views_and_single_pair_matrix_is_two_dimensional() -> None:
+    coherence = make_pairwise_source(n_channels=1).coherence(
+        n_fft=32,
+        win_length=32,
+        hop_length=16,
+        window="boxcar",
+    )
+    csd = make_pairwise_source(n_channels=2).csd(
+        n_fft=32,
+        win_length=32,
+        hop_length=16,
+        window="boxcar",
+        scaling="density",
+    )
+    transfer = make_pairwise_source(n_channels=2).transfer_function(
+        n_fft=32,
+        win_length=32,
+        hop_length=16,
+        window="boxcar",
+        scaling="spectrum",
+    )
+
+    with pytest.raises(ValueError, match="only the 'coherence'"):
+        coherence.plot(view="unknown")
+    with pytest.raises(ValueError, match="magnitude.*phase.*level"):
+        csd.plot(view="unknown")
+    with pytest.raises(ValueError, match="gain.*phase.*gain_db"):
+        transfer.plot(view="unknown")
+
+    axes = _axes_list(coherence.plot_matrix())
+    assert len(axes) == 1
+    assert len(axes[0].lines) == 1
+    plt.close("all")
+
+
+def test_plot_dispatch_rejects_noncallable_and_incomplete_typed_hooks() -> None:
+    class BadFrequencyHook:
+        _plot_frequency_values = object()
+
+    class BadMatrixHook:
+        _matrix_plot_entries = object()
+
+    with pytest.raises(TypeError, match="_plot_frequency_values must be callable"):
+        _typed_frequency_values(BadFrequencyHook(), view=None, aw=False)
+    with pytest.raises(TypeError, match="_matrix_plot_entries must be callable"):
+        _typed_matrix_entries(BadMatrixHook(), view=None, aw=False)
+
+    class EntriesOnly:
+        n_source_channels = 1
+
+        @staticmethod
+        def _matrix_plot_entries(*, view: str | None, Aw: bool) -> tuple:  # noqa: N803
+            del view, Aw
+            return ()
+
+    class EmptyTyped:
+        n_source_channels = 0
+
+        @staticmethod
+        def _matrix_plot_entries(*, view: str | None, Aw: bool) -> tuple:  # noqa: N803
+            del view, Aw
+            return ()
+
+        @staticmethod
+        def _plot_frequency_values(*, view: str | None, Aw: bool) -> tuple[np.ndarray[Any, Any], str]:  # noqa: N803
+            del view, Aw
+            return np.array([0.0]), "Typed"
+
+    with pytest.raises(TypeError, match="frequency plotting contract"):
+        create_operation("matrix").plot(EntriesOnly())
+    with pytest.raises(ValueError, match="at least one source channel"):
+        create_operation("matrix").plot(EmptyTyped())
+
+    spectral = make_pairwise_source(n_channels=1).fft(n_fft=32)
+    with pytest.raises(ValueError, match="supported only by a typed"):
+        spectral.plot(view="magnitude")
+    with pytest.raises(ValueError, match="supported only by a typed"):
+        spectral.plot(plot_type="matrix", view="magnitude")

--- a/tests/visualization/test_pairwise_plotting.py
+++ b/tests/visualization/test_pairwise_plotting.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from typing import Any
+from unittest.mock import patch
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+from dask.array.core import Array as DaArray
 from matplotlib.axes import Axes
 
 from tests.frame_helpers import channel_first_values
@@ -125,6 +127,20 @@ def test_pairwise_matrix_plot_uses_typed_output_input_cells_and_leaves_sparse_ce
             )
         else:
             assert not axis.lines
+
+
+def test_pairwise_matrix_plot_materializes_values_once() -> None:
+    frame = make_pairwise_source(n_channels=2).csd(
+        n_fft=32,
+        win_length=32,
+        hop_length=16,
+        window="boxcar",
+        scaling="density",
+    )
+    original_compute = DaArray.compute
+    with patch.object(DaArray, "compute", autospec=True, side_effect=original_compute) as compute:
+        _axes_list(frame.plot_matrix(view="magnitude"))
+    assert compute.call_count == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/visualization/test_plotting.py
+++ b/tests/visualization/test_plotting.py
@@ -803,19 +803,19 @@ class TestPlotting:
         assert ax.get_title() == "Test Channel"
         assert len(ax.xaxis.get_gridlines()) > 0
 
-    def test_matrix_plot_strategy_coherence(self) -> None:
-        """Verify MatrixPlotStrategy.plot returns per-channel axes with coherence labels."""
+    def test_matrix_plot_strategy_ordinary_spectral_frame(self) -> None:
+        """Ordinary SpectralFrame matrices always use amplitude levels."""
         strategy = MatrixPlotStrategy()
-        result = strategy.plot(self.mock_coherence_spectral_frame)
+        result = strategy.plot(self.mock_spectral_frame)
 
         assert isinstance(result, Iterator)
         axes_list = list(result)
-        assert len(axes_list) == self.mock_coherence_spectral_frame.n_channels
+        assert len(axes_list) == 4
 
-        for i, ax in enumerate(axes_list):
+        for i, ax in enumerate(axes_list[:2]):
             assert ax.get_xlabel() == "Frequency [Hz]"
-            assert "coherence" in ax.get_ylabel().lower()
-            assert self.mock_coherence_spectral_frame.labels[i] in ax.get_title()
+            assert "Amplitude level" in ax.get_ylabel()
+            assert self.mock_spectral_frame.labels[i] in ax.get_title()
 
     def test_matrix_plot_strategy_aw(self) -> None:
         """Verify MatrixPlotStrategy.plot with Aw=True produces A-weighted labels."""
@@ -854,8 +854,8 @@ class TestPlotting:
         # Verify grid is displayed
         assert len(ax.xaxis.get_gridlines()) > 0
 
-        # Test single-channel coherence data plot
-        result = strategy.plot(self.mock_single_coherence_spectral_frame)
+        # Test ordinary single-channel spectral data plot
+        result = strategy.plot(self.mock_single_spectral_frame)
 
         # Verify result is an Iterator of Axes
         assert isinstance(result, Iterator)
@@ -864,20 +864,20 @@ class TestPlotting:
 
         # Verify axis labels and title
         assert axes_list[0].get_xlabel() == "Frequency [Hz]"
-        assert "coherence" in axes_list[0].get_ylabel().lower()
-        label = self.mock_single_coherence_spectral_frame.labels[0]
+        assert "Amplitude level" in axes_list[0].get_ylabel()
+        label = self.mock_single_spectral_frame.labels[0]
         assert label in axes_list[0].get_title()
 
         # Test with custom title and unit
         result = strategy.plot(
-            self.mock_single_coherence_spectral_frame,
+            self.mock_single_spectral_frame,
             title="Custom Matrix Title",
             ylabel="Custom Y Units",
         )
         # Verify result is an iterator, then convert to list
         assert isinstance(result, Iterator)
         axes_list = list(result)
-        assert axes_list[0].get_title() == "ch1-ch1"
+        assert axes_list[0].get_title() == "ch1"
         assert "Custom Y Units" in axes_list[0].get_ylabel()
         assert axes_list[0].figure.get_suptitle() == "Custom Matrix Title"
 
@@ -913,13 +913,13 @@ class TestPlotting:
         """Test FrequencyPlotStrategy edge cases."""
         strategy = FrequencyPlotStrategy()
 
-        # Test with coherence operation history frame
+        # History is not a quantity dispatch signal for ordinary SpectralFrame.
         self.mock_spectral_frame.operation_history = [{"operation": "wandas.audio.coherence"}]
         self.mock_spectral_frame.magnitude = np.abs(self.mock_spectral_frame.dB)
 
         result = strategy.plot(self.mock_spectral_frame, overlay=True)
         assert isinstance(result, Axes)
-        assert "coherence" in result.get_ylabel()
+        assert "Amplitude level" in result.get_ylabel()
 
         # Reset operation history
         self.mock_spectral_frame.operation_history = []
@@ -1092,8 +1092,8 @@ class TestPlotting:
         result = strategy.plot(self.mock_spectral_frame, overlay=True)
         assert isinstance(result, Axes)
 
-        # Test overlay mode with coherence data
-        result = strategy.plot(self.mock_coherence_spectral_frame, overlay=True)
+        # A history-like label does not change ordinary spectral plotting.
+        result = strategy.plot(self.mock_spectral_frame, overlay=True)
         assert isinstance(result, Axes)
 
         # Test overlay mode with externally provided ax
@@ -1197,17 +1197,17 @@ class TestPlotting:
         """Test frame with multiple operation history entries."""
         strategy = FrequencyPlotStrategy()
 
-        # Frame with multiple operation history entries
+        # Frame with multiple operation history entries; plotting remains typed
+        # by the concrete Frame rather than the last operation ID.
         self.mock_spectral_frame.operation_history = [
             {"operation": "fft"},
-            {"operation": "wandas.audio.coherence"},  # last operation is coherence
+            {"operation": "wandas.audio.coherence"},
         ]
         self.mock_spectral_frame.magnitude = np.abs(self.mock_spectral_frame.dB)
 
         result = strategy.plot(self.mock_spectral_frame, overlay=True)
         assert isinstance(result, Axes)
-        # Last operation is coherence — ylabel must reflect it
-        assert "coherence" in result.get_ylabel()
+        assert "Amplitude level" in result.get_ylabel()
         # Frequency axis label must still be present
         assert result.get_xlabel() == "Frequency [Hz]"
 
@@ -1542,22 +1542,22 @@ class TestPublicCoherencePlot:
         for line, expected_channel in zip(plotted_lines, expected, strict=True):
             np.testing.assert_allclose(line.get_ydata(), expected_channel)
 
-    def test_public_coherence_plots_use_raw_magnitude(self) -> None:
+    def test_public_coherence_plots_use_raw_coherence(self) -> None:
         coherence = self._make_coherence_frame()
         assert coherence.operation_history[-1]["operation"] == "wandas.audio.coherence"
-        raw_magnitude = np.asarray(coherence.magnitude)
+        raw_coherence = np.asarray(coherence.coherence)
 
         frequency_axes = self._axes_list(coherence.plot())
-        assert all(ax.get_ylabel() == "coherence" for ax in frequency_axes)
-        self._assert_raw_lines(frequency_axes, raw_magnitude)
+        assert all(ax.get_ylabel() == "Coherence" for ax in frequency_axes)
+        self._assert_raw_lines(frequency_axes, raw_coherence)
 
-        frequency_overlay = self._axes_list(coherence.plot(overlay=True, Aw=True))
-        assert frequency_overlay[0].get_ylabel() == "coherence"
-        self._assert_raw_lines(frequency_overlay, raw_magnitude)
+        frequency_overlay = self._axes_list(coherence.plot(overlay=True))
+        assert frequency_overlay[0].get_ylabel() == "Coherence"
+        self._assert_raw_lines(frequency_overlay, raw_coherence)
 
         matrix_axes = self._axes_list(coherence.plot_matrix())
-        assert all(ax.get_ylabel() == "coherence" for ax in matrix_axes)
-        self._assert_raw_lines(matrix_axes, raw_magnitude)
+        assert all(ax.get_ylabel() == "Coherence" for ax in matrix_axes)
+        self._assert_raw_lines(matrix_axes, raw_coherence)
 
         frequency_figure, frequency_ax = plt.subplots()
         frequency_result = coherence.plot(
@@ -1565,7 +1565,6 @@ class TestPublicCoherencePlot:
             title="Custom Coherence",
             ylabel="Custom coherence",
             label="coherence series",
-            Aw=True,
             color="tab:red",
             linewidth=2,
         )
@@ -1575,7 +1574,7 @@ class TestPublicCoherencePlot:
         assert frequency_ax.lines[0].get_label() == "coherence series"
         assert frequency_ax.lines[0].get_color() == "tab:red"
         assert frequency_ax.lines[0].get_linewidth() == 2
-        self._assert_raw_lines([frequency_ax], raw_magnitude)
+        self._assert_raw_lines([frequency_ax], raw_coherence)
         plt.close(frequency_figure)
 
         matrix_figure, matrix_ax = plt.subplots()
@@ -1583,15 +1582,23 @@ class TestPublicCoherencePlot:
             ax=matrix_ax,
             title="Custom Matrix Coherence",
             ylabel="Custom matrix coherence",
-            Aw=True,
             color="tab:blue",
             linewidth=2,
         )
         assert matrix_result is matrix_ax
         assert matrix_ax.get_title() == "Custom Matrix Coherence"
         assert matrix_ax.get_ylabel() == "Custom matrix coherence"
-        self._assert_raw_lines([matrix_ax], raw_magnitude)
+        self._assert_raw_lines([matrix_ax], raw_coherence)
         plt.close(matrix_figure)
+
+        changed_history = coherence.with_metadata({"quantity": "unrelated"})
+        changed_axes = self._axes_list(changed_history.plot(overlay=True))
+        self._assert_raw_lines(changed_axes, raw_coherence)
+
+        with pytest.raises(ValueError, match="A-weighting"):
+            coherence.plot(Aw=True)
+        with pytest.raises(ValueError, match="A-weighting"):
+            coherence.plot_matrix(Aw=True)
 
 
 class TestChannelFramePlotParameters:

--- a/tests/visualization/test_plotting.py
+++ b/tests/visualization/test_plotting.py
@@ -676,6 +676,7 @@ class TestPlotting:
             self.mock_noct_frame.dB[0],
             ax,
             label="Test NOct",
+            alpha=0.5,
         )
         # Verify step plot is used with grid and legend displayed
         assert len(ax.xaxis.get_gridlines()) > 0  # Verify grid is displayed
@@ -796,6 +797,7 @@ class TestPlotting:
             ax,
             title="Test Channel",
             ylabel="Test Label",
+            alpha=0.5,
         )
 
         assert ax.get_xlabel() == "Frequency [Hz]"

--- a/wandas/__init__.py
+++ b/wandas/__init__.py
@@ -10,6 +10,7 @@ from .frames.cepstral import CepstralFrame
 from .frames.cepstrogram import CepstrogramFrame
 from .frames.channel import ChannelFrame
 from .frames.noct import NOctFrame
+from .frames.pairwise import CoherenceFrame, CrossSpectralFrame, TransferFunctionFrame
 from .frames.spectral import SpectralFrame
 from .frames.spectrogram import SpectrogramFrame
 from .io.read import read
@@ -34,6 +35,9 @@ __all__ = [
     "CepstrogramFrame",
     "SpectralFrame",
     "SpectrogramFrame",
+    "CoherenceFrame",
+    "CrossSpectralFrame",
+    "TransferFunctionFrame",
     "NOctFrame",
     "ChannelFrameDataset",
     "read",

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -1230,6 +1230,18 @@ class BaseFrame(ABC, Generic[T]):
             raise TypeError(f"Channel list contains mixed or unsupported values: {selector!r}")
         raise TypeError(f"Invalid channel selector type: {type(selector).__name__}")
 
+    def _selection_constructor_kwargs(self, indices: Sequence[int]) -> dict[str, Any]:
+        """Return private constructor state for a channel-row selection.
+
+        The default Frame state is fully described by channel metadata and IDs.
+        Domain-specific Frames may override this narrow hook when a row selection
+        also needs to select an immutable companion state (for example, flattened
+        output/input pair records). The generic Frame machinery remains unaware of
+        that domain.
+        """
+        del indices
+        return {}
+
     def _select_channels(self: S, indices: list[int], lineage: LineageNode) -> S:
         """Create a channel subset that preserves metadata, offsets, and lineage."""
         return self._create_new_instance(
@@ -1238,6 +1250,7 @@ class BaseFrame(ABC, Generic[T]):
             channel_ids=self._channel_ids_for_selection(indices),
             source_time_offset=self.source_time_offset[indices],
             lineage=lineage,
+            **self._selection_constructor_kwargs(indices),
         )
 
     @recipe_operation(
@@ -1426,6 +1439,7 @@ class BaseFrame(ABC, Generic[T]):
             channel_ids=self._channel_ids_for_selection(indices),
             source_time_offset=source_time_offset,
             lineage=self._required_semantic_lineage(),
+            **self._selection_constructor_kwargs(indices),
         )
 
     def _channel_selector_for_lineage(self, key: Any) -> dict[str, Any] | None:
@@ -1613,9 +1627,11 @@ class BaseFrame(ABC, Generic[T]):
 
         source_time_offset = kwargs.pop("source_time_offset", self.source_time_offset)
 
-        # Get additional initialization arguments from derived classes
+        # Get additional initialization arguments from derived classes. Explicit
+        # reconstruction state is authoritative: domain-specific selection hooks
+        # may intentionally replace one part of the copied constructor state.
         additional_kwargs = self._get_additional_init_kwargs()
-        kwargs.update(additional_kwargs)
+        init_state = {**additional_kwargs, **kwargs}
 
         init_kwargs: dict[str, Any] = {
             "data": data,
@@ -1627,7 +1643,7 @@ class BaseFrame(ABC, Generic[T]):
             "source_time_offset": source_time_offset,
             "previous": self,
             "lineage": lineage,
-            **kwargs,
+            **init_state,
         }
         result = type(self)(**init_kwargs)
 

--- a/wandas/frames/__init__.py
+++ b/wandas/frames/__init__.py
@@ -4,6 +4,7 @@ from wandas.frames.cepstral import CepstralFrame
 from wandas.frames.cepstrogram import CepstrogramFrame
 from wandas.frames.channel import ChannelFrame
 from wandas.frames.noct import NOctFrame
+from wandas.frames.pairwise import CoherenceFrame, CrossSpectralFrame, TransferFunctionFrame
 from wandas.frames.roughness import RoughnessFrame
 from wandas.frames.spectral import SpectralFrame
 from wandas.frames.spectrogram import SpectrogramFrame
@@ -14,6 +15,9 @@ __all__ = [
     "CepstrogramFrame",
     "SpectralFrame",
     "SpectrogramFrame",
+    "CoherenceFrame",
+    "CrossSpectralFrame",
+    "TransferFunctionFrame",
     "NOctFrame",
     "RoughnessFrame",
 ]

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -2,9 +2,10 @@
 operations."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, cast, runtime_checkable
 
 import numpy as np
+from dask.array.core import Array as DaArray
 
 from wandas.pipeline.decorators import recipe_operation
 from wandas.processing.spectral import validate_noct_recipe_params
@@ -21,6 +22,28 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+PairwiseFrameT = TypeVar("PairwiseFrameT", bound=PairwiseSpectralFrame)
+
+
+@runtime_checkable
+class _PairwiseSpectralOperationProtocol(Protocol):
+    """Minimum typed operation surface needed by the pairwise Frame builder."""
+
+    @property
+    def n_fft(self) -> int: ...
+
+    @property
+    def window(self) -> str: ...
+
+    def process(self, data: DaArray, *inputs: DaArray) -> DaArray: ...
+
+
+@runtime_checkable
+class _ScaledPairwiseSpectralOperationProtocol(_PairwiseSpectralOperationProtocol, Protocol):
+    """Pairwise operation surface for CSD and transfer scaling state."""
+
+    @property
+    def scaling(self) -> str: ...
 
 
 def _build_cross_channel_source_time_offsets(source_time_offset: Any) -> Any:
@@ -44,6 +67,103 @@ def _validate_real_cepstrum_input(data: Any) -> None:
         )
 
 
+def _cross_channel_spectral_transform(
+    source: TransformFrameProtocol,
+    operation_name: str,
+    label_prefix: str,
+    label_template: str,
+    output_frame_class: type[PairwiseFrameT],
+    quantity: Literal["coherence", "csd", "transfer"],
+    denominator_role: Literal["input", "output"] = "input",
+    operation_override: _PairwiseSpectralOperationProtocol | None = None,
+    **params: Any,
+) -> PairwiseFrameT:
+    """Build one typed flattened pairwise spectral Frame lazily.
+
+    The generic output class is the sole source of the concrete return type.  This
+    helper owns orchestration only; numerical settings and processing remain on the
+    supplied Operation, while pair metadata, lineage, and Frame construction remain
+    in the Frame layer.
+    """
+    from wandas.processing import create_operation
+
+    from ..pairwise import _metadata_for_pair_state, build_pair_state
+
+    logger.debug(f"Applying operation={operation_name} with params={params} (lazy)")
+
+    operation_candidate = (
+        operation_override
+        if operation_override is not None
+        else create_operation(operation_name, source.sampling_rate, **params)
+    )
+    if not isinstance(operation_candidate, _PairwiseSpectralOperationProtocol):
+        raise TypeError(
+            f"Operation '{operation_name}' does not expose the pairwise spectral contract (process, n_fft, and window)."
+        )
+    operation = operation_candidate
+    result_data = operation.process(source._effective_data)
+
+    n_fft = operation.n_fft
+    if isinstance(n_fft, bool) or not isinstance(n_fft, int):
+        raise TypeError(
+            f"Operation '{operation_name}' must provide a positive integer n_fft "
+            f"to create a dedicated pairwise Frame, but got {type(n_fft).__name__}."
+        )
+    if n_fft <= 0:
+        raise ValueError(
+            f"Operation '{operation_name}' must provide a positive integer n_fft "
+            f"to create a dedicated pairwise Frame, but got {n_fft}."
+        )
+
+    scaling: Literal["spectrum", "density"] | None = None
+    if quantity != "coherence":
+        if not isinstance(operation, _ScaledPairwiseSpectralOperationProtocol):
+            raise TypeError(
+                f"Operation '{operation_name}' does not expose the scaled pairwise spectral contract; "
+                "CSD and transfer operations must provide a scaling property."
+            )
+        operation_scaling = operation.scaling
+        if operation_scaling == "spectrum":
+            scaling = "spectrum"
+        elif operation_scaling == "density":
+            scaling = "density"
+        else:
+            raise ValueError(f"Operation '{operation_name}' must provide a valid scaling mode")
+
+    source_channel_metadata = source._channel_metadata
+    pair_state = build_pair_state(
+        source_channel_metadata,
+        source._channel_ids,
+        quantity=quantity,
+        scaling=scaling,
+        denominator_role=denominator_role,
+        label_template=label_template,
+    )
+    channel_metadata = _metadata_for_pair_state(pair_state, source_channel_metadata)
+    logger.debug(f"Created {output_frame_class.__name__} with operation {operation_name} added to graph")
+
+    constructor_kwargs: dict[str, Any] = {
+        "data": result_data,
+        "sampling_rate": source.sampling_rate,
+        "n_fft": n_fft,
+        "window": operation.window,
+        "pair_state": pair_state,
+        "source_channel_ids": tuple(source._channel_ids),
+        "label": f"{label_prefix} {source.label}",
+        "metadata": source.metadata,
+        "channel_metadata": channel_metadata,
+        "channel_ids": [record.row_id for record in pair_state],
+        "source_time_offset": _build_cross_channel_source_time_offsets(source.source_time_offset),
+        "lineage": source._required_semantic_lineage(),
+        "previous": source._as_base_frame,
+    }
+    if quantity != "coherence":
+        constructor_kwargs["scaling"] = scaling
+        if quantity == "transfer":
+            constructor_kwargs["denominator_role"] = denominator_role
+    return output_frame_class(**constructor_kwargs)
+
+
 class ChannelTransformMixin:
     """Mixin providing methods related to frequency transformations.
 
@@ -55,86 +175,6 @@ class ChannelTransformMixin:
     def _as_base_frame(self: TransformFrameProtocol) -> "BaseFrame[Any]":
         """Cast self to BaseFrame for use as ``previous`` in new frames."""
         return cast(BaseFrame[Any], self)
-
-    def _cross_channel_spectral_transform(
-        self: TransformFrameProtocol,
-        operation_name: str,
-        label_prefix: str,
-        label_template: str,
-        output_frame_class: type["PairwiseSpectralFrame"],
-        quantity: Literal["coherence", "csd", "transfer"],
-        denominator_role: Literal["input", "output"] = "input",
-        operation_override: Any | None = None,
-        **params: Any,
-    ) -> "PairwiseSpectralFrame":
-        """Shared implementation for cross-channel spectral transforms.
-
-        Used by ``coherence``, ``csd``, and ``transfer_function``. The concrete
-        output class and its typed numerical definition are supplied by the
-        public/versioned boundary; no downstream consumer infers quantity from
-        labels or lineage.
-        """
-        from wandas.processing import create_operation
-
-        from ..pairwise import _metadata_for_pair_state, build_pair_state
-
-        logger.debug(f"Applying operation={operation_name} with params={params} (lazy)")
-
-        operation = (
-            operation_override
-            if operation_override is not None
-            else create_operation(operation_name, self.sampling_rate, **params)
-        )
-        result_data = operation.process(self._effective_data)
-
-        operation_params = operation.to_params()
-        n_fft = operation_params["n_fft"]
-        if isinstance(n_fft, bool) or not isinstance(n_fft, int):
-            raise TypeError(
-                f"Operation '{operation_name}' must provide a positive integer n_fft "
-                f"to create a dedicated pairwise Frame, but got {type(n_fft).__name__}."
-            )
-        if n_fft <= 0:
-            raise ValueError(
-                f"Operation '{operation_name}' must provide a positive integer n_fft "
-                f"to create a dedicated pairwise Frame, but got {n_fft}."
-            )
-        scaling = operation_params.get("scaling")
-        source_channel_metadata = cast(Any, self).channels.to_list()
-        pair_state = build_pair_state(
-            source_channel_metadata,
-            cast(Any, self)._channel_ids,
-            quantity=quantity,
-            scaling=scaling,
-            denominator_role=denominator_role,
-            label_template=label_template,
-        )
-        channel_metadata = _metadata_for_pair_state(pair_state, source_channel_metadata)
-        logger.debug(f"Created {output_frame_class.__name__} with operation {operation_name} added to graph")
-
-        lineage = cast(Any, self)._required_semantic_lineage()
-        constructor_kwargs: dict[str, Any] = {
-            "data": result_data,
-            "sampling_rate": self.sampling_rate,
-            "n_fft": n_fft,
-            "window": operation_params["window"],
-            "pair_state": pair_state,
-            "source_channel_ids": tuple(cast(Any, self)._channel_ids),
-            "label": f"{label_prefix} {self.label}",
-            "metadata": self.metadata,
-            "channel_metadata": channel_metadata,
-            "channel_ids": [record.row_id for record in pair_state],
-            "source_time_offset": _build_cross_channel_source_time_offsets(cast(Any, self).source_time_offset),
-            "lineage": lineage,
-            "previous": self._as_base_frame,
-        }
-        if quantity != "coherence":
-            if scaling not in {"spectrum", "density"}:
-                raise ValueError(f"Operation '{operation_name}' must provide a valid scaling mode")
-            constructor_kwargs["scaling"] = scaling
-            if quantity == "transfer":
-                constructor_kwargs["denominator_role"] = denominator_role
-        return output_frame_class(**constructor_kwargs)
 
     @recipe_operation("wandas.audio.cepstrum", version=2)
     def cepstrum(
@@ -555,20 +595,18 @@ class ChannelTransformMixin:
         """
         from ..pairwise import CoherenceFrame
 
-        return cast(
+        return _cross_channel_spectral_transform(
+            self,
+            "coherence",
+            "Coherence of",
+            "$\\gamma_{{{out_label}, {in_label}}}$",
             CoherenceFrame,
-            self._cross_channel_spectral_transform(
-                "coherence",
-                "Coherence of",
-                "$\\gamma_{{{out_label}, {in_label}}}$",
-                CoherenceFrame,
-                "coherence",
-                n_fft=n_fft,
-                hop_length=hop_length,
-                win_length=win_length,
-                window=window,
-                detrend=detrend,
-            ),
+            "coherence",
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            detrend=detrend,
         )
 
     @recipe_operation("wandas.audio.coherence", version=1)
@@ -583,20 +621,18 @@ class ChannelTransformMixin:
         """Replay the released coherence pair-label order."""
         from ..pairwise import CoherenceFrame
 
-        return cast(
+        return _cross_channel_spectral_transform(
+            self,
+            "coherence",
+            "Coherence of",
+            "$\\gamma_{{{in_label}, {out_label}}}$",
             CoherenceFrame,
-            self._cross_channel_spectral_transform(
-                "coherence",
-                "Coherence of",
-                "$\\gamma_{{{in_label}, {out_label}}}$",
-                CoherenceFrame,
-                "coherence",
-                n_fft=n_fft,
-                hop_length=hop_length,
-                win_length=win_length,
-                window=window,
-                detrend=detrend,
-            ),
+            "coherence",
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            detrend=detrend,
         )
 
     @recipe_operation("wandas.audio.csd", version=2)
@@ -647,22 +683,20 @@ class ChannelTransformMixin:
         """
         from ..pairwise import CrossSpectralFrame
 
-        return cast(
+        return _cross_channel_spectral_transform(
+            self,
+            "csd",
+            "CSD of",
+            "csd({out_label}, {in_label})",
             CrossSpectralFrame,
-            self._cross_channel_spectral_transform(
-                "csd",
-                "CSD of",
-                "csd({out_label}, {in_label})",
-                CrossSpectralFrame,
-                "csd",
-                n_fft=n_fft,
-                hop_length=hop_length,
-                win_length=win_length,
-                window=window,
-                detrend=detrend,
-                scaling=scaling,
-                average=average,
-            ),
+            "csd",
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            detrend=detrend,
+            scaling=scaling,
+            average=average,
         )
 
     @recipe_operation("wandas.audio.csd", version=1)
@@ -679,22 +713,20 @@ class ChannelTransformMixin:
         """Replay the released CSD pair-label order."""
         from ..pairwise import CrossSpectralFrame
 
-        return cast(
+        return _cross_channel_spectral_transform(
+            self,
+            "csd",
+            "CSD of",
+            "csd({in_label}, {out_label})",
             CrossSpectralFrame,
-            self._cross_channel_spectral_transform(
-                "csd",
-                "CSD of",
-                "csd({in_label}, {out_label})",
-                CrossSpectralFrame,
-                "csd",
-                n_fft=n_fft,
-                hop_length=hop_length,
-                win_length=win_length,
-                window=window,
-                detrend=detrend,
-                scaling=scaling,
-                average=average,
-            ),
+            "csd",
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            detrend=detrend,
+            scaling=scaling,
+            average=average,
         )
 
     @recipe_operation("wandas.audio.transfer_function", version=2)
@@ -747,23 +779,21 @@ class ChannelTransformMixin:
         """
         from ..pairwise import TransferFunctionFrame
 
-        return cast(
+        return _cross_channel_spectral_transform(
+            self,
+            "transfer_function",
+            "Transfer function of",
+            "$H_{{{out_label}, {in_label}}}$",
             TransferFunctionFrame,
-            self._cross_channel_spectral_transform(
-                "transfer_function",
-                "Transfer function of",
-                "$H_{{{out_label}, {in_label}}}$",
-                TransferFunctionFrame,
-                "transfer",
-                "input",
-                n_fft=n_fft,
-                hop_length=hop_length,
-                win_length=win_length,
-                window=window,
-                detrend=detrend,
-                scaling=scaling,
-                average=average,
-            ),
+            "transfer",
+            "input",
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            detrend=detrend,
+            scaling=scaling,
+            average=average,
         )
 
     @recipe_operation("wandas.audio.transfer_function", version=1)
@@ -792,22 +822,20 @@ class ChannelTransformMixin:
             scaling=scaling,
             average=average,
         )
-        return cast(
+        return _cross_channel_spectral_transform(
+            self,
+            "transfer_function",
+            "Transfer function of",
+            "$H_{{{in_label}, {out_label}}}$",
             TransferFunctionFrame,
-            self._cross_channel_spectral_transform(
-                "transfer_function",
-                "Transfer function of",
-                "$H_{{{in_label}, {out_label}}}$",
-                TransferFunctionFrame,
-                "transfer",
-                "output",
-                operation_override=operation,
-                n_fft=n_fft,
-                hop_length=hop_length,
-                win_length=win_length,
-                window=window,
-                detrend=detrend,
-                scaling=scaling,
-                average=average,
-            ),
+            "transfer",
+            "output",
+            operation_override=operation,
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            detrend=detrend,
+            scaling=scaling,
+            average=average,
         )

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -519,7 +519,23 @@ class ChannelTransformMixin:
         window: str = "hann",
         detrend: str = "constant",
     ) -> "CoherenceFrame":
-        """Calculate magnitude squared coherence.
+        """Calculate typed magnitude-squared coherence for every channel pair.
+
+        The result is a :class:`CoherenceFrame` with flattened ``(pair,
+        frequency)`` storage and output-major/input-minor pair order.  Its real
+        raw values are dimensionless and lie in ``[0, 1]``; ``NaN`` is retained
+        for undefined zero-energy bins.  Pair roles, source identity, domains,
+        and row order are carried by immutable typed state, not labels or
+        operation history.  See the spectral numerical contracts for the
+        canonical mathematical definition.
+
+        Sampling rate and user metadata are preserved.  Each pair's
+        ``source_time_offset`` is derived from its input-role source offset, and
+        input calibration is consumed before the pairwise operation.  Constructing
+        the result remains Dask-lazy; accessing data or plotting is the
+        materialization boundary.  Invalid spectral parameters, input shape, or
+        coherence-domain values raise an actionable ``TypeError`` or
+        ``ValueError`` instead of being silently coerced.
 
         Args:
             n_fft: Number of FFT points. Default is 2048.
@@ -530,7 +546,12 @@ class ChannelTransformMixin:
             detrend: Detrend method. Options: "constant", "linear", None.
 
         Returns:
-            CoherenceFrame containing raw magnitude-squared coherence values.
+            CoherenceFrame whose public single-pair shape is ``(frequency,)`` and
+            whose multi-pair shape is ``(pair, frequency)``.  Use ``.coherence``
+            for the quantity-specific raw values.
+
+        Example:
+            ``coherence = frame.coherence(n_fft=1024, window="hann")``
         """
         from ..pairwise import CoherenceFrame
 
@@ -589,7 +610,23 @@ class ChannelTransformMixin:
         scaling: str = "spectrum",
         average: str = "mean",
     ) -> "CrossSpectralFrame":
-        """Calculate cross-spectral density matrix.
+        """Calculate a typed cross-spectral density matrix.
+
+        The result is a :class:`CrossSpectralFrame` with flattened
+        ``(pair, frequency)`` storage and output-major/input-minor pair order.
+        Each raw complex row stores ``P_out_in = conj(X_input) * X_output``;
+        pair domains provide the unit and reference, with ``/Hz`` included for
+        ``scaling="density"``.  Pair roles and domains are immutable typed state;
+        labels and operation history are display/provenance views only.  See the
+        spectral numerical contracts for the canonical definition and scaling.
+
+        Sampling rate and user metadata are preserved.  Pair
+        ``source_time_offset`` uses the input-role source offset, and input
+        calibration is consumed before constructing output metadata.  The result
+        stays Dask-lazy until data, a property, or a plot is materialized.
+        Invalid spectral parameters or domain/shape violations raise an actionable
+        ``TypeError`` or ``ValueError``.  Use the quantity-specific ``magnitude``,
+        ``phase``, and ``level_db`` properties; pairwise A-weighting is rejected.
 
         Args:
             n_fft: Number of FFT points. Default is 2048.
@@ -602,7 +639,11 @@ class ChannelTransformMixin:
             average: Method for averaging segments. Default is "mean".
 
         Returns:
-            CrossSpectralFrame containing complex cross-spectral values.
+            CrossSpectralFrame whose public single-pair shape is ``(frequency,)``
+            and whose multi-pair shape is ``(pair, frequency)``.
+
+        Example:
+            ``spectrum = frame.csd(n_fft=1024, scaling="density")``
         """
         from ..pairwise import CrossSpectralFrame
 
@@ -667,11 +708,25 @@ class ChannelTransformMixin:
         scaling: str = "spectrum",
         average: str = "mean",
     ) -> "TransferFunctionFrame":
-        """Calculate transfer function matrix.
+        """Calculate the canonical typed output/input transfer-function matrix.
 
-        The transfer function represents the signal transfer characteristics between
-        channels in the frequency domain and represents the input-output relationship
-        of the system.
+        The v2 result is a :class:`TransferFunctionFrame` with flattened
+        ``(pair, frequency)`` storage and output-major/input-minor pair order.  It
+        stores ``H_out_in = P_out_in / P_in_in`` and carries the denominator
+        definition, pair roles, unit/reference domain, and row order as immutable
+        typed state.  Labels and operation history do not define its meaning; the
+        released v1 denominator contract is replayed separately by the v1 Recipe
+        handler.  See the spectral numerical contracts for the canonical formulas.
+
+        Sampling rate and user metadata are preserved.  Pair
+        ``source_time_offset`` uses the input-role source offset, and input
+        calibration is consumed before output metadata is derived.  Construction
+        remains Dask-lazy; accessing data, a property, or a plot materializes the
+        requested values.  Invalid spectral parameters or shape/domain violations
+        raise an actionable ``TypeError`` or ``ValueError``.  ``gain_db`` is
+        available only after selecting dimensionless pairs; ``transfer_level_db``
+        uses each pair's explicit reference ratio.  Pairwise A-weighting is
+        rejected.
 
         Args:
             n_fft: Number of FFT points. Default is 2048.
@@ -684,7 +739,11 @@ class ChannelTransformMixin:
             average: Method for averaging segments. Default is "mean".
 
         Returns:
-            TransferFunctionFrame containing complex output/input transfer values.
+            TransferFunctionFrame whose public single-pair shape is ``(frequency,)``
+            and whose multi-pair shape is ``(pair, frequency)``.
+
+        Example:
+            ``transfer = frame.transfer_function(n_fft=1024, scaling="spectrum")``
         """
         from ..pairwise import TransferFunctionFrame
 

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -2,7 +2,7 @@
 operations."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeGuard, TypeVar, cast
 
 import numpy as np
 from dask.array.core import Array as DaArray
@@ -25,7 +25,6 @@ logger = logging.getLogger(__name__)
 PairwiseFrameT = TypeVar("PairwiseFrameT", bound=PairwiseSpectralFrame)
 
 
-@runtime_checkable
 class _PairwiseSpectralOperationProtocol(Protocol):
     """Minimum typed operation surface needed by the pairwise Frame builder."""
 
@@ -38,12 +37,35 @@ class _PairwiseSpectralOperationProtocol(Protocol):
     def process(self, data: DaArray, *inputs: DaArray) -> DaArray: ...
 
 
-@runtime_checkable
 class _ScaledPairwiseSpectralOperationProtocol(_PairwiseSpectralOperationProtocol, Protocol):
     """Pairwise operation surface for CSD and transfer scaling state."""
 
     @property
     def scaling(self) -> str: ...
+
+
+def _is_pairwise_spectral_operation(value: object) -> TypeGuard[_PairwiseSpectralOperationProtocol]:
+    """Check the runtime portion of the pairwise Operation protocol.
+
+    ``runtime_checkable`` Protocol checks are intentionally avoided here: their
+    treatment of dynamic test doubles differs between supported Python versions.
+    The structural check keeps the validation actionable while ``TypeGuard``
+    provides the static narrowing needed by the builder.
+    """
+    try:
+        process = getattr(value, "process")
+        getattr(value, "n_fft")
+        getattr(value, "window")
+    except AttributeError:
+        return False
+    return callable(process)
+
+
+def _is_scaled_pairwise_spectral_operation(
+    value: object,
+) -> TypeGuard[_ScaledPairwiseSpectralOperationProtocol]:
+    """Check the additional scaling property required by CSD and transfer."""
+    return _is_pairwise_spectral_operation(value) and hasattr(value, "scaling")
 
 
 def _build_cross_channel_source_time_offsets(source_time_offset: Any) -> Any:
@@ -96,7 +118,7 @@ def _cross_channel_spectral_transform(
         if operation_override is not None
         else create_operation(operation_name, source.sampling_rate, **params)
     )
-    if not isinstance(operation_candidate, _PairwiseSpectralOperationProtocol):
+    if not _is_pairwise_spectral_operation(operation_candidate):
         raise TypeError(
             f"Operation '{operation_name}' does not expose the pairwise spectral contract (process, n_fft, and window)."
         )
@@ -117,7 +139,7 @@ def _cross_channel_spectral_transform(
 
     scaling: Literal["spectrum", "density"] | None = None
     if quantity != "coherence":
-        if not isinstance(operation, _ScaledPairwiseSpectralOperationProtocol):
+        if not _is_scaled_pairwise_spectral_operation(operation):
             raise TypeError(
                 f"Operation '{operation_name}' does not expose the scaled pairwise spectral contract; "
                 "CSD and transfer operations must provide a scaling property."

--- a/wandas/frames/mixins/channel_transform_mixin.py
+++ b/wandas/frames/mixins/channel_transform_mixin.py
@@ -2,7 +2,7 @@
 operations."""
 
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import numpy as np
 
@@ -10,6 +10,7 @@ from wandas.pipeline.decorators import recipe_operation
 from wandas.processing.spectral import validate_noct_recipe_params
 
 from ...core.base_frame import BaseFrame
+from ..pairwise import CoherenceFrame, CrossSpectralFrame, PairwiseSpectralFrame, TransferFunctionFrame
 from .protocols import TransformFrameProtocol
 
 if TYPE_CHECKING:
@@ -20,30 +21,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-
-def _build_cross_channel_metadata(
-    channel_metadata: list[Any],
-    label_template: str,
-) -> list[Any]:
-    """Build channel metadata for cross-channel spectral operations.
-
-    Args:
-        channel_metadata: list. Input channel metadata list.
-        label_template: str. Format string with ``{in_label}`` and ``{out_label}`` placeholders.
-    """
-    from wandas.core.metadata import ChannelMetadata
-
-    result = []
-    for out_ch in channel_metadata:
-        for in_ch in channel_metadata:
-            meta = ChannelMetadata()
-            meta.label = label_template.format(in_label=in_ch.label, out_label=out_ch.label)
-            meta.unit = ""
-            meta.ref = 1
-            meta["metadata"] = {"in_ch": in_ch["metadata"], "out_ch": out_ch["metadata"]}
-            result.append(meta)
-    return result
 
 
 def _build_cross_channel_source_time_offsets(source_time_offset: Any) -> Any:
@@ -84,16 +61,22 @@ class ChannelTransformMixin:
         operation_name: str,
         label_prefix: str,
         label_template: str,
+        output_frame_class: type["PairwiseSpectralFrame"],
+        quantity: Literal["coherence", "csd", "transfer"],
+        denominator_role: Literal["input", "output"] = "input",
         operation_override: Any | None = None,
         **params: Any,
-    ) -> "SpectralFrame":
+    ) -> "PairwiseSpectralFrame":
         """Shared implementation for cross-channel spectral transforms.
 
-        Used by ``coherence``, ``csd``, and ``transfer_function``.
+        Used by ``coherence``, ``csd``, and ``transfer_function``. The concrete
+        output class and its typed numerical definition are supplied by the
+        public/versioned boundary; no downstream consumer infers quantity from
+        labels or lineage.
         """
         from wandas.processing import create_operation
 
-        from ..spectral import SpectralFrame
+        from ..pairwise import _metadata_for_pair_state, build_pair_state
 
         logger.debug(f"Applying operation={operation_name} with params={params} (lazy)")
 
@@ -104,35 +87,54 @@ class ChannelTransformMixin:
         )
         result_data = operation.process(self._effective_data)
 
-        logger.debug(f"Created new SpectralFrame with operation {operation_name} added to graph")
-
-        channel_metadata = _build_cross_channel_metadata(self._channel_metadata, label_template)
-
         operation_params = operation.to_params()
         n_fft = operation_params["n_fft"]
         if isinstance(n_fft, bool) or not isinstance(n_fft, int):
             raise TypeError(
                 f"Operation '{operation_name}' must provide a positive integer n_fft "
-                f"to create a SpectralFrame, but got {type(n_fft).__name__}."
+                f"to create a dedicated pairwise Frame, but got {type(n_fft).__name__}."
             )
         if n_fft <= 0:
             raise ValueError(
                 f"Operation '{operation_name}' must provide a positive integer n_fft "
-                f"to create a SpectralFrame, but got {n_fft}."
+                f"to create a dedicated pairwise Frame, but got {n_fft}."
             )
-        lineage = cast(Any, self)._required_semantic_lineage()
-        return SpectralFrame(
-            data=result_data,
-            sampling_rate=self.sampling_rate,
-            n_fft=n_fft,
-            window=operation_params["window"],
-            label=f"{label_prefix} {self.label}",
-            metadata=self.metadata,
-            channel_metadata=channel_metadata,
-            source_time_offset=_build_cross_channel_source_time_offsets(cast(Any, self).source_time_offset),
-            lineage=lineage,
-            previous=self._as_base_frame,
+        scaling = operation_params.get("scaling")
+        source_channel_metadata = cast(Any, self).channels.to_list()
+        pair_state = build_pair_state(
+            source_channel_metadata,
+            cast(Any, self)._channel_ids,
+            quantity=quantity,
+            scaling=scaling,
+            denominator_role=denominator_role,
+            label_template=label_template,
         )
+        channel_metadata = _metadata_for_pair_state(pair_state, source_channel_metadata)
+        logger.debug(f"Created {output_frame_class.__name__} with operation {operation_name} added to graph")
+
+        lineage = cast(Any, self)._required_semantic_lineage()
+        constructor_kwargs: dict[str, Any] = {
+            "data": result_data,
+            "sampling_rate": self.sampling_rate,
+            "n_fft": n_fft,
+            "window": operation_params["window"],
+            "pair_state": pair_state,
+            "source_channel_ids": tuple(cast(Any, self)._channel_ids),
+            "label": f"{label_prefix} {self.label}",
+            "metadata": self.metadata,
+            "channel_metadata": channel_metadata,
+            "channel_ids": [record.row_id for record in pair_state],
+            "source_time_offset": _build_cross_channel_source_time_offsets(cast(Any, self).source_time_offset),
+            "lineage": lineage,
+            "previous": self._as_base_frame,
+        }
+        if quantity != "coherence":
+            if scaling not in {"spectrum", "density"}:
+                raise ValueError(f"Operation '{operation_name}' must provide a valid scaling mode")
+            constructor_kwargs["scaling"] = scaling
+            if quantity == "transfer":
+                constructor_kwargs["denominator_role"] = denominator_role
+        return output_frame_class(**constructor_kwargs)
 
     @recipe_operation("wandas.audio.cepstrum", version=2)
     def cepstrum(
@@ -516,7 +518,7 @@ class ChannelTransformMixin:
         win_length: int | None = None,
         window: str = "hann",
         detrend: str = "constant",
-    ) -> "SpectralFrame":
+    ) -> "CoherenceFrame":
         """Calculate magnitude squared coherence.
 
         Args:
@@ -528,17 +530,24 @@ class ChannelTransformMixin:
             detrend: Detrend method. Options: "constant", "linear", None.
 
         Returns:
-            SpectralFrame containing magnitude squared coherence
+            CoherenceFrame containing raw magnitude-squared coherence values.
         """
-        return self._cross_channel_spectral_transform(
-            "coherence",
-            "Coherence of",
-            "$\\gamma_{{{out_label}, {in_label}}}$",
-            n_fft=n_fft,
-            hop_length=hop_length,
-            win_length=win_length,
-            window=window,
-            detrend=detrend,
+        from ..pairwise import CoherenceFrame
+
+        return cast(
+            CoherenceFrame,
+            self._cross_channel_spectral_transform(
+                "coherence",
+                "Coherence of",
+                "$\\gamma_{{{out_label}, {in_label}}}$",
+                CoherenceFrame,
+                "coherence",
+                n_fft=n_fft,
+                hop_length=hop_length,
+                win_length=win_length,
+                window=window,
+                detrend=detrend,
+            ),
         )
 
     @recipe_operation("wandas.audio.coherence", version=1)
@@ -549,17 +558,24 @@ class ChannelTransformMixin:
         win_length: int | None = None,
         window: str = "hann",
         detrend: str = "constant",
-    ) -> "SpectralFrame":
+    ) -> "CoherenceFrame":
         """Replay the released coherence pair-label order."""
-        return self._cross_channel_spectral_transform(
-            "coherence",
-            "Coherence of",
-            "$\\gamma_{{{in_label}, {out_label}}}$",
-            n_fft=n_fft,
-            hop_length=hop_length,
-            win_length=win_length,
-            window=window,
-            detrend=detrend,
+        from ..pairwise import CoherenceFrame
+
+        return cast(
+            CoherenceFrame,
+            self._cross_channel_spectral_transform(
+                "coherence",
+                "Coherence of",
+                "$\\gamma_{{{in_label}, {out_label}}}$",
+                CoherenceFrame,
+                "coherence",
+                n_fft=n_fft,
+                hop_length=hop_length,
+                win_length=win_length,
+                window=window,
+                detrend=detrend,
+            ),
         )
 
     @recipe_operation("wandas.audio.csd", version=2)
@@ -572,7 +588,7 @@ class ChannelTransformMixin:
         detrend: str = "constant",
         scaling: str = "spectrum",
         average: str = "mean",
-    ) -> "SpectralFrame":
+    ) -> "CrossSpectralFrame":
         """Calculate cross-spectral density matrix.
 
         Args:
@@ -586,19 +602,26 @@ class ChannelTransformMixin:
             average: Method for averaging segments. Default is "mean".
 
         Returns:
-            SpectralFrame containing cross-spectral density matrix
+            CrossSpectralFrame containing complex cross-spectral values.
         """
-        return self._cross_channel_spectral_transform(
-            "csd",
-            "CSD of",
-            "csd({out_label}, {in_label})",
-            n_fft=n_fft,
-            hop_length=hop_length,
-            win_length=win_length,
-            window=window,
-            detrend=detrend,
-            scaling=scaling,
-            average=average,
+        from ..pairwise import CrossSpectralFrame
+
+        return cast(
+            CrossSpectralFrame,
+            self._cross_channel_spectral_transform(
+                "csd",
+                "CSD of",
+                "csd({out_label}, {in_label})",
+                CrossSpectralFrame,
+                "csd",
+                n_fft=n_fft,
+                hop_length=hop_length,
+                win_length=win_length,
+                window=window,
+                detrend=detrend,
+                scaling=scaling,
+                average=average,
+            ),
         )
 
     @recipe_operation("wandas.audio.csd", version=1)
@@ -611,19 +634,26 @@ class ChannelTransformMixin:
         detrend: str = "constant",
         scaling: str = "spectrum",
         average: str = "mean",
-    ) -> "SpectralFrame":
+    ) -> "CrossSpectralFrame":
         """Replay the released CSD pair-label order."""
-        return self._cross_channel_spectral_transform(
-            "csd",
-            "CSD of",
-            "csd({in_label}, {out_label})",
-            n_fft=n_fft,
-            hop_length=hop_length,
-            win_length=win_length,
-            window=window,
-            detrend=detrend,
-            scaling=scaling,
-            average=average,
+        from ..pairwise import CrossSpectralFrame
+
+        return cast(
+            CrossSpectralFrame,
+            self._cross_channel_spectral_transform(
+                "csd",
+                "CSD of",
+                "csd({in_label}, {out_label})",
+                CrossSpectralFrame,
+                "csd",
+                n_fft=n_fft,
+                hop_length=hop_length,
+                win_length=win_length,
+                window=window,
+                detrend=detrend,
+                scaling=scaling,
+                average=average,
+            ),
         )
 
     @recipe_operation("wandas.audio.transfer_function", version=2)
@@ -636,7 +666,7 @@ class ChannelTransformMixin:
         detrend: str = "constant",
         scaling: str = "spectrum",
         average: str = "mean",
-    ) -> "SpectralFrame":
+    ) -> "TransferFunctionFrame":
         """Calculate transfer function matrix.
 
         The transfer function represents the signal transfer characteristics between
@@ -654,19 +684,27 @@ class ChannelTransformMixin:
             average: Method for averaging segments. Default is "mean".
 
         Returns:
-            SpectralFrame containing transfer function matrix
+            TransferFunctionFrame containing complex output/input transfer values.
         """
-        return self._cross_channel_spectral_transform(
-            "transfer_function",
-            "Transfer function of",
-            "$H_{{{out_label}, {in_label}}}$",
-            n_fft=n_fft,
-            hop_length=hop_length,
-            win_length=win_length,
-            window=window,
-            detrend=detrend,
-            scaling=scaling,
-            average=average,
+        from ..pairwise import TransferFunctionFrame
+
+        return cast(
+            TransferFunctionFrame,
+            self._cross_channel_spectral_transform(
+                "transfer_function",
+                "Transfer function of",
+                "$H_{{{out_label}, {in_label}}}$",
+                TransferFunctionFrame,
+                "transfer",
+                "input",
+                n_fft=n_fft,
+                hop_length=hop_length,
+                win_length=win_length,
+                window=window,
+                detrend=detrend,
+                scaling=scaling,
+                average=average,
+            ),
         )
 
     @recipe_operation("wandas.audio.transfer_function", version=1)
@@ -679,9 +717,11 @@ class ChannelTransformMixin:
         detrend: str = "constant",
         scaling: str = "spectrum",
         average: str = "mean",
-    ) -> "SpectralFrame":
+    ) -> "TransferFunctionFrame":
         """Replay the released transfer-function denominator contract."""
         from wandas.processing.spectral import _RecipeTransferFunctionV1
+
+        from ..pairwise import TransferFunctionFrame
 
         operation = _RecipeTransferFunctionV1(
             self.sampling_rate,
@@ -693,16 +733,22 @@ class ChannelTransformMixin:
             scaling=scaling,
             average=average,
         )
-        return self._cross_channel_spectral_transform(
-            "transfer_function",
-            "Transfer function of",
-            "$H_{{{in_label}, {out_label}}}$",
-            operation_override=operation,
-            n_fft=n_fft,
-            hop_length=hop_length,
-            win_length=win_length,
-            window=window,
-            detrend=detrend,
-            scaling=scaling,
-            average=average,
+        return cast(
+            TransferFunctionFrame,
+            self._cross_channel_spectral_transform(
+                "transfer_function",
+                "Transfer function of",
+                "$H_{{{in_label}, {out_label}}}$",
+                TransferFunctionFrame,
+                "transfer",
+                "output",
+                operation_override=operation,
+                n_fft=n_fft,
+                hop_length=hop_length,
+                win_length=win_length,
+                window=window,
+                detrend=detrend,
+                scaling=scaling,
+                average=average,
+            ),
         )

--- a/wandas/frames/mixins/protocols.py
+++ b/wandas/frames/mixins/protocols.py
@@ -4,11 +4,12 @@ This module contains common protocols used by mixin classes.
 """
 
 import logging
-from typing import Any, Literal, Protocol, TypeVar, runtime_checkable
+from typing import Any, Protocol, TypeVar, runtime_checkable
 
 from dask.array.core import Array as DaArray
 
 from wandas.core.metadata import ChannelMetadata
+from wandas.processing.semantic import LineageNode
 from wandas.utils.types import NDArrayReal
 
 logger = logging.getLogger(__name__)
@@ -131,9 +132,6 @@ class ProcessingFrameProtocol(BaseFrameProtocol, Protocol):
     ) -> "ProcessingFrameProtocol": ...
 
 
-from wandas.frames.pairwise import PairwiseSpectralFrame  # noqa: E402
-
-
 @runtime_checkable
 class TransformFrameProtocol(BaseFrameProtocol, Protocol):
     """Protocol related to transform operations.
@@ -145,17 +143,12 @@ class TransformFrameProtocol(BaseFrameProtocol, Protocol):
     @property
     def _as_base_frame(self) -> BaseFrame[Any]: ...
 
-    def _cross_channel_spectral_transform(
-        self,
-        operation_name: str,
-        label_prefix: str,
-        label_template: str,
-        output_frame_class: type[PairwiseSpectralFrame],
-        quantity: Literal["coherence", "csd", "transfer"],
-        denominator_role: Literal["input", "output"] = "input",
-        operation_override: Any | None = None,
-        **params: Any,
-    ) -> PairwiseSpectralFrame: ...
+    _channel_ids: list[str]
+
+    def _required_semantic_lineage(self) -> LineageNode: ...
+
+    @property
+    def source_time_offset(self) -> NDArrayReal: ...
 
 
 # Type variable definitions

--- a/wandas/frames/mixins/protocols.py
+++ b/wandas/frames/mixins/protocols.py
@@ -4,7 +4,7 @@ This module contains common protocols used by mixin classes.
 """
 
 import logging
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import Any, Literal, Protocol, TypeVar, runtime_checkable
 
 from dask.array.core import Array as DaArray
 
@@ -131,7 +131,7 @@ class ProcessingFrameProtocol(BaseFrameProtocol, Protocol):
     ) -> "ProcessingFrameProtocol": ...
 
 
-from wandas.frames.spectral import SpectralFrame  # noqa: E402
+from wandas.frames.pairwise import PairwiseSpectralFrame  # noqa: E402
 
 
 @runtime_checkable
@@ -150,9 +150,12 @@ class TransformFrameProtocol(BaseFrameProtocol, Protocol):
         operation_name: str,
         label_prefix: str,
         label_template: str,
+        output_frame_class: type[PairwiseSpectralFrame],
+        quantity: Literal["coherence", "csd", "transfer"],
+        denominator_role: Literal["input", "output"] = "input",
         operation_override: Any | None = None,
         **params: Any,
-    ) -> SpectralFrame: ...
+    ) -> PairwiseSpectralFrame: ...
 
 
 # Type variable definitions

--- a/wandas/frames/pairwise.py
+++ b/wandas/frames/pairwise.py
@@ -60,6 +60,13 @@ def _normalize_nonblank(value: object, *, name: str) -> str:
     return value.strip()
 
 
+def _normalize_source_channel_id(value: object, *, name: str) -> str:
+    """Validate an opaque source ID without changing its caller-provided text."""
+    if not isinstance(value, str) or not value.strip():
+        raise TypeError(f"{name} must be a non-blank string")
+    return value
+
+
 def _normalize_pairwise_data(
     data: DaArray | np.ndarray[Any, Any],
     *,
@@ -110,6 +117,8 @@ def _validate_coherence_block(values: np.ndarray[Any, Any]) -> np.ndarray[Any, A
         raise ValueError("Coherence values must not contain infinity")
     finite = values[np.isfinite(values)]
     tolerance = 1e-12
+    if np.issubdtype(values.dtype, np.floating):
+        tolerance = max(tolerance, 4.0 * np.finfo(values.dtype).eps)
     if finite.size and ((finite < -tolerance).any() or (finite > 1.0 + tolerance).any()):
         raise ValueError("Coherence finite values must lie between 0 and 1")
     return values
@@ -150,7 +159,7 @@ def build_pair_state(
     """Build output-major/input-minor state from source Frame metadata."""
     if len(channel_metadata) != len(channel_ids):
         raise ValueError("Pairwise source metadata and channel IDs must have equal lengths")
-    source_ids = tuple(_normalize_nonblank(value, name="Source channel id") for value in channel_ids)
+    source_ids = tuple(_normalize_source_channel_id(value, name="Source channel id") for value in channel_ids)
     if len(set(source_ids)) != len(source_ids):
         raise ValueError("Pairwise source channel IDs must be unique")
     roles = tuple(
@@ -180,7 +189,7 @@ def build_pair_state(
                 out_label=output.label,
                 in_label=input_.label,
             )
-            row_id = f"pair:{output.channel_id}:{input_.channel_id}"
+            row_id = f"pair:{pair.pair_index}"
             records.append(SpectralPairState(pair, domain, row_id, display_label))
     return tuple(records)
 
@@ -260,7 +269,9 @@ def _normalize_pair_state(
         if len(set(normalized_ids)) != len(normalized_ids):
             raise ValueError("Pair state source channel IDs must be unique")
     else:
-        normalized_ids = tuple(_normalize_nonblank(item, name="Source channel id") for item in source_channel_ids)
+        normalized_ids = tuple(
+            _normalize_source_channel_id(item, name="Source channel id") for item in source_channel_ids
+        )
         if len(normalized_ids) != source_count:
             raise ValueError("Source channel ID count must match the pair state source channel count")
         if len(set(normalized_ids)) != len(normalized_ids):
@@ -377,12 +388,23 @@ class PairwiseSpectralFrame(BaseFrame[Any]):
                 f"{type(self).__name__} output channel calibration must be 1.0; "
                 "input calibration is consumed before the pairwise operation and must not be reapplied."
             )
+        for row, (channel, record) in enumerate(zip(channel_metadata, records, strict=True)):
+            if channel.unit != record.domain.unit or float(channel.ref) != float(record.domain.reference):
+                raise ValueError(
+                    f"{type(self).__name__} channel metadata at row {row} must match its typed pair domain."
+                )
+        expected_channel_ids = [record.row_id for record in records]
         if channel_ids is None:
-            channel_ids = [record.row_id for record in records]
+            channel_ids = expected_channel_ids
         if len(channel_ids) != len(records):
             raise ValueError("Pair channel ID count must match pair data rows")
         if len(set(channel_ids)) != len(channel_ids):
             raise ValueError("Pair channel IDs must be unique")
+        if channel_ids != expected_channel_ids:
+            raise ValueError(
+                "Pair channel IDs must match typed pair row IDs; "
+                "channel row identity is carried by pair_state, not by an arbitrary label."
+            )
         self.n_fft = normalized_n_fft
         self.window = normalized_window
         self._frequency_indices = normalized_frequency_indices
@@ -636,6 +658,10 @@ class PairwiseSpectralFrame(BaseFrame[Any]):
     ) -> tuple[np.ndarray[Any, Any], str]:
         raise NotImplementedError
 
+    def _plot_ylabel(self, *, view: str | None, Aw: bool) -> str:  # noqa: N803
+        """Return a quantity-specific ylabel without materializing Frame data."""
+        raise NotImplementedError
+
     def plot(
         self,
         plot_type: str = "frequency",
@@ -717,10 +743,13 @@ class CoherenceFrame(PairwiseSpectralFrame):
         view: str | None,
         Aw: bool,  # noqa: N803
     ) -> tuple[np.ndarray[Any, Any], str]:
+        return np.asarray(self.coherence), self._plot_ylabel(view=view, Aw=Aw)
+
+    def _plot_ylabel(self, *, view: str | None, Aw: bool) -> str:  # noqa: N803
         reject_pairwise_a_weighting(Aw)
         if view not in {None, "coherence", "raw"}:
             raise ValueError("CoherenceFrame supports only the 'coherence' plot view")
-        return np.asarray(self.coherence), "Coherence"
+        return "Coherence"
 
 
 class CrossSpectralFrame(PairwiseSpectralFrame):
@@ -776,14 +805,25 @@ class CrossSpectralFrame(PairwiseSpectralFrame):
         view: str | None,
         Aw: bool,  # noqa: N803
     ) -> tuple[np.ndarray[Any, Any], str]:
+        ylabel = self._plot_ylabel(view=view, Aw=Aw)
+        selected = "magnitude" if view is None else view
+        if selected == "magnitude":
+            return np.asarray(self.magnitude), ylabel
+        if selected == "phase":
+            return np.asarray(self.phase), ylabel
+        if selected == "level":
+            return np.asarray(self.level_db), ylabel
+        raise AssertionError("CrossSpectralFrame._plot_ylabel must validate the view")
+
+    def _plot_ylabel(self, *, view: str | None, Aw: bool) -> str:  # noqa: N803
         reject_pairwise_a_weighting(Aw)
         selected = "magnitude" if view is None else view
         if selected == "magnitude":
-            return np.asarray(self.magnitude), self._unit_summary("CSD magnitude")
+            return self._unit_summary("CSD magnitude")
         if selected == "phase":
-            return np.asarray(self.phase), "CSD phase [rad]"
+            return "CSD phase [rad]"
         if selected == "level":
-            return np.asarray(self.level_db), "CSD level [dB]"
+            return "CSD level [dB]"
         raise ValueError("CrossSpectralFrame view must be 'magnitude', 'phase', or 'level'")
 
 
@@ -871,16 +911,29 @@ class TransferFunctionFrame(PairwiseSpectralFrame):
         view: str | None,
         Aw: bool,  # noqa: N803
     ) -> tuple[np.ndarray[Any, Any], str]:
+        ylabel = self._plot_ylabel(view=view, Aw=Aw)
+        selected = "gain" if view is None else view
+        if selected == "gain":
+            return np.asarray(self.gain), ylabel
+        if selected == "phase":
+            return np.asarray(self.phase), ylabel
+        if selected == "gain_db":
+            return np.asarray(self.gain_db), ylabel
+        if selected == "transfer_level_db":
+            return np.asarray(self.transfer_level_db), ylabel
+        raise AssertionError("TransferFunctionFrame._plot_ylabel must validate the view")
+
+    def _plot_ylabel(self, *, view: str | None, Aw: bool) -> str:  # noqa: N803
         reject_pairwise_a_weighting(Aw)
         selected = "gain" if view is None else view
         if selected == "gain":
-            return np.asarray(self.gain), self._unit_summary("Transfer gain")
+            return self._unit_summary("Transfer gain")
         if selected == "phase":
-            return np.asarray(self.phase), "Transfer phase [rad]"
+            return "Transfer phase [rad]"
         if selected == "gain_db":
-            return np.asarray(self.gain_db), "Transfer gain [dB]"
+            return "Transfer gain [dB]"
         if selected == "transfer_level_db":
-            return np.asarray(self.transfer_level_db), "Transfer level [dB]"
+            return "Transfer level [dB]"
         raise ValueError("TransferFunctionFrame view must be 'gain', 'phase', 'gain_db', or 'transfer_level_db'")
 
 

--- a/wandas/frames/pairwise.py
+++ b/wandas/frames/pairwise.py
@@ -377,6 +377,8 @@ class PairwiseSpectralFrame(BaseFrame[Any]):
             data_rows=int(normalized_data.shape[0]),
             source_channel_ids=source_channel_ids,
         )
+        if not records:
+            raise ValueError("Pairwise Frames require at least one selected pair")
         scaling = cast(SpectralScaling | None, getattr(self, "scaling", None))
         denominator_role = cast(TransferDenominator, getattr(self, "denominator_role", "input"))
         for record in records:
@@ -553,7 +555,7 @@ class PairwiseSpectralFrame(BaseFrame[Any]):
     def _frequency_indices_for_slice(self, selector: slice) -> tuple[int, ...]:
         """Map a public frequency slice onto canonical one-sided bin IDs."""
         start, stop, step = selector.indices(len(self._frequency_indices))
-        return self._frequency_indices[slice(start, stop, step)]
+        return tuple(self._frequency_indices[index] for index in range(start, stop, step))
 
     def _handle_multidim_indexing(self: PairwiseFrameT, key: tuple[Any, ...]) -> PairwiseFrameT:
         """Select pair rows and represented frequency bins together."""
@@ -735,11 +737,43 @@ class CoherenceFrame(PairwiseSpectralFrame):
 
     _pair_quantity = "coherence"
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        raw_data = args[0] if args else kwargs.get("data")
-        if raw_data is not None and not isinstance(raw_data, DaArray):
-            _validate_coherence_block(np.asarray(raw_data))
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        data: DaArray | np.ndarray[Any, Any],
+        sampling_rate: float,
+        n_fft: int,
+        window: str,
+        pair_state: Sequence[SpectralPairState],
+        frequency_indices: Sequence[int] | None = None,
+        source_channel_ids: Sequence[str] | None = None,
+        label: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
+        channel_ids: list[str] | None = None,
+        previous: BaseFrame[Any] | None = None,
+        source_time_offset: float | Sequence[float] | NDArrayReal = 0.0,
+        lineage: Any | None = None,
+        operation_history_prefix: Sequence[Mapping[str, Any]] = (),
+    ) -> None:
+        if not isinstance(data, DaArray):
+            _validate_coherence_block(np.asarray(data))
+        super().__init__(
+            data=data,
+            sampling_rate=sampling_rate,
+            n_fft=n_fft,
+            window=window,
+            pair_state=pair_state,
+            frequency_indices=frequency_indices,
+            source_channel_ids=source_channel_ids,
+            label=label,
+            metadata=metadata,
+            channel_metadata=channel_metadata,
+            channel_ids=channel_ids,
+            previous=previous,
+            source_time_offset=source_time_offset,
+            lineage=lineage,
+            operation_history_prefix=operation_history_prefix,
+        )
         # Keep Dask operation construction lazy; validation runs when a block is
         # materialized and therefore cannot trigger an eager compute here.
         self._xr = self._xr.copy(data=da.map_blocks(_validate_coherence_block, self._data, dtype=self._data.dtype))
@@ -769,11 +803,46 @@ class CrossSpectralFrame(PairwiseSpectralFrame):
 
     _pair_quantity = "csd"
 
-    def __init__(self, scaling: SpectralScaling, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        data: DaArray | np.ndarray[Any, Any],
+        sampling_rate: float,
+        n_fft: int,
+        window: str,
+        pair_state: Sequence[SpectralPairState],
+        *,
+        scaling: SpectralScaling,
+        frequency_indices: Sequence[int] | None = None,
+        source_channel_ids: Sequence[str] | None = None,
+        label: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
+        channel_ids: list[str] | None = None,
+        previous: BaseFrame[Any] | None = None,
+        source_time_offset: float | Sequence[float] | NDArrayReal = 0.0,
+        lineage: Any | None = None,
+        operation_history_prefix: Sequence[Mapping[str, Any]] = (),
+    ) -> None:
         if scaling not in {"spectrum", "density"}:
             raise ValueError("CrossSpectralFrame scaling must be 'spectrum' or 'density'")
         self._scaling = scaling
-        super().__init__(*args, **kwargs)
+        super().__init__(
+            data=data,
+            sampling_rate=sampling_rate,
+            n_fft=n_fft,
+            window=window,
+            pair_state=pair_state,
+            frequency_indices=frequency_indices,
+            source_channel_ids=source_channel_ids,
+            label=label,
+            metadata=metadata,
+            channel_metadata=channel_metadata,
+            channel_ids=channel_ids,
+            previous=previous,
+            source_time_offset=source_time_offset,
+            lineage=lineage,
+            operation_history_prefix=operation_history_prefix,
+        )
 
     @property
     def scaling(self) -> SpectralScaling:
@@ -846,10 +915,24 @@ class TransferFunctionFrame(PairwiseSpectralFrame):
 
     def __init__(
         self,
+        data: DaArray | np.ndarray[Any, Any],
+        sampling_rate: float,
+        n_fft: int,
+        window: str,
+        pair_state: Sequence[SpectralPairState],
+        *,
         scaling: SpectralScaling,
         denominator_role: TransferDenominator = "input",
-        *args: Any,
-        **kwargs: Any,
+        frequency_indices: Sequence[int] | None = None,
+        source_channel_ids: Sequence[str] | None = None,
+        label: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
+        channel_ids: list[str] | None = None,
+        previous: BaseFrame[Any] | None = None,
+        source_time_offset: float | Sequence[float] | NDArrayReal = 0.0,
+        lineage: Any | None = None,
+        operation_history_prefix: Sequence[Mapping[str, Any]] = (),
     ) -> None:
         if scaling not in {"spectrum", "density"}:
             raise ValueError("TransferFunctionFrame scaling must be 'spectrum' or 'density'")
@@ -857,7 +940,23 @@ class TransferFunctionFrame(PairwiseSpectralFrame):
             raise ValueError("TransferFunctionFrame denominator_role must be 'input' or 'output'")
         self._scaling = scaling
         self._denominator_role = denominator_role
-        super().__init__(*args, **kwargs)
+        super().__init__(
+            data=data,
+            sampling_rate=sampling_rate,
+            n_fft=n_fft,
+            window=window,
+            pair_state=pair_state,
+            frequency_indices=frequency_indices,
+            source_channel_ids=source_channel_ids,
+            label=label,
+            metadata=metadata,
+            channel_metadata=channel_metadata,
+            channel_ids=channel_ids,
+            previous=previous,
+            source_time_offset=source_time_offset,
+            lineage=lineage,
+            operation_history_prefix=operation_history_prefix,
+        )
 
     @property
     def scaling(self) -> SpectralScaling:

--- a/wandas/frames/pairwise.py
+++ b/wandas/frames/pairwise.py
@@ -743,7 +743,25 @@ class PairwiseSpectralFrame(BaseFrame[Any]):
 
 
 class CoherenceFrame(PairwiseSpectralFrame):
-    """Magnitude-squared coherence values in the dimensionless 0-to-1 domain."""
+    """Magnitude-squared coherence in the dimensionless 0-to-1 domain.
+
+    ``data`` is real numeric, rank one or two, and uses flattened
+    ``(pair, frequency)`` storage internally.  A single pair is exposed with
+    the normal single-channel public shape.  ``n_fft``, ``window``, and
+    ``pair_state`` are required constructor state; ``frequency_indices`` may
+    retain a selected, ordered subset of the ``n_fft // 2 + 1`` frequency
+    bins.  ``pair_state`` supplies the output/input roles, source identity,
+    dimensionless domain, and row order; labels and lineage do not define
+    quantity meaning.
+
+    Finite values must be in the inclusive ``[0, 1]`` range within the
+    dtype-appropriate tolerance.  NaN represents undefined coherence and is
+    preserved.  The constructor and all public operations remain lazy for
+    Dask input.  Pair selection, frequency slicing, metadata changes, and
+    annotation copies preserve this concrete type and the corresponding
+    typed rows; arithmetic, amplitude-level APIs, inverse FFT, synthesis, and
+    A-weighting are not defined for this Frame.
+    """
 
     _pair_quantity = "coherence"
 
@@ -809,7 +827,24 @@ class CoherenceFrame(PairwiseSpectralFrame):
 
 
 class CrossSpectralFrame(PairwiseSpectralFrame):
-    """Complex cross-spectral values ``P_out_in`` with typed pair domains."""
+    """Complex cross-spectral values ``P_out_in`` with typed pair domains.
+
+    ``data`` is complex numeric, rank one or two, with flattened
+    ``(pair, frequency)`` storage internally.  The required constructor state
+    is ``sampling_rate``, ``n_fft``, ``window``, ``scaling``, and immutable
+    ``pair_state``; ``frequency_indices`` selects an ordered subset of the
+    ``n_fft // 2 + 1`` bins.  Each pair represents
+    ``conj(X_input) * X_output`` and its typed domain determines the channel
+    unit, reference, and level denominator.  ``scaling`` is either
+    ``"spectrum"`` or ``"density"``; density domains include ``/Hz``.
+
+    ``magnitude``, ``phase``, and ``level_db`` are the quantity-specific
+    public projections, where ``level_db`` uses ``10 * log10`` of the
+    magnitude/reference ratio.  Dask input remains lazy.  Pair selection,
+    frequency slicing, metadata changes, and annotation copies preserve the
+    concrete type and row-matched pair state; arithmetic and A-weighting are
+    rejected rather than inferred from labels or history.
+    """
 
     _pair_quantity = "csd"
 
@@ -919,7 +954,26 @@ class CrossSpectralFrame(PairwiseSpectralFrame):
 
 
 class TransferFunctionFrame(PairwiseSpectralFrame):
-    """Complex transfer values with truthful denominator and reference state."""
+    """Complex transfer values with truthful denominator and reference state.
+
+    ``data`` is complex numeric, rank one or two, with flattened
+    ``(pair, frequency)`` storage internally.  The required constructor state
+    is ``sampling_rate``, ``n_fft``, ``window``, ``scaling``,
+    ``denominator_role``, and immutable ``pair_state``; ``frequency_indices``
+    selects an ordered subset of the ``n_fft // 2 + 1`` bins.  The canonical
+    ``denominator_role="input"`` stores
+    ``H_out_in = P_out_in / P_in_in``.  The truthful legacy v1 value uses
+    ``denominator_role="output"`` and is never relabeled as canonical v2.
+
+    ``gain``, ``phase``, ``gain_db``, and ``transfer_level_db`` are the
+    quantity-specific public projections.  ``gain_db`` is available only when
+    every selected pair is dimensionless; ``transfer_level_db`` uses each
+    typed output/input reference ratio.  Zero-denominator non-finite values
+    remain observable.  Dask input remains lazy, and selection, slicing,
+    annotation, and metadata operations preserve the concrete type and typed
+    rows.  Arithmetic and A-weighting are rejected rather than inferred from
+    labels or operation history.
+    """
 
     _pair_quantity = "transfer"
 
@@ -1061,7 +1115,6 @@ class TransferFunctionFrame(PairwiseSpectralFrame):
 __all__ = [
     "CoherenceFrame",
     "CrossSpectralFrame",
-    "PairwiseSpectralFrame",
     "SpectralPairState",
     "TransferFunctionFrame",
     "build_pair_state",

--- a/wandas/frames/pairwise.py
+++ b/wandas/frames/pairwise.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import copy
 import numbers
+from abc import ABC, abstractmethod
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, cast
@@ -314,7 +315,7 @@ def _expected_pair_domain(
     return derive_transfer_domain(record.pair, denominator_role)
 
 
-class PairwiseSpectralFrame(BaseFrame[Any]):
+class PairwiseSpectralFrame(BaseFrame[Any], ABC):
     """Private flattened pairwise frequency-domain Frame base.
 
     The array contract is ``(pair, frequency)`` internally and public
@@ -578,8 +579,6 @@ class PairwiseSpectralFrame(BaseFrame[Any]):
         selected_data = self._data[indices]
         frequency_indices = self._frequency_indices
         if axis_selectors:
-            if len(axis_selectors) != 1:
-                raise ValueError("Pairwise Frames expose only one non-channel frequency axis")
             selector = cast(slice, axis_selectors[0])
             frequency_indices = self._frequency_indices_for_slice(selector)
             selected_data = selected_data[(slice(None), selector)]
@@ -674,6 +673,7 @@ class PairwiseSpectralFrame(BaseFrame[Any]):
             for row, record in enumerate(self._pair_state)
         )
 
+    @abstractmethod
     def _plot_frequency_values(
         self,
         *,
@@ -682,6 +682,7 @@ class PairwiseSpectralFrame(BaseFrame[Any]):
     ) -> tuple[np.ndarray[Any, Any], str]:
         raise NotImplementedError
 
+    @abstractmethod
     def _plot_ylabel(self, *, view: str | None, Aw: bool) -> str:  # noqa: N803
         """Return a quantity-specific ylabel without materializing Frame data."""
         raise NotImplementedError
@@ -939,7 +940,7 @@ class CrossSpectralFrame(PairwiseSpectralFrame):
             return np.asarray(self.phase), ylabel
         if selected == "level":
             return np.asarray(self.level_db), ylabel
-        raise AssertionError("CrossSpectralFrame._plot_ylabel must validate the view")
+        raise AssertionError("CrossSpectralFrame._plot_ylabel must validate the view")  # pragma: no cover
 
     def _plot_ylabel(self, *, view: str | None, Aw: bool) -> str:  # noqa: N803
         reject_pairwise_a_weighting(Aw)
@@ -1096,7 +1097,7 @@ class TransferFunctionFrame(PairwiseSpectralFrame):
             return np.asarray(self.gain_db), ylabel
         if selected == "transfer_level_db":
             return np.asarray(self.transfer_level_db), ylabel
-        raise AssertionError("TransferFunctionFrame._plot_ylabel must validate the view")
+        raise AssertionError("TransferFunctionFrame._plot_ylabel must validate the view")  # pragma: no cover
 
     def _plot_ylabel(self, *, view: str | None, Aw: bool) -> str:  # noqa: N803
         reject_pairwise_a_weighting(Aw)

--- a/wandas/frames/pairwise.py
+++ b/wandas/frames/pairwise.py
@@ -419,8 +419,8 @@ class PairwiseSpectralFrame(BaseFrame[Any]):
                 "Pair channel IDs must match typed pair row IDs; "
                 "channel row identity is carried by pair_state, not by an arbitrary label."
             )
-        self.n_fft = normalized_n_fft
-        self.window = normalized_window
+        self._n_fft = normalized_n_fft
+        self._window = normalized_window
         self._frequency_indices = normalized_frequency_indices
         self._pair_state = records
         self._source_channel_ids = normalized_source_ids
@@ -440,6 +440,16 @@ class PairwiseSpectralFrame(BaseFrame[Any]):
     @property
     def _data_domain(self) -> Literal["real", "complex"]:
         return "real"
+
+    @property
+    def n_fft(self) -> int:
+        """Return the immutable FFT length used to define the frequency axis."""
+        return self._n_fft
+
+    @property
+    def window(self) -> str:
+        """Return the immutable window identifier used by the operation."""
+        return self._window
 
     @property
     def n_pairs(self) -> int:

--- a/wandas/frames/pairwise.py
+++ b/wandas/frames/pairwise.py
@@ -1,0 +1,894 @@
+"""Dedicated Frame types for flattened pairwise spectral quantities.
+
+The numerical operations remain in :mod:`wandas.processing.spectral`.  This
+module owns the domain boundary: immutable ordered pair state, quantity-specific
+properties, typed plotting projections, and propagation of pair state through
+the common Frame reconstruction paths.
+"""
+
+from __future__ import annotations
+
+import copy
+import numbers
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, cast
+
+import dask.array as da
+import numpy as np
+from dask.array.core import Array as DaArray
+
+from wandas.core.base_frame import BaseFrame
+from wandas.core.metadata import ChannelCalibration, ChannelMetadata
+from wandas.processing.spectral_contracts import (
+    DerivedSpectralDomain,
+    OrderedSpectralPair,
+    SpectralChannelRole,
+    SpectralScaling,
+    TransferDenominator,
+    csd_level,
+    derive_coherence_domain,
+    derive_csd_domain,
+    derive_transfer_domain,
+    reject_pairwise_a_weighting,
+    transfer_level,
+)
+from wandas.utils.optional_imports import require_pandas
+from wandas.utils.types import NDArrayReal
+
+if TYPE_CHECKING:
+    import pandas as pd
+    from matplotlib.axes import Axes
+
+
+PairwiseFrameT = TypeVar("PairwiseFrameT", bound="PairwiseSpectralFrame")
+PairQuantity = Literal["coherence", "csd", "transfer"]
+
+
+def _normalize_positive_integer(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, numbers.Integral):
+        raise TypeError(f"{name} must be a positive integer")
+    normalized = int(value)
+    if normalized <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return normalized
+
+
+def _normalize_nonblank(value: object, *, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise TypeError(f"{name} must be a non-blank string")
+    return value.strip()
+
+
+def _normalize_pairwise_data(
+    data: DaArray | np.ndarray[Any, Any],
+    *,
+    n_fft: int,
+    frequency_count: int,
+    frame_type: str,
+    domain: Literal["real", "complex"],
+) -> DaArray:
+    """Normalize rank and dtype without materializing a Dask graph."""
+    if not isinstance(data, DaArray):
+        data = da.asarray(data)
+    if data.ndim == 1:
+        data = data.reshape(1, -1)
+    elif data.ndim != 2:
+        raise ValueError(
+            f"Invalid data rank for {frame_type}\n"
+            f"  Got: {data.ndim}D with shape {data.shape}\n"
+            "  Expected: one or two dimensions with (pair, frequency) semantics."
+        )
+    expected_bins = frequency_count
+    if int(data.shape[-1]) != expected_bins:
+        raise ValueError(
+            f"Invalid frequency bin count for {frame_type}\n"
+            f"  Got: {data.shape[-1]} bins\n"
+            f"  Expected: {expected_bins} represented bins for n_fft={n_fft}."
+        )
+    dtype = np.dtype(data.dtype)
+    is_complex = np.issubdtype(dtype, np.complexfloating)
+    is_real = np.issubdtype(dtype, np.floating) or np.issubdtype(dtype, np.integer)
+    if domain == "real" and not is_real:
+        raise TypeError(
+            f"{frame_type} requires a real numeric dtype\n"
+            f"  Got: {dtype}\n"
+            "  Pass magnitude-squared coherence values without a complex phase."
+        )
+    if domain == "complex" and not is_complex:
+        raise TypeError(
+            f"{frame_type} requires a complex numeric dtype\n"
+            f"  Got: {dtype}\n"
+            "  Pass the stored complex pairwise quantity."
+        )
+    return data
+
+
+def _validate_coherence_block(values: np.ndarray[Any, Any]) -> np.ndarray[Any, Any]:
+    """Validate one lazy coherence block at its materialization boundary."""
+    if np.isinf(values).any():
+        raise ValueError("Coherence values must not contain infinity")
+    finite = values[np.isfinite(values)]
+    tolerance = 1e-12
+    if finite.size and ((finite < -tolerance).any() or (finite > 1.0 + tolerance).any()):
+        raise ValueError("Coherence finite values must lie between 0 and 1")
+    return values
+
+
+@dataclass(frozen=True, slots=True)
+class SpectralPairState:
+    """Immutable row state for one flattened output/input pair.
+
+    ``pair`` is the numerical role truth. ``display_label`` is retained only as
+    the current display contract, including the released Recipe v1 label order;
+    it is never used to recover pair meaning.
+    """
+
+    pair: OrderedSpectralPair
+    domain: DerivedSpectralDomain
+    row_id: str
+    display_label: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.pair, OrderedSpectralPair):
+            raise TypeError("SpectralPairState.pair must be an OrderedSpectralPair")
+        if not isinstance(self.domain, DerivedSpectralDomain):
+            raise TypeError("SpectralPairState.domain must be a DerivedSpectralDomain")
+        object.__setattr__(self, "row_id", _normalize_nonblank(self.row_id, name="Pair row id"))
+        object.__setattr__(self, "display_label", _normalize_nonblank(self.display_label, name="Pair display label"))
+
+
+def build_pair_state(
+    channel_metadata: Sequence[ChannelMetadata],
+    channel_ids: Sequence[str],
+    *,
+    quantity: PairQuantity,
+    scaling: SpectralScaling | None = None,
+    denominator_role: TransferDenominator = "input",
+    label_template: str,
+) -> tuple[SpectralPairState, ...]:
+    """Build output-major/input-minor state from source Frame metadata."""
+    if len(channel_metadata) != len(channel_ids):
+        raise ValueError("Pairwise source metadata and channel IDs must have equal lengths")
+    source_ids = tuple(_normalize_nonblank(value, name="Source channel id") for value in channel_ids)
+    if len(set(source_ids)) != len(source_ids):
+        raise ValueError("Pairwise source channel IDs must be unique")
+    roles = tuple(
+        SpectralChannelRole(
+            index=index,
+            label=channel.label,
+            unit=channel.unit,
+            reference=channel.ref,
+            channel_id=source_ids[index],
+        )
+        for index, channel in enumerate(channel_metadata)
+    )
+    source_count = len(roles)
+    records: list[SpectralPairState] = []
+    for output in roles:
+        for input_ in roles:
+            pair = OrderedSpectralPair(output=output, input=input_, n_channels=source_count)
+            if quantity == "coherence":
+                domain = derive_coherence_domain()
+            elif quantity == "csd":
+                if scaling is None:
+                    raise ValueError("CSD pair state requires a scaling mode")
+                domain = derive_csd_domain(pair, scaling)
+            else:
+                domain = derive_transfer_domain(pair, denominator_role)
+            display_label = label_template.format(
+                out_label=output.label,
+                in_label=input_.label,
+            )
+            row_id = f"pair:{output.channel_id}:{input_.channel_id}"
+            records.append(SpectralPairState(pair, domain, row_id, display_label))
+    return tuple(records)
+
+
+def _metadata_for_pair_state(
+    records: Sequence[SpectralPairState],
+    source_channel_metadata: Sequence[ChannelMetadata] | None = None,
+) -> list[ChannelMetadata]:
+    """Derive pair metadata, preserving source extras without making them semantic."""
+    source_extras: dict[int, dict[str, Any]] = {}
+    if source_channel_metadata is not None:
+        source_extras = {index: copy.deepcopy(channel.extra) for index, channel in enumerate(source_channel_metadata)}
+        if any(
+            index not in source_extras
+            for record in records
+            for index in (record.pair.output.index, record.pair.input.index)
+        ):
+            raise ValueError("Source channel metadata does not cover every pair role")
+
+    return [
+        ChannelMetadata(
+            label=record.display_label,
+            calibration=ChannelCalibration(
+                factor=1.0,
+                unit=record.domain.unit,
+                ref=record.domain.reference,
+            ),
+            extra=(
+                {
+                    "output": copy.deepcopy(source_extras[record.pair.output.index]),
+                    "input": copy.deepcopy(source_extras[record.pair.input.index]),
+                }
+                if source_channel_metadata is not None
+                else {}
+            ),
+        )
+        for record in records
+    ]
+
+
+def _normalize_pair_state(
+    value: Sequence[SpectralPairState],
+    *,
+    data_rows: int,
+    source_channel_ids: Sequence[str] | None,
+) -> tuple[tuple[SpectralPairState, ...], tuple[str, ...]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise TypeError("pair_state must be an ordered sequence of SpectralPairState values")
+    records = tuple(value)
+    if len(records) != data_rows:
+        raise ValueError(
+            f"Pair state row count must match data rows\n  Rows: {data_rows}\n  Pair state: {len(records)}"
+        )
+    if any(not isinstance(record, SpectralPairState) for record in records):
+        raise TypeError("pair_state must contain only SpectralPairState values")
+    if len({record.pair.pair_index for record in records}) != len(records):
+        raise ValueError("Pair state contains duplicate output/input pairs")
+    if len({record.row_id for record in records}) != len(records):
+        raise ValueError("Pair state contains duplicate row IDs")
+    if records:
+        source_count = records[0].pair.n_channels
+        if any(record.pair.n_channels != source_count for record in records):
+            raise ValueError("Pair state records must use one source channel count")
+    else:
+        source_count = 0
+    if source_channel_ids is None:
+        ids_by_index = ["" for _ in range(source_count)]
+        for record in records:
+            ids_by_index[record.pair.output.index] = record.pair.output.channel_id
+            ids_by_index[record.pair.input.index] = record.pair.input.channel_id
+        normalized_ids = tuple(ids_by_index)
+        if any(not value for value in normalized_ids):
+            raise ValueError(
+                "Pair state does not identify every source channel; "
+                "pass source_channel_ids explicitly for a selected pair subset"
+            )
+        if len(set(normalized_ids)) != len(normalized_ids):
+            raise ValueError("Pair state source channel IDs must be unique")
+    else:
+        normalized_ids = tuple(_normalize_nonblank(item, name="Source channel id") for item in source_channel_ids)
+        if len(normalized_ids) != source_count:
+            raise ValueError("Source channel ID count must match the pair state source channel count")
+        if len(set(normalized_ids)) != len(normalized_ids):
+            raise ValueError("Source channel IDs must be unique")
+    if any(
+        record.pair.output.channel_id != normalized_ids[record.pair.output.index]
+        or record.pair.input.channel_id != normalized_ids[record.pair.input.index]
+        for record in records
+    ):
+        raise ValueError("Pair role channel IDs do not match source channel IDs")
+    return records, normalized_ids
+
+
+def _expected_pair_domain(
+    record: SpectralPairState,
+    *,
+    quantity: PairQuantity,
+    scaling: SpectralScaling | None,
+    denominator_role: TransferDenominator,
+) -> DerivedSpectralDomain:
+    """Derive the domain that a concrete pairwise Frame is allowed to carry."""
+    if quantity == "coherence":
+        return derive_coherence_domain()
+    if quantity == "csd":
+        if scaling is None:
+            raise ValueError("CSD pair state requires a scaling mode")
+        return derive_csd_domain(record.pair, scaling)
+    return derive_transfer_domain(record.pair, denominator_role)
+
+
+class PairwiseSpectralFrame(BaseFrame[Any]):
+    """Private flattened pairwise frequency-domain Frame base.
+
+    The array contract is ``(pair, frequency)`` internally and public
+    ``data`` follows the normal Frame convention by suppressing the pair axis
+    for a single pair.  Pair meaning is carried by immutable
+    :class:`SpectralPairState` records, never by labels or lineage.
+    """
+
+    _xarray_dim_suffix = ("channel", "frequency")
+    _pair_quantity: ClassVar[PairQuantity]
+
+    def __init__(
+        self,
+        data: DaArray | np.ndarray[Any, Any],
+        sampling_rate: float,
+        n_fft: int,
+        window: str,
+        pair_state: Sequence[SpectralPairState],
+        frequency_indices: Sequence[int] | None = None,
+        source_channel_ids: Sequence[str] | None = None,
+        label: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        channel_metadata: Sequence[ChannelMetadata | dict[str, Any]] | None = None,
+        channel_ids: list[str] | None = None,
+        previous: BaseFrame[Any] | None = None,
+        source_time_offset: float | Sequence[float] | NDArrayReal = 0.0,
+        lineage: Any | None = None,
+        operation_history_prefix: Sequence[Mapping[str, Any]] = (),
+    ) -> None:
+        normalized_n_fft = _normalize_positive_integer(n_fft, name="n_fft")
+        normalized_window = _normalize_nonblank(window, name="window")
+        complete_frequency_count = normalized_n_fft // 2 + 1
+        if frequency_indices is None:
+            normalized_frequency_indices = tuple(range(complete_frequency_count))
+        else:
+            if isinstance(frequency_indices, (str, bytes)):
+                raise TypeError("frequency_indices must be an ordered sequence of integers")
+            normalized_frequency_indices = tuple(frequency_indices)
+            if not normalized_frequency_indices:
+                raise ValueError("frequency_indices must contain at least one frequency bin")
+            if any(
+                isinstance(index, bool) or not isinstance(index, numbers.Integral)
+                for index in normalized_frequency_indices
+            ):
+                raise TypeError("frequency_indices must contain only integer bin indices")
+            normalized_frequency_indices = tuple(int(index) for index in normalized_frequency_indices)
+            if any(index < 0 or index >= complete_frequency_count for index in normalized_frequency_indices):
+                raise ValueError("frequency_indices contains a bin outside the n_fft frequency axis")
+            if len(set(normalized_frequency_indices)) != len(normalized_frequency_indices):
+                raise ValueError("frequency_indices must not contain duplicate bins")
+        normalized_data = _normalize_pairwise_data(
+            data,
+            n_fft=normalized_n_fft,
+            frequency_count=len(normalized_frequency_indices),
+            frame_type=type(self).__name__,
+            domain=self._data_domain,
+        )
+        records, normalized_source_ids = _normalize_pair_state(
+            pair_state,
+            data_rows=int(normalized_data.shape[0]),
+            source_channel_ids=source_channel_ids,
+        )
+        scaling = cast(SpectralScaling | None, getattr(self, "scaling", None))
+        denominator_role = cast(TransferDenominator, getattr(self, "denominator_role", "input"))
+        for record in records:
+            expected_domain = _expected_pair_domain(
+                record,
+                quantity=self._pair_quantity,
+                scaling=scaling,
+                denominator_role=denominator_role,
+            )
+            if record.domain != expected_domain:
+                raise ValueError(
+                    f"{type(self).__name__} pair domain does not match its typed pair and definition: "
+                    f"expected {expected_domain!r}, got {record.domain!r}"
+                )
+        if channel_metadata is None:
+            channel_metadata = _metadata_for_pair_state(records)
+        else:
+            channel_metadata = self._normalize_channel_metadata_for_count(channel_metadata, len(records))
+        if any(float(channel.calibration.factor) != 1.0 for channel in channel_metadata):
+            raise ValueError(
+                f"{type(self).__name__} output channel calibration must be 1.0; "
+                "input calibration is consumed before the pairwise operation and must not be reapplied."
+            )
+        if channel_ids is None:
+            channel_ids = [record.row_id for record in records]
+        if len(channel_ids) != len(records):
+            raise ValueError("Pair channel ID count must match pair data rows")
+        if len(set(channel_ids)) != len(channel_ids):
+            raise ValueError("Pair channel IDs must be unique")
+        self.n_fft = normalized_n_fft
+        self.window = normalized_window
+        self._frequency_indices = normalized_frequency_indices
+        self._pair_state = records
+        self._source_channel_ids = normalized_source_ids
+        super().__init__(
+            data=normalized_data,
+            sampling_rate=sampling_rate,
+            label=label,
+            metadata=metadata,
+            channel_metadata=channel_metadata,
+            channel_ids=channel_ids,
+            source_time_offset=source_time_offset,
+            lineage=lineage,
+            operation_history_prefix=operation_history_prefix,
+            previous=previous,
+        )
+
+    @property
+    def _data_domain(self) -> Literal["real", "complex"]:
+        return "real"
+
+    @property
+    def n_pairs(self) -> int:
+        """Return the number of flattened pair rows currently selected."""
+        return len(self._pair_state)
+
+    @property
+    def n_source_channels(self) -> int:
+        """Return the source channel count used by canonical pair indices."""
+        return len(self._source_channel_ids)
+
+    @property
+    def source_channel_ids(self) -> tuple[str, ...]:
+        """Return immutable opaque source-channel IDs in source index order."""
+        return self._source_channel_ids
+
+    @property
+    def pairs(self) -> tuple[OrderedSpectralPair, ...]:
+        """Return ordered pair roles in current row order."""
+        return tuple(record.pair for record in self._pair_state)
+
+    @property
+    def ordered_pairs(self) -> tuple[OrderedSpectralPair, ...]:
+        """Alias for :attr:`pairs` emphasizing row ordering."""
+        return self.pairs
+
+    @property
+    def pair_state(self) -> tuple[SpectralPairState, ...]:
+        """Return immutable typed state for every current flattened row."""
+        return self._pair_state
+
+    @property
+    def pair_domains(self) -> tuple[DerivedSpectralDomain, ...]:
+        """Return immutable derived unit/reference state for every row."""
+        return tuple(record.domain for record in self._pair_state)
+
+    @property
+    def freqs(self) -> NDArrayReal:
+        """Return the represented one-sided frequency bins in Hz."""
+        complete = np.fft.rfftfreq(self.n_fft, 1.0 / self.sampling_rate)
+        return complete[list(self._frequency_indices)].copy()
+
+    def pair_at(self, row_index: int) -> OrderedSpectralPair:
+        """Return the typed pair at a current flattened row index."""
+        if isinstance(row_index, bool) or not isinstance(row_index, numbers.Integral):
+            raise TypeError("Pair row index must be an integer")
+        index = int(row_index)
+        if index < 0:
+            index += self.n_pairs
+        if not 0 <= index < self.n_pairs:
+            raise IndexError(f"Pair row index out of range: {row_index}")
+        return self._pair_state[index].pair
+
+    def get_pair(self, row_index: int) -> OrderedSpectralPair:
+        """Return the typed pair at a current flattened row index."""
+        return self.pair_at(row_index)
+
+    def pair_row_index(self, output: int | str, input: int | str) -> int:
+        """Return the current row for an output/input source-ID or index pair.
+
+        String selectors are opaque source IDs. Display labels are intentionally
+        not accepted as identity selectors.
+        """
+        output_index = self._source_index(output, role="output")
+        input_index = self._source_index(input, role="input")
+        for row, record in enumerate(self._pair_state):
+            if record.pair.output.index == output_index and record.pair.input.index == input_index:
+                return row
+        raise KeyError(
+            f"Pair ({output!r}, {input!r}) is not selected. Select only an output/input pair present in this Frame."
+        )
+
+    def select_pair(self: PairwiseFrameT, output: int | str, input: int | str) -> PairwiseFrameT:
+        """Return one selected pair while preserving its concrete Frame type."""
+        return cast(PairwiseFrameT, self.get_channel(self.pair_row_index(output, input)))
+
+    def select_pairs(self: PairwiseFrameT, rows: Sequence[int]) -> PairwiseFrameT:
+        """Return selected flattened rows with their exact typed pair state."""
+        if not isinstance(rows, Sequence) or isinstance(rows, (str, bytes)):
+            raise TypeError("Pair rows must be an ordered sequence of integer row indices")
+        normalized: list[int] = []
+        for value in rows:
+            if isinstance(value, bool) or not isinstance(value, numbers.Integral):
+                raise TypeError("Pair rows must contain integer indices")
+            index = int(value)
+            if index < 0:
+                index += self.n_pairs
+            if not 0 <= index < self.n_pairs:
+                raise IndexError(f"Pair row index out of range: {value}")
+            normalized.append(index)
+        if not normalized:
+            raise ValueError("Cannot select an empty pair set")
+        return cast(PairwiseFrameT, self.get_channel(normalized))
+
+    def _source_index(self, value: int | str, *, role: str) -> int:
+        if isinstance(value, bool) or not isinstance(value, (numbers.Integral, str)):
+            raise TypeError(f"{role} selector must be a source-channel integer index or opaque ID")
+        if isinstance(value, str):
+            if value not in self._source_channel_ids:
+                raise KeyError(f"Unknown {role} source channel ID {value!r}; display labels are not pair identity")
+            return self._source_channel_ids.index(value)
+        index = int(value)
+        if index < 0:
+            index += self.n_source_channels
+        if not 0 <= index < self.n_source_channels:
+            raise IndexError(f"{role} source channel index out of range: {value}")
+        return index
+
+    def _selection_constructor_kwargs(self, indices: Sequence[int]) -> dict[str, Any]:
+        """Select typed rows alongside BaseFrame's channel-row selection."""
+        return {"pair_state": tuple(self._pair_state[index] for index in indices)}
+
+    def _frequency_indices_for_slice(self, selector: slice) -> tuple[int, ...]:
+        """Map a public frequency slice onto canonical one-sided bin IDs."""
+        start, stop, step = selector.indices(len(self._frequency_indices))
+        return self._frequency_indices[slice(start, stop, step)]
+
+    def _handle_multidim_indexing(self: PairwiseFrameT, key: tuple[Any, ...]) -> PairwiseFrameT:
+        """Select pair rows and represented frequency bins together."""
+        if len(key) > self._data.ndim:
+            raise ValueError(f"Invalid key length: {len(key)} for shape {self.shape}")
+        indices = self._channel_indices(key[0])
+        axis_selectors = key[1:]
+        if axis_selectors and not all(isinstance(selector, slice) for selector in axis_selectors):
+            raise ValueError("Only slice selectors on the frequency axis are supported for pairwise Frames")
+        selected_data = self._data[indices]
+        frequency_indices = self._frequency_indices
+        if axis_selectors:
+            if len(axis_selectors) != 1:
+                raise ValueError("Pairwise Frames expose only one non-channel frequency axis")
+            selector = cast(slice, axis_selectors[0])
+            frequency_indices = self._frequency_indices_for_slice(selector)
+            selected_data = selected_data[(slice(None), selector)]
+        return self._create_new_instance(
+            data=selected_data,
+            channel_metadata=self._borrowed_channel_metadata_descriptors(indices),
+            channel_ids=self._channel_ids_for_selection(indices),
+            source_time_offset=self.source_time_offset[indices],
+            lineage=self._required_semantic_lineage(),
+            frequency_indices=frequency_indices,
+            **self._selection_constructor_kwargs(indices),
+        )
+
+    def _create_new_instance(self: PairwiseFrameT, data: DaArray, **kwargs: Any) -> PairwiseFrameT:
+        """Preserve or subset typed state during generic Frame reconstruction."""
+        if "pair_state" not in kwargs:
+            channel_ids = kwargs.get("channel_ids")
+            if channel_ids is None or tuple(channel_ids) == tuple(self._channel_ids):
+                kwargs["pair_state"] = self._pair_state
+            else:
+                by_id = dict(zip(self._channel_ids, self._pair_state, strict=True))
+                try:
+                    kwargs["pair_state"] = tuple(by_id[channel_id] for channel_id in channel_ids)
+                except KeyError as exc:
+                    raise ValueError(
+                        "Pair state cannot be reconstructed from unknown row IDs; "
+                        "use the pair selection hook or preserve existing pair IDs."
+                    ) from exc
+        return super()._create_new_instance(data, **kwargs)
+
+    def _get_additional_init_kwargs(self) -> dict[str, Any]:
+        """Preserve frequency and source-identity state for Frame copies."""
+        return {
+            "n_fft": self.n_fft,
+            "window": self.window,
+            "source_channel_ids": self._source_channel_ids,
+            "frequency_indices": self._frequency_indices,
+        }
+
+    def _get_dataframe_index(self) -> pd.Index[Any]:
+        """Return frequency rows for DataFrame export."""
+        pd = require_pandas(f"{type(self).__name__}.to_dataframe")
+        return pd.Index(self.freqs, name="frequency")
+
+    def _reject_arithmetic(self) -> None:
+        raise TypeError(
+            f"Arithmetic is undefined for {type(self).__name__}; "
+            "select a quantity-specific pair or use its documented property."
+        )
+
+    def _binary_op(self, *args: Any, **kwargs: Any) -> Any:
+        self._reject_arithmetic()
+
+    def _binary_operand_op(self, *args: Any, **kwargs: Any) -> Any:
+        self._reject_arithmetic()
+
+    def __array_ufunc__(self, *args: Any, **kwargs: Any) -> Any:
+        """Reject NumPy arithmetic that would otherwise bypass the quantity contract."""
+        self._reject_arithmetic()
+
+    def _supports_base_reverse_scalar_op(self) -> bool:
+        return True
+
+    def _public_pair_values(self, values: np.ndarray[Any, Any]) -> np.ndarray[Any, Any]:
+        return values if self.n_pairs != 1 else values[0]
+
+    def _row_values(self, values: np.ndarray[Any, Any]) -> np.ndarray[Any, Any]:
+        if self.n_pairs == 1:
+            return values.reshape(1, -1)
+        return values
+
+    def _unit_summary(self, prefix: str) -> str:
+        units = {record.domain.unit for record in self._pair_state}
+        unit = next(iter(units)) if len(units) == 1 else "pair-dependent units"
+        return f"{prefix} [{unit}]"
+
+    def _matrix_plot_entries(
+        self,
+        view: str | None,
+        Aw: bool,  # noqa: N803
+    ) -> tuple[tuple[int, int, np.ndarray[Any, Any], str], ...]:
+        """Return typed matrix positions and plotted values for the strategy."""
+        values, _ = self._plot_frequency_values(view=view, Aw=Aw)
+        rows = self._row_values(values)
+        return tuple(
+            (
+                record.pair.output.index,
+                record.pair.input.index,
+                rows[row],
+                self.channels[row].label,
+            )
+            for row, record in enumerate(self._pair_state)
+        )
+
+    def _plot_frequency_values(
+        self,
+        *,
+        view: str | None,
+        Aw: bool,  # noqa: N803
+    ) -> tuple[np.ndarray[Any, Any], str]:
+        raise NotImplementedError
+
+    def plot(
+        self,
+        plot_type: str = "frequency",
+        ax: Axes | None = None,
+        title: str | None = None,
+        overlay: bool = False,
+        xlabel: str | None = None,
+        ylabel: str | None = None,
+        alpha: float = 1.0,
+        xlim: tuple[float, float] | None = None,
+        ylim: tuple[float, float] | None = None,
+        Aw: bool = False,  # noqa: N803
+        view: str | None = None,
+        **kwargs: Any,
+    ) -> Axes | Iterator[Axes]:
+        """Plot a quantity-specific frequency or typed pair matrix view.
+
+        ``view`` is interpreted by the concrete Frame (for example ``phase`` or
+        ``level``); no operation history or display label is inspected. Plotting
+        materializes the requested values, while Frame construction remains lazy.
+        """
+        from wandas.visualization.plotting import create_operation
+
+        strategy = create_operation(plot_type)
+        plot_kwargs: dict[str, Any] = {
+            "title": title,
+            "overlay": overlay,
+            "Aw": Aw,
+            "view": view,
+            **kwargs,
+        }
+        if xlabel is not None:
+            plot_kwargs["xlabel"] = xlabel
+        if ylabel is not None:
+            plot_kwargs["ylabel"] = ylabel
+        if alpha != 1.0:
+            plot_kwargs["alpha"] = alpha
+        if xlim is not None:
+            plot_kwargs["xlim"] = xlim
+        if ylim is not None:
+            plot_kwargs["ylim"] = ylim
+        return strategy.plot(self, ax=ax, **plot_kwargs)
+
+    def plot_matrix(
+        self,
+        plot_type: str = "matrix",
+        *,
+        view: str | None = None,
+        **kwargs: Any,
+    ) -> Axes | Iterator[Axes]:
+        """Plot selected pairs at their typed output-row/input-column cells."""
+        from wandas.visualization.plotting import create_operation
+
+        return create_operation(plot_type).plot(self, view=view, **kwargs)
+
+
+class CoherenceFrame(PairwiseSpectralFrame):
+    """Magnitude-squared coherence values in the dimensionless 0-to-1 domain."""
+
+    _pair_quantity = "coherence"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raw_data = args[0] if args else kwargs.get("data")
+        if raw_data is not None and not isinstance(raw_data, DaArray):
+            _validate_coherence_block(np.asarray(raw_data))
+        super().__init__(*args, **kwargs)
+        # Keep Dask operation construction lazy; validation runs when a block is
+        # materialized and therefore cannot trigger an eager compute here.
+        self._xr = self._xr.copy(data=da.map_blocks(_validate_coherence_block, self._data, dtype=self._data.dtype))
+
+    @property
+    def coherence(self) -> NDArrayReal:
+        """Return raw magnitude-squared coherence values in the public shape."""
+        return cast(NDArrayReal, self.data)
+
+    def _plot_frequency_values(
+        self,
+        *,
+        view: str | None,
+        Aw: bool,  # noqa: N803
+    ) -> tuple[np.ndarray[Any, Any], str]:
+        reject_pairwise_a_weighting(Aw)
+        if view not in {None, "coherence", "raw"}:
+            raise ValueError("CoherenceFrame supports only the 'coherence' plot view")
+        return np.asarray(self.coherence), "Coherence"
+
+
+class CrossSpectralFrame(PairwiseSpectralFrame):
+    """Complex cross-spectral values ``P_out_in`` with typed pair domains."""
+
+    _pair_quantity = "csd"
+
+    def __init__(self, scaling: SpectralScaling, *args: Any, **kwargs: Any) -> None:
+        if scaling not in {"spectrum", "density"}:
+            raise ValueError("CrossSpectralFrame scaling must be 'spectrum' or 'density'")
+        self._scaling = scaling
+        super().__init__(*args, **kwargs)
+
+    @property
+    def scaling(self) -> SpectralScaling:
+        """Return the immutable CSD scaling contract."""
+        return self._scaling
+
+    @property
+    def _data_domain(self) -> Literal["real", "complex"]:
+        return "complex"
+
+    @property
+    def magnitude(self) -> NDArrayReal:
+        """Return ``abs(P_out_in)`` in the public shape."""
+        return cast(NDArrayReal, np.abs(self.data))
+
+    @property
+    def phase(self) -> NDArrayReal:
+        """Return ``angle(P_out_in)`` in radians in the public shape."""
+        return cast(NDArrayReal, np.angle(self.data))
+
+    @property
+    def level_db(self) -> NDArrayReal:
+        """Return CSD level ``10 * log10(abs(P_out_in) / pair_reference)``."""
+        magnitude = self._row_values(np.asarray(self.magnitude))
+        levels = np.stack(
+            [
+                csd_level(row.astype(complex), record.domain.reference)
+                for row, record in zip(magnitude, self._pair_state)
+            ]
+        )
+        return cast(NDArrayReal, self._public_pair_values(levels))
+
+    def _get_additional_init_kwargs(self) -> dict[str, Any]:
+        result = super()._get_additional_init_kwargs()
+        result["scaling"] = self.scaling
+        return result
+
+    def _plot_frequency_values(
+        self,
+        *,
+        view: str | None,
+        Aw: bool,  # noqa: N803
+    ) -> tuple[np.ndarray[Any, Any], str]:
+        reject_pairwise_a_weighting(Aw)
+        selected = "magnitude" if view is None else view
+        if selected == "magnitude":
+            return np.asarray(self.magnitude), self._unit_summary("CSD magnitude")
+        if selected == "phase":
+            return np.asarray(self.phase), "CSD phase [rad]"
+        if selected == "level":
+            return np.asarray(self.level_db), "CSD level [dB]"
+        raise ValueError("CrossSpectralFrame view must be 'magnitude', 'phase', or 'level'")
+
+
+class TransferFunctionFrame(PairwiseSpectralFrame):
+    """Complex transfer values with truthful denominator and reference state."""
+
+    _pair_quantity = "transfer"
+
+    def __init__(
+        self,
+        scaling: SpectralScaling,
+        denominator_role: TransferDenominator = "input",
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        if scaling not in {"spectrum", "density"}:
+            raise ValueError("TransferFunctionFrame scaling must be 'spectrum' or 'density'")
+        if denominator_role not in {"input", "output"}:
+            raise ValueError("TransferFunctionFrame denominator_role must be 'input' or 'output'")
+        self._scaling = scaling
+        self._denominator_role = denominator_role
+        super().__init__(*args, **kwargs)
+
+    @property
+    def scaling(self) -> SpectralScaling:
+        """Return the immutable transfer scaling contract."""
+        return self._scaling
+
+    @property
+    def denominator_role(self) -> TransferDenominator:
+        """Return the immutable transfer denominator definition."""
+        return self._denominator_role
+
+    @property
+    def _data_domain(self) -> Literal["real", "complex"]:
+        return "complex"
+
+    @property
+    def definition(self) -> str:
+        """Return the persisted numerical-definition identifier."""
+        return "canonical_input_denominator" if self.denominator_role == "input" else "legacy_output_denominator"
+
+    @property
+    def gain(self) -> NDArrayReal:
+        """Return linear transfer gain ``abs(H_out_in)``."""
+        return cast(NDArrayReal, np.abs(self.data))
+
+    @property
+    def phase(self) -> NDArrayReal:
+        """Return transfer phase ``angle(H_out_in)`` in radians."""
+        return cast(NDArrayReal, np.angle(self.data))
+
+    @property
+    def gain_db(self) -> NDArrayReal:
+        """Return ``20 * log10(abs(H))`` for dimensionless selected pairs only."""
+        if any(record.domain.unit != "1" for record in self._pair_state):
+            raise ValueError(
+                "gain_db is defined only for dimensionless transfer pairs. "
+                "Select a same-unit pair first or use transfer_level_db for explicit unit references."
+            )
+        with np.errstate(divide="ignore", invalid="ignore"):
+            result = 20.0 * np.log10(self._row_values(np.asarray(self.gain)))
+        return cast(NDArrayReal, self._public_pair_values(result))
+
+    @property
+    def transfer_level_db(self) -> NDArrayReal:
+        """Return transfer level relative to each typed output/input reference ratio."""
+        gains = self._row_values(np.asarray(self.gain))
+        levels = np.stack(
+            [
+                transfer_level(row.astype(complex), record.domain.reference)
+                for row, record in zip(gains, self._pair_state)
+            ]
+        )
+        return cast(NDArrayReal, self._public_pair_values(levels))
+
+    def _get_additional_init_kwargs(self) -> dict[str, Any]:
+        result = super()._get_additional_init_kwargs()
+        result.update({"scaling": self.scaling, "denominator_role": self.denominator_role})
+        return result
+
+    def _plot_frequency_values(
+        self,
+        *,
+        view: str | None,
+        Aw: bool,  # noqa: N803
+    ) -> tuple[np.ndarray[Any, Any], str]:
+        reject_pairwise_a_weighting(Aw)
+        selected = "gain" if view is None else view
+        if selected == "gain":
+            return np.asarray(self.gain), self._unit_summary("Transfer gain")
+        if selected == "phase":
+            return np.asarray(self.phase), "Transfer phase [rad]"
+        if selected == "gain_db":
+            return np.asarray(self.gain_db), "Transfer gain [dB]"
+        if selected == "transfer_level_db":
+            return np.asarray(self.transfer_level_db), "Transfer level [dB]"
+        raise ValueError("TransferFunctionFrame view must be 'gain', 'phase', 'gain_db', or 'transfer_level_db'")
+
+
+__all__ = [
+    "CoherenceFrame",
+    "CrossSpectralFrame",
+    "PairwiseSpectralFrame",
+    "SpectralPairState",
+    "TransferFunctionFrame",
+    "build_pair_state",
+]

--- a/wandas/frames/pairwise.py
+++ b/wandas/frames/pairwise.py
@@ -255,6 +255,18 @@ def _normalize_pair_state(
             raise ValueError("Pair state records must use one source channel count")
     else:
         source_count = 0
+    canonical_roles: list[SpectralChannelRole | None] = [None] * source_count
+    for row, record in enumerate(records):
+        for role_name, role in (("output", record.pair.output), ("input", record.pair.input)):
+            canonical = canonical_roles[role.index]
+            if canonical is None:
+                canonical_roles[role.index] = role
+            elif role != canonical:
+                raise ValueError(
+                    "Pair state contains inconsistent source channel roles"
+                    f" at source index {role.index} in row {row} ({role_name});"
+                    f" expected {canonical!r}, got {role!r}"
+                )
     if source_channel_ids is None:
         ids_by_index = ["" for _ in range(source_count)]
         for record in records:

--- a/wandas/frames/pairwise.py
+++ b/wandas/frames/pairwise.py
@@ -21,6 +21,7 @@ from dask.array.core import Array as DaArray
 
 from wandas.core.base_frame import BaseFrame
 from wandas.core.metadata import ChannelCalibration, ChannelMetadata
+from wandas.pipeline.decorators import recipe_operation
 from wandas.processing.spectral_contracts import (
     DerivedSpectralDomain,
     OrderedSpectralPair,
@@ -523,8 +524,16 @@ class PairwiseSpectralFrame(BaseFrame[Any], ABC):
             f"Pair ({output!r}, {input!r}) is not selected. Select only an output/input pair present in this Frame."
         )
 
+    @recipe_operation("wandas.frame.select_pair")
     def select_pair(self: PairwiseFrameT, output: int | str, input: int | str) -> PairwiseFrameT:
-        """Return one selected pair while preserving its concrete Frame type."""
+        """Return one selected pair while preserving typed identity and Recipe intent.
+
+        ``output`` and ``input`` are source-channel indices or opaque source IDs;
+        display labels are not accepted as identity.  When this call is extracted
+        into a Recipe, the selectors are replayed against the source Frame at apply
+        time, so a valid source with a different channel order still selects the
+        requested source pair rather than a captured flattened row number.
+        """
         return cast(PairwiseFrameT, self.get_channel(self.pair_row_index(output, input)))
 
     def select_pairs(self: PairwiseFrameT, rows: Sequence[int]) -> PairwiseFrameT:

--- a/wandas/io/wdf_frames.py
+++ b/wandas/io/wdf_frames.py
@@ -547,7 +547,7 @@ def _pair_role_from_state(
         f"{field}.source_id",
         frame_type,
         nonblank=True,
-        canonical=True,
+        canonical=False,
     )
     if source_id != source_channel_ids[index]:
         raise _invalid_constructor_value(
@@ -654,7 +654,7 @@ def _validated_pairwise_constructor_state(
         source_count,
         unique=True,
         nonblank=True,
-        canonical=True,
+        canonical=False,
     )
 
     raw_pairs = state["pairs"]

--- a/wandas/io/wdf_frames.py
+++ b/wandas/io/wdf_frames.py
@@ -127,6 +127,14 @@ def _validate_codec_tensor(codec: FrameCodec, data: DaArray) -> None:
 
 def _require_fields(state: Mapping[str, Any], expected: set[str], frame_type: str) -> None:
     """Require an exact constructor-state field set without defaults."""
+    if not isinstance(state, Mapping):
+        raise ValueError(
+            "Invalid WDF Frame constructor state\n"
+            f"  Frame type: {frame_type}\n"
+            f"  Got: {type(state).__name__}\n"
+            "  Expected: a JSON object\n"
+            "Resave the file with a compatible Wandas version."
+        )
     if set(state) != expected:
         raise ValueError(
             "Invalid WDF Frame constructor state\n"
@@ -379,6 +387,563 @@ def _roughness_decode(common: dict[str, Any], state: Mapping[str, Any]) -> BaseF
     )
 
 
+_PAIRWISE_STATE_FIELDS = frozenset(
+    {"n_fft", "window", "frequency_indices", "source_channel_count", "source_channel_ids", "pairs"}
+)
+_PAIRWISE_SCALING_FIELDS = frozenset({"scaling"})
+_PAIRWISE_TRANSFER_FIELDS = frozenset({"scaling", "denominator_role", "definition"})
+_PAIR_STATE_FIELDS = frozenset({"row_id", "pair_index", "output", "input", "domain", "display_label"})
+_PAIR_ROLE_FIELDS = frozenset({"index", "source_id", "label", "unit", "reference"})
+_PAIR_DOMAIN_FIELDS = frozenset({"unit", "reference"})
+_VALID_SCALINGS = frozenset({"spectrum", "density"})
+_VALID_TRANSFER_DEFINITIONS = {
+    "input": "canonical_input_denominator",
+    "output": "legacy_output_denominator",
+}
+
+
+def _nonnegative_integer_value(value: object, field: str, frame_type: str) -> int:
+    """Return one strict non-negative JSON integer."""
+    if type(value) is not int or value < 0:
+        raise _invalid_constructor_value(frame_type, field, value, "a non-negative JSON integer")
+    return value
+
+
+def _positive_reference_value(value: object, field: str, frame_type: str) -> float:
+    """Return one strict positive finite reference value."""
+    if type(value) not in {int, float}:
+        raise _invalid_constructor_value(frame_type, field, value, "a positive finite JSON number")
+    normalized = float(cast(int | float, value))
+    if not np.isfinite(normalized) or normalized <= 0:
+        raise _invalid_constructor_value(frame_type, field, value, "a positive finite JSON number")
+    return normalized
+
+
+def _string_value(
+    value: object,
+    field: str,
+    frame_type: str,
+    *,
+    nonblank: bool = False,
+    canonical: bool = False,
+) -> str:
+    """Validate one JSON string without using it as pair identity implicitly."""
+    if not isinstance(value, str):
+        raise _invalid_constructor_value(frame_type, field, value, "a JSON string")
+    if nonblank and not value.strip():
+        raise _invalid_constructor_value(frame_type, field, value, "a non-blank JSON string")
+    if canonical and value != value.strip():
+        raise _invalid_constructor_value(
+            frame_type,
+            field,
+            value,
+            "a JSON string without surrounding whitespace",
+        )
+    return value
+
+
+def _string_vector(
+    value: object,
+    field: str,
+    frame_type: str,
+    expected_length: int,
+    *,
+    unique: bool = False,
+    nonblank: bool = False,
+    canonical: bool = False,
+) -> tuple[str, ...]:
+    """Validate one exact JSON string vector."""
+    if not isinstance(value, list) or len(value) != expected_length:
+        raise _invalid_constructor_value(
+            frame_type,
+            field,
+            value,
+            f"a JSON string list of length {expected_length}",
+        )
+    result = tuple(
+        _string_value(
+            item,
+            f"{field}[{index}]",
+            frame_type,
+            nonblank=nonblank,
+            canonical=canonical,
+        )
+        for index, item in enumerate(value)
+    )
+    if unique and len(set(result)) != len(result):
+        raise _invalid_constructor_value(frame_type, field, value, "a list of unique JSON strings")
+    return result
+
+
+def _pair_role_state(role: Any) -> dict[str, Any]:
+    """Encode one typed source role using JSON scalar values only."""
+    return {
+        "index": int(role.index),
+        "source_id": str(role.channel_id),
+        "label": str(role.label),
+        "unit": str(role.unit),
+        "reference": float(role.reference),
+    }
+
+
+def _pair_record_state(record: Any) -> dict[str, Any]:
+    """Encode one immutable selected pair row without history or label inference."""
+    pair = record.pair
+    return {
+        "row_id": str(record.row_id),
+        "pair_index": int(pair.pair_index),
+        "output": _pair_role_state(pair.output),
+        "input": _pair_role_state(pair.input),
+        "domain": {
+            "unit": str(record.domain.unit),
+            "reference": float(record.domain.reference),
+        },
+        "display_label": str(record.display_label),
+    }
+
+
+def _pairwise_state(frame: BaseFrame[Any], *, fields: set[str]) -> dict[str, Any]:
+    """Encode typed pair state shared by the three dedicated Frame codecs."""
+    typed = cast(Any, frame)
+    state: dict[str, Any] = {
+        "n_fft": int(typed.n_fft),
+        "window": str(typed.window),
+        "frequency_indices": [int(value) for value in typed._frequency_indices],
+        "source_channel_count": int(typed.n_source_channels),
+        "source_channel_ids": [str(value) for value in typed.source_channel_ids],
+        "pairs": [_pair_record_state(record) for record in typed.pair_state],
+    }
+    if "scaling" in fields:
+        state["scaling"] = str(typed.scaling)
+    if "denominator_role" in fields:
+        state["denominator_role"] = str(typed.denominator_role)
+        state["definition"] = str(typed.definition)
+    return state
+
+
+def _pair_role_from_state(
+    value: object,
+    *,
+    field: str,
+    frame_type: str,
+    source_channel_count: int,
+    source_channel_ids: tuple[str, ...],
+) -> Any:
+    """Validate and reconstruct one immutable typed source role."""
+    if not isinstance(value, Mapping):
+        raise _invalid_constructor_value(frame_type, field, value, "a JSON object")
+    value = cast(Mapping[str, Any], value)
+    _require_fields(value, set(_PAIR_ROLE_FIELDS), frame_type)
+    index = _nonnegative_integer_value(value["index"], f"{field}.index", frame_type)
+    if index >= source_channel_count:
+        raise _invalid_constructor_value(
+            frame_type,
+            f"{field}.index",
+            index,
+            f"an index in [0, {source_channel_count})",
+        )
+    source_id = _string_value(
+        value["source_id"],
+        f"{field}.source_id",
+        frame_type,
+        nonblank=True,
+        canonical=True,
+    )
+    if source_id != source_channel_ids[index]:
+        raise _invalid_constructor_value(
+            frame_type,
+            f"{field}.source_id",
+            source_id,
+            f"source_channel_ids[{index}] ({source_channel_ids[index]!r})",
+        )
+    label = _string_value(value["label"], f"{field}.label", frame_type)
+    unit = _string_value(value["unit"], f"{field}.unit", frame_type, canonical=True)
+    reference = _positive_reference_value(value["reference"], f"{field}.reference", frame_type)
+
+    from wandas.processing.spectral_contracts import SpectralChannelRole
+
+    return SpectralChannelRole(
+        index=index,
+        label=label,
+        unit=unit,
+        reference=reference,
+        channel_id=source_id,
+    )
+
+
+def _pair_domain_from_state(value: object, *, field: str, frame_type: str) -> Any:
+    """Validate and reconstruct one derived unit/reference domain."""
+    if not isinstance(value, Mapping):
+        raise _invalid_constructor_value(frame_type, field, value, "a JSON object")
+    value = cast(Mapping[str, Any], value)
+    _require_fields(value, set(_PAIR_DOMAIN_FIELDS), frame_type)
+    unit = _string_value(value["unit"], f"{field}.unit", frame_type, canonical=True)
+    reference = _positive_reference_value(value["reference"], f"{field}.reference", frame_type)
+
+    from wandas.processing.spectral_contracts import DerivedSpectralDomain
+
+    return DerivedSpectralDomain(unit=unit, reference=reference)
+
+
+def _validated_pairwise_constructor_state(
+    state: Mapping[str, Any],
+    data: DaArray,
+    *,
+    frame_type: str,
+    quantity: Literal["coherence", "csd", "transfer"],
+) -> tuple[int, str, tuple[int, ...], tuple[str, ...], tuple[Any, ...], str | None, str | None]:
+    """Validate and decode a dedicated pairwise Frame constructor state."""
+    if quantity == "coherence":
+        expected_fields = set(_PAIRWISE_STATE_FIELDS)
+    elif quantity == "csd":
+        expected_fields = set(_PAIRWISE_STATE_FIELDS | _PAIRWISE_SCALING_FIELDS)
+    else:
+        expected_fields = set(_PAIRWISE_STATE_FIELDS | _PAIRWISE_TRANSFER_FIELDS)
+    _require_fields(state, expected_fields, frame_type)
+
+    n_fft = _positive_integer(state, "n_fft", frame_type)
+    window = _nonblank_string(state, "window", frame_type)
+    if window != window.strip():
+        raise _invalid_constructor_value(
+            frame_type,
+            "window",
+            window,
+            "a non-blank JSON string without surrounding whitespace",
+        )
+    complete_frequency_count = n_fft // 2 + 1
+    frequency_indices = state["frequency_indices"]
+    if not isinstance(frequency_indices, list) or not frequency_indices:
+        raise _invalid_constructor_value(
+            frame_type,
+            "frequency_indices",
+            frequency_indices,
+            "a non-empty JSON list of canonical rfft bin indices",
+        )
+    normalized_frequency_indices: list[int] = []
+    seen_frequency_indices: set[int] = set()
+    for index, value in enumerate(frequency_indices):
+        bin_index = _nonnegative_integer_value(value, f"frequency_indices[{index}]", frame_type)
+        if bin_index >= complete_frequency_count:
+            raise _invalid_constructor_value(
+                frame_type,
+                f"frequency_indices[{index}]",
+                bin_index,
+                f"an index in [0, {complete_frequency_count})",
+            )
+        if bin_index in seen_frequency_indices:
+            raise _invalid_constructor_value(
+                frame_type,
+                f"frequency_indices[{index}]",
+                bin_index,
+                "a unique canonical rfft bin index",
+            )
+        seen_frequency_indices.add(bin_index)
+        normalized_frequency_indices.append(bin_index)
+    if len(normalized_frequency_indices) != int(data.shape[-1]):
+        raise _invalid_constructor_value(
+            frame_type,
+            "frequency_indices",
+            frequency_indices,
+            f"a list with exactly {data.shape[-1]} represented frequency bins",
+        )
+    source_count = _positive_integer(state, "source_channel_count", frame_type)
+    source_ids = _string_vector(
+        state["source_channel_ids"],
+        "source_channel_ids",
+        frame_type,
+        source_count,
+        unique=True,
+        nonblank=True,
+        canonical=True,
+    )
+
+    raw_pairs = state["pairs"]
+    data_rows = int(data.shape[0])
+    if not isinstance(raw_pairs, list) or len(raw_pairs) != data_rows or not raw_pairs:
+        raise _invalid_constructor_value(
+            frame_type,
+            "pairs",
+            raw_pairs,
+            f"a non-empty JSON list with exactly {data_rows} selected pair rows",
+        )
+    if len(raw_pairs) > source_count * source_count:
+        raise _invalid_constructor_value(
+            frame_type,
+            "pairs",
+            len(raw_pairs),
+            f"at most {source_count * source_count} unique pair rows",
+        )
+
+    scaling: str | None = None
+    denominator_role: str | None = None
+    if quantity in {"csd", "transfer"}:
+        scaling_value = state["scaling"]
+        if not isinstance(scaling_value, str) or scaling_value not in _VALID_SCALINGS:
+            raise _invalid_constructor_value(
+                frame_type,
+                "scaling",
+                scaling_value,
+                "one of the JSON strings 'spectrum' or 'density'",
+            )
+        scaling = scaling_value
+    if quantity == "transfer":
+        denominator_value = state["denominator_role"]
+        if not isinstance(denominator_value, str) or denominator_value not in _VALID_TRANSFER_DEFINITIONS:
+            raise _invalid_constructor_value(
+                frame_type,
+                "denominator_role",
+                denominator_value,
+                "one of the JSON strings 'input' or 'output'",
+            )
+        denominator_role = cast(str, denominator_value)
+        definition = state["definition"]
+        expected_definition = _VALID_TRANSFER_DEFINITIONS[denominator_role]
+        if definition != expected_definition:
+            raise _invalid_constructor_value(
+                frame_type,
+                "definition",
+                definition,
+                f"the exact JSON string {expected_definition!r} for denominator_role={denominator_role!r}",
+            )
+
+    from wandas.frames.pairwise import SpectralPairState
+    from wandas.processing.spectral_contracts import (
+        OrderedSpectralPair,
+        derive_coherence_domain,
+        derive_csd_domain,
+        derive_transfer_domain,
+    )
+
+    records: list[Any] = []
+    seen_pair_indices: set[int] = set()
+    seen_row_ids: set[str] = set()
+    for row, raw_pair in enumerate(raw_pairs):
+        field = f"pairs[{row}]"
+        if not isinstance(raw_pair, Mapping):
+            raise _invalid_constructor_value(frame_type, field, raw_pair, "a JSON object")
+        raw_pair = cast(Mapping[str, Any], raw_pair)
+        _require_fields(raw_pair, set(_PAIR_STATE_FIELDS), frame_type)
+        row_id = _string_value(raw_pair["row_id"], f"{field}.row_id", frame_type, nonblank=True, canonical=True)
+        if row_id in seen_row_ids:
+            raise _invalid_constructor_value(
+                frame_type,
+                f"{field}.row_id",
+                row_id,
+                "a unique pair row ID; duplicate IDs are invalid",
+            )
+        seen_row_ids.add(row_id)
+        pair_index = _nonnegative_integer_value(raw_pair["pair_index"], f"{field}.pair_index", frame_type)
+        if pair_index >= source_count * source_count:
+            raise _invalid_constructor_value(
+                frame_type,
+                f"{field}.pair_index",
+                pair_index,
+                f"an index in [0, {source_count * source_count})",
+            )
+        if pair_index in seen_pair_indices:
+            raise _invalid_constructor_value(
+                frame_type,
+                f"{field}.pair_index",
+                pair_index,
+                "a unique pair index; duplicate pairs are invalid",
+            )
+        seen_pair_indices.add(pair_index)
+
+        output = _pair_role_from_state(
+            raw_pair["output"],
+            field=f"{field}.output",
+            frame_type=frame_type,
+            source_channel_count=source_count,
+            source_channel_ids=source_ids,
+        )
+        input_ = _pair_role_from_state(
+            raw_pair["input"],
+            field=f"{field}.input",
+            frame_type=frame_type,
+            source_channel_count=source_count,
+            source_channel_ids=source_ids,
+        )
+        pair = OrderedSpectralPair(output=output, input=input_, n_channels=source_count)
+        if pair.pair_index != pair_index:
+            raise _invalid_constructor_value(
+                frame_type,
+                f"{field}.pair_index",
+                pair_index,
+                f"output.index * source_channel_count + input.index ({pair.pair_index})",
+            )
+        domain = _pair_domain_from_state(raw_pair["domain"], field=f"{field}.domain", frame_type=frame_type)
+        display_label = _string_value(
+            raw_pair["display_label"],
+            f"{field}.display_label",
+            frame_type,
+            nonblank=True,
+            canonical=True,
+        )
+
+        if quantity == "coherence":
+            expected_domain = derive_coherence_domain()
+        elif quantity == "csd":
+            expected_domain = derive_csd_domain(pair, cast(str, scaling))
+        else:
+            expected_domain = derive_transfer_domain(pair, cast(Any, denominator_role))
+        if domain != expected_domain:
+            raise _invalid_constructor_value(
+                frame_type,
+                f"{field}.domain",
+                {"unit": domain.unit, "reference": domain.reference},
+                f"the domain derived from the typed pair ({expected_domain!r})",
+            )
+        records.append(
+            SpectralPairState(
+                pair=pair,
+                domain=domain,
+                row_id=row_id,
+                display_label=display_label,
+            )
+        )
+
+    return n_fft, window, tuple(normalized_frequency_indices), source_ids, tuple(records), scaling, denominator_role
+
+
+def _validate_pairwise_common(
+    common: Mapping[str, Any],
+    records: tuple[Any, ...],
+    *,
+    frame_type: str,
+) -> None:
+    """Ensure common WDF row metadata agrees with typed pair state."""
+    channel_ids = common.get("channel_ids")
+    expected_ids = [record.row_id for record in records]
+    if not isinstance(channel_ids, list) or channel_ids != expected_ids:
+        raise ValueError(
+            "Invalid WDF pair row identity\n"
+            f"  Frame type: {frame_type}\n"
+            f"  Stored channel IDs: {channel_ids!r}\n"
+            f"  Expected typed pair row IDs: {expected_ids!r}\n"
+            "Pair row order and identity must be preserved explicitly."
+        )
+    channel_metadata = common.get("channel_metadata")
+    if not isinstance(channel_metadata, list) or len(channel_metadata) != len(records):
+        raise ValueError(
+            "Invalid WDF pair channel metadata\n"
+            f"  Frame type: {frame_type}\n"
+            f"  Got: {channel_metadata!r}\n"
+            f"  Expected one metadata record per selected pair ({len(records)})"
+        )
+    from wandas.core.metadata import ChannelMetadata
+
+    for row, (metadata, record) in enumerate(zip(channel_metadata, records, strict=True)):
+        if not isinstance(metadata, ChannelMetadata):
+            raise ValueError(
+                "Invalid WDF pair channel metadata\n"
+                f"  Frame type: {frame_type}\n"
+                f"  Row: {row}\n"
+                f"  Got: {type(metadata).__name__}\n"
+                "  Expected: ChannelMetadata"
+            )
+        if (
+            metadata.unit != record.domain.unit
+            or float(metadata.ref) != float(record.domain.reference)
+            or float(metadata.calibration.factor) != 1.0
+        ):
+            raise ValueError(
+                "Invalid WDF pair channel metadata\n"
+                f"  Frame type: {frame_type}\n"
+                f"  Row: {row}\n"
+                "  Stored unit/reference metadata does not agree with the typed pair domain\n"
+                "  Pair domain and consumed calibration must be reconstructed from constructor state."
+            )
+
+
+def _validate_coherence_constructor_state(state: Mapping[str, Any], data: DaArray) -> object:
+    return _validated_pairwise_constructor_state(state, data, frame_type="CoherenceFrame", quantity="coherence")
+
+
+def _coherence_state(frame: BaseFrame[Any]) -> dict[str, Any]:
+    return _pairwise_state(frame, fields=set())
+
+
+def _coherence_decode(common: dict[str, Any], state: Mapping[str, Any]) -> BaseFrame[Any]:
+    from wandas.frames.pairwise import CoherenceFrame
+
+    n_fft, window, frequency_indices, source_ids, records, _, _ = _validated_pairwise_constructor_state(
+        state,
+        common["data"],
+        frame_type="CoherenceFrame",
+        quantity="coherence",
+    )
+    _validate_pairwise_common(common, records, frame_type="CoherenceFrame")
+    return CoherenceFrame(
+        **common,
+        n_fft=n_fft,
+        window=window,
+        frequency_indices=frequency_indices,
+        pair_state=records,
+        source_channel_ids=source_ids,
+    )
+
+
+def _validate_csd_constructor_state(state: Mapping[str, Any], data: DaArray) -> object:
+    return _validated_pairwise_constructor_state(state, data, frame_type="CrossSpectralFrame", quantity="csd")
+
+
+def _csd_state(frame: BaseFrame[Any]) -> dict[str, Any]:
+    return _pairwise_state(frame, fields=set(_PAIRWISE_SCALING_FIELDS))
+
+
+def _csd_decode(common: dict[str, Any], state: Mapping[str, Any]) -> BaseFrame[Any]:
+    from wandas.frames.pairwise import CrossSpectralFrame
+
+    n_fft, window, frequency_indices, source_ids, records, scaling, _ = _validated_pairwise_constructor_state(
+        state,
+        common["data"],
+        frame_type="CrossSpectralFrame",
+        quantity="csd",
+    )
+    _validate_pairwise_common(common, records, frame_type="CrossSpectralFrame")
+    return CrossSpectralFrame(
+        **common,
+        n_fft=n_fft,
+        window=window,
+        frequency_indices=frequency_indices,
+        pair_state=records,
+        source_channel_ids=source_ids,
+        scaling=cast(Any, scaling),
+    )
+
+
+def _validate_transfer_constructor_state(state: Mapping[str, Any], data: DaArray) -> object:
+    return _validated_pairwise_constructor_state(state, data, frame_type="TransferFunctionFrame", quantity="transfer")
+
+
+def _transfer_state(frame: BaseFrame[Any]) -> dict[str, Any]:
+    return _pairwise_state(frame, fields=set(_PAIRWISE_TRANSFER_FIELDS))
+
+
+def _transfer_decode(common: dict[str, Any], state: Mapping[str, Any]) -> BaseFrame[Any]:
+    from wandas.frames.pairwise import TransferFunctionFrame
+
+    n_fft, window, frequency_indices, source_ids, records, scaling, denominator_role = (
+        _validated_pairwise_constructor_state(
+            state,
+            common["data"],
+            frame_type="TransferFunctionFrame",
+            quantity="transfer",
+        )
+    )
+    _validate_pairwise_common(common, records, frame_type="TransferFunctionFrame")
+    return TransferFunctionFrame(
+        **common,
+        n_fft=n_fft,
+        window=window,
+        frequency_indices=frequency_indices,
+        pair_state=records,
+        source_channel_ids=source_ids,
+        scaling=cast(Any, scaling),
+        denominator_role=cast(Any, denominator_role),
+    )
+
+
 @lru_cache(maxsize=1)
 def _codecs() -> tuple[FrameCodec, ...]:
     """Build the registry lazily to keep Frame imports cycle-free."""
@@ -386,6 +951,7 @@ def _codecs() -> tuple[FrameCodec, ...]:
     from wandas.frames.cepstrogram import CepstrogramFrame
     from wandas.frames.channel import ChannelFrame
     from wandas.frames.noct import NOctFrame
+    from wandas.frames.pairwise import CoherenceFrame, CrossSpectralFrame, TransferFunctionFrame
     from wandas.frames.roughness import RoughnessFrame
     from wandas.frames.spectral import SpectralFrame
     from wandas.frames.spectrogram import SpectrogramFrame
@@ -405,6 +971,30 @@ def _codecs() -> tuple[FrameCodec, ...]:
             _validate_spectral_constructor_state,
             _spectral_decode,
             "numeric",
+            frozenset({2}),
+        ),
+        FrameCodec(
+            CoherenceFrame,
+            _coherence_state,
+            _validate_coherence_constructor_state,
+            _coherence_decode,
+            "real",
+            frozenset({2}),
+        ),
+        FrameCodec(
+            CrossSpectralFrame,
+            _csd_state,
+            _validate_csd_constructor_state,
+            _csd_decode,
+            "complex",
+            frozenset({2}),
+        ),
+        FrameCodec(
+            TransferFunctionFrame,
+            _transfer_state,
+            _validate_transfer_constructor_state,
+            _transfer_decode,
+            "complex",
             frozenset({2}),
         ),
         FrameCodec(

--- a/wandas/pipeline/builtins.py
+++ b/wandas/pipeline/builtins.py
@@ -24,6 +24,7 @@ def builtin_recipe_operations() -> tuple[RecipeOperation, ...]:
     from wandas.frames.channel import ChannelFrame
     from wandas.frames.mixins.channel_processing_mixin import ChannelProcessingMixin
     from wandas.frames.mixins.channel_transform_mixin import ChannelTransformMixin
+    from wandas.frames.pairwise import PairwiseSpectralFrame
     from wandas.frames.spectral import SpectralFrame
     from wandas.frames.spectrogram import SpectrogramFrame
 
@@ -32,6 +33,7 @@ def builtin_recipe_operations() -> tuple[RecipeOperation, ...]:
         ChannelProcessingMixin,
         ChannelTransformMixin,
         ChannelFrame,
+        PairwiseSpectralFrame,
         CepstralFrame,
         CepstrogramFrame,
         SpectralFrame,

--- a/wandas/processing/spectral_contracts.py
+++ b/wandas/processing/spectral_contracts.py
@@ -1,7 +1,7 @@
 """Architecture-neutral contracts for ordered pairwise spectra.
 
-The concrete Frame types for pairwise quantities are tracked separately in
-Issue #406.  This module owns only immutable channel roles, pair ordering,
+The concrete Frame types for pairwise quantities consume these contracts.
+This module owns only immutable channel roles, pair ordering,
 derived linear-domain metadata, level formulas, and transfer-ratio edge-case
 handling so those rules can be shared without making ``SpectralFrame`` infer a
 quantity from lineage or display labels.
@@ -18,6 +18,7 @@ import numpy as np
 from wandas.utils.types import NDArrayComplex, NDArrayReal
 
 SpectralScaling = Literal["spectrum", "density"]
+TransferDenominator = Literal["input", "output"]
 
 
 def _normalize_index(value: object, *, name: str) -> int:
@@ -43,6 +44,7 @@ class SpectralChannelRole:
     label: str
     unit: str
     reference: float
+    channel_id: str = ""
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "index", _normalize_index(self.index, name="Channel index"))
@@ -56,6 +58,14 @@ class SpectralChannelRole:
             "reference",
             _normalize_reference(self.reference, name="Channel reference"),
         )
+        if not isinstance(self.channel_id, str):
+            raise TypeError("Channel id must be a string")
+        object.__setattr__(self, "channel_id", self.channel_id.strip() or f"c{self.index}")
+
+    @property
+    def source_id(self) -> str:
+        """Return the opaque source-channel identity used for pair selection."""
+        return self.channel_id
 
 
 @dataclass(frozen=True, slots=True)
@@ -144,10 +154,23 @@ def derive_coherence_domain() -> DerivedSpectralDomain:
     return DerivedSpectralDomain(unit="1", reference=1.0)
 
 
-def derive_transfer_domain(pair: OrderedSpectralPair) -> DerivedSpectralDomain:
-    """Derive transfer unit/reference as output divided by input."""
-    output_unit = pair.output.unit
-    input_unit = pair.input.unit
+def derive_transfer_domain(
+    pair: OrderedSpectralPair,
+    denominator_role: TransferDenominator = "input",
+) -> DerivedSpectralDomain:
+    """Derive transfer unit/reference for the selected denominator role.
+
+    The default is the canonical ``H[output, input] = P[output, input] /
+    P[input, input]`` contract. ``denominator_role="output"`` is retained for
+    truthful Recipe v1 replay, whose released numerical definition divided by
+    the output auto-spectrum.
+    """
+    if denominator_role not in {"input", "output"}:
+        raise ValueError("Transfer denominator role must be 'input' or 'output'")
+    numerator_role = pair.output if denominator_role == "input" else pair.input
+    denominator = pair.input if denominator_role == "input" else pair.output
+    output_unit = numerator_role.unit
+    input_unit = denominator.unit
     if not output_unit and not input_unit or output_unit == input_unit:
         unit = "1"
     elif not input_unit:
@@ -158,7 +181,7 @@ def derive_transfer_domain(pair: OrderedSpectralPair) -> DerivedSpectralDomain:
         unit = f"{output_unit}/{input_unit}"
     return DerivedSpectralDomain(
         unit=unit,
-        reference=pair.output.reference / pair.input.reference,
+        reference=numerator_role.reference / denominator.reference,
     )
 
 
@@ -177,11 +200,11 @@ def transfer_level(value: NDArrayComplex, reference: float) -> NDArrayReal:
 
 
 def reject_pairwise_a_weighting(enabled: bool) -> None:
-    """Reject A-weighting for CSD and transfer quantities explicitly."""
+    """Reject A-weighting for dedicated pairwise quantities explicitly."""
     if enabled:
         raise ValueError(
-            "A-weighting is unsupported for CSD and transfer-function quantities. "
-            "Use a dedicated quantity-aware projection instead."
+            "A-weighting is unsupported for coherence, CSD, and transfer-function quantities. "
+            "Use the dedicated quantity-aware projection instead."
         )
 
 
@@ -240,6 +263,7 @@ __all__ = [
     "OrderedSpectralPair",
     "SpectralChannelRole",
     "SpectralScaling",
+    "TransferDenominator",
     "as_output_input_pairs",
     "csd_level",
     "derive_coherence_domain",

--- a/wandas/processing/spectral_contracts.py
+++ b/wandas/processing/spectral_contracts.py
@@ -60,7 +60,10 @@ class SpectralChannelRole:
         )
         if not isinstance(self.channel_id, str):
             raise TypeError("Channel id must be a string")
-        object.__setattr__(self, "channel_id", self.channel_id.strip() or f"c{self.index}")
+        if not self.channel_id:
+            object.__setattr__(self, "channel_id", f"c{self.index}")
+        elif not self.channel_id.strip():
+            raise ValueError("Channel id must be a non-blank string")
 
     @property
     def source_id(self) -> str:

--- a/wandas/visualization/plotting.py
+++ b/wandas/visualization/plotting.py
@@ -41,6 +41,18 @@ TFrame = TypeVar("TFrame", bound="BaseFrame[Any]")
 PlotLabel = str | Sequence[str] | None
 
 
+def _typed_hook(frame: Any, name: str) -> Callable[..., Any] | None:
+    """Resolve a typed plotting hook from the Frame class, not its instance."""
+    descriptor = inspect.getattr_static(type(frame), name, None)
+    if descriptor is None:
+        return None
+    bind = getattr(descriptor, "__get__", None)
+    hook = bind(frame, type(frame)) if bind is not None else descriptor
+    if not callable(hook):
+        raise TypeError(f"{type(frame).__name__}.{name} must be callable")
+    return cast("Callable[..., Any]", hook)
+
+
 def _typed_frequency_values(frame: Any, *, view: str | None, aw: bool) -> tuple[Any, str] | None:
     """Return values from a Frame's quantity-specific plotting contract.
 
@@ -49,12 +61,10 @@ def _typed_frequency_values(frame: Any, *, view: str | None, aw: bool) -> tuple[
     metadata-like instance attributes from becoming an implicit quantity
     dispatch mechanism.
     """
-    hook = getattr(type(frame), "_plot_frequency_values", None)
+    hook = _typed_hook(frame, "_plot_frequency_values")
     if hook is None:
         return None
-    if not callable(hook):
-        raise TypeError(f"{type(frame).__name__}._plot_frequency_values must be callable")
-    values, ylabel = frame._plot_frequency_values(view=view, Aw=aw)
+    values, ylabel = hook(view=view, Aw=aw)
     return values, str(ylabel)
 
 
@@ -65,22 +75,18 @@ def _typed_matrix_entries(
     aw: bool,
 ) -> tuple[tuple[int, int, Any, str], ...] | None:
     """Return typed output/input matrix entries when the Frame provides them."""
-    hook = getattr(type(frame), "_matrix_plot_entries", None)
+    hook = _typed_hook(frame, "_matrix_plot_entries")
     if hook is None:
         return None
-    if not callable(hook):
-        raise TypeError(f"{type(frame).__name__}._matrix_plot_entries must be callable")
-    return tuple(frame._matrix_plot_entries(view=view, Aw=aw))
+    return tuple(hook(view=view, Aw=aw))
 
 
 def _typed_plot_ylabel(frame: Any, *, view: str | None, aw: bool) -> str | None:
     """Return a typed plot label without materializing the plotted values."""
-    hook = getattr(type(frame), "_plot_ylabel", None)
+    hook = _typed_hook(frame, "_plot_ylabel")
     if hook is None:
         return None
-    if not callable(hook):
-        raise TypeError(f"{type(frame).__name__}._plot_ylabel must be callable")
-    return str(frame._plot_ylabel(view=view, Aw=aw))
+    return str(hook(view=view, Aw=aw))
 
 
 def _spectrogram_axis_values(frame: Any, data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:

--- a/wandas/visualization/plotting.py
+++ b/wandas/visualization/plotting.py
@@ -4,7 +4,7 @@ import abc
 import inspect
 import logging
 from collections.abc import Callable, Iterator, Sequence
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar, cast
 
 import numpy as np
 
@@ -39,13 +39,38 @@ logger = logging.getLogger(__name__)
 
 TFrame = TypeVar("TFrame", bound="BaseFrame[Any]")
 PlotLabel = str | Sequence[str] | None
-_COHERENCE_OPERATION_ID = "wandas.audio.coherence"
 
 
-def _is_coherence_operation(frame: Any) -> bool:
-    """Return whether the frame's latest operation is the public coherence operation."""
-    operation_history = frame.operation_history
-    return bool(operation_history) and operation_history[-1]["operation"] == _COHERENCE_OPERATION_ID
+def _typed_frequency_values(frame: Any, *, view: str | None, aw: bool) -> tuple[Any, str] | None:
+    """Return values from a Frame's quantity-specific plotting contract.
+
+    Dedicated pairwise Frames expose this hook on their class.  Looking up the
+    attribute on the class (rather than on the instance) keeps arbitrary
+    metadata-like instance attributes from becoming an implicit quantity
+    dispatch mechanism.
+    """
+    hook = getattr(type(frame), "_plot_frequency_values", None)
+    if hook is None:
+        return None
+    if not callable(hook):
+        raise TypeError(f"{type(frame).__name__}._plot_frequency_values must be callable")
+    values, ylabel = frame._plot_frequency_values(view=view, Aw=aw)
+    return values, str(ylabel)
+
+
+def _typed_matrix_entries(
+    frame: Any,
+    *,
+    view: str | None,
+    aw: bool,
+) -> tuple[tuple[int, int, Any, str], ...] | None:
+    """Return typed output/input matrix entries when the Frame provides them."""
+    hook = getattr(type(frame), "_matrix_plot_entries", None)
+    if hook is None:
+        return None
+    if not callable(hook):
+        raise TypeError(f"{type(frame).__name__}._matrix_plot_entries must be callable")
+    return tuple(frame._matrix_plot_entries(view=view, Aw=aw))
 
 
 def _spectrogram_axis_values(frame: Any, data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
@@ -367,22 +392,21 @@ class FrequencyPlotStrategy(PlotStrategy["SpectralFrame"]):
         axes_cls = _matplotlib_axes_type("frequency plot")
         line2d_cls = _matplotlib_line2d_type("frequency plot")
         is_aw = kwargs.pop("Aw", False)
-        if _is_coherence_operation(bf):
-            data = bf.magnitude
-            ylabel = kwargs.pop("ylabel", "coherence")
+        view = kwargs.pop("view", None)
+        typed_values = _typed_frequency_values(bf, view=view, aw=is_aw)
+        if typed_values is not None:
+            data, default_ylabel = typed_values
+            ylabel = kwargs.pop("ylabel", default_ylabel)
         else:
-            last_operation = ""
-            if len(bf.operation_history) > 0:
-                last_operation = str(bf.operation_history[-1]["operation"]).rsplit(".", maxsplit=1)[-1]
-            is_amplitude = last_operation in {"fft", "stft", "welch", "to_spectral_envelope"}
-            if is_aw:
-                data = bf.dBA
-                quantity = "amplitude" if is_amplitude else "spectrum magnitude"
-                default_ylabel = f"A-weighted {quantity} level [dB re channel ref]"
-            else:
-                data = bf.dB
-                quantity = "Amplitude" if is_amplitude else "Spectrum magnitude"
-                default_ylabel = f"{quantity} level [dB re channel ref]"
+            if view is not None:
+                raise ValueError(
+                    "The 'view' argument is supported only by a typed quantity Frame; "
+                    "ordinary SpectralFrame plotting uses its amplitude level."
+                )
+            data = bf.dBA if is_aw else bf.dB
+            default_ylabel = (
+                "A-weighted amplitude level [dB re channel ref]" if is_aw else "Amplitude level [dB re channel ref]"
+            )
             ylabel = kwargs.pop("ylabel", default_ylabel)
         data = _reshape_to_2d(data)
         xlabel = kwargs.pop("xlabel", "Frequency [Hz]")
@@ -749,25 +773,34 @@ class MatrixPlotStrategy(PlotStrategy["SpectralFrame"]):
         axes_cls = _matplotlib_axes_type("matrix plot")
         line2d_cls = _matplotlib_line2d_type("matrix plot")
         is_aw = kwargs.pop("Aw", False)
-        if _is_coherence_operation(bf):
-            data = bf.magnitude
-            ylabel = kwargs.pop("ylabel", "coherence")
+        view = kwargs.pop("view", None)
+        typed_entries = _typed_matrix_entries(bf, view=view, aw=is_aw)
+        typed_values = _typed_frequency_values(bf, view=view, aw=is_aw)
+        if typed_entries is not None:
+            if typed_values is None:
+                raise TypeError(f"{type(bf).__name__} exposes matrix entries without a frequency plotting contract")
+            _, default_ylabel = typed_values
+            ylabel = kwargs.pop("ylabel", default_ylabel)
         else:
+            if view is not None:
+                raise ValueError(
+                    "The 'view' argument is supported only by a typed quantity Frame; "
+                    "ordinary SpectralFrame plotting uses its amplitude level."
+                )
             if is_aw:
-                unit = "dBA"
                 data = bf.dBA
+                default_ylabel = "A-weighted amplitude level [dB re channel ref]"
             else:
-                unit = "dB"
                 data = bf.dB
-            ylabel = kwargs.pop("ylabel", f"Spectrum level [{unit}]")
-
-        data = _reshape_to_2d(data)
+                default_ylabel = "Amplitude level [dB re channel ref]"
+            data = _reshape_to_2d(data)
+            ylabel = kwargs.pop("ylabel", default_ylabel)
 
         xlabel = kwargs.pop("xlabel", "Frequency [Hz]")
         alpha = kwargs.pop("alpha", 1)
         plot_kwargs = filter_kwargs(line2d_cls, kwargs, strict_mode=True)
         ax_set = filter_kwargs(axes_cls.set, kwargs, strict_mode=True)
-        num_channels = bf.n_channels
+
         # If an Axes is provided, prefer drawing into it (treat as overlay)
         if ax is not None:
             overlay = True
@@ -776,23 +809,85 @@ class MatrixPlotStrategy(PlotStrategy["SpectralFrame"]):
                 fig, ax = plt.subplots(1, 1, figsize=(6, 6))
             else:
                 fig = ax.figure
-            self.channel_plot(
-                bf.freqs,
-                data.T,
-                ax,  # Always Axes type here
-                title=title or bf.label or "Spectral Data",
-                ylabel=ylabel,
-                xlabel=xlabel,
-                alpha=alpha,
-                **plot_kwargs,
-            )
+            if ax is None:
+                raise RuntimeError("Matplotlib did not provide an Axes for matrix plotting")
+            if typed_entries is None:
+                self.channel_plot(
+                    bf.freqs,
+                    data.T,
+                    ax,  # Always Axes type here
+                    title=title or bf.label or "Spectral Data",
+                    ylabel=ylabel,
+                    xlabel=xlabel,
+                    alpha=alpha,
+                    **plot_kwargs,
+                )
+            else:
+                for output_index, input_index, channel_data, pair_label in typed_entries:
+                    del output_index, input_index
+                    self.channel_plot(
+                        bf.freqs,
+                        channel_data,
+                        ax,
+                        label=pair_label,
+                        title=title or bf.label or "Spectral Data",
+                        ylabel=ylabel,
+                        xlabel=xlabel,
+                        alpha=alpha,
+                        **plot_kwargs,
+                    )
             ax.set(**ax_set)
             if fig is not None:
                 fig.suptitle(title or bf.label or "Spectral Data")
             if ax.figure != fig:  # Only show if we created the figure
                 plt.tight_layout()
                 plt.show()
-            return ax
+            return cast("Axes", ax)
+
+        if typed_entries is not None:
+            source_count = int(getattr(bf, "n_source_channels", 0))
+            if source_count <= 0:
+                raise ValueError("A typed pairwise matrix requires at least one source channel")
+            fig, axs = plt.subplots(
+                source_count,
+                source_count,
+                figsize=(3 * source_count, 3 * source_count),
+                sharex=True,
+                sharey=True,
+            )
+            axes_grid = np.asarray(axs, dtype=object)
+            if axes_grid.ndim == 0:
+                axes_grid = axes_grid.reshape(1, 1)
+            elif axes_grid.ndim != 2:
+                axes_grid = axes_grid.reshape(source_count, source_count)
+            entry_by_position = {
+                (int(output_index), int(input_index)): (channel_data, pair_label)
+                for output_index, input_index, channel_data, pair_label in typed_entries
+            }
+            for output_index in range(source_count):
+                for input_index in range(source_count):
+                    ax_i = axes_grid[output_index, input_index]
+                    entry = entry_by_position.get((output_index, input_index))
+                    if entry is not None:
+                        channel_data, pair_label = entry
+                        self.channel_plot(
+                            bf.freqs,
+                            channel_data,
+                            ax_i,
+                            title=pair_label,
+                            ylabel=ylabel,
+                            xlabel=xlabel,
+                            alpha=alpha,
+                            **plot_kwargs,
+                        )
+                    ax_i.set(**ax_set)
+                    ax_i.set_xlabel(xlabel)
+            fig.suptitle(title or bf.label or "Spectral Data")
+            plt.tight_layout()
+            plt.show()
+            return _return_axes_iterator(fig.axes)
+
+        num_channels = bf.n_channels
         num_rows = int(np.ceil(np.sqrt(num_channels)))
         fig, axs = plt.subplots(
             num_rows,
@@ -821,6 +916,7 @@ class MatrixPlotStrategy(PlotStrategy["SpectralFrame"]):
                 **plot_kwargs,
             )
             ax_i.set(**ax_set)
+            ax_i.set_xlabel(xlabel)
         fig.suptitle(title or bf.label or "Spectral Data")
         plt.tight_layout()
         plt.show()

--- a/wandas/visualization/plotting.py
+++ b/wandas/visualization/plotting.py
@@ -830,7 +830,9 @@ class MatrixPlotStrategy(PlotStrategy["SpectralFrame"]):
             else:
                 fig = ax.figure
             if ax is None:
-                raise RuntimeError("Matplotlib did not provide an Axes for matrix plotting")
+                raise RuntimeError(  # pragma: no cover
+                    "Matplotlib did not provide an Axes for matrix plotting"
+                )
             if typed_entries is None:
                 self.channel_plot(
                     bf.freqs,
@@ -879,7 +881,7 @@ class MatrixPlotStrategy(PlotStrategy["SpectralFrame"]):
             if axes_grid.ndim == 0:
                 axes_grid = axes_grid.reshape(1, 1)
             elif axes_grid.ndim != 2:
-                axes_grid = axes_grid.reshape(source_count, source_count)
+                axes_grid = axes_grid.reshape(source_count, source_count)  # pragma: no cover
             entry_by_position = {
                 (int(output_index), int(input_index)): (channel_data, pair_label)
                 for output_index, input_index, channel_data, pair_label in typed_entries

--- a/wandas/visualization/plotting.py
+++ b/wandas/visualization/plotting.py
@@ -73,6 +73,16 @@ def _typed_matrix_entries(
     return tuple(frame._matrix_plot_entries(view=view, Aw=aw))
 
 
+def _typed_plot_ylabel(frame: Any, *, view: str | None, aw: bool) -> str | None:
+    """Return a typed plot label without materializing the plotted values."""
+    hook = getattr(type(frame), "_plot_ylabel", None)
+    if hook is None:
+        return None
+    if not callable(hook):
+        raise TypeError(f"{type(frame).__name__}._plot_ylabel must be callable")
+    return str(frame._plot_ylabel(view=view, Aw=aw))
+
+
 def _spectrogram_axis_values(frame: Any, data: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     freqs = np.fft.rfftfreq(frame.n_fft, 1.0 / frame.sampling_rate)
     times = np.arange(data.shape[-1]) * frame.hop_length / frame.sampling_rate
@@ -775,11 +785,15 @@ class MatrixPlotStrategy(PlotStrategy["SpectralFrame"]):
         is_aw = kwargs.pop("Aw", False)
         view = kwargs.pop("view", None)
         typed_entries = _typed_matrix_entries(bf, view=view, aw=is_aw)
-        typed_values = _typed_frequency_values(bf, view=view, aw=is_aw)
         if typed_entries is not None:
-            if typed_values is None:
-                raise TypeError(f"{type(bf).__name__} exposes matrix entries without a frequency plotting contract")
-            _, default_ylabel = typed_values
+            typed_ylabel = _typed_plot_ylabel(bf, view=view, aw=is_aw)
+            if typed_ylabel is None:
+                typed_values = _typed_frequency_values(bf, view=view, aw=is_aw)
+                if typed_values is None:
+                    raise TypeError(f"{type(bf).__name__} exposes matrix entries without a frequency plotting contract")
+                _, default_ylabel = typed_values
+            else:
+                default_ylabel = typed_ylabel
             ylabel = kwargs.pop("ylabel", default_ylabel)
         else:
             if view is not None:


### PR DESCRIPTION
Closes #406
Related #391
Follow-up to #401 / PR #419
Follow-up to #399 / PR #403

## Summary

Implements Issue #406 from main commit `b300fdabbb1b0c2e49d788785e55bba3c320d41a`. Latest reviewable head: `b9d32850c6c1aad690701c4262c15f91d89691df`.

### Dedicated Frame architecture

- Adds public `CoherenceFrame`, `CrossSpectralFrame`, and `TransferFunctionFrame`.
- Each concrete type uses a private `BaseFrame`-derived flattened pairwise base; none inherits `SpectralFrame` or `SpectralPropertiesMixin`.
- `ChannelFrame.coherence()`, `.csd()`, and `.transfer_function()` return the exact dedicated type.
- Generic `SpectralFrame` remains the FFT/Welch amplitude-spectrum container with its existing amplitude API.
- Undefined pairwise arithmetic is rejected with an actionable error.

### Typed pair state and representation

- Preserves the internal `(pair, frequency)` representation so existing flattened storage, Recipe payloads, WDF shape, and Dask graphs remain compatible; this issue does not migrate to a 3-D pair tensor.
- Uses canonical output-major/input-minor order: `pair_index = output_index * n_source_channels + input_index`.
- Immutable `SpectralChannelRole`, `OrderedSpectralPair`, `DerivedSpectralDomain`, and `SpectralPairState` are the semantic source of truth for source identity, roles, domains, references, row identity, and display state.
- Source IDs are opaque and preserved exactly; pair row IDs are derived from the unique pair index, so delimiter-containing and surrounding-whitespace IDs cannot collide or be normalized into another identity.
- Exposes `n_pairs`, `n_source_channels`, immutable ordered source IDs/pairs, `pair_state`, `pair_domains`, row-to-pair lookup, stable output/input selection, and pair subset selection.
- Source-index roles are required to be consistent across every selected row. Selection, frequency slicing, labels, metadata, channel extras, iteration, and reconstruction retain concrete type and row-matched typed state.
- Input-role source-time offsets are preserved. Input calibration is consumed before the operation; output pair metadata has calibration factor 1.0.

### Quantity-specific public properties

- `CoherenceFrame`: raw `data`, `coherence`, `freqs`, typed pair state, frequency/matrix plotting. It does not expose generic `dB`, `dBA`, A-weighting, amplitude `magnitude`, `power`, `ifft()`, or `noct_synthesis()`.
- `CrossSpectralFrame`: raw complex `data`, `magnitude`, `phase`, `level_db`, `freqs`, immutable `n_fft`/`window`/`scaling`, typed domains, and typed plots. `level_db` is `10 * log10(abs(P_out_in) / pair_reference)`.
- `TransferFunctionFrame`: raw complex `data`, `gain`, `phase`, `gain_db`, `transfer_level_db`, `freqs`, immutable scaling and denominator definition. `gain_db` is dimensionless-pair-only; `transfer_level_db` uses the explicit output/input reference ratio and `20 * log10`.
- Zero denominators remain observable as NaN/infinite/non-finite results; near-zero finite values are not floored, clipped, or silently regularized.
- Pairwise A-weighting fails explicitly through `reject_pairwise_a_weighting()`.

### Transfer v1 truthfulness and Recipe compatibility

- New public calls emit Recipe v2 and reconstruct the exact dedicated Frame type.
- Coherence/CSD v1 replay preserves released reversed display labels while typed roles retain actual output/input array meaning.
- Transfer v1 explicitly stores and replays the released output-axis denominator as `legacy_output_denominator`; it is never represented as canonical v2.
- Transfer v2 stores the canonical input denominator `H_out_in = P_out_in / P_in_in`.
- Recipe extraction, `to_dict`, JSON serialization/deserialization, load, apply, and WDF round-trip use the central infrastructure without operation-specific branches.

### Typed plotting

- Plot dispatch is based on class-bound typed Frame hooks, never operation ID, operation history, labels, value ranges, or a generic quantity enum.
- Removed `_COHERENCE_OPERATION_ID`, `_is_coherence_operation`, and the former coherence special branches in Frequency/Matrix plotting.
- Coherence plots show raw 0--1 values with default ylabel `Coherence`.
- CSD and transfer plots provide typed linear, phase, and level/gain views with unit-aware labels; matrix plots use typed output/input cells and leave absent pair cells empty.
- Matrix plotting obtains ylabel without a second typed-value materialization; a regression test verifies one Dask compute.
- Overlay/non-overlay, supplied Axes, custom labels/titles, phase/level views, mono/multi-pair, subsets, and A-weighting rejection are covered.
- Ordinary `SpectralFrame` plotting retains amplitude-level and A-weighted amplitude behavior.

### WDF and public API

- Adds exact built-in WDF codecs for all three dedicated Frame types.
- Constructor state explicitly persists and validates `n_fft`, `window`, frequency selection, scaling, source count/IDs, ordered roles, pair domains/references, pair row IDs, and Transfer denominator definition.
- Constructor and WDF boundaries agree on row IDs, typed metadata domains, calibration factor, role identity, dtype/rank/bin counts, references, duplicate/missing pairs, and selected subsets.
- Old WDF `SpectralFrame` artifacts remain exact `SpectralFrame` artifacts; no operation-history/label-based migration is attempted. Older Wandas versions fail explicitly on new exact pairwise types.
- Updates `wandas.__init__`, `wandas.frames`, `__all__`, TYPE_CHECKING/protocol annotations, `ChannelFrame` return annotations, API reference, compatibility table, release notes, README, and the canonical spectral numerical contract.
- The three types are available as `wandas.CoherenceFrame`, `wandas.CrossSpectralFrame`, and `wandas.TransferFunctionFrame`.

### Automated review follow-up

Addressed automated review findings from the prior ready-for-review head:

- collision-free pair row IDs and exact opaque source ID preservation, including colon and surrounding-whitespace IDs;
- symmetric public constructor/WDF validation for row IDs and unit/reference metadata;
- dtype-scaled float32 coherence tolerance without clipping;
- one-materialization typed matrix plotting;
- consistent immutable role definition per source index;
- class-bound plotting hook dispatch so instance attributes cannot shadow the typed contract;
- rejection of empty pair state so every constructible public Frame is WDF-roundtrippable;
- complete typed public constructor signatures for all three exported Frame classes;
- preservation of reverse frequency slices and their canonical frequency-bin state;
- immutable `n_fft` and `window` properties so the frequency-axis definition cannot be changed after construction;
- complete public contracts in the three concrete class docstrings and removal of the private pairwise base from module `__all__`;
- `PairwiseSpectralFrame` is now an ABC with abstract plotting hooks, and the remaining pairwise/spectral-contract/plotting coverage gaps are covered or explicitly unreachable defensive branches.
- Pairwise transform orchestration is a module-private `TypeVar`-bound builder: `output_frame_class: type[PairwiseFrameT]` determines the concrete return type; all six public/Recipe v1 paths return it directly. The private builder is no longer part of `TransformFrameProtocol`, and it reads `n_fft`, `window`, and `scaling` from typed Operation properties rather than `to_params()`.
- Python 3.14 compatibility is preserved by using a small `TypeGuard` for runtime structural validation instead of `runtime_checkable Protocol` checks that reject dynamic test doubles on that interpreter.

### Validation

- Required pairwise-focused suites: 220 passed (24 channel-transform, 43 pairwise Frame, 16 Recipe-version, 137 WDF tests).
- `uv run pytest -q`: 3308 passed, 3 skipped, 210 warnings.
- `uv run ruff check wandas tests scripts learning-path`: passed.
- `uv run ruff format --check wandas tests scripts learning-path`: passed.
- `uv run ty check wandas tests scripts learning-path`: passed.
- `uv run python scripts/check_public_docstrings.py`: passed.
- `uv run marimo check --strict learning-path/*.py`: passed.
- `uv run mkdocs build --strict -f docs/mkdocs.yml`: passed; only existing nav/auth/font warnings were emitted.
- `git diff --check`: passed.
- Changed production coverage remains 99% overall; the latest full run reports pairwise, spectral contracts, WDF, channel transform, and plotting at 100%.
- Wheel build/install smoke passed for Wandas 0.6.2 and verified all three top-level exports.
- Pyodide validation passed: 336 passed, 7 intentional dependency skips, 0 failures.

### Independent final-head review

A separate read-only review of the final head `b9d32850c6c1aad690701c4262c15f91d89691df` against main found no P0/P1/P2 issues. It verified the TypeVar-bound concrete return inference, all six cast-free public/Recipe paths, the Protocol boundary, typed Operation properties, the Python 3.14-safe TypeGuard, and the absence of changes to numerical kernels, Recipe/WDF contracts, or pair state. The reviewer also confirmed focused 220-pass and full 3308-pass results, all repository checks, and successful Python 3.10/3.14, Windows, Pyodide, docs, wheel, and CI Gate checks.

### Remaining risks and #391

- Existing non-interactive Matplotlib and missing-font warnings remain environment-dependent.
- Older Wandas versions cannot read new exact pairwise WDF types; they fail explicitly rather than guessing a generic quantity.
- No new dependency or 3-D pair-axis migration is introduced.
- The related #391 child issues (#397--#402) are closed. After this PR is merged, #391 can be closed as the parent audit tracker; this PR intentionally does not close #391 automatically.

PRはマージしていません。


