### PR TITLE
Improve the executable five-minute tutorial

### DIFF
--- a/docs/src/tutorial/index.md
+++ b/docs/src/tutorial/index.md
@@ -1,10 +1,14 @@
 # Tutorial / チュートリアル
 
-This is a five-minute introduction to the core Wandas workflow: create or read a
-signal, apply one operation, and inspect the result.
+In five minutes, we will build one mono signal, put it in a Wandas
+`ChannelFrame`, filter it, and compare the result in the time and frequency
+domains. The example uses one NumPy array because `wd.generate_sin(freqs=[...])`
+creates one channel per frequency; that is useful in other workflows, but not
+for this mixed-signal filter example.
 
-このページでは、信号の作成または読込、処理、結果の確認というWandasの基本workflowを
-5分で体験します。
+この5分チュートリアルでは、モノラル信号を1つ作り、Wandasの`ChannelFrame`に渡して、
+時間領域と周波数領域で処理前後を比較します。ここでは、周波数ごとに別チャンネルを
+作る`wd.generate_sin(freqs=[...])`ではなく、NumPyで同じ配列に2つの成分を合成します。
 
 ## Installation / インストール
 
@@ -13,69 +17,170 @@ pip install wandas
 ```
 
 The optional `io`, `marimo`, and analysis extras are documented with the
-workflow that needs them. The learning apps include their own setup context.
+workflow that needs them.
 
 必要なworkflowに応じた`io`、`marimo`、解析extraは各ドキュメントで説明しています。
-learning appにも必要なセットアップ情報があります。
 
-## Import / インポート
+## 1. Create one mono signal / 1つのモノラル信号を作る
 
-```python exec="on" session="wd_demo"
+The two sine waves share one time axis and are added to one NumPy array. The
+result is one mono signal containing 440 Hz and 1,800 Hz components.
+
+2つの正弦波を同じ時間軸上で加算し、1つのNumPy配列にします。そのため、結果は440 Hzと
+1,800 Hzの成分を持つ1つのモノラル信号です。
+
+```python exec="on" session="wd_tutorial" source="above"
+import numpy as np
 import wandas as wd
 ```
 
-## Create or read a signal / 信号の作成または読込
+```python exec="on" session="wd_tutorial" source="above"
+sampling_rate = 16_000
+duration = 1.0
+time = np.arange(int(sampling_rate * duration), dtype=np.float64) / sampling_rate
 
-The executable example uses a generated signal, so it runs without a file or
-network connection.
+mixed_signal = (
+    np.sin(2 * np.pi * 440 * time)
+    + 0.6 * np.sin(2 * np.pi * 1_800 * time)
+)
+signal = wd.from_numpy(mixed_signal, sampling_rate=sampling_rate).rename_channels({0: "Original"})
 
-実行例では生成信号を使うため、ファイルやネットワーク接続は不要です。
-
-```python exec="on" session="wd_demo"
-audio = wd.generate_sin(freqs=[440, 1_000], duration=1.0, sampling_rate=16_000)
-print(f"Sampling rate / サンプリングレート: {audio.sampling_rate} Hz")
-print(f"Channels / チャンネル数: {audio.n_channels}")
-print(f"Duration / 長さ: {audio.duration} s")
+print(f"Frame / 型: {type(signal).__name__}")
+print(f"Channels / チャンネル数: {signal.n_channels}")
+print(f"Labels / ラベル: {signal.labels}")
 ```
 
-For a local WAV file, the same workflow starts with one ordinary read call:
+`wd.from_numpy()` turns the one-dimensional array into a mono `ChannelFrame`.
+Renaming the channel makes the comparison legend readable later.
 
-手元のWAVファイルを使う場合も、最初の読込は次の1行です:
+`wd.from_numpy()`は1次元配列をモノラルの`ChannelFrame`にします。チャンネル名を変更しておくと、
+後の比較図の凡例も読みやすくなります。
 
-```python
-audio = wd.read("recording.wav")
+## 2. Filter and combine the Frames / Frameを処理して比較用にまとめる
+
+The cutoff lies between the two components. `low_pass_filter()` returns a new
+Frame, and `concat_frame()` keeps the original and filtered channels together
+for a direct comparison.
+
+カットオフ周波数を2つの成分の間に置きます。`low_pass_filter()`は新しいFrameを返し、
+`concat_frame()`で元信号と処理後信号を比較用のFrameにまとめます。
+
+```python exec="on" session="wd_tutorial" source="above"
+processed = (
+    signal
+    .low_pass_filter(cutoff=1_000)
+    .rename_channels({0: "After 1 kHz low-pass"})
+)
+
+comparison = signal.concat_frame(processed)
+print(f"Comparison labels / 比較ラベル: {comparison.labels}")
 ```
 
