### PR TITLE
Organize RecipePlan learning path navigation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -89,9 +89,8 @@ plugins:
 # ─── ナビゲーション ────────────────────────
 nav:
   - Home: index.md
-  - Tutorials:
-      - Overview: tutorial/index.md
-      - Reuse Processing with RecipePlan: tutorial/pipeline-recipes.md
+  - Tutorial:
+      - Five-minute Tutorial: tutorial/index.md
   - How-to Guides:
       - Cepstral Analysis: how-to/cepstral-analysis.md
       - Pipeline Recipes: how-to/pipeline-recipes.md

--- a/docs/src/api/pipeline.md
+++ b/docs/src/api/pipeline.md
@@ -3,11 +3,11 @@
 The `wandas.pipeline` module provides portable Recipe extraction, validation,
 serialization, replay, and extension declarations. For a guided executable
 lesson, use the <a href="../../learning-path/06_reusable_pipeline_recipes.html">Reusable Pipeline Recipes Learning Path</a>.
-For task-oriented procedures, use the [RecipePlan how-to guide](../how-to/pipeline-recipes.md).
+For task-oriented procedures, use the [RecipePlan How-to](../how-to/pipeline-recipes.md).
 
 段階的に学ぶ実行可能な教材は
 <a href="../../learning-path/06_reusable_pipeline_recipes.html">Reusable Pipeline Recipes Learning Path</a>へ、
-具体的な作業手順は[RecipePlan how-to guide](../how-to/pipeline-recipes.md)へ進んでください。
+具体的な作業手順は[RecipePlan How-to](../how-to/pipeline-recipes.md)へ進んでください。
 
 ::: wandas.pipeline
 

--- a/docs/src/api/pipeline.md
+++ b/docs/src/api/pipeline.md
@@ -1,8 +1,13 @@
 # Pipeline Recipes API
 
 The `wandas.pipeline` module provides portable Recipe extraction, validation,
-serialization, replay, and extension declarations. Workflow guidance belongs in
-the [Recipe tutorial](../tutorial/pipeline-recipes.md) and [how-to guide](../how-to/pipeline-recipes.md).
+serialization, replay, and extension declarations. For a guided executable
+lesson, use the <a href="../../learning-path/06_reusable_pipeline_recipes.html">Reusable Pipeline Recipes Learning Path</a>.
+For task-oriented procedures, use the [RecipePlan how-to guide](../how-to/pipeline-recipes.md).
+
+段階的に学ぶ実行可能な教材は
+<a href="../../learning-path/06_reusable_pipeline_recipes.html">Reusable Pipeline Recipes Learning Path</a>へ、
+具体的な作業手順は[RecipePlan how-to guide](../how-to/pipeline-recipes.md)へ進んでください。
 
 ::: wandas.pipeline
 

--- a/docs/src/how-to/pipeline-recipes.md
+++ b/docs/src/how-to/pipeline-recipes.md
@@ -1,8 +1,12 @@
 # Work with RecipePlan
 
-The [Recipe tutorial](../tutorial/pipeline-recipes.md) demonstrates the first
-replay. Use these procedures when a concrete task needs more than that short
-path.
+For a guided, executable introduction, start with the
+<a href="../../learning-path/06_reusable_pipeline_recipes.html">Reusable Pipeline Recipes Learning Path</a>.
+Use this how-to when you already know the task you need to complete.
+
+RecipePlanを初めて段階的に学ぶ場合は、実行可能な
+<a href="../../learning-path/06_reusable_pipeline_recipes.html">Reusable Pipeline Recipes Learning Path</a>
+から始めてください。具体的な作業が決まっている場合に、このHow-toを使います。
 
 ## Choose WDF or Recipe
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,9 +6,11 @@ library, understand its contracts, and contribute to it.
 
 ## Choose a path
 