-## Basic processing / 基本的な処理
+The original `signal` remains available, while `processed` and `comparison`
+are new Frames. The next two examples use the same `comparison` object, so the
+legend identifies which curve is original and which is filtered.
 
-Apply a low-pass filter and keep the returned Frame for the next step. The
-input Frame remains unchanged.
+元の`signal`はそのまま残り、`processed`と`comparison`は新しいFrameです。次の2つの例では
+同じ`comparison`を使うため、凡例から元信号とフィルタ後信号を識別できます。
 
-ローパスフィルタを適用し、返されたFrameを次の処理へ渡します。入力Frameは変更されません。
+## 3. Compare the time waveform / 時間波形を比較する
 
-```python exec="on" session="wd_demo"
-filtered = audio.low_pass_filter(cutoff=800)
+`ChannelFrame.plot()` uses the Frame data and channel labels to draw both
+waveforms. The SVG conversion is kept in a hidden document-only setup block;
+the reader-facing code is only the Wandas plotting call.
+
+`ChannelFrame.plot()`はFrameのデータとチャンネル名を使って2つの波形を描きます。SVG変換は
+非表示のドキュメント用セットアップに分離し、読者向けコードはWandasの描画呼び出しだけにします。
+
+```python exec="on" session="wd_tutorial"
+from html import escape
+import io
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def inline_svg(axes, caption):
+    figure = axes.figure
+    buffer = io.StringIO()
+    try:
+        figure.savefig(
+            buffer,
+            format="svg",
+            bbox_inches="tight",
+            metadata={"Date": None},
+        )
+        svg = buffer.getvalue()
+        svg_start = svg.find("<svg")
+        if svg_start < 0:
+            raise ValueError("Matplotlib did not produce an SVG document")
+        return f'<figure class="tutorial-figure"><figcaption>{escape(caption)}</figcaption>{svg[svg_start:]}</figure>'
+    finally:
+        plt.close(figure)
 ```
 
-## Visualization / 可視化
-
-```python exec="on" session="wd_demo"
-filtered.plot(title="Low-pass filtered signal / ローパスフィルタ後の信号")
+```python exec="on" session="wd_tutorial" source="above" html="on"
+waveform_ax = comparison.plot(
+    overlay=True,
+    xlim=(0, 0.02),
+    title="Original vs filtered",
+)
+print(inline_svg(waveform_ax, "Time waveform: original and filtered"))
 ```
 
-For one representative channel selection, use a label query such as:
+The high-frequency ripple is reduced in the filtered curve, while the slower
+440 Hz shape remains recognizable.
 
-代表的なチャンネル選択では、ラベルqueryを次のように使えます:
+フィルタ後の曲線では高周波の細かな揺らぎが小さくなり、低い440 Hzの形はおおむね残ります。
 