-- **Try it first:** follow the [five-minute Tutorial](tutorial/index.md) to
-  create, process, and visualize a signal.
-- **Run executable examples:** start the <a href="learning-path/01_getting_started.html">Learning Path</a>.
+- **Try Wandas first:** complete the [five-minute Tutorial](tutorial/index.md)
+  to create, process, and visualize a signal.
+- **Continue learning:** proceed through the executable
+  <a href="learning-path/01_getting_started.html">Learning Path</a>, starting
+  with Getting Started.
 - **Complete a task:** start with a [How-to guide](how-to/cepstral-analysis.md).
 - **Check an API contract:** open the [API Reference](api/index.md), generated
   from Python docstrings.

--- a/docs/src/tutorial/index.md
+++ b/docs/src/tutorial/index.md
@@ -193,8 +193,8 @@ It leads into working with real data and signal-processing basics.
 へ進んでください。実データの読み込み、基本的な信号処理へ順番に進めます。
 
 For a specific task or API contract, use the
-[How-to Guides](../how-to/cepstral-analysis.md) or
+[How-to guide](../how-to/cepstral-analysis.md) or
 [API Reference](../api/index.md).
 
-具体的な作業手順は[How-to Guides](../how-to/cepstral-analysis.md)、
+具体的な作業手順は[How-to guide](../how-to/cepstral-analysis.md)、
 APIの契約は[API Reference](../api/index.md)を参照してください。

--- a/docs/src/tutorial/index.md
+++ b/docs/src/tutorial/index.md
@@ -182,10 +182,19 @@ you want another view, while the original Frame remains available for reuse.
 同じ`chained_comparison`を`plot()`や`fft().plot()`へ渡して別の視点で確認できます。元のFrameも
 再利用のために残ります。
 
-## Next steps / 次に読むもの
+## Next step / 次のステップ
 
-- <a href="../learning-path/01_getting_started.html">Getting Started learning app</a>: setup and the first interactive workflow.
-- <a href="../learning-path/02_working_with_data.html">Working with Data learning app</a>: read and inspect local data files.
-- <a href="../learning-path/03_signal_processing_basics.html">Signal Processing Basics learning app</a>: filtering and frequency analysis.
-- [RecipePlan tutorial](pipeline-recipes.md): reuse a public Frame workflow on another input.
-- [API Reference](../api/index.md): generated contracts for public symbols.
+Continue with the executable
+<a href="../learning-path/01_getting_started.html">Getting Started Learning Path</a>.
+It leads into working with real data and signal-processing basics.
+
+次は、実行可能な
+<a href="../learning-path/01_getting_started.html">Getting Started Learning Path</a>
+へ進んでください。実データの読み込み、基本的な信号処理へ順番に進めます。
+
+For a specific task or API contract, use the
+[How-to Guides](../how-to/cepstral-analysis.md) or
+[API Reference](../api/index.md).
+
+具体的な作業手順は[How-to Guides](../how-to/cepstral-analysis.md)、
+APIの契約は[API Reference](../api/index.md)を参照してください。

--- a/docs/src/tutorial/pipeline-recipes.md
+++ b/docs/src/tutorial/pipeline-recipes.md
@@ -1,54 +1,13 @@
-# Reuse a processing workflow with RecipePlan
+# RecipePlan tutorial has moved / RecipePlanチュートリアルは移動しました
 
-When the same preprocessing steps should run on another recording, a
-`RecipePlan` separates the public Frame operations from the input data. This
-short tutorial builds one plan, serializes it in memory, replays it, and checks
-the result against direct method calls.
+The guided RecipePlan lesson is now part of the executable Learning Path.
 
-## First replay
+RecipePlanの段階的な学習教材は、実行可能なLearning Pathへ集約しました。
 
-Start with ordinary Frame methods. Extract the plan from the processed template,
-round-trip its JSON-compatible mapping, and apply it to a different Frame:
-
-```python exec="on" session="recipe_tutorial"
-import json
-
-import numpy as np
-import wandas as wd
-from wandas.pipeline import RecipePlan
-
-template = wd.from_numpy(
-    np.array([[1.0, 2.0, 4.0, 7.0]]),
-    sampling_rate=8_000,
-    ch_labels=["sensor"],
-)
-template_result = template.remove_dc().normalize()
-plan = RecipePlan.from_frame(template_result, input_names=("signal",))
-
-loaded = RecipePlan.from_dict(json.loads(json.dumps(plan.to_dict())))
-new_signal = wd.from_numpy(
-    np.array([[2.0, 5.0, 8.0, 14.0]]),
-    sampling_rate=8_000,
-    metadata={"recording": "next"},
-    ch_labels=["sensor"],
-)
-
-replayed = loaded.apply({"signal": new_signal})
-direct = new_signal.remove_dc().normalize()
-np.testing.assert_allclose(replayed.data, direct.data)
-assert replayed.metadata == {"recording": "next"}
-print("Replay matches direct calls: yes")
-```
-
-The assertion is the important part: replay and direct calls have the same
-numerical result, while runtime metadata comes from the new input. A plan stores
-reusable operation intent, not the template's samples.
-
-## Continue from here
-
-- Run the <a href="../../learning-path/06_reusable_pipeline_recipes.html">Reusable Pipeline Recipes Learning Path</a>
-  for a complete create, save, load, apply, and result-verification workflow.
-- Use the [RecipePlan How-to](../how-to/pipeline-recipes.md) for file persistence,
-  multiple inputs, external arrays, and runtime-only errors.
-- Consult the [Pipeline API Reference](../api/pipeline.md) for generated
-  signatures and exceptions.
+- <a href="../../learning-path/06_reusable_pipeline_recipes.html">Reusable Pipeline Recipes Learning Path</a>
+  — learn how to extract, serialize, load, and replay a `RecipePlan`.
+  `RecipePlan`の抽出、保存、読込、再実行を段階的に学びます。
+- [RecipePlan How-to](../how-to/pipeline-recipes.md)
+  — complete a specific RecipePlan task. 目的が決まっている作業を完了する手順です。
+- [Pipeline API Reference](../api/pipeline.md)
+  — check signatures, contracts, and exceptions. シグネチャ、契約、例外を確認します。