-```python
-audio.rename_channels({0: "acc_x"}).get_channel(query="acc_x")
+## 4. Compare the frequency spectrum / 周波数スペクトルを比較する
+
+`fft()` creates a Wandas `SpectralFrame`, and its `plot()` method displays the
+frequency components. No signal samples or spectrum values need to be passed
+to Matplotlib directly.
+
+`fft()`はWandasの`SpectralFrame`を作り、その`plot()`で周波数成分を表示します。信号サンプルや
+スペクトル値をMatplotlibへ直接渡す必要はありません。
+
+```python exec="on" session="wd_tutorial" source="above" html="on"
+spectrum_ax = comparison.fft().plot(
+    overlay=True,
+    xlim=(0, 2_500),
+    title="FFT: original vs filtered",
+)
+print(inline_svg(spectrum_ax, "FFT spectrum: original and filtered"))
 ```
 
-The generated API reference documents the other query forms and their
-validation rules: [ChannelFrame.get_channel](../api/frames.md).
+The original spectrum has clear peaks at 440 Hz and 1,800 Hz. After the
+1,000 Hz low-pass filter, the 440 Hz peak remains close to its original level,
+while the 1,800 Hz peak is much smaller.
 
-詳細なquery形式と検証規則は生成された[ChannelFrame.get_channel API reference](../api/frames.md)
-を参照してください。
+元信号のスペクトルには440 Hzと1,800 Hzのピークがあります。1,000 Hzローパスフィルタ後は、
+440 Hzのピークが元に近い大きさで残り、1,800 Hzのピークは大きく小さくなります。
+
+## 5. Keep the workflow chainable / 処理をメソッドチェーンで書く
+
+The complete processing and analysis path stays composable: create a Frame,
+apply an operation, combine it for comparison, then run FFT and plotting.
+
+Frameの作成、処理、比較、FFT、可視化までを自然なメソッドチェーンとして組み合わせられます。
+
+```python exec="on" session="wd_tutorial" source="above"
+chained = (
+    signal
+    .low_pass_filter(cutoff=1_000)
+    .rename_channels({0: "After 1 kHz low-pass"})
+)
+chained_comparison = signal.concat_frame(chained)
+chained_spectrum = chained_comparison.fft()
+```
+
+The same `chained_comparison` can be passed to `plot()` or `fft().plot()` when
+you want another view, while the original Frame remains available for reuse.
+
+同じ`chained_comparison`を`plot()`や`fft().plot()`へ渡して別の視点で確認できます。元のFrameも
+再利用のために残ります。
 
 ## Next steps / 次に読むもの
 

--- a/tests/docs/test_tutorial_contract.py
+++ b/tests/docs/test_tutorial_contract.py
@@ -5,6 +5,8 @@ import sys
 from html.parser import HTMLParser
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MKDOCS_CONFIG = REPO_ROOT / "docs/mkdocs.yml"
 
@@ -30,6 +32,7 @@ class _CodeTextParser(HTMLParser):
 
 def test_tutorial_build_contains_executed_code_and_inline_svg(tmp_path) -> None:
     """The tutorial's executable source and generated figures are the docs contract."""
+    pytest.importorskip("mkdocs", reason="MkDocs is installed only in the docs dependency group")
     site_dir = tmp_path / "site"
     environment = {**os.environ, "MPLBACKEND": "Agg"}
     completed = subprocess.run(

--- a/tests/docs/test_tutorial_contract.py
+++ b/tests/docs/test_tutorial_contract.py
@@ -1,0 +1,79 @@
+import os
+import re
+import subprocess
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MKDOCS_CONFIG = REPO_ROOT / "docs/mkdocs.yml"
+
+
+class _CodeTextParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self._in_code = False
+        self.parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "code":
+            self._in_code = True
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "code":
+            self._in_code = False
+
+    def handle_data(self, data: str) -> None:
+        if self._in_code:
+            self.parts.append(data)
+
+
+def test_tutorial_build_contains_executed_code_and_inline_svg(tmp_path) -> None:
+    """The tutorial's executable source and generated figures are the docs contract."""
+    site_dir = tmp_path / "site"
+    environment = {**os.environ, "MPLBACKEND": "Agg"}
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mkdocs",
+            "build",
+            "--strict",
+            "-f",
+            str(MKDOCS_CONFIG),
+            "-d",
+            str(site_dir),
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+    tutorial = site_dir / "tutorial" / "index.html"
+    assert tutorial.exists()
+    html = tutorial.read_text(encoding="utf-8")
+    code = _CodeTextParser()
+    code.feed(html)
+    code_text = "".join(code.parts)
+
+    assert "wd.from_numpy" in code_text
+    assert "low_pass_filter" in code_text
+    assert "concat_frame" in code_text
+    assert "comparison.plot" in code_text
+    assert "comparison.fft().plot" in code_text
+    tutorial_figures = re.findall(
+        r'<figure class="tutorial-figure">.*?</figure>',
+        html,
+        flags=re.DOTALL,
+    )
+    assert len(tutorial_figures) == 2
+    assert all("<svg" in figure for figure in tutorial_figures)
+    assert "<figcaption>Time waveform: original and filtered</figcaption>" in html
+    assert "<figcaption>FFT spectrum: original and filtered</figcaption>" in html
+    assert "Original" in html
+    assert "After 1 kHz low-pass" in html


### PR DESCRIPTION
## Summary

- Rework the five-minute tutorial around one NumPy mono signal containing 440 Hz and 1,800 Hz.
- Demonstrate `wd.from_numpy()`, `low_pass_filter()`, `rename_channels()`, `concat_frame()`, `plot()`, and `fft().plot()`.
- Use markdown-exec sessions and source display so the reader can copy the main code.
- Generate the waveform and spectrum as inline SVG during the MkDocs build, with the SVG-only helper hidden and figures closed reliably.
- Add a focused generated-HTML contract test; no generated image files or workflow changes are included.

## Validation

- `uv run --no-sync mkdocs build --strict -f docs/mkdocs.yml`
- `uv run pytest tests/docs/test_tutorial_contract.py -q --no-cov`
- Related docs, filter, FFT, and plotting tests passed.
- Ruff check, format check, and ty check passed.
- CI routing reports `docs=true` for the tutorial and contract-test paths.

The full local `tests/docs` run has two unrelated failures caused by the existing ignored `learning-path/06_skill_validation.py`; the remaining 33 docs tests pass.