--- a/tests/docs/test_tutorial_contract.py
+++ b/tests/docs/test_tutorial_contract.py
@@ -71,8 +71,10 @@ def built_site(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 
 def _hrefs(path: Path) -> list[str]:
+    assert path.exists(), f"Generated page is missing: {path}"
     parser = _HrefParser()
     parser.feed(path.read_text(encoding="utf-8"))
+    parser.close()
     return parser.hrefs
 
 

--- a/tests/docs/test_tutorial_contract.py
+++ b/tests/docs/test_tutorial_contract.py
@@ -30,10 +30,21 @@ class _CodeTextParser(HTMLParser):
             self.parts.append(data)
 
 
-def test_tutorial_build_contains_executed_code_and_inline_svg(tmp_path) -> None:
-    """The tutorial's executable source and generated figures are the docs contract."""
+class _HrefParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.hrefs: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "a":
+            self.hrefs.extend(value for name, value in attrs if name == "href" and value is not None)
+
+
+@pytest.fixture(scope="module")
+def built_site(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Build the docs once for the executable and navigation contracts."""
     pytest.importorskip("mkdocs", reason="MkDocs is installed only in the docs dependency group")
-    site_dir = tmp_path / "site"
+    site_dir = tmp_path_factory.mktemp("mkdocs-site")
     environment = {**os.environ, "MPLBACKEND": "Agg"}
     completed = subprocess.run(
         [
@@ -56,6 +67,22 @@ def test_tutorial_build_contains_executed_code_and_inline_svg(tmp_path) -> None:
     )
 
     assert completed.returncode == 0, completed.stdout + completed.stderr
+    return site_dir
+
+
+def _hrefs(path: Path) -> list[str]:
+    parser = _HrefParser()
+    parser.feed(path.read_text(encoding="utf-8"))
+    return parser.hrefs
+
+
+def _has_href(hrefs: list[str], fragment: str) -> bool:
+    return any(fragment in href for href in hrefs)
+
+
+def test_tutorial_build_contains_executed_code_and_inline_svg(built_site: Path) -> None:
+    """The tutorial's executable source and generated figures are the docs contract."""
+    site_dir = built_site
 
     tutorial = site_dir / "tutorial" / "index.html"
     assert tutorial.exists()
@@ -80,3 +107,48 @@ def test_tutorial_build_contains_executed_code_and_inline_svg(tmp_path) -> None:
     assert "<figcaption>FFT spectrum: original and filtered</figcaption>" in html
     assert "Original" in html
     assert "After 1 kHz low-pass" in html
+
+
+def test_learning_path_navigation_contract(built_site: Path) -> None:
+    """The beginner path and the legacy RecipePlan URL remain discoverable."""
+    config = (REPO_ROOT / "docs/mkdocs.yml").read_text(encoding="utf-8")
+    assert "tutorial/pipeline-recipes.md" not in config
+    assert "Five-minute Tutorial: tutorial/index.md" in config
+
+    home_source = (REPO_ROOT / "docs/src/index.md").read_text(encoding="utf-8")
+    assert home_source.index("Try Wandas first") < home_source.index("Continue learning")
+
+    home = built_site / "index.html"
+    home_hrefs = _hrefs(home)
+    assert _has_href(home_hrefs, "tutorial/")
+    assert _has_href(home_hrefs, "learning-path/01_getting_started.html")
+
+    tutorial = built_site / "tutorial" / "index.html"
+    tutorial_hrefs = _hrefs(tutorial)
+    assert _has_href(tutorial_hrefs, "learning-path/01_getting_started.html")
+    assert not any("tutorial/pipeline-recipes" in href for href in tutorial_hrefs)
+
+    legacy_source = REPO_ROOT / "docs/src/tutorial/pipeline-recipes.md"
+    legacy_text = legacy_source.read_text(encoding="utf-8")
+    assert "exec=" not in legacy_text
+    assert "\nassert " not in legacy_text
+
+    legacy = built_site / "tutorial" / "pipeline-recipes" / "index.html"
+    assert legacy.exists()
+    legacy_html = legacy.read_text(encoding="utf-8")
+    legacy_hrefs = _hrefs(legacy)
+    assert "Reusable Pipeline Recipes Learning Path" in legacy_html
+    assert "RecipePlan How-to" in legacy_html
+    assert "Pipeline API Reference" in legacy_html
+    assert _has_href(legacy_hrefs, "06_reusable_pipeline_recipes.html")
+    assert _has_href(legacy_hrefs, "how-to/pipeline-recipes")
+    assert _has_href(legacy_hrefs, "api/pipeline")
+
+    how_to_hrefs = _hrefs(built_site / "how-to" / "pipeline-recipes" / "index.html")
+    assert _has_href(how_to_hrefs, "06_reusable_pipeline_recipes.html")
+    assert not any("tutorial/pipeline-recipes" in href for href in how_to_hrefs)
+
+    api_hrefs = _hrefs(built_site / "api" / "pipeline" / "index.html")
+    assert _has_href(api_hrefs, "06_reusable_pipeline_recipes.html")
+    assert _has_href(api_hrefs, "how-to/pipeline-recipes")
+    assert not any("tutorial/pipeline-recipes" in href for href in api_hrefs)


### PR DESCRIPTION
## Summary

- make the five-minute Tutorial the only Tutorial navigation entry
- guide readers from Home and the five-minute Tutorial to Learning Path 01
- replace the legacy RecipePlan tutorial content with a migration page
- make Learning Path 06 the guided RecipePlan entry point from the How-to and API pages
- add stable generated-HTML contracts for the updated learning flow

## Validation

- `uv run --no-sync pytest tests/docs/test_tutorial_contract.py tests/docs/test_docs_links.py -q --no-cov` — 5 passed
- `uv run --no-sync mkdocs build --strict -f docs/mkdocs.yml` — passed
- `uv run --no-sync ruff check tests/docs` — passed
- `uv run --no-sync ruff format --check tests/docs` — passed
- `uv run --no-sync ty check tests/docs` — passed
- `git diff --check` — passed
- docs CI routing — `docs=true`

The full `tests/docs` run has 34 passing tests and 2 unrelated existing failures in `learning-path/06_skill_validation.py` (fixture path resolution and private `.compute()` detection).