### PR TITLE
docs: organize Learning Path navigation and add i18n PoC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,21 @@ jobs:
       - name: Learning Path翻訳カタログの検証
         run: uv run --no-sync python scripts/validate_learning_path_i18n.py
 
+      - name: Learning Path全体のexport planを検証
+        run: uv run --no-sync python scripts/export_learning_path.py --all --dry-run
+
+      - name: Learning Path PoCを日英export
+        env:
+          MPLBACKEND: Agg
+        run: >-
+          uv run --no-sync python scripts/export_learning_path.py
+          --poc --output "$RUNNER_TEMP/wandas-learning-path-poc" --jobs 2
+
+      - name: Learning Path PoCの生成HTMLを検証
+        run: >-
+          uv run --no-sync python scripts/validate_learning_path_i18n.py
+          --site "$RUNNER_TEMP/wandas-learning-path-poc"
+
       - name: Documentation contract tests
         run: uv run --no-sync pytest tests/docs -q --no-cov
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
     if: needs.route.outputs.docs == 'true'
     needs: route
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - name: チェックアウト
         uses: actions/checkout@v4
@@ -123,6 +123,9 @@ jobs:
 
       - name: Learning applicationsのsource check
         run: uv run --no-sync marimo check --strict learning-path/*.py
+
+      - name: Learning Path翻訳カタログの検証
+        run: uv run --no-sync python scripts/validate_learning_path_i18n.py
 
       - name: Documentation contract tests
         run: uv run --no-sync pytest tests/docs -q --no-cov

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,19 +33,15 @@ jobs:
       - name: Validate learning applications
         run: uv run --no-sync marimo check --strict learning-path/*.py
 
+      - name: Validate Learning Path translations
+        run: uv run --no-sync python scripts/validate_learning_path_i18n.py
+
       - name: Build MkDocs documentation
         # uv run を使って uv の環境で mkdocs を実行
         run: uv run --no-sync mkdocs build --strict -f docs/mkdocs.yml
 
       - name: Export learning applications
-        shell: bash
-        run: |
-          mkdir -p docs/site/learning-path
-          for file in learning-path/*.py; do
-            uv run --no-sync marimo export html "$file" \
-              -o "docs/site/learning-path/$(basename "${file%.py}.html")" \
-              -f
-          done
+        run: uv run --no-sync python scripts/export_learning_path.py --all --output docs/site
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -41,6 +41,8 @@ jobs:
         run: uv run --no-sync mkdocs build --strict -f docs/mkdocs.yml
 
       - name: Export learning applications
+        env:
+          MPLBACKEND: Agg
         run: uv run --no-sync python scripts/export_learning_path.py --all --output docs/site --jobs 1
 
       - name: Validate exported Learning Path HTML

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -41,7 +41,10 @@ jobs:
         run: uv run --no-sync mkdocs build --strict -f docs/mkdocs.yml
 
       - name: Export learning applications
-        run: uv run --no-sync python scripts/export_learning_path.py --all --output docs/site
+        run: uv run --no-sync python scripts/export_learning_path.py --all --output docs/site --jobs 1
+
+      - name: Validate exported Learning Path HTML
+        run: uv run --no-sync python scripts/validate_learning_path_i18n.py --site docs/site --all
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/docs/design/learning-path-internationalization.md
+++ b/docs/design/learning-path-internationalization.md
@@ -1,0 +1,275 @@
+# Learning Path の日英対応 PoC
+
+## 現在の構成
+
+Learning Path は `learning-path/*.py` の marimo アプリである。MkDocs は
+`docs/src` を `docs/site` へビルドした後、デプロイワークフローが各アプリを
+`marimo export html` で一度ずつ `docs/site/learning-path/` へ出力している。
+したがって、現在の日本語ページのURLは次のとおりである。
+
+```text
+/learning-path/01_getting_started.html
+```
+
+`mkdocs-static-i18n` は依存関係に存在するが、MkDocs設定では有効化されていない。
+また、Learning Path のHTMLはMkDocsのMarkdownページではない。
+
+このPoCの対象は、追跡対象の9教材のうち次の2教材だけである。
+
+- `learning-path/01_getting_started.py`
+- `learning-path/06_reusable_pipeline_recipes.py`
+
+他の教材は日本語版だけをマニフェストに登録し、内容を変更していない。
+
+## 要件と採用案
+
+実行コードは各教材に1つだけ残す。説明文、見出し、実行結果、図タイトル、表、
+リンクラベルは `learning-path/translations/*.json` のカタログから取得し、教材は
+`-- --locale ja` または `-- --locale en` で選択されたカタログを使う。
+
+`learning-path/manifest.json` が教材ID、ソース、利用可能locale、前後の教材、PoC
+対象を一元管理する。`scripts/export_learning_path.py` はこのマニフェストだけを
+読み、ローカル、CI、デプロイで同じexport経路を使う。
+
+教材のタイトルのような翻訳対象の値は、manifestへ重複して書かず、同じlesson IDの
+catalogに置く。これにより、教材の順序・URL・利用可能localeはmanifest、日英の文章は
+catalogという一つずつの責務になり、タイトルの修正箇所も増やさない。
+
+採用した構成は方式C（1つのmarimoソース + locale別カタログ）に、薄いマニフェストと
+export/検証スクリプトを組み合わせたものだ。実行コードを複製せず、翻訳者はPython
+ソースを編集せずにカタログを更新できる。カタログにキーを追加・削除したときは、
+ソース参照との不一致をCIが検出する。
+
+## 方式の比較
+
+| 方式 | コード重複 | 翻訳漏れ/コード不一致 | marimoセル依存 | 静的export | 主な故障モード |
+| --- | --- | --- | --- | --- | --- |
+| A. `.ja.py` と `.en.py` を複製 | 大きい | 検査は可能だが差分が二重になる | 2ファイルを別々に維持 | 相性はよい | API変更、セル追加、出力修正の片側漏れ |
+| B. 1ページに日英を併記 | なし | キー管理が不要でも翻訳漏れを機械検出しにくい | 1つだが教材の表示量が倍になる | 相性はよい | 学習者が読む順序と表示言語が曖昧 |
+| C. 1ソース + カタログ | なし | キー、locale、placeholder、export HTMLを検査できる | localeを読むセルを依存グラフに追加 | 1ソースをlocaleごとに実行できる | カタログキーの誤り、リンク基準位置の誤り |
+| D. gettext/生成ソース/MkDocsプラグイン | 方式次第 | gettextは成熟、生成ソースは差分検査が必要 | 生成後のmarimoソースが別物になり得る | MkDocs用はmarimoHTMLに直接適用されない | 生成物の同期、依存増、ビルド境界の不一致 |
+
+Aは短期的には単純だが、今回の目的である「APIや教材コードを1か所だけ直す」と
+反する。Bは初心者にとって常に二言語が見えるため、教材の焦点とページ長が悪化する。
+Dのgettextは通常のMarkdownやPythonメッセージには有効だが、marimoセルの実行結果、
+Matplotlibの引数、静的export後のリンクを一つの契約として扱うには追加の生成規約が
+必要である。`mkdocs-static-i18n` もMkDocs管理下のMarkdownを対象にするため、今回の
+追加exportを置き換えない。
+
+残りの比較軸は次のように整理した。API変更時の修正箇所はAだけが日英2ソースに分かれ、
+B/C/Dは実行コードを共有できる。ただしDは生成前後の同期契約が別に必要になる。翻訳
+レビューは、Aがコード差分に埋もれ、Bが同じページ内で長くなり、Cは同じキーのja/enを
+隣接行でレビューできる。DはPOなどの翻訳ツールを使える一方、生成されたmarimoソース
+までレビュー対象になる。ローカル実行はA/Bが単一export、Cがlocale別export、Dが
+カタログ生成とexportの複数段階になる。PoCのCI時間はBが最小だが常に2言語を表示し、
+A/Cは対象lessonを2回実行する。Cは標準ライブラリだけで段階導入でき、Dは形式に応じた
+追加依存または生成ツールが必要になる。3言語以上ではCのcatalog locale追加とmanifest
+登録で拡張できるが、Aはソース複製数が増える。既存URL維持と未翻訳fallbackをmanifest
+から一緒に検査できる点もCの利点である。
+
+## 翻訳カタログ形式
+
+PoCでは、1つのJSON内で各キーの `ja` と `en` を行配列として隣接させる形式を採用した。
+
+```json
+{
+  "messages": {
+    "title": {
+      "ja": ["01 環境構築とウォームアップ"],
+      "en": ["01 Getting Started with Wandas"]
+    }
+  }
+}
+```
+
+長いMarkdownをJSONの巨大なエスケープ文字列にせず、行配列にすることで、空行、
+コードフェンス、表、リンクを通常のレビュー差分として扱える。読み込みは標準
+ライブラリの `json` だけで、Python 3.10以上の通常実行に依存を追加しない。
+
+比較した形式の判断は次のとおりである。
+
+- Pythonモジュール内の辞書: 実装は容易だが、翻訳者がPythonを編集することになるため不採用。
+- JSON: 標準ライブラリ、locale/keyの集合比較、placeholder検査に適するため採用。
+- YAML: 長文は読みやすいが、教材実行時の追加パーサ依存と暗黙型の問題があるため不採用。
+- TOML: 表現力は十分だが、Python 3.10では `tomllib` がなく、追加依存が必要なため不採用。
+- gettext PO: 翻訳レビューと既存gettextツールは強いが、Python標準ライブラリだけではPOを
+  直接読むAPIがなく、Markdown/リンク/教材単位の契約を別途実装するため今回は不採用。
+- Markdown断片: 長文の記述性は最もよいが、localeとキーの対応を独自規約で解析する必要があり、
+  日英を同じキーの下でレビューしにくいため不採用。
+
+カタログ値内の `{name}` は単純なnamed placeholderだけ許可する。CIは日英のplaceholder
+集合、空の値、未知locale、Markdownコードフェンス、内部リンク形式を検証する。
+
+## locale の受け渡しとmarimoの仕様
+
+使用中の依存関係では `pyproject.toml` が `marimo>=0.23.3`、`uv.lock` が `0.23.9`
+を固定している。ローカルの `marimo export html --help` と公式ドキュメントを確認した
+結果、exportサブコマンドはファイル名の後の `--` 以降を教材のコマンドライン引数へ渡す。
+
+```bash
+uv run --no-sync marimo export html \
+  learning-path/01_getting_started.py \
+  -o /tmp/01.html -f -- --locale en
+```
+
+教材側は標準ライブラリの `argparse.parse_known_args()` で `--locale` を読み、通常の
+`marimo edit` や既存のオフラインテストが持つ他の引数は無視する。未知のlocaleは
+`argparse` が拒否する。これはmarimo内部APIやソース文字列書換えに依存しない。
+
+marimo自身のlocale設定は、公式ガイドによれば日付・時刻、数値、相対時刻の表示形式を
+主に変更し、本文、UIテキスト、エラーメッセージを翻訳しない。教材本文の切り替えには
+使わない。
+
+静的exportの実測では `<html lang="en">` が生成された。使用中の0.23.9のexport CLIに
+`lang`指定はなく、教材ごとのHTML全体の`lang`を設定する公開APIも確認できなかった。
+`html_head_file` のようなrun-mode設定やexport後のHTML文字列置換には依存しない。この
+PoCではブラウザUIの既定langを変更しないことを制限として受け入れる。将来marimoが
+静的exportの公開設定としてlangを提供した場合だけ再評価する。
+
+参照した公式資料:
+
+- [Run notebooks as scripts](https://docs.marimo.io/guides/scripts/)
+- [Static HTML](https://docs.marimo.io/guides/exporting/static_html/)
+- [marimo i18n](https://docs.marimo.io/guides/configuration/internationalization/)
+
+## URLと未翻訳教材
+
+日本語は既存URLを維持する。
+
+```text
+/learning-path/01_getting_started.html
+/learning-path/06_reusable_pipeline_recipes.html
+```
+
+英語は同じソースをlocaleだけ変えて次へ出力する。
+
+```text
+/en/learning-path/01_getting_started.html
+/en/learning-path/06_reusable_pipeline_recipes.html
+```
+
+リンクはサイトルートではなく相対URLにして、GitHub Pagesの `/wandas/` 配下でも動く
+ようにする。日英対応ページには `日本語 | English` の静的リンクを置く。
+本文のlocale切り替えはexport時に完了させ、ページは静的HTMLとして配信する。カスタム
+JavaScript、サーバー実行、Pyodide、marimo WASM、CookieやLocal Storageは必要としない。
+
+未翻訳教材の方針は「英語ページから日本語版へフォールバック」である。例えば英語の
+01ページの前後リンクは、まだ英語化されていない00/02へ `Japanese only` と表示して
+日本語URLへ向ける。英語ページが存在しない教材への `/en/` リンクは作らない。日本語
+ページでは従来どおり日本語の前後リンクを表示する。
+
+06の英語本文からMkDocsのhow-to/APIへ移るリンクも、現時点で英語MkDocsページがない
+ため、日本語の既存ページへ相対リンクする。MkDocs本体の英語化後に、同じリンク生成
+ヘルパーで英語ページへ切り替える。
+
+## CI契約
+
+`tests/docs/test_learning_path_i18n.py` と `scripts/validate_learning_path_i18n.py`
+は次を検査する。
+
+- マニフェストのlesson/source/locale/前後リンクが妥当である。
+- 01/06の全参照キーに `ja` と `en` があり、値が空でない。
+- 未知locale、未知キー、参照されないキーを拒否する。
+- 日英のplaceholder集合が一致する。
+- Markdownコードフェンスと内部リンク形式が壊れていない。
+- 同じmarimoソースを使う01/06の日本語・英語4ページを静的exportする。
+- export HTMLに日本語/英語タイトル、言語切り替え、前後リンクがある。
+- 未翻訳教材への英語リンクが存在せず、主要なWandasコードマーカーが両localeにある。
+- HTMLにPython tracebackや主要なimport errorがない。
+
+既存の `tests/docs/test_learning_path_executable_contracts.py` は全教材の
+`marimo check --strict` とオフライン実行を引き続き担当する。PoCのexportは01/06の4回
+だけであり、全教材を日英2回実行する契約はまだ追加しない。
+
+## ローカル実行とデプロイ
+
+カタログだけを検証する。
+
+```bash
+uv run --no-sync python scripts/validate_learning_path_i18n.py
+```
+
+PoCの日本語・英語を同じ経路でexportし、生成HTMLを検証する。
+
+```bash
+uv run --no-sync python scripts/export_learning_path.py \
+  --poc --output /tmp/wandas-learning-path-site --jobs 2
+uv run --no-sync python scripts/validate_learning_path_i18n.py \
+  --site /tmp/wandas-learning-path-site
+```
+
+個別の確認には次を使える。
+
+```bash
+uv run --no-sync python scripts/export_learning_path.py \
+  --lesson 01_getting_started --locale en --output /tmp/wandas-site
+uv run --no-sync python scripts/export_learning_path.py \
+  --lesson 06_reusable_pipeline_recipes --locale ja --output /tmp/wandas-site
+```
+
+デプロイワークフローはMkDocsをビルドした後、次の1コマンドで全教材を出力する。
+
+```bash
+uv run --no-sync python scripts/export_learning_path.py --all --output docs/site
+```
+
+生成HTMLはリポジトリへ追加しない。
+
+## MkDocs本体との関係
+
+今回 `mkdocs-static-i18n` は有効化しない。将来MkDocs本体を多言語化する場合は、例えば
+`docs/src/en/` を英語ツリー、既存の `docs/src/` を日本語ツリーとして設定し、プラグイン
+が生成する `/en/` の通常ページと、exportスクリプトが生成する `/en/learning-path/` を
+同じサイトルートに置く。MkDocsのnavとLearning Pathマニフェストは別の責務として保ち、
+`/en/learning-path/` をMarkdownページの変換対象にしない。
+
+Material for MkDocsの言語切り替えは通常ページのlocale URLへリンクできる。Learning Path
+のmarimo HTMLには独自の静的リンクがあるため、Materialのヘッダー切り替えをそのまま
+marimoページへ注入することはせず、サイト全体の切り替え設計が固まった時点で同じURL
+規約に合わせる。
+
+## 全教材への移行手順
+
+1. `manifest.json` に対象教材のlocaleと前後関係を登録する。
+2. 教材内の学習者向け文章、print出力、図/表ラベルを `t("key")` に置き換える。
+   変数名、Wandas API、単位、URL、数式はそのままにし、見えるコメントは英語または
+   言語に依存しない短い説明へ整理する。
+3. JSONカタログへ日本語を移し、同じキーの英訳を追加する。未翻訳ならlocaleを`ja`
+   のみにして、英語リンクを生成しない。
+4. `validate_learning_path_i18n.py`、`marimo check --strict`、該当lessonのexportを
+   実行する。
+5. 英語カタログのレビュー後、マニフェストのlocaleを`["ja", "en"]`へ変更する。
+6. 全教材が揃ったら、デプロイの `--all` はそのまま使い、必要ならCIのPoC対象を全教材
+   へ段階的に拡大する。
+
+現在の9教材を日英化した場合、静的ページ数は日本語9ページ + 英語9ページの18ページ
+になる。exportは図やデータ処理を実行するため、CIではまず代表教材を必須にし、全教材
+の英語exportは翻訳済みマニフェストの割合とCI実行時間を見て並列数・ジョブ分割を決める。
+デプロイは公開成果物を一貫させるため全localeをexportする。
+
+## PoCで判明した制限と故障モード
+
+- marimoのUI本文とHTML全体の`lang`は翻訳カタログの対象外である。
+- カタログは行配列JSONなので、Markdown専用エディタのプレビューはない。レビューでは
+  キー単位の差分と生成HTMLを確認する。
+- `--locale` は教材が解釈する引数であり、marimo本文翻訳の機能ではない。exportスクリプト
+  が必ず検証済みlocaleを渡す。
+- `docs/site` のようなMkDocs出力と同じルートに英語ツリーを作るため、出力先を手書きする
+  shell loopへ戻すと日本語/英語の片側漏れが起きる。デプロイはスクリプトだけを呼ぶ。
+- カタログのリンク基準位置を間違えると、日英で同じMarkdownでもリンク先が変わる。
+  そのため06のhow-to/APIリンクとナビゲーションはlocale別に検証する。
+- 依存APIの変更は、共有Pythonソースと既存の全教材オフライン契約で検出する。翻訳内容
+  の意味の正しさや表現品質は自動検査できないため、翻訳レビューは別途必要である。
+
+## 採用案を撤回する条件
+
+次のいずれかが現れた場合は、カタログ方式を見直す。
+
+- 教材の大半が動的UIや入力状態による多言語切り替えを必要とし、静的2回exportで表現できない。
+- カタログレビューが大規模化し、JSON行配列よりPOや翻訳管理ツールの方が明らかに保守しやすい。
+- marimoの公開API変更で、同じソースのlocale別静的exportが安定して再現できなくなる。
+- CIのexport時間・メモリが教材数に対して許容できず、代表exportだけでは品質を保証できない。
+- MkDocs本体の多言語構成が `/en/learning-path/` を別の生成物で占有し、URL契約を保てない。
+
+この場合でも、Aのソース複製へ戻る前に、共有Pythonロジック + gettext/Markdownカタログ、
+またはMkDocsとmarimoのビルド境界を統合する生成方式を比較し直す。

--- a/docs/design/learning-path-internationalization.md
+++ b/docs/design/learning-path-internationalization.md
@@ -137,6 +137,20 @@ command constructionは `marimo_export_command()` というpure functionに分�
 している。教材側は `argparse.parse_known_args()` でlocaleを読み、marimoや他の引数を
 private APIなしで共存させる。
 
+export CLIに `--locale` を指定した場合、export planと実際の出力は指定したlocaleの
+plan itemだけになる。指定localeを持たない教材へ別localeでフォールバックすることは
+なく、選択結果がなければエラーにする。例えば次のコマンドは英語版1件だけを生成する。
+
+```bash
+uv run --no-sync python scripts/export_learning_path.py \
+  --lesson 01_getting_started \
+  --locale en \
+  --output /tmp/wandas-site
+```
+
+`--locale` を省略した場合は従来どおり各lessonの全available localeを計画し、
+`--all --locale en` は現在英語対応している01と06の英語版だけを計画する。
+
 marimoのstatic HTML exportには、0.23.9のCLI上、ページ全体の `lang` をlocale別に設定
 する公開引数/APIがない。実測では日本語・英語の両HTMLとも `<html lang="en">` になった。
 export後のHTML文字列置換は壊れやすいため導入せず、これは残る制限として記録する。
@@ -175,8 +189,9 @@ export後のHTML文字列置換は壊れやすいため導入せず、これは�
 ## learner-visible codeと図
 
 locale/catalog/t/helper/navigationの初期化、静的Markdown、動的な数値・metadata表示、
-RecipePlanのassertionはhidden cellに置く。visible cellは次のように、日英どちらでも
-そのまま読めるWandas/Pythonコードにする。
+RecipePlanのassertionはhidden cellに置く。教材を実行するために読者が必要とする
+`json`、`numpy`、`wandas`、`wandas.pipeline` などのpublic importはvisible cellに置く。
+visible cellは次のように、日英どちらでもそのまま読めるWandas/Pythonコードにする。
 
 - Wandas API、Python変数名、単位は英語のままにする。
 - 翻訳keyや `print(t(...))` をvisible codeへ残さない。

--- a/docs/design/learning-path-internationalization.md
+++ b/docs/design/learning-path-internationalization.md
@@ -1,275 +1,297 @@
 # Learning Path の日英対応 PoC
 
-## 現在の構成
+## 現在の構成と対象
 
-Learning Path は `learning-path/*.py` の marimo アプリである。MkDocs は
-`docs/src` を `docs/site` へビルドした後、デプロイワークフローが各アプリを
-`marimo export html` で一度ずつ `docs/site/learning-path/` へ出力している。
-したがって、現在の日本語ページのURLは次のとおりである。
+Learning Path は `learning-path/[0-9][0-9]_*.py` の marimo アプリである。MkDocs は
+`docs/src` を `docs/site` へビルドし、デプロイ時に Learning Path を追加で静的HTMLへ
+exportする。日本語の既存URLは次のとおりである。
 
 ```text
 /learning-path/01_getting_started.html
 ```
 
-`mkdocs-static-i18n` は依存関係に存在するが、MkDocs設定では有効化されていない。
-また、Learning Path のHTMLはMkDocsのMarkdownページではない。
+`mkdocs-static-i18n` は通常のMkDocs用依存関係にあるが、Learning PathはMkDocsの
+Markdownではないため、このPoCでは有効化しない。対象は次の2教材であり、他の教材の
+内容は変更しない。
 
-このPoCの対象は、追跡対象の9教材のうち次の2教材だけである。
-
-- `learning-path/01_getting_started.py`
-- `learning-path/06_reusable_pipeline_recipes.py`
-
-他の教材は日本語版だけをマニフェストに登録し、内容を変更していない。
-
-## 要件と採用案
-
-実行コードは各教材に1つだけ残す。説明文、見出し、実行結果、図タイトル、表、
-リンクラベルは `learning-path/translations/*.json` のカタログから取得し、教材は
-`-- --locale ja` または `-- --locale en` で選択されたカタログを使う。
-
-`learning-path/manifest.json` が教材ID、ソース、利用可能locale、前後の教材、PoC
-対象を一元管理する。`scripts/export_learning_path.py` はこのマニフェストだけを
-読み、ローカル、CI、デプロイで同じexport経路を使う。
-
-教材のタイトルのような翻訳対象の値は、manifestへ重複して書かず、同じlesson IDの
-catalogに置く。これにより、教材の順序・URL・利用可能localeはmanifest、日英の文章は
-catalogという一つずつの責務になり、タイトルの修正箇所も増やさない。
-
-採用した構成は方式C（1つのmarimoソース + locale別カタログ）に、薄いマニフェストと
-export/検証スクリプトを組み合わせたものだ。実行コードを複製せず、翻訳者はPython
-ソースを編集せずにカタログを更新できる。カタログにキーを追加・削除したときは、
-ソース参照との不一致をCIが検出する。
-
-## 方式の比較
-
-| 方式 | コード重複 | 翻訳漏れ/コード不一致 | marimoセル依存 | 静的export | 主な故障モード |
-| --- | --- | --- | --- | --- | --- |
-| A. `.ja.py` と `.en.py` を複製 | 大きい | 検査は可能だが差分が二重になる | 2ファイルを別々に維持 | 相性はよい | API変更、セル追加、出力修正の片側漏れ |
-| B. 1ページに日英を併記 | なし | キー管理が不要でも翻訳漏れを機械検出しにくい | 1つだが教材の表示量が倍になる | 相性はよい | 学習者が読む順序と表示言語が曖昧 |
-| C. 1ソース + カタログ | なし | キー、locale、placeholder、export HTMLを検査できる | localeを読むセルを依存グラフに追加 | 1ソースをlocaleごとに実行できる | カタログキーの誤り、リンク基準位置の誤り |
-| D. gettext/生成ソース/MkDocsプラグイン | 方式次第 | gettextは成熟、生成ソースは差分検査が必要 | 生成後のmarimoソースが別物になり得る | MkDocs用はmarimoHTMLに直接適用されない | 生成物の同期、依存増、ビルド境界の不一致 |
-
-Aは短期的には単純だが、今回の目的である「APIや教材コードを1か所だけ直す」と
-反する。Bは初心者にとって常に二言語が見えるため、教材の焦点とページ長が悪化する。
-Dのgettextは通常のMarkdownやPythonメッセージには有効だが、marimoセルの実行結果、
-Matplotlibの引数、静的export後のリンクを一つの契約として扱うには追加の生成規約が
-必要である。`mkdocs-static-i18n` もMkDocs管理下のMarkdownを対象にするため、今回の
-追加exportを置き換えない。
-
-残りの比較軸は次のように整理した。API変更時の修正箇所はAだけが日英2ソースに分かれ、
-B/C/Dは実行コードを共有できる。ただしDは生成前後の同期契約が別に必要になる。翻訳
-レビューは、Aがコード差分に埋もれ、Bが同じページ内で長くなり、Cは同じキーのja/enを
-隣接行でレビューできる。DはPOなどの翻訳ツールを使える一方、生成されたmarimoソース
-までレビュー対象になる。ローカル実行はA/Bが単一export、Cがlocale別export、Dが
-カタログ生成とexportの複数段階になる。PoCのCI時間はBが最小だが常に2言語を表示し、
-A/Cは対象lessonを2回実行する。Cは標準ライブラリだけで段階導入でき、Dは形式に応じた
-追加依存または生成ツールが必要になる。3言語以上ではCのcatalog locale追加とmanifest
-登録で拡張できるが、Aはソース複製数が増える。既存URL維持と未翻訳fallbackをmanifest
-から一緒に検査できる点もCの利点である。
-
-## 翻訳カタログ形式
-
-PoCでは、1つのJSON内で各キーの `ja` と `en` を行配列として隣接させる形式を採用した。
-
-```json
-{
-  "messages": {
-    "title": {
-      "ja": ["01 環境構築とウォームアップ"],
-      "en": ["01 Getting Started with Wandas"]
-    }
-  }
-}
+```text
+learning-path/01_getting_started.py
+learning-path/06_reusable_pipeline_recipes.py
 ```
 
-長いMarkdownをJSONの巨大なエスケープ文字列にせず、行配列にすることで、空行、
-コードフェンス、表、リンクを通常のレビュー差分として扱える。読み込みは標準
-ライブラリの `json` だけで、Python 3.10以上の通常実行に依存を追加しない。
+使用中の `pyproject.toml` は `marimo>=0.23.3`、ロック済みの環境は marimo 0.23.9
+である。0.23.9の `marimo export html --help` には locale オプションはないが、
+`NAME [ARGS]...` と `--` 以降をノートブックへ渡す仕様がある。
 
-比較した形式の判断は次のとおりである。
+## 採用案
 
-- Pythonモジュール内の辞書: 実装は容易だが、翻訳者がPythonを編集することになるため不採用。
-- JSON: 標準ライブラリ、locale/keyの集合比較、placeholder検査に適するため採用。
-- YAML: 長文は読みやすいが、教材実行時の追加パーサ依存と暗黙型の問題があるため不採用。
-- TOML: 表現力は十分だが、Python 3.10では `tomllib` がなく、追加依存が必要なため不採用。
-- gettext PO: 翻訳レビューと既存gettextツールは強いが、Python標準ライブラリだけではPOを
-  直接読むAPIがなく、Markdown/リンク/教材単位の契約を別途実装するため今回は不採用。
-- Markdown断片: 長文の記述性は最もよいが、localeとキーの対応を独自規約で解析する必要があり、
-  日英を同じキーの下でレビューしにくいため不採用。
+方式C「1つのmarimoソース + locale別翻訳カタログ」を採用する。
 
-カタログ値内の `{name}` は単純なnamed placeholderだけ許可する。CIは日英のplaceholder
-集合、空の値、未知locale、Markdownコードフェンス、内部リンク形式を検証する。
+- Pythonの実行コードは教材ごとに1つだけ持つ。
+- 説明、見出し、表、動的な読者向け結果、リンクラベルはカタログから生成する。
+- 日本語は既存の `/learning-path/`、英語は `/en/learning-path/` へ出力する。
+- localeごとに同じソースを別プロセスで実行し、静的HTMLを生成する。
+- 翻訳実装の初期化と動的な翻訳結果は `hide_code=True` のセルに置く。
+- 学習者向けセルには翻訳キー、`t()`、locale/catalog/helperを置かない。
+- 本文の切り替えにJavaScript、Pyodide、WASM、サーバー、Cookie、Local Storageを使わない。
 
-## locale の受け渡しとmarimoの仕様
+タイトルは教材カタログに置く。manifestには教材の順序、source、locale、URLを決める
+情報だけを置き、同じタイトルを二重管理しない。
 
-使用中の依存関係では `pyproject.toml` が `marimo>=0.23.3`、`uv.lock` が `0.23.9`
-を固定している。ローカルの `marimo export html --help` と公式ドキュメントを確認した
-結果、exportサブコマンドはファイル名の後の `--` 以降を教材のコマンドライン引数へ渡す。
+## 方式比較
+
+| 方式 | コード/文章の重複 | API変更 | 漏れ検出とレビュー | marimo/静的export | 段階導入・将来性 | 主な故障モード |
+| --- | --- | --- | --- | --- | --- | --- |
+| A. `.ja.py` と `.en.py` | コードも説明も大きく重複 | 日英2ファイル | 差分が二重。片側のセル追加を検出し続ける必要 | exportは単純 | 未翻訳は単純だが、3言語で複製が増える | API、セル依存、コード修正の片側漏れ |
+| B. 1ページ併記 | コードは共有、表示文は同じページに2つ | 1箇所 | 翻訳キーの漏れを機械的に扱いにくく、ページが長い | exportは単純 | locale単位の公開と相性が悪い | 学習者の読む言語が曖昧、表示量が倍 |
+| C. 1ソース + カタログ | 実行コードなし、翻訳文はlocaleごと | 1ソース | key/locale/placeholder/HTMLをCIで検査でき、隣接したja/enをレビューできる | 同じソースを2回export。セル依存はhidden setupだけ増える | jaのみ→日英へmanifestを変更して導入 | カタログキー、相対リンク、locale引数の誤り |
+| D. gettext/生成ソース/MkDocsプラグイン | 方式次第 | 共有可能 | POツールは強いが、生成ソースとmarimo出力の同期契約が増える | MkDocsプラグインは追加export済みHTMLを直接処理しない | 大規模化には候補 | 生成境界、追加依存、生成物のレビュー漏れ |
+
+Cは、Pythonコード重複、API変更時の修正箇所、静的HTML配信、未翻訳教材の混在、CIでの
+不一致検出を同時に満たす。Aは短期的には分かりやすいが、今回の「API変更を1箇所だけ
+直す」という条件に反する。Bは表示言語を選べず、Cより翻訳漏れを明確に検出しにくい。
+Dはgettext自体を否定しないが、現在の9教材規模では、marimo実行・図・前後リンクまで
+含む契約を保つための生成基盤が過剰である。
+
+## manifest、順序、export plan
+
+`learning-path/manifest.json` の lessons 配列がLearning Pathの唯一の順序である。
+`previous` と `next` はmanifestに保存せず、配列位置から導出する。これにより、教材の
+追加・削除・並べ替えで前後関係を三重管理しない。
+
+`load_manifest()` は次を検査する。
+
+- `git ls-files -z -- learning-path` から得た追跡済みの numbered source集合と、manifestのsource集合が完全一致する。
+- ignored/untrackedのscratch `.py` は公開集合に入らない。
+- Gitが使えない、または `git ls-files` に失敗した場合は、危険な `Path.glob()` fallbackを使わず明示的に失敗する。
+- lesson ID、source、`Path(source).stem`、存在性が一致し、ID/sourceが重複しない。
+- 既定localeは `ja` で、各lessonは `ja` を持つ。
+- manifestに書かれた `previous`/`next` は拒否する。
+- `build_export_plan()` が各localeの出力先を決定し、重複を拒否する。
+
+`scripts/export_learning_path.py --all --dry-run` は、manifestの全日本語ページと、
+manifestで `en` を宣言したページだけの英語ページを、決定的な順序で表示する。現在は
+日本語9ページ、英語2ページの11項目である。CIはこの全planをdry-runで検査し、重い実行
+はPoCの4ページに限定する。
+
+## 翻訳カタログ
+
+カタログは標準ライブラリの `json` だけで読める行配列JSONとする。
+
+```text
+learning-path/translations/common.json
+learning-path/translations/01_getting_started.json
+learning-path/translations/06_reusable_pipeline_recipes.json
+```
+
+`common.json` は次のhelper所有キーだけを持ち、教材カタログへ複製しない。
+
+- `language.ja`, `language.en`
+- `navigation.heading`, `navigation.previous`, `navigation.next`
+- `navigation.japanese_only`
+
+教材固有の title、説明、表、図の解説、動的結果はlesson catalogに置く。commonとlesson
+で同名keyがあれば拒否する。commonのキー集合は固定し、未知key・欠落keyも拒否するため、
+共通文言の未使用・勝手な追加を放置しない。
+
+YAMLは読みやすいが実行時依存が増え、暗黙型の事故もある。Python辞書は翻訳者がPythonを
+編集する。TOMLはPython 3.10の標準ライブラリに `tomllib` がなく、POは標準ライブラリ
+だけでは直接読めず、Markdown断片はkey/localeの集合検査を別規約にする必要がある。
+そのため今回は採用しない。gettextへの移行は、翻訳量とレビュー運用がJSONを上回った
+場合に再評価する。
+
+### placeholder
+
+翻訳値の動的値は `[[name]]` だけを使う。
+
+```text
+config = {"sampling_rate": 48000}
+\frac{a}{b}
+サンプル数: [[samples]]
+```
+
+`name` は `[A-Za-z_][A-Za-z0-9_]*` に限定する。`str.format()`、format specifier、
+属性アクセス、`{{`/`}}` escapingは使わないので、Markdown、Python辞書、JSON、LaTeXの
+literalな `{` と `}` はそのまま書ける。日英のplaceholder集合を比較し、実行時には不足値
+と余分な値の両方を lesson ID・key・locale付きで拒否する。
+
+## localeの受け渡し
+
+marimoの公開CLIを使い、exportスクリプトだけが翻訳カタログを持つlessonへlocaleを渡す。
 
 ```bash
 uv run --no-sync marimo export html \
   learning-path/01_getting_started.py \
-  -o /tmp/01.html -f -- --locale en
+  -o docs/site/learning-path/01_getting_started.html \
+  -f -- --locale ja
+
+uv run --no-sync marimo export html \
+  learning-path/01_getting_started.py \
+  -o docs/site/en/learning-path/01_getting_started.html \
+  -f -- --locale en
 ```
 
-教材側は標準ライブラリの `argparse.parse_known_args()` で `--locale` を読み、通常の
-`marimo edit` や既存のオフラインテストが持つ他の引数は無視する。未知のlocaleは
-`argparse` が拒否する。これはmarimo内部APIやソース文字列書換えに依存しない。
+実際には `scripts/export_learning_path.py` がこのコマンドを構成する。翻訳カタログを
+持たないlegacy教材は、`-- --locale` を付けず、PR前と同じmarimo export引数で出力する。
+command constructionは `marimo_export_command()` というpure functionに分離し、テスト
+している。教材側は `argparse.parse_known_args()` でlocaleを読み、marimoや他の引数を
+private APIなしで共存させる。
 
-marimo自身のlocale設定は、公式ガイドによれば日付・時刻、数値、相対時刻の表示形式を
-主に変更し、本文、UIテキスト、エラーメッセージを翻訳しない。教材本文の切り替えには
-使わない。
-
-静的exportの実測では `<html lang="en">` が生成された。使用中の0.23.9のexport CLIに
-`lang`指定はなく、教材ごとのHTML全体の`lang`を設定する公開APIも確認できなかった。
-`html_head_file` のようなrun-mode設定やexport後のHTML文字列置換には依存しない。この
-PoCではブラウザUIの既定langを変更しないことを制限として受け入れる。将来marimoが
-静的exportの公開設定としてlangを提供した場合だけ再評価する。
+marimoのstatic HTML exportには、0.23.9のCLI上、ページ全体の `lang` をlocale別に設定
+する公開引数/APIがない。実測では日本語・英語の両HTMLとも `<html lang="en">` になった。
+export後のHTML文字列置換は壊れやすいため導入せず、これは残る制限として記録する。
 
 参照した公式資料:
 
-- [Run notebooks as scripts](https://docs.marimo.io/guides/scripts/)
-- [Static HTML](https://docs.marimo.io/guides/exporting/static_html/)
-- [marimo i18n](https://docs.marimo.io/guides/configuration/internationalization/)
+- [marimo static HTML export](https://docs.marimo.io/guides/exporting/static_html/)
+- [marimo internationalization](https://docs.marimo.io/guides/configuration/internationalization/)
+- [marimo scripts and CLI arguments](https://docs.marimo.io/guides/scripts/)
 
-## URLと未翻訳教材
+## URL、言語切り替え、navigation
 
-日本語は既存URLを維持する。
-
-```text
-/learning-path/01_getting_started.html
-/learning-path/06_reusable_pipeline_recipes.html
-```
-
-英語は同じソースをlocaleだけ変えて次へ出力する。
+出力先は次の固定規約である。
 
 ```text
-/en/learning-path/01_getting_started.html
-/en/learning-path/06_reusable_pipeline_recipes.html
+/learning-path/<lesson>.html
+/en/learning-path/<lesson>.html
 ```
 
-リンクはサイトルートではなく相対URLにして、GitHub Pagesの `/wandas/` 配下でも動く
-ようにする。日英対応ページには `日本語 | English` の静的リンクを置く。
-本文のlocale切り替えはexport時に完了させ、ページは静的HTMLとして配信する。カスタム
-JavaScript、サーバー実行、Pyodide、marimo WASM、CookieやLocal Storageは必要としない。
+リンクは相対URLで生成するため、GitHub Pagesの `/wandas/` サブパスでも動作する。
+`language_switch_markdown()` は教材タイトル直下に配置し、対応localeの存在するリンク
+だけを `日本語 | English` として表示する。`navigation_markdown()` は末尾にだけ配置し、
+前後教材へ移動する。両方ともJavaScriptを使わず、日英ページは相互リンクする。
 
-未翻訳教材の方針は「英語ページから日本語版へフォールバック」である。例えば英語の
-01ページの前後リンクは、まだ英語化されていない00/02へ `Japanese only` と表示して
-日本語URLへ向ける。英語ページが存在しない教材への `/en/` リンクは作らない。日本語
-ページでは従来どおり日本語の前後リンクを表示する。
+未翻訳教材へ移動する英語ページでは、存在しない `/en/` URLを作らない。対象が日本語
+だけなら、日本語URLへのリンクに `(Japanese only)` を付ける。日本語ページには注記を
+付けない。06の英語本文から日本語のMkDocs how-to/APIへ移るリンクも同じ注記を付ける。
+リンク先と注記は `docs_reference_links()` に集約しており、将来MkDocsが英語化された
+ときにこのhelperを変更する。
 
-06の英語本文からMkDocsのhow-to/APIへ移るリンクも、現時点で英語MkDocsページがない
-ため、日本語の既存ページへ相対リンクする。MkDocs本体の英語化後に、同じリンク生成
-ヘルパーで英語ページへ切り替える。
+01の教材本文のまとめは `まとめ` / `Summary`、末尾の移動見出しは `教材間の移動` /
+`Navigate between lessons` とし、「次のステップ」の同名見出しを重複させない。HTML
+検証はタイトル直下のswitch、末尾navigation、見出しの重複、fallback注記、リンク先の
+存在を文字列の全文snapshotや画素比較なしで確認する。
+
+## learner-visible codeと図
+
+locale/catalog/t/helper/navigationの初期化、静的Markdown、動的な数値・metadata表示、
+RecipePlanのassertionはhidden cellに置く。visible cellは次のように、日英どちらでも
+そのまま読めるWandas/Pythonコードにする。
+
+- Wandas API、Python変数名、単位は英語のままにする。
+- 翻訳keyや `print(t(...))` をvisible codeへ残さない。
+- 長いコメントやdocstringは説明用Markdownへ移し、コードから意味が明らかなコメントは削る。
+- 06の `np.testing.assert_allclose()` とmetadata/history assertionはhidden verification cellに移し、成功は読みやすい結果として表示する。
+- Matplotlibの図内タイトル、legend、軸ラベルへ新しい日本語を渡さない。図内はAPI名、単位、数値、短いASCIIラベルに限定し、説明は図の前後のlocalized `mo.md()` に置く。
+- フォントファイル、font package、`japanize-matplotlib` は追加しない。
+
+marimoのexport HTMLはhidden cellのsourceも実行用notebook metadataとして保持する。その
+ためHTML全文からi18n文字列を禁止するのではなく、validatorがexport metadataの
+`config.hide_code`を読み、visible cellにだけhelperがないことを確認する。source側の
+AST検査も併用する。
 
 ## CI契約
 
-`tests/docs/test_learning_path_i18n.py` と `scripts/validate_learning_path_i18n.py`
-は次を検査する。
+次の契約を標準ライブラリ中心のvalidatorとテストで維持する。
 
-- マニフェストのlesson/source/locale/前後リンクが妥当である。
-- 01/06の全参照キーに `ja` と `en` があり、値が空でない。
-- 未知locale、未知キー、参照されないキーを拒否する。
-- 日英のplaceholder集合が一致する。
-- Markdownコードフェンスと内部リンク形式が壊れていない。
-- 同じmarimoソースを使う01/06の日本語・英語4ページを静的exportする。
-- export HTMLに日本語/英語タイトル、言語切り替え、前後リンクがある。
-- 未翻訳教材への英語リンクが存在せず、主要なWandasコードマーカーが両localeにある。
-- HTMLにPython tracebackや主要なimport errorがない。
+- tracked numbered lesson集合とmanifest source集合が一致する。
+- ID/source stem、source存在、locale、catalog、出力先、配列順navigationが妥当である。
+- common/lesson key、ja/en coverage、空値、unknown locale/key、placeholder集合、literal brace、コードフェンス、内部リンクを検査する。
+- 01/06のsourceに日英別 `.ja.py`/`.en.py` がなく、visible cellに翻訳実装がない。
+- `marimo check --strict`、日本語export、英語export、offline executionでエラーやtracebackがない。
+- `--all --dry-run` が全日本語lesson、英語を宣言したlesson、決定的順序だけを計画する。
+- CIの実exportは01/06の4ページを `--jobs 2` で行い、生成HTMLのタイトル、switch、navigation、主要Wandasコード、fallback、Japanese-only注記、リンク存在を検証する。
 
-既存の `tests/docs/test_learning_path_executable_contracts.py` は全教材の
-`marimo check --strict` とオフライン実行を引き続き担当する。PoCのexportは01/06の4回
-だけであり、全教材を日英2回実行する契約はまだ追加しない。
-
-## ローカル実行とデプロイ
-
-カタログだけを検証する。
+CI jobはdocs変更時に次を実行する。
 
 ```bash
 uv run --no-sync python scripts/validate_learning_path_i18n.py
-```
-
-PoCの日本語・英語を同じ経路でexportし、生成HTMLを検証する。
-
-```bash
+uv run --no-sync python scripts/export_learning_path.py --all --dry-run
 uv run --no-sync python scripts/export_learning_path.py \
-  --poc --output /tmp/wandas-learning-path-site --jobs 2
+  --poc --output "$RUNNER_TEMP/wandas-learning-path-poc" --jobs 2
 uv run --no-sync python scripts/validate_learning_path_i18n.py \
-  --site /tmp/wandas-learning-path-site
+  --site "$RUNNER_TEMP/wandas-learning-path-poc"
 ```
 
-個別の確認には次を使える。
+既存の `tests/docs/test_learning_path_executable_contracts.py` は全教材のoffline
+`marimo check --strict`/実行契約を引き続き担当する。全教材を日英2回実行する重い契約は、
+翻訳済み教材数と実測CI時間を見て段階的に拡大する。
+
+## ローカルとデプロイ
+
+PoCを確認する。
 
 ```bash
 uv run --no-sync python scripts/export_learning_path.py \
-  --lesson 01_getting_started --locale en --output /tmp/wandas-site
-uv run --no-sync python scripts/export_learning_path.py \
-  --lesson 06_reusable_pipeline_recipes --locale ja --output /tmp/wandas-site
+  --poc --output /tmp/wandas-learning-path-poc --jobs 2
+uv run --no-sync python scripts/validate_learning_path_i18n.py \
+  --site /tmp/wandas-learning-path-poc
 ```
 
-デプロイワークフローはMkDocsをビルドした後、次の1コマンドで全教材を出力する。
+全サイトと同じ経路を一時ディレクトリで確認する場合は、MkDocs build後に次を実行する。
 
 ```bash
-uv run --no-sync python scripts/export_learning_path.py --all --output docs/site
+uv run --no-sync python scripts/export_learning_path.py \
+  --all --output /tmp/wandas-full-site --jobs 1
+uv run --no-sync python scripts/validate_learning_path_i18n.py \
+  --site /tmp/wandas-full-site --all
 ```
 
-生成HTMLはリポジトリへ追加しない。
+デプロイのdefault並列度は `jobs=1` とする。Matplotlib/Dask/音声処理を並列実行して
+メモリ使用量や非決定性を増やさず、従来の直列exportを維持する。PoCテストだけは明示的
+に2並列を使って並列経路も検査する。対象数0でもThreadPoolExecutorを作らない。
+
+GitHub Pagesへのdeployは次の順序を必須とする。
+
+1. `marimo check` とカタログ検証。
+2. MkDocs build。
+3. `export_learning_path.py --all --jobs 1`。
+4. `validate_learning_path_i18n.py --site docs/site --all`。
+5. 検証成功後に `docs/site` を公開。
+
+生成HTMLはGit管理しない。
 
 ## MkDocs本体との関係
 
-今回 `mkdocs-static-i18n` は有効化しない。将来MkDocs本体を多言語化する場合は、例えば
-`docs/src/en/` を英語ツリー、既存の `docs/src/` を日本語ツリーとして設定し、プラグイン
-が生成する `/en/` の通常ページと、exportスクリプトが生成する `/en/learning-path/` を
-同じサイトルートに置く。MkDocsのnavとLearning Pathマニフェストは別の責務として保ち、
-`/en/learning-path/` をMarkdownページの変換対象にしない。
+同一PRでMkDocs全体の多言語化は行わない。将来は既存の日本語 `docs/src/` と英語
+`docs/src/en/`（または採用する `mkdocs-static-i18n` の規約）を整理し、通常ページの
+英語出力 `/en/` とLearning Pathの `/en/learning-path/` を同じサイトルートへ置く。
+Learning Path HTMLをMkDocs Markdownのnavへ重ねず、manifest/export planを別責務として
+維持する。Material for MkDocsの言語切り替えは通常ページのlocale URLと統合できるが、
+marimoページ内の静的switchは残し、JavaScript注入に依存しない。`/en/learning-path/`を
+通常ページの出力が占有しないことを統合時の契約にする。
 
-Material for MkDocsの言語切り替えは通常ページのlocale URLへリンクできる。Learning Path
-のmarimo HTMLには独自の静的リンクがあるため、Materialのヘッダー切り替えをそのまま
-marimoページへ注入することはせず、サイト全体の切り替え設計が固まった時点で同じURL
-規約に合わせる。
+SUPPORTED_LOCALESは現在 `("ja", "en")` に固定され、英語prefixもこの実装で定義して
+いる。したがって「manifestへlocaleを追加するだけで3言語へ拡張できる」とは言わない。
+第三言語を追加する場合は、locale検証、URL prefix、locale switch、カタログcoverage、
+HTML validator、CI plan、fallbackをコードとテストへ追加し、出力リンクを実測してから
+manifestを変更する。日英専用の単純さを、未検証の汎用frameworkより優先する。
 
-## 全教材への移行手順
+## 全教材への移行手順と判断条件
 
-1. `manifest.json` に対象教材のlocaleと前後関係を登録する。
-2. 教材内の学習者向け文章、print出力、図/表ラベルを `t("key")` に置き換える。
-   変数名、Wandas API、単位、URL、数式はそのままにし、見えるコメントは英語または
-   言語に依存しない短い説明へ整理する。
-3. JSONカタログへ日本語を移し、同じキーの英訳を追加する。未翻訳ならlocaleを`ja`
-   のみにして、英語リンクを生成しない。
-4. `validate_learning_path_i18n.py`、`marimo check --strict`、該当lessonのexportを
-   実行する。
-5. 英語カタログのレビュー後、マニフェストのlocaleを`["ja", "en"]`へ変更する。
-6. 全教材が揃ったら、デプロイの `--all` はそのまま使い、必要ならCIのPoC対象を全教材
-   へ段階的に拡大する。
+全教材を展開するときは、教材ごとに次を繰り返す。
 
-現在の9教材を日英化した場合、静的ページ数は日本語9ページ + 英語9ページの18ページ
-になる。exportは図やデータ処理を実行するため、CIではまず代表教材を必須にし、全教材
-の英語exportは翻訳済みマニフェストの割合とCI実行時間を見て並列数・ジョブ分割を決める。
-デプロイは公開成果物を一貫させるため全localeをexportする。
+1. 既存sourceを1つのままにし、visible codeから説明用コメント、長いdocstring、文章printを整理する。
+2. 翻訳対象を `t("key")` とhidden outputへ移し、図内の新しい日本語を作らない。
+3. lesson catalogへja/enを追加し、common keyを複製しない。値とplaceholderをレビューする。
+4. `manifest.json` の `catalog` と `en` を追加し、export plan、source検査、両localeのmarimo checkを通す。
+5. HTMLのswitch、navigation、リンク、fallback、Wandas code markerを検証する。
+6. 翻訳レビュー後にデプロイの全planへ含める。
 
-## PoCで判明した制限と故障モード
+manifestのlocaleをjaのみからja/enへ変える前提は、実行コードの意味がlocale間で同じ、
+catalog key/placeholderが揃う、静的exportがネットワークなしで完了する、英語リンク先が
+存在する、という4点である。翻訳品質・表現の自然さは機械検査だけでは保証できない。
 
-- marimoのUI本文とHTML全体の`lang`は翻訳カタログの対象外である。
-- カタログは行配列JSONなので、Markdown専用エディタのプレビューはない。レビューでは
-  キー単位の差分と生成HTMLを確認する。
-- `--locale` は教材が解釈する引数であり、marimo本文翻訳の機能ではない。exportスクリプト
-  が必ず検証済みlocaleを渡す。
-- `docs/site` のようなMkDocs出力と同じルートに英語ツリーを作るため、出力先を手書きする
-  shell loopへ戻すと日本語/英語の片側漏れが起きる。デプロイはスクリプトだけを呼ぶ。
-- カタログのリンク基準位置を間違えると、日英で同じMarkdownでもリンク先が変わる。
-  そのため06のhow-to/APIリンクとナビゲーションはlocale別に検証する。
-- 依存APIの変更は、共有Pythonソースと既存の全教材オフライン契約で検出する。翻訳内容
-  の意味の正しさや表現品質は自動検査できないため、翻訳レビューは別途必要である。
+次の場合は、全教材展開を止めて方式を再評価する。
 
-## 採用案を撤回する条件
+- locale別静的exportでは表現できない動的UIや入力状態の翻訳が主流になる。
+- marimoの公開CLIが変わり、同じsourceへ安全に引数を渡せなくなる。
+- exportの時間・メモリが、representative CIとjobs=1 deployで許容できない。
+- JSONのkey単位レビューがPOや別の翻訳管理方式より明らかに不利になる。
+- MkDocs本体が `/en/learning-path/` を占有し、現在の相対URL契約を維持できない。
+- HTMLのlang設定が必要条件となり、marimoに公式APIがないまま文字列置換しか選べない。
 
-次のいずれかが現れた場合は、カタログ方式を見直す。
-
-- 教材の大半が動的UIや入力状態による多言語切り替えを必要とし、静的2回exportで表現できない。
-- カタログレビューが大規模化し、JSON行配列よりPOや翻訳管理ツールの方が明らかに保守しやすい。
-- marimoの公開API変更で、同じソースのlocale別静的exportが安定して再現できなくなる。
-- CIのexport時間・メモリが教材数に対して許容できず、代表exportだけでは品質を保証できない。
-- MkDocs本体の多言語構成が `/en/learning-path/` を別の生成物で占有し、URL契約を保てない。
-
-この場合でも、Aのソース複製へ戻る前に、共有Pythonロジック + gettext/Markdownカタログ、
-またはMkDocsとmarimoのビルド境界を統合する生成方式を比較し直す。
+このPoCで残る制限は、HTML全体の `lang` がlocale別にならないこと、翻訳の意味品質を
+自動判定できないこと、第三言語にコード変更が必要なこと、visible/hidden codeのHTML検査
+が現在のmarimo export metadata（`notebook.cells[].config.hide_code`）に依存することである。
+marimoを更新するときは `marimo export html --help`、`lang`、cell metadataを再確認する。

--- a/learning-path/01_getting_started.py
+++ b/learning-path/01_getting_started.py
@@ -4,11 +4,16 @@ __generated_with = "0.23.1"
 app = marimo.App()
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _():
     import marimo as mo
 
-    from scripts.learning_path_i18n import load_catalog, locale_from_argv, navigation_markdown
+    from scripts.learning_path_i18n import (
+        language_switch_markdown,
+        load_catalog,
+        locale_from_argv,
+        navigation_markdown,
+    )
 
     locale = locale_from_argv()
     catalog = load_catalog("01_getting_started", locale)
@@ -16,12 +21,18 @@ def _():
     def t(key, **values):
         return catalog.text(key, **values)
 
-    return locale, mo, navigation_markdown, t
+    return language_switch_markdown, locale, mo, navigation_markdown, t
 
 
 @app.cell(hide_code=True)
 def _(mo, t):
     mo.md(f"# {t('title')}\n\n{t('intro')}")
+    return
+
+
+@app.cell(hide_code=True)
+def _(language_switch_markdown, locale, mo):
+    mo.md(language_switch_markdown("01_getting_started", locale))
     return
 
 
@@ -37,48 +48,15 @@ def _(mo, t):
     return
 
 
-@app.cell
-def _(t):
-    # Show the recommended installation command without executing it.
-    # !pip install "wandas[marimo,io,psychoacoustic]"
-
-    # Optional development version:
-    # !pip install git+https://github.com/kasahart/wandas.git
-
-    print(t("install_recommended"))
-    print('!pip install "wandas[marimo,io,psychoacoustic]"')
-    return
-
-
 @app.cell(hide_code=True)
 def _(mo, t):
     mo.md(t("installation_dev"))
     return
 
 
-@app.cell
-def _(t):
-    # Development installation for this repository.
-    # !pip install -e .
-
-    print(t("development_install"))
-    print("!pip install -e .")
-    return
-
-
 @app.cell(hide_code=True)
 def _(mo, t):
     mo.md(t("installation_visualization"))
-    return
-
-
-@app.cell
-def _(t):
-    # Dependencies used by the marimo Learning Path apps.
-    # !pip install "wandas[marimo,io,psychoacoustic]"
-
-    print(t("visualization_install"))
-    print('!pip install "wandas[marimo,io,psychoacoustic]"')
     return
 
 
@@ -89,14 +67,18 @@ def _(mo, t):
 
 
 @app.cell
-def _(t):
-    # Import the basic libraries.
-    import matplotlib.pyplot as plt  # Matplotlib visualization library.
-    import numpy as np  # NumPy numerical foundation.
+def _():
+    import matplotlib.pyplot as plt
+    import numpy as np
 
-    import wandas as wd  # Wandas signal-processing library.
+    import wandas as wd
 
-    print(
+    return np, plt, wd
+
+
+@app.cell(hide_code=True)
+def _(mo, np, plt, t, wd):
+    mo.md(
         t(
             "library_versions",
             wandas=wd.__version__,
@@ -104,9 +86,7 @@ def _(t):
             matplotlib=plt.matplotlib.__version__,
         )
     )
-
-    print(t("libraries_ready"))
-    return plt, wd
+    return
 
 
 @app.cell(hide_code=True)
@@ -116,13 +96,9 @@ def _(mo, t):
 
 
 @app.cell
-def _(plt, t):
-    # Configure plot display.
-
-    plt.rcParams["figure.figsize"] = (10, 6)  # Readable figure size.
-    plt.rcParams["figure.dpi"] = 100  # Dots per inch.
-
-    print(t("plot_configuration_complete"))
+def _(plt):
+    plt.rcParams["figure.figsize"] = (10, 6)
+    plt.rcParams["figure.dpi"] = 100
     return
 
 
@@ -132,13 +108,11 @@ def _(mo, t):
     return
 
 
-@app.cell
-def _(t):
-    # Verify that marimo is available.
+@app.cell(hide_code=True)
+def _(mo, t):
     from importlib.metadata import version as _metadata_version
 
-    marimo_version = _metadata_version("marimo")
-    print(t("marimo_available", version=marimo_version))
+    mo.md(t("marimo_available", version=_metadata_version("marimo")))
     return
 
 
@@ -149,11 +123,14 @@ def _(mo, t):
 
 
 @app.cell
-def _(t, wd):
-    # Generate a one-channel sine wave with the default settings.
+def _(wd):
     simple_tone = wd.generate_sin()
+    return (simple_tone,)
 
-    print(
+
+@app.cell(hide_code=True)
+def _(mo, simple_tone, t):
+    mo.md(
         t(
             "signal_info",
             channels=simple_tone.n_channels,
@@ -163,7 +140,7 @@ def _(t, wd):
             labels=simple_tone.labels,
         )
     )
-    return (simple_tone,)
+    return
 
 
 @app.cell(hide_code=True)
@@ -174,8 +151,6 @@ def _(mo, t):
 
 @app.cell
 def _(simple_tone):
-    # Display a complete analysis with the public describe() API.
-    # Keep the figure open so marimo can render it as cell output.
     simple_tone.describe(is_close=False)
     return
 
@@ -193,26 +168,11 @@ def _(mo, t):
 
 
 @app.cell
-def _(t, wd):
-    # Generate a more complex signal.
-    complex_signal = wd.generate_sin(
-        freqs=[440, 880, 1320],  # Fundamental plus the second and third harmonics.
-        duration=2.0,  # Two seconds.
-        sampling_rate=8000,  # 8 kHz sampling rate.
-    ).sum()
-
-    # Process it with a readable method chain.
+def _(wd):
+    complex_signal = wd.generate_sin(freqs=[440, 880, 1320], duration=2.0, sampling_rate=8000).sum()
     processed = complex_signal.fade(fade_ms=10).low_pass_filter(cutoff=1000)
-
-    print(t("method_chain_complete"))
-
-    # Inspect which operations were applied.
     processed.print_operation_history()
 
-    # Compare the original and processed signals.
-    combined_signal = complex_signal.concat_frame(processed, label_prefix="processed")
-
-    # Pass detailed settings to the public describe() API.
     config = {
         "fmin": 100,
         "fmax": 3000,
@@ -222,15 +182,20 @@ def _(t, wd):
         "waveform": {"ylim": (-3, 3)},
         "spectral": {"xlim": (-60, 0)},
     }
-
-    # Display the detailed analysis with these settings.
+    combined_signal = complex_signal.concat_frame(processed, label_prefix="processed")
     combined_signal.describe(**config)
     return (combined_signal,)
 
 
+@app.cell(hide_code=True)
+def _(mo, t):
+    mo.md(t("spectrum_context"))
+    return
+
+
 @app.cell
-def _(combined_signal, t):
-    combined_signal.fft().plot(overlay=True, title=t("spectrum_plot_title"))
+def _(combined_signal):
+    combined_signal.fft().plot(overlay=True, title="Original and filtered signal spectrum")
     return
 
 
@@ -241,58 +206,25 @@ def _(mo, t):
 
 
 @app.cell
-def _(t, wd):
-    # Define a function for trying different processing parameters.
+def _(wd):
     def experiment_with_signal(frequency=440, duration=1.0, filter_cutoff=500):
-        """
-        Experiment with frequency, duration, and filter cutoff.
-
-        Generate a sine-wave signal with the requested parameters, apply a low-pass
-        filter, and return the original and filtered signals for comparison.
-
-        Args:
-            frequency: Fundamental frequency in Hz. The default is 440 Hz (A4).
-            duration: Signal duration in seconds. The default is 1.0 second.
-            filter_cutoff: Low-pass cutoff frequency in Hz. Components above this
-                frequency are attenuated.
-
-        Returns:
-            ChannelFrame: A frame containing the original signal and filtered signal.
-                The channel labels are "signal" and "filtered_signal".
-
-        Examples:
-            >>> # Run with the default parameters.
-            >>> result = experiment_with_signal()
-            >>> result.fft().plot(overlay=True)
-
-            >>> # Try different parameters.
-            >>> result = experiment_with_signal(frequency=880, filter_cutoff=1500)
-            >>> result.fft().plot(overlay=True)
-        """
-
-        # Generate the fundamental and its second harmonic.
         signal = wd.generate_sin(
             freqs=[frequency, frequency * 2],
             duration=duration,
             sampling_rate=4000,
         ).sum()
-
-        # Apply the low-pass filter.
         filtered = signal.low_pass_filter(cutoff=filter_cutoff)
+        return signal.concat_frame(filtered, label_prefix="filtered")
 
-        # Add the processed signal for comparison.
-        combined = signal.concat_frame(filtered, label_prefix="filtered")
-        return combined
-
-    # Run the basic experiment with default parameters.
-    experiment_with_signal().fft().plot(overlay=True, title=t("spectrum_plot_title"))
+    experiment_with_signal().fft().plot(overlay=True, title="Original and filtered signal spectrum")
     return (experiment_with_signal,)
 
 
 @app.cell
-def _(experiment_with_signal, t):
-    # Try a higher frequency and a different cutoff.
-    experiment_with_signal(frequency=880, filter_cutoff=1500).fft().plot(overlay=True, title=t("spectrum_plot_title"))
+def _(experiment_with_signal):
+    experiment_with_signal(frequency=880, filter_cutoff=1500).fft().plot(
+        overlay=True, title="Original and filtered signal spectrum"
+    )
     return
 
 
@@ -302,15 +234,13 @@ def _(mo, t):
     return
 
 
-@app.cell
-def _(t):
-    # Print a short troubleshooting checklist.
-    # !pip install "wandas[marimo,io,psychoacoustic]" --upgrade
+@app.cell(hide_code=True)
+def _(mo, t):
     from importlib.metadata import version as _metadata_version
 
     import matplotlib
 
-    print(
+    mo.md(
         t(
             "troubleshooting_output",
             backend=matplotlib.get_backend(),
@@ -328,7 +258,7 @@ def _(mo, t):
 
 @app.cell(hide_code=True)
 def _(mo, t):
-    mo.md(t("next_steps"))
+    mo.md(t("summary"))
     return
 
 

--- a/learning-path/01_getting_started.py
+++ b/learning-path/01_getting_started.py
@@ -8,485 +8,333 @@ app = marimo.App()
 def _():
     import marimo as mo
 
-    return (mo,)
+    from scripts.learning_path_i18n import load_catalog, locale_from_argv, navigation_markdown
+
+    locale = locale_from_argv()
+    catalog = load_catalog("01_getting_started", locale)
+
+    def t(key, **values):
+        return catalog.text(key, **values)
+
+    return locale, mo, navigation_markdown, t
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    # 01 環境構築とウォームアップ
-    ## Wandasを動かしてみよう
-
-    このmarimoアプリでは、Wandasをインストールし、基本的な環境設定を行って、最初の信号処理を体験します。
-
-    **学習目標:**
-    - Wandasのインストールと環境設定
-    - marimo環境でのインタラクティブな操作
-    - 最初の信号生成と可視化
-    - 基本的な操作の習得
-
-    **前提条件:**
-    - Python 3.10+（3.10以上）
-    - marimo環境
-    """)
+def _(mo, t):
+    mo.md(f"# {t('title')}\n\n{t('intro')}")
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 🎯 なぜ環境構築が重要か
-
-    ### 信号処理のワークフロー
-
-    信号処理の作業では、以下のようなサイクルを繰り返します：
-
-    1. **データ収集** → 2. **前処理** → 3. **分析** → 4. **可視化** → 5. **解釈**
-
-    このサイクルを効率的に回すためには、適切な環境設定が不可欠です。Wandasは、このワークフローを**1つの統合された環境**で実現します。
-
-    ### インタラクティブな探索の重要性
-
-    信号処理では、**試行錯誤**が不可欠です：
-    - フィルタのパラメータを調整しながら効果を確認
-    - 異なる可視化方法を比較
-    - 処理結果をリアルタイムで評価
-
-    marimo + Wandasの組み合わせで、これを可能にします。
-    """)
+def _(mo, t):
+    mo.md(t("why_environment"))
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 📦 インストール
-
-    ### 方法1: PyPIからインストール（推奨）
-
-    最新の安定版をインストールします。
-    """)
+def _(mo, t):
+    mo.md(t("installation_pypi"))
     return
 
 
 @app.cell
-def _():
-    # Wandasの最新版をインストール
+def _(t):
+    # Show the recommended installation command without executing it.
     # !pip install "wandas[marimo,io,psychoacoustic]"
 
-    # 開発版の場合は（オプション）
+    # Optional development version:
     # !pip install git+https://github.com/kasahart/wandas.git
 
-    print("Wandas learning path の推奨インストールコマンド:")
+    print(t("install_recommended"))
     print('!pip install "wandas[marimo,io,psychoacoustic]"')
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### 方法2: 開発環境の場合
-
-    このリポジトリをクローンしている場合は：
-    """)
+def _(mo, t):
+    mo.md(t("installation_dev"))
     return
 
 
 @app.cell
-def _():
-    # 開発インストール（このリポジトリの場合）
+def _(t):
+    # Development installation for this repository.
     # !pip install -e .
 
-    print("開発インストールコマンド:")
+    print(t("development_install"))
     print("!pip install -e .")
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### 可視化ライブラリのインストール
-
-    marimo 表示と学習パス内の WDF/音響解析セルのために必要です。
-    """)
+def _(mo, t):
+    mo.md(t("installation_visualization"))
     return
 
 
 @app.cell
-def _():
-    # marimo学習アプリ用のライブラリ
+def _(t):
+    # Dependencies used by the marimo Learning Path apps.
     # !pip install "wandas[marimo,io,psychoacoustic]"
 
-    print("marimo環境のインストール:")
+    print(t("visualization_install"))
     print('!pip install "wandas[marimo,io,psychoacoustic]"')
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 🔧 基本的なインポートと確認
-
-    ### 必要なライブラリのインポート
-    """)
+def _(mo, t):
+    mo.md(t("imports"))
     return
 
 
 @app.cell
-def _():
-    # 基本的なライブラリをインポート
-    import matplotlib.pyplot as plt  # Matplotlib - 可視化ライブラリ
-    import numpy as np  # NumPy - 数値計算の基礎ライブラリ
+def _(t):
+    # Import the basic libraries.
+    import matplotlib.pyplot as plt  # Matplotlib visualization library.
+    import numpy as np  # NumPy numerical foundation.
 
-    import wandas as wd  # Wandasライブラリ本体 - 信号処理のメインライブラリ
+    import wandas as wd  # Wandas signal-processing library.
 
-    # バージョン情報を確認
-    print(f"Wandas: {wd.__version__}")
-    print(f"NumPy: {np.__version__}")
-    print(f"Matplotlib: {plt.matplotlib.__version__}")
+    print(
+        t(
+            "library_versions",
+            wandas=wd.__version__,
+            numpy=np.__version__,
+            matplotlib=plt.matplotlib.__version__,
+        )
+    )
 
-    print("\n✅ すべてのライブラリが正常にインポートされました！")
+    print(t("libraries_ready"))
     return plt, wd
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 🎨 marimo環境の設定
-
-    ### プロット表示の設定
-
-    信号処理では、**グラフを見ながら探索的に確認**することが重要です：
-    - 時間範囲や周波数範囲を絞って詳細を確認
-    - 複数の処理結果を並べて比較
-    - ラベルや凡例で注目点を確認
-
-    この学習パスでは、marimo上でMatplotlibの静的な図を確認しながら進めます。
-    """)
+def _(mo, t):
+    mo.md(t("plot_config"))
     return
 
 
 @app.cell
-def _(plt):
-    # プロット表示の設定
+def _(plt, t):
+    # Configure plot display.
 
-    # プロットのサイズを設定 - 見やすさを調整
-    plt.rcParams["figure.figsize"] = (10, 6)  # 図のサイズ (幅10インチ、高さ6インチ)
-    plt.rcParams["figure.dpi"] = 100  # 解像度 (dots per inch)
+    plt.rcParams["figure.figsize"] = (10, 6)  # Readable figure size.
+    plt.rcParams["figure.dpi"] = 100  # Dots per inch.
 
-    print("✅ プロット表示の設定が完了しました！")
-    print("\nグラフ表示:")
-    print("- 図は marimo のセル出力として表示されます")
-    print("- 必要に応じて plot() の xlim/ylim などで表示範囲を調整します")
-    print("- 比較したい結果は複数セルや複数軸に並べて確認します")
+    print(t("plot_configuration_complete"))
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### marimoの確認
-
-    marimoアプリとして実行できる環境か確認します。
-    """)
+def _(mo, t):
+    mo.md(t("marimo_check"))
     return
 
 
 @app.cell
-def _():
-    # marimoが利用可能か確認 - アプリ実行環境の前提条件
+def _(t):
+    # Verify that marimo is available.
     from importlib.metadata import version as _metadata_version
 
     marimo_version = _metadata_version("marimo")
-    print(f"✅ marimo: {marimo_version} - marimoアプリとして実行できます")
-    print("   起動例: marimo edit learning-path/01_getting_started.py")
+    print(t("marimo_available", version=marimo_version))
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 🎵 最初の信号生成
-
-    ### なぜ信号生成から始めるのか
-
-    実際のデータ分析に入る前に、**既知の信号を生成**することで：
-    - Wandasの基本操作を学ぶ
-    - 期待される結果を確認できる
-    - トラブルシューティングが容易
-
-    これは信号処理の**「Hello, World!」**のようなものです。
-    """)
+def _(mo, t):
+    mo.md(t("signal_generation"))
     return
 
 
 @app.cell
-def _(wd):
-    # 既定値で1チャンネルの正弦波を生成
+def _(t, wd):
+    # Generate a one-channel sine wave with the default settings.
     simple_tone = wd.generate_sin()
 
-    # 生成された信号の基本情報を表示
-    print("生成された信号の情報:")
-    print(f"  チャンネル数: {simple_tone.n_channels}")  # チャンネル数 (モノラル=1, ステレオ=2)
-    print(f"  サンプリングレート: {simple_tone.sampling_rate} Hz")  # 1秒間のサンプル数
-    print(f"  長さ: {simple_tone.duration:.1f} 秒")  # 信号の時間長
-    print(f"  サンプル数: {simple_tone.n_samples}")  # 総サンプル数
-    print(f"  チャンネル名: {simple_tone.labels}")  # 各チャンネルの名前
+    print(
+        t(
+            "signal_info",
+            channels=simple_tone.n_channels,
+            sampling_rate=simple_tone.sampling_rate,
+            duration=f"{simple_tone.duration:.1f}",
+            samples=simple_tone.n_samples,
+            labels=simple_tone.labels,
+        )
+    )
     return (simple_tone,)
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### 信号の可視化
-
-    Wandasの最も強力な機能の一つが、**一つのメソッドで包括的な可視化**ができることです。
-    """)
+def _(mo, t):
+    mo.md(t("visualization"))
     return
 
 
 @app.cell
 def _(simple_tone):
-    # describe()メソッドで完全な分析を表示 - Wandasの強力な可視化機能
-    # is_close=False: 図を自動で閉じず、marimo のセル出力として保持する設定
+    # Display a complete analysis with the public describe() API.
+    # Keep the figure open so marimo can render it as cell output.
     simple_tone.describe(is_close=False)
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    **🎉 `describe()`メソッドで:**
-    - **時間領域**: 波形の形状を確認
-    - **周波数領域**: スペクトル（周波数成分）を確認
-    - **時間周波数領域**: スペクトログラム（時間変化）を確認
-
-    が一度に表示されました。
-    """)
+def _(mo, t):
+    mo.md(t("describe_result"))
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 🔄 メソッドチェーンの体験
-
-    ### Wandasの核心機能
-
-    Wandasの最大の特徴は、**メソッドチェーン**による直感的な処理です。
-
-    これはpandasのようなAPIで、処理を**自然言語のように**連鎖できます。
-    """)
+def _(mo, t):
+    mo.md(t("method_chain"))
     return
 
 
 @app.cell
-def _(wd):
-    # より複雑な信号を生成
+def _(t, wd):
+    # Generate a more complex signal.
     complex_signal = wd.generate_sin(
-        freqs=[440, 880, 1320],  # 基本音 + 倍音 (440Hzの2倍と3倍)
-        duration=2.0,  # 2秒間 - より長い信号
-        sampling_rate=8000,  # 8kHz - 電話品質のサンプリングレート
+        freqs=[440, 880, 1320],  # Fundamental plus the second and third harmonics.
+        duration=2.0,  # Two seconds.
+        sampling_rate=8000,  # 8 kHz sampling rate.
     ).sum()
 
-    # メソッドチェーンで処理 - pandasライクな直感的な処理
-    processed = (
-        complex_signal.fade(fade_ms=10).low_pass_filter(  # フェイドイン・アウトの時間 (10ミリ秒)
-            cutoff=1000
-        )  # 1kHzでローパスフィルタ
-    )
+    # Process it with a readable method chain.
+    processed = complex_signal.fade(fade_ms=10).low_pass_filter(cutoff=1000)
 
-    print("✅ メソッドチェーンによる処理が完了しました！")
+    print(t("method_chain_complete"))
 
-    # 処理履歴を表示 - どのような処理が適用されたかを確認
+    # Inspect which operations were applied.
     processed.print_operation_history()
 
-    # 処理前後の比較 - 信号処理の効果を視覚的に確認
+    # Compare the original and processed signals.
     combined_signal = complex_signal.concat_frame(processed, label_prefix="processed")
 
-    # 公開describe() APIへ渡す詳細設定
+    # Pass detailed settings to the public describe() API.
     config = {
-        "fmin": 100,  # 周波数軸の最小値 (100Hz)
-        "fmax": 3000,  # 周波数軸の最大値 (3000Hz)
-        "cmap": "jet",  # カラーマップ (jet: 虹色)
-        "vmin": -80,  # スペクトログラムの最小値 (dB)
-        "vmax": -20,  # スペクトログラムの最大値 (dB)
-        "waveform": {"ylim": (-3, 3)},  # 波形のY軸範囲
-        "spectral": {"xlim": (-60, 0)},  # スペクトルのX軸範囲 (dB)
+        "fmin": 100,
+        "fmax": 3000,
+        "cmap": "jet",
+        "vmin": -80,
+        "vmax": -20,
+        "waveform": {"ylim": (-3, 3)},
+        "spectral": {"xlim": (-60, 0)},
     }
 
-    # 設定を適用して詳細な分析を表示
+    # Display the detailed analysis with these settings.
     combined_signal.describe(**config)
     return (combined_signal,)
 
 
 @app.cell
-def _(combined_signal):
-    combined_signal.fft().plot(overlay=True)  # 元の信号と処理後の信号を比較表示
+def _(combined_signal, t):
+    combined_signal.fft().plot(overlay=True, title=t("spectrum_plot_title"))
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 🎮 インタラクティブな実験
-
-    ### パラメータを変更して実験
-
-    信号処理の面白さは、**パラメータを変更しながら結果を確認**できることです。
-
-    以下のセルで、さまざまなパラメータを試してみましょう。
-    """)
+def _(mo, t):
+    mo.md(t("interactive_experiment"))
     return
 
 
 @app.cell
-def _(wd):
-    # 実験用の関数を定義 - パラメータを変更して信号処理を試すための関数
+def _(t, wd):
+    # Define a function for trying different processing parameters.
     def experiment_with_signal(frequency=440, duration=1.0, filter_cutoff=500):
         """
-        周波数、時間、フィルタのカットオフを変更して実験。
+        Experiment with frequency, duration, and filter cutoff.
 
-        指定されたパラメータで正弦波信号を生成し、ローパスフィルタを適用して
-        元の信号とフィルタ済み信号を比較できるようにします。
+        Generate a sine-wave signal with the requested parameters, apply a low-pass
+        filter, and return the original and filtered signals for comparison.
 
         Args:
-            frequency: float, default=440. 基本周波数 [Hz]。この周波数とその2倍の周波数（倍音）で
-                信号を生成します。A4音（440Hz）がデフォルトです。
-            duration: float, default=1.0. 信号の長さ [秒]。生成される信号の時間長を指定します。
-            filter_cutoff: float, default=500. ローパスフィルタのカットオフ周波数 [Hz]。
-                この周波数以上の成分が減衰されます。
+            frequency: Fundamental frequency in Hz. The default is 440 Hz (A4).
+            duration: Signal duration in seconds. The default is 1.0 second.
+            filter_cutoff: Low-pass cutoff frequency in Hz. Components above this
+                frequency are attenuated.
 
         Returns:
-            ChannelFrame: 元の信号とフィルタ済み信号が結合されたChannelFrame。
-                チャンネル名は元の信号が "signal"、フィルタ済みが "filtered_signal" となります。
+            ChannelFrame: A frame containing the original signal and filtered signal.
+                The channel labels are "signal" and "filtered_signal".
 
         Examples:
-            >>> # デフォルトパラメータで実行
+            >>> # Run with the default parameters.
             >>> result = experiment_with_signal()
             >>> result.fft().plot(overlay=True)
 
-            >>> # パラメータを変更して実験
+            >>> # Try different parameters.
             >>> result = experiment_with_signal(frequency=880, filter_cutoff=1500)
             >>> result.fft().plot(overlay=True)
         """
 
-        # 信号生成 - 指定された周波数で基本音と倍音を作成
+        # Generate the fundamental and its second harmonic.
         signal = wd.generate_sin(
-            freqs=[frequency, frequency * 2],  # 基本音 + 倍音
-            duration=duration,  # 指定された長さ
-            sampling_rate=4000,  # 4kHzサンプリング (実験用)
+            freqs=[frequency, frequency * 2],
+            duration=duration,
+            sampling_rate=4000,
         ).sum()
 
-        # フィルタ処理 - 指定されたカットオフ周波数でローパスフィルタ適用
+        # Apply the low-pass filter.
         filtered = signal.low_pass_filter(cutoff=filter_cutoff)
 
-        # 処理した信号を元の信号のchannel frameに追加 - 比較のため
+        # Add the processed signal for comparison.
         combined = signal.concat_frame(filtered, label_prefix="filtered")
         return combined
 
-    # デフォルトパラメータで実行 - 基本的な実験
-    experiment_with_signal().fft().plot(overlay=True, title="Original and Filtered Signal Spectrum")
+    # Run the basic experiment with default parameters.
+    experiment_with_signal().fft().plot(overlay=True, title=t("spectrum_plot_title"))
     return (experiment_with_signal,)
 
 
 @app.cell
-def _(experiment_with_signal):
-    # パラメータを変更して実験
-    # 例: より高い周波数で試す
-    experiment_with_signal(frequency=880, filter_cutoff=1500).fft().plot(
-        overlay=True, title="Original and Filtered Signal Spectrum"
+def _(experiment_with_signal, t):
+    # Try a higher frequency and a different cutoff.
+    experiment_with_signal(frequency=880, filter_cutoff=1500).fft().plot(overlay=True, title=t("spectrum_plot_title"))
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, t):
+    mo.md(t("troubleshooting"))
+    return
+
+
+@app.cell
+def _(t):
+    # Print a short troubleshooting checklist.
+    # !pip install "wandas[marimo,io,psychoacoustic]" --upgrade
+    from importlib.metadata import version as _metadata_version
+
+    import matplotlib
+
+    print(
+        t(
+            "troubleshooting_output",
+            backend=matplotlib.get_backend(),
+            version=_metadata_version("marimo"),
+        )
     )
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 🛠️ トラブルシューティング
-
-    ### よくある問題と解決法
-
-    #### 1. marimoアプリが起動しない
-    ```python
-    # 解決法
-    !pip install "wandas[marimo,io,psychoacoustic]" --upgrade
-    marimo edit learning-path/01_getting_started.py
-    ```
-
-    #### 2. バージョン互換性の問題
-    - Python 3.10+（3.10以上）を使用してください
-    - 最新版のWandasを使用してください
-
-    #### 3. メモリ不足
-    - 時間を短くする
-    - サンプリングレートを下げる
-
-    #### 4. プロットが表示されない
-    - `marimo edit learning-path/01_getting_started.py` で起動しているか確認
-    - ブラウザを再読み込みしてセルを再実行
-    """)
-    return
-
-
-@app.cell
-def _():
-    # トラブルシューティング: marimo表示が動作しない場合の確認
-    # !pip install "wandas[marimo,io,psychoacoustic]" --upgrade  # アップグレードが必要な場合
-    print("marimo表示のトラブルシューティング:")
-    print("1. marimo edit learning-path/01_getting_started.py で起動")
-    print("2. wandas[marimo,io,psychoacoustic] がインストールされているか確認")
-    print("3. ブラウザを再読み込みしてセルを再実行")
-    from importlib.metadata import version as _metadata_version
-
-    import matplotlib
-
-    print(f"現在のMatplotlibバックエンド: {matplotlib.get_backend()}")
-    print(f"✅ marimoバージョン: {_metadata_version('marimo')}")
+def _(mo, t):
+    mo.md(t("s3"))
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## ☁️ S3からWAVを読み込む
-
-    S3から取得したバイト列をそのまま`wd.read()`に渡せます。
-    ファイル保存は不要です。
-    """)
+def _(mo, t):
+    mo.md(t("next_steps"))
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 📚 次のステップ
-
-    環境構築と基本操作が完了しました！
-
-    **前のmarimoアプリ**: [00_why_wandas](00_why_wandas.html)
-
-    **次のmarimoアプリ**: [02_working_with_data](02_working_with_data.html)
-
-    ここでは、実際のデータファイル（WAV, CSVなど）を読み込んで、Wandasのデータ構造について紹介します。
-
-    ### 🎯 これまでに学んだこと
-    - ✅ Wandasのインストールと環境設定
-    - ✅ インタラクティブなmarimo環境の構築
-    - ✅ 信号生成と基本的な可視化
-    - ✅ メソッドチェーンによる直感的な処理
-    - ✅ パラメータ変更による実験
-
-    ### 🚀 次の学習目標
-    - 実際のデータファイルの読み込み
-    - ChannelFrameデータ構造の理解
-    - チャンネル操作とインデックスアクセス
-    - メタデータの管理
-
-    ---
-
-    **準備はできましたか？次のmarimoアプリへ進みましょう！** 🎵
-    """)
+def _(locale, mo, navigation_markdown):
+    mo.md(navigation_markdown("01_getting_started", locale))
     return
 
 

--- a/learning-path/06_reusable_pipeline_recipes.py
+++ b/learning-path/06_reusable_pipeline_recipes.py
@@ -6,54 +6,45 @@ app = marimo.App()
 
 @app.cell
 def _():
-    # この教材で使う公開APIと検証用ライブラリを読み込む
+    # Import the public APIs and validation libraries used in this lesson.
     import json
 
     import marimo as mo
     import numpy as np
 
     import wandas as wd
+    from scripts.learning_path_i18n import (
+        docs_relative_href,
+        load_catalog,
+        locale_from_argv,
+        navigation_markdown,
+    )
     from wandas import pipeline as pipeline_api
 
-    return json, mo, np, pipeline_api, wd
+    locale = locale_from_argv()
+    catalog = load_catalog("06_reusable_pipeline_recipes", locale)
+
+    def t(key, **values):
+        return catalog.text(key, **values)
+
+    return docs_relative_href, json, locale, mo, navigation_markdown, np, pipeline_api, t, wd
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    # 同じ信号処理をRecipeとして再利用する
-
-    複数の録音へ同じ前処理を適用するとき、メソッドチェーンを各所へコピーすると、
-    パラメータ変更や処理順の確認が難しくなります。`RecipePlan` は、通常のFrame操作から
-    「どの公開操作を、どの順番とパラメータで適用するか」を取り出します。
-
-    Recipeは波形データそのものを保存しません。別のFrameを名前付き入力として渡すと、
-    同じ処理をlazyなFrameグラフとして組み立て直します。
-
-    この教材では次を確認します。
-
-    1. 通常のFrame操作からRecipeを作る
-    2. JSONとして保存できるschemaへ変換し、読み戻す
-    3. 別のFrameへ適用し、直接呼び出した結果と一致することを確かめる
-    4. 複数Frameを使う処理でも入力名が明示されることを確かめる
-    """)
+def _(mo, t):
+    mo.md(f"# {t('title')}\n\n{t('intro')}")
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 1. 普通のFrame操作を記録する
-
-    Recipe専用のbuilderは使いません。代表入力に対して、再利用したい公開Frame操作を
-    そのまま呼び出します。ここではDC成分を除き、振幅を正規化します。
-    """)
+def _(mo, t):
+    mo.md(t("record_frame"))
     return
 
 
 @app.cell
-def _(np, wd):
-    # 再利用したい前処理を、代表となる小さな信号へ適用する
+def _(np, t, wd):
+    # Apply the reusable preprocessing to a small representative signal.
     template_signal = wd.from_numpy(
         np.array([[1.0, 2.0, 4.0, 7.0]]),
         sampling_rate=8_000,
@@ -61,71 +52,60 @@ def _(np, wd):
     )
     template_result = template_signal.remove_dc().normalize()
 
-    print("代表入力の履歴:", [record["operation"] for record in template_result.operation_history])
+    print(t("template_history", operations=[record["operation"] for record in template_result.operation_history]))
     return template_result, template_signal
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    `RecipePlan.from_frame()` は結果Frameのsemantic lineageを読みます。公開操作1回が
-    Recipe node 1件になり、元のサンプル値はplanへ入りません。`input_names` は、あとで
-    runtime dataを渡すための名前です。
-    """)
+def _(mo, t, template_result):
+    mo.md(t("lineage_explanation"))
     return
 
 
 @app.cell
-def _(pipeline_api, template_result):
-    # semantic lineageを名前付き入力を持つRecipeへ変換する
+def _(pipeline_api, t, template_result):
+    # Convert semantic lineage into a Recipe with named inputs.
     recipe_plan = pipeline_api.RecipePlan.from_frame(template_result, input_names=("signal",))
     recipe_payload = recipe_plan.to_dict()
     _operation_ids = [node["operation"] for node in recipe_payload["nodes"]]
 
-    print("入力名:", recipe_payload["inputs"][0]["name"])
-    print("Recipe operations:", _operation_ids)
+    print(t("recipe_inputs", input_name=recipe_payload["inputs"][0]["name"]))
+    print(t("recipe_operations", operations=_operation_ids))
     return recipe_payload
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 2. JSONで保存できる形へ変換する
-
-    `to_dict()` の結果はschema version付きのJSON-compatible valueです。
-    payloadはliveなPython operation objectを保存せず、stable operation IDを保持します。
-    `RecipePlan.from_dict()` はIDをbuilt-in registryで解決し、未知のfield、operation、version、
-    不正なgraphを拒否します。extensionではextract/load/applyに同じregistryを渡します。
-    """)
+def _(mo, t):
+    mo.md(t("recipe_schema"))
     return
 
 
 @app.cell
-def _(json, pipeline_api, recipe_payload):
-    # schemaをJSON文字列にし、runtime objectを共有せずにplanを読み戻す
+def _(json, pipeline_api, recipe_payload, t):
+    # Serialize the schema and load the plan without sharing runtime objects.
     recipe_json = json.dumps(recipe_payload)
     loaded_recipe = pipeline_api.RecipePlan.from_dict(json.loads(recipe_json))
 
-    print("Schema:", recipe_payload["schema"], recipe_payload["version"])
-    print("JSON size:", len(recipe_json.encode("utf-8")), "bytes")
+    print(
+        t(
+            "schema_info",
+            schema=recipe_payload["schema"],
+            version=recipe_payload["version"],
+            size=len(recipe_json.encode("utf-8")),
+        )
+    )
     return (loaded_recipe,)
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 3. 別のFrameへ適用する
-
-    planに記録されるのは操作intentです。サンプル、metadata、label、sampling rateは
-    `apply()` へ渡すruntime Frameが所有します。`apply()` 自体はlazy graphを作るだけで、
-    このセルでは検証のため最後に `frame.data` からNumPy値を取得します。
-    """)
+def _(mo, t):
+    mo.md(t("json_round_trip"))
     return
 
 
 @app.cell
-def _(loaded_recipe, np, wd):
-    # Recipe replayと同じFrameメソッドの直接呼び出しを比較する
+def _(loaded_recipe, np, t, wd):
+    # Compare Recipe replay with the same Frame methods called directly.
     runtime_signal = wd.from_numpy(
         np.array([[2.0, 5.0, 8.0, 14.0]]),
         sampling_rate=8_000,
@@ -141,29 +121,39 @@ def _(loaded_recipe, np, wd):
     assert replayed_signal.metadata == {"recording": "next"}
     assert runtime_signal.operation_history == []
 
-    print("直接呼び出しと一致: yes")
-    print("runtime metadata:", replayed_signal.metadata)
-    print("元のruntime Frameの履歴:", runtime_signal.operation_history)
+    print(
+        t(
+            "direct_result",
+            metadata=replayed_signal.metadata,
+            history=runtime_signal.operation_history,
+        )
+    )
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 4. 複数入力も名前で区別する
+def _(mo, recipe_payload, t):
+    operation_ids = [node["operation"] for node in recipe_payload["nodes"]]
+    mo.md(
+        t(
+            "recipe_table",
+            input_name=recipe_payload["inputs"][0]["name"],
+            node_count=len(operation_ids),
+            operations=", ".join(operation_ids),
+        )
+    )
+    return
 
-    Frame同士の演算、`mix()`、NumPy/Dask operandは、追加のruntime inputになります。
-    値やNumPy/Daskというcontainer種別はschemaへ埋め込まれません。
 
-    次の例では `base` と `other` を明示し、別の2つのFrameへmix Recipeを適用します。
-    `mix()` はsource timeではなく現在のarray indexで信号を重ねます。
-    """)
+@app.cell(hide_code=True)
+def _(mo, t):
+    mo.md(t("multiple_inputs"))
     return
 
 
 @app.cell
-def _(np, pipeline_api, wd):
-    # 2つのFrame入力を持つmix Recipeを作り、別の入力ペアへ適用する
+def _(np, pipeline_api, t, wd):
+    # Build a two-input mix Recipe and apply it to another input pair.
     base_template = wd.from_numpy(np.array([[1.0, 1.0, 1.0, 1.0]]), sampling_rate=8_000)
     other_template = wd.from_numpy(np.array([[2.0, 2.0, 2.0, 2.0]]), sampling_rate=8_000)
     mix_template_result = base_template.mix(other_template)
@@ -175,32 +165,25 @@ def _(np, pipeline_api, wd):
     _mix_values = mixed_replay.data
     np.testing.assert_allclose(_mix_values, 7.0)
 
-    print("mix入力:", [item.name for item in mix_recipe.inputs])
-    print("replay結果:", _mix_values.tolist())
+    print(t("mix_result", inputs=[item.name for item in mix_recipe.inputs], values=_mix_values.tolist()))
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## まとめ
+def _(docs_relative_href, locale, mo, t):
+    mo.md(
+        t(
+            "summary",
+            how_to_href=docs_relative_href(locale, "how-to/pipeline-recipes/"),
+            api_href=docs_relative_href(locale, "api/pipeline/"),
+        )
+    )
+    return
 
-    - いつもどおりFrameメソッドを呼び、結果から`RecipePlan`を作る
-    - Recipeは操作intentとgraphだけを持ち、波形やDask graphを保存しない
-    - 実行時のoperation behaviorはstable IDに対応するregistry handlerが供給する
-    - `to_dict()` / `from_dict()` でstrictなschemaを往復する
-    - `apply()` では抽出時に決めた名前でruntime inputを渡す
-    - replay後もruntime Frameのmetadataを保持し、入力Frameは変更しない
-    - 任意の`Frame.apply(callable)`はruntime-onlyで、portable Recipeにはならない
 
-    詳細な入力形状と制約は
-    [RecipePlan how-to](../how-to/pipeline-recipes/) を、API signatureは
-    [Pipeline API reference](../api/pipeline/) を参照してください。
-
-    **前のmarimoアプリ**: [05_custom_functions](05_custom_functions.html)
-
-    **次のmarimoアプリ**: [07_per_channel_calibration](07_per_channel_calibration.html)
-    """)
+@app.cell(hide_code=True)
+def _(locale, mo, navigation_markdown):
+    mo.md(navigation_markdown("06_reusable_pipeline_recipes", locale))
     return
 
 

--- a/learning-path/06_reusable_pipeline_recipes.py
+++ b/learning-path/06_reusable_pipeline_recipes.py
@@ -6,12 +6,8 @@ app = marimo.App()
 
 @app.cell(hide_code=True)
 def _():
-    import json
-
     import marimo as mo
-    import numpy as np
 
-    import wandas as wd
     from scripts.learning_path_i18n import (
         docs_reference_links,
         language_switch_markdown,
@@ -19,7 +15,6 @@ def _():
         locale_from_argv,
         navigation_markdown,
     )
-    from wandas import pipeline as pipeline_api
 
     locale = locale_from_argv()
     catalog = load_catalog("06_reusable_pipeline_recipes", locale)
@@ -30,15 +25,11 @@ def _():
     return (
         catalog,
         docs_reference_links,
-        json,
         language_switch_markdown,
         locale,
         mo,
         navigation_markdown,
-        np,
-        pipeline_api,
         t,
-        wd,
     )
 
 
@@ -58,6 +49,18 @@ def _(language_switch_markdown, locale, mo):
 def _(mo, t):
     mo.md(t("record_frame"))
     return
+
+
+@app.cell
+def _():
+    import json
+
+    import numpy as np
+
+    import wandas as wd
+    from wandas import pipeline as pipeline_api
+
+    return json, np, pipeline_api, wd
 
 
 @app.cell

--- a/learning-path/06_reusable_pipeline_recipes.py
+++ b/learning-path/06_reusable_pipeline_recipes.py
@@ -4,9 +4,8 @@ __generated_with = "0.23.9"
 app = marimo.App()
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _():
-    # Import the public APIs and validation libraries used in this lesson.
     import json
 
     import marimo as mo
@@ -14,7 +13,8 @@ def _():
 
     import wandas as wd
     from scripts.learning_path_i18n import (
-        docs_relative_href,
+        docs_reference_links,
+        language_switch_markdown,
         load_catalog,
         locale_from_argv,
         navigation_markdown,
@@ -27,12 +27,30 @@ def _():
     def t(key, **values):
         return catalog.text(key, **values)
 
-    return docs_relative_href, json, locale, mo, navigation_markdown, np, pipeline_api, t, wd
+    return (
+        catalog,
+        docs_reference_links,
+        json,
+        language_switch_markdown,
+        locale,
+        mo,
+        navigation_markdown,
+        np,
+        pipeline_api,
+        t,
+        wd,
+    )
 
 
 @app.cell(hide_code=True)
 def _(mo, t):
     mo.md(f"# {t('title')}\n\n{t('intro')}")
+    return
+
+
+@app.cell(hide_code=True)
+def _(language_switch_markdown, locale, mo):
+    mo.md(language_switch_markdown("06_reusable_pipeline_recipes", locale))
     return
 
 
@@ -43,17 +61,20 @@ def _(mo, t):
 
 
 @app.cell
-def _(np, t, wd):
-    # Apply the reusable preprocessing to a small representative signal.
+def _(np, wd):
     template_signal = wd.from_numpy(
         np.array([[1.0, 2.0, 4.0, 7.0]]),
         sampling_rate=8_000,
         ch_labels=["sensor"],
     )
     template_result = template_signal.remove_dc().normalize()
-
-    print(t("template_history", operations=[record["operation"] for record in template_result.operation_history]))
     return template_result, template_signal
+
+
+@app.cell(hide_code=True)
+def _(mo, t, template_result):
+    mo.md(t("template_history", operations=[record["operation"] for record in template_result.operation_history]))
+    return
 
 
 @app.cell(hide_code=True)
@@ -63,72 +84,10 @@ def _(mo, t, template_result):
 
 
 @app.cell
-def _(pipeline_api, t, template_result):
-    # Convert semantic lineage into a Recipe with named inputs.
+def _(pipeline_api, template_result):
     recipe_plan = pipeline_api.RecipePlan.from_frame(template_result, input_names=("signal",))
     recipe_payload = recipe_plan.to_dict()
-    _operation_ids = [node["operation"] for node in recipe_payload["nodes"]]
-
-    print(t("recipe_inputs", input_name=recipe_payload["inputs"][0]["name"]))
-    print(t("recipe_operations", operations=_operation_ids))
-    return recipe_payload
-
-
-@app.cell(hide_code=True)
-def _(mo, t):
-    mo.md(t("recipe_schema"))
-    return
-
-
-@app.cell
-def _(json, pipeline_api, recipe_payload, t):
-    # Serialize the schema and load the plan without sharing runtime objects.
-    recipe_json = json.dumps(recipe_payload)
-    loaded_recipe = pipeline_api.RecipePlan.from_dict(json.loads(recipe_json))
-
-    print(
-        t(
-            "schema_info",
-            schema=recipe_payload["schema"],
-            version=recipe_payload["version"],
-            size=len(recipe_json.encode("utf-8")),
-        )
-    )
-    return (loaded_recipe,)
-
-
-@app.cell(hide_code=True)
-def _(mo, t):
-    mo.md(t("json_round_trip"))
-    return
-
-
-@app.cell
-def _(loaded_recipe, np, t, wd):
-    # Compare Recipe replay with the same Frame methods called directly.
-    runtime_signal = wd.from_numpy(
-        np.array([[2.0, 5.0, 8.0, 14.0]]),
-        sampling_rate=8_000,
-        metadata={"recording": "next"},
-        ch_labels=["sensor"],
-    )
-    replayed_signal = loaded_recipe.apply({"signal": runtime_signal})
-    direct_signal = runtime_signal.remove_dc().normalize()
-
-    _replayed_values = replayed_signal.data
-    _direct_values = direct_signal.data
-    np.testing.assert_allclose(_replayed_values, _direct_values)
-    assert replayed_signal.metadata == {"recording": "next"}
-    assert runtime_signal.operation_history == []
-
-    print(
-        t(
-            "direct_result",
-            metadata=replayed_signal.metadata,
-            history=runtime_signal.operation_history,
-        )
-    )
-    return
+    return (recipe_payload,)
 
 
 @app.cell(hide_code=True)
@@ -147,13 +106,72 @@ def _(mo, recipe_payload, t):
 
 @app.cell(hide_code=True)
 def _(mo, t):
+    mo.md(t("recipe_schema"))
+    return
+
+
+@app.cell
+def _(json, pipeline_api, recipe_payload):
+    recipe_json = json.dumps(recipe_payload)
+    loaded_recipe = pipeline_api.RecipePlan.from_dict(json.loads(recipe_json))
+    return loaded_recipe, recipe_json
+
+
+@app.cell(hide_code=True)
+def _(mo, recipe_json, recipe_payload, t):
+    mo.md(
+        t(
+            "schema_info",
+            schema=recipe_payload["schema"],
+            version=recipe_payload["version"],
+            size=len(recipe_json.encode("utf-8")),
+        )
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, t):
+    mo.md(t("json_round_trip"))
+    return
+
+
+@app.cell
+def _(loaded_recipe, np, wd):
+    runtime_signal = wd.from_numpy(
+        np.array([[2.0, 5.0, 8.0, 14.0]]),
+        sampling_rate=8_000,
+        metadata={"recording": "next"},
+        ch_labels=["sensor"],
+    )
+    replayed_signal = loaded_recipe.apply({"signal": runtime_signal})
+    direct_signal = runtime_signal.remove_dc().normalize()
+    return direct_signal, replayed_signal, runtime_signal
+
+
+@app.cell(hide_code=True)
+def _(direct_signal, mo, np, replayed_signal, runtime_signal, t):
+    np.testing.assert_allclose(replayed_signal.data, direct_signal.data)
+    assert replayed_signal.metadata == {"recording": "next"}
+    assert runtime_signal.operation_history == []
+    mo.md(
+        t(
+            "direct_result",
+            metadata=replayed_signal.metadata,
+            history=runtime_signal.operation_history,
+        )
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, t):
     mo.md(t("multiple_inputs"))
     return
 
 
 @app.cell
-def _(np, pipeline_api, t, wd):
-    # Build a two-input mix Recipe and apply it to another input pair.
+def _(np, pipeline_api, wd):
     base_template = wd.from_numpy(np.array([[1.0, 1.0, 1.0, 1.0]]), sampling_rate=8_000)
     other_template = wd.from_numpy(np.array([[2.0, 2.0, 2.0, 2.0]]), sampling_rate=8_000)
     mix_template_result = base_template.mix(other_template)
@@ -162,22 +180,20 @@ def _(np, pipeline_api, t, wd):
     next_base = wd.from_numpy(np.array([[3.0, 3.0, 3.0, 3.0]]), sampling_rate=8_000)
     next_other = wd.from_numpy(np.array([[4.0, 4.0, 4.0, 4.0]]), sampling_rate=8_000)
     mixed_replay = mix_recipe.apply({"base": next_base, "other": next_other})
-    _mix_values = mixed_replay.data
-    np.testing.assert_allclose(_mix_values, 7.0)
+    return mix_recipe, mixed_replay
 
-    print(t("mix_result", inputs=[item.name for item in mix_recipe.inputs], values=_mix_values.tolist()))
+
+@app.cell(hide_code=True)
+def _(mix_recipe, mixed_replay, mo, np, t):
+    mix_values = mixed_replay.data
+    np.testing.assert_allclose(mix_values, 7.0)
+    mo.md(t("mix_result", inputs=[item.name for item in mix_recipe.inputs], values=mix_values.tolist()))
     return
 
 
 @app.cell(hide_code=True)
-def _(docs_relative_href, locale, mo, t):
-    mo.md(
-        t(
-            "summary",
-            how_to_href=docs_relative_href(locale, "how-to/pipeline-recipes/"),
-            api_href=docs_relative_href(locale, "api/pipeline/"),
-        )
-    )
+def _(catalog, docs_reference_links, locale, mo, t):
+    mo.md(t("summary", **docs_reference_links(locale, catalog)))
     return
 
 

--- a/learning-path/manifest.json
+++ b/learning-path/manifest.json
@@ -1,0 +1,76 @@
+{
+  "default_locale": "ja",
+  "locales": {
+    "ja": "日本語",
+    "en": "English"
+  },
+  "lessons": [
+    {
+      "id": "00_why_wandas",
+      "source": "learning-path/00_why_wandas.py",
+      "locales": ["ja"],
+      "previous": null,
+      "next": "01_getting_started"
+    },
+    {
+      "id": "01_getting_started",
+      "source": "learning-path/01_getting_started.py",
+      "locales": ["ja", "en"],
+      "catalog": "01_getting_started.json",
+      "previous": "00_why_wandas",
+      "next": "02_working_with_data",
+      "poc": true
+    },
+    {
+      "id": "02_working_with_data",
+      "source": "learning-path/02_working_with_data.py",
+      "locales": ["ja"],
+      "previous": "01_getting_started",
+      "next": "03_signal_processing_basics"
+    },
+    {
+      "id": "03_signal_processing_basics",
+      "source": "learning-path/03_signal_processing_basics.py",
+      "locales": ["ja"],
+      "previous": "02_working_with_data",
+      "next": "04_advanced_processing"
+    },
+    {
+      "id": "04_advanced_processing",
+      "source": "learning-path/04_advanced_processing.py",
+      "locales": ["ja"],
+      "previous": "03_signal_processing_basics",
+      "next": "05_custom_functions"
+    },
+    {
+      "id": "05_custom_functions",
+      "source": "learning-path/05_custom_functions.py",
+      "locales": ["ja"],
+      "previous": "04_advanced_processing",
+      "next": "06_reusable_pipeline_recipes"
+    },
+    {
+      "id": "06_reusable_pipeline_recipes",
+      "source": "learning-path/06_reusable_pipeline_recipes.py",
+      "locales": ["ja", "en"],
+      "catalog": "06_reusable_pipeline_recipes.json",
+      "previous": "05_custom_functions",
+      "next": "07_per_channel_calibration",
+      "poc": true
+    },
+    {
+      "id": "07_per_channel_calibration",
+      "source": "learning-path/07_per_channel_calibration.py",
+      "locales": ["ja"],
+      "previous": "06_reusable_pipeline_recipes",
+      "next": "08_metadata_driven_dataset_search"
+    },
+    {
+      "id": "08_metadata_driven_dataset_search",
+      "source": "learning-path/08_metadata_driven_dataset_search.py",
+      "locales": ["ja"],
+      "previous": "07_per_channel_calibration",
+      "next": null
+    }
+  ]
+}

--- a/learning-path/manifest.json
+++ b/learning-path/manifest.json
@@ -8,69 +8,51 @@
     {
       "id": "00_why_wandas",
       "source": "learning-path/00_why_wandas.py",
-      "locales": ["ja"],
-      "previous": null,
-      "next": "01_getting_started"
+      "locales": ["ja"]
     },
     {
       "id": "01_getting_started",
       "source": "learning-path/01_getting_started.py",
       "locales": ["ja", "en"],
       "catalog": "01_getting_started.json",
-      "previous": "00_why_wandas",
-      "next": "02_working_with_data",
       "poc": true
     },
     {
       "id": "02_working_with_data",
       "source": "learning-path/02_working_with_data.py",
-      "locales": ["ja"],
-      "previous": "01_getting_started",
-      "next": "03_signal_processing_basics"
+      "locales": ["ja"]
     },
     {
       "id": "03_signal_processing_basics",
       "source": "learning-path/03_signal_processing_basics.py",
-      "locales": ["ja"],
-      "previous": "02_working_with_data",
-      "next": "04_advanced_processing"
+      "locales": ["ja"]
     },
     {
       "id": "04_advanced_processing",
       "source": "learning-path/04_advanced_processing.py",
-      "locales": ["ja"],
-      "previous": "03_signal_processing_basics",
-      "next": "05_custom_functions"
+      "locales": ["ja"]
     },
     {
       "id": "05_custom_functions",
       "source": "learning-path/05_custom_functions.py",
-      "locales": ["ja"],
-      "previous": "04_advanced_processing",
-      "next": "06_reusable_pipeline_recipes"
+      "locales": ["ja"]
     },
     {
       "id": "06_reusable_pipeline_recipes",
       "source": "learning-path/06_reusable_pipeline_recipes.py",
       "locales": ["ja", "en"],
       "catalog": "06_reusable_pipeline_recipes.json",
-      "previous": "05_custom_functions",
-      "next": "07_per_channel_calibration",
       "poc": true
     },
     {
       "id": "07_per_channel_calibration",
       "source": "learning-path/07_per_channel_calibration.py",
-      "locales": ["ja"],
-      "previous": "06_reusable_pipeline_recipes",
-      "next": "08_metadata_driven_dataset_search"
+      "locales": ["ja"]
     },
     {
       "id": "08_metadata_driven_dataset_search",
       "source": "learning-path/08_metadata_driven_dataset_search.py",
-      "locales": ["ja"],
-      "previous": "07_per_channel_calibration",
-      "next": null
+      "locales": ["ja"]
     }
   ]
 }

--- a/learning-path/translations/01_getting_started.json
+++ b/learning-path/translations/01_getting_started.json
@@ -85,38 +85,62 @@
         "",
         "### 方法1: PyPIからインストール（推奨）",
         "",
-        "最新の安定版をインストールします。"
+        "最新の安定版をインストールします。",
+        "",
+        "```bash",
+        "pip install \"wandas[marimo,io,psychoacoustic]\"",
+        "```"
       ],
       "en": [
         "## 📦 Install Wandas",
         "",
         "### Option 1: Install from PyPI (recommended)",
         "",
-        "Install the latest stable release."
+        "Install the latest stable release.",
+        "",
+        "```bash",
+        "pip install \"wandas[marimo,io,psychoacoustic]\"",
+        "```"
       ]
     },
     "installation_dev": {
       "ja": [
         "### 方法2: 開発環境の場合",
         "",
-        "このリポジトリをクローンしている場合は："
+        "このリポジトリをクローンしている場合は：",
+        "",
+        "```bash",
+        "pip install -e .",
+        "```"
       ],
       "en": [
         "### Option 2: Use a development checkout",
         "",
-        "If you have cloned this repository:"
+        "If you have cloned this repository:",
+        "",
+        "```bash",
+        "pip install -e .",
+        "```"
       ]
     },
     "installation_visualization": {
       "ja": [
         "### 可視化ライブラリのインストール",
         "",
-        "marimo 表示と学習パス内の WDF/音響解析セルのために必要です。"
+        "marimo 表示と学習パス内の WDF/音響解析セルのために必要です。",
+        "",
+        "```bash",
+        "pip install \"wandas[marimo,io,psychoacoustic]\"",
+        "```"
       ],
       "en": [
         "### Install visualization dependencies",
         "",
-        "These extras support marimo output and the WDF and acoustics examples in the Learning Path."
+        "These extras support marimo output and the WDF and acoustics examples in the Learning Path.",
+        "",
+        "```bash",
+        "pip install \"wandas[marimo,io,psychoacoustic]\"",
+        "```"
       ]
     },
     "imports": {
@@ -329,9 +353,9 @@
         "No temporary file is required."
       ]
     },
-    "next_steps": {
+    "summary": {
       "ja": [
-        "## 📚 次のステップ",
+        "## 📚 まとめ",
         "",
         "環境構築と基本操作が完了しました！",
         "",
@@ -355,7 +379,7 @@
         "**準備はできましたか？次のmarimoアプリへ進みましょう！** 🎵"
       ],
       "en": [
-        "## 📚 Next steps",
+        "## 📚 Summary",
         "",
         "You have completed the environment setup and the basic workflow.",
         "",
@@ -379,87 +403,53 @@
         "**Ready to continue? Open the next marimo app.** 🎵"
       ]
     },
-    "install_recommended": {
-      "ja": ["Wandas learning path の推奨インストールコマンド:"],
-      "en": ["Recommended installation command for the Wandas Learning Path:"]
-    },
-    "development_install": {
-      "ja": ["開発インストールコマンド:"],
-      "en": ["Development installation command:"]
-    },
-    "visualization_install": {
-      "ja": ["marimo環境のインストール:"],
-      "en": ["Install the marimo extras:"]
-    },
     "library_versions": {
       "ja": [
-        "Wandas: {wandas}",
-        "NumPy: {numpy}",
-        "Matplotlib: {matplotlib}"
+        "Wandas: [[wandas]]",
+        "NumPy: [[numpy]]",
+        "Matplotlib: [[matplotlib]]"
       ],
       "en": [
-        "Wandas: {wandas}",
-        "NumPy: {numpy}",
-        "Matplotlib: {matplotlib}"
-      ]
-    },
-    "libraries_ready": {
-      "ja": ["✅ すべてのライブラリが正常にインポートされました！"],
-      "en": ["✅ All libraries were imported successfully!"]
-    },
-    "plot_configuration_complete": {
-      "ja": [
-        "✅ プロット表示の設定が完了しました！",
-        "",
-        "グラフ表示:",
-        "- 図は marimo のセル出力として表示されます",
-        "- 必要に応じて plot() の xlim/ylim などで表示範囲を調整します",
-        "- 比較したい結果は複数セルや複数軸に並べて確認します"
-      ],
-      "en": [
-        "✅ Plot display is configured.",
-        "",
-        "Working with graphs:",
-        "- Figures appear as marimo cell outputs",
-        "- Adjust the display range with plot() options such as xlim and ylim",
-        "- Compare results across cells or axes"
+        "Wandas: [[wandas]]",
+        "NumPy: [[numpy]]",
+        "Matplotlib: [[matplotlib]]"
       ]
     },
     "marimo_available": {
       "ja": [
-        "✅ marimo: {version} - marimoアプリとして実行できます",
+        "✅ marimo: [[version]] - marimoアプリとして実行できます",
         "   起動例: marimo edit learning-path/01_getting_started.py"
       ],
       "en": [
-        "✅ marimo: {version} - the environment can run a marimo app",
+        "✅ marimo: [[version]] - the environment can run a marimo app",
         "   Example: marimo edit learning-path/01_getting_started.py"
       ]
     },
     "signal_info": {
       "ja": [
         "生成された信号の情報:",
-        "  チャンネル数: {channels}",
-        "  サンプリングレート: {sampling_rate} Hz",
-        "  長さ: {duration} 秒",
-        "  サンプル数: {samples}",
-        "  チャンネル名: {labels}"
+        "  チャンネル数: [[channels]]",
+        "  サンプリングレート: [[sampling_rate]] Hz",
+        "  長さ: [[duration]] 秒",
+        "  サンプル数: [[samples]]",
+        "  チャンネル名: [[labels]]"
       ],
       "en": [
         "Generated signal:",
-        "  Channels: {channels}",
-        "  Sampling rate: {sampling_rate} Hz",
-        "  Duration: {duration} seconds",
-        "  Samples: {samples}",
-        "  Channel labels: {labels}"
+        "  Channels: [[channels]]",
+        "  Sampling rate: [[sampling_rate]] Hz",
+        "  Duration: [[duration]] seconds",
+        "  Samples: [[samples]]",
+        "  Channel labels: [[labels]]"
       ]
     },
-    "method_chain_complete": {
-      "ja": ["✅ メソッドチェーンによる処理が完了しました！"],
-      "en": ["✅ The method-chaining workflow is complete!"]
-    },
-    "spectrum_plot_title": {
-      "ja": ["元の信号とフィルタ後の信号のスペクトル"],
-      "en": ["Original and filtered signal spectrum"]
+    "spectrum_context": {
+      "ja": [
+        "元の信号とフィルタ後の信号のスペクトルを比較します。図内のタイトルと軸はASCII表記にして、説明はここで読みます。"
+      ],
+      "en": [
+        "Compare the original and filtered signal spectra. The figure uses ASCII labels; read the interpretation here."
+      ]
     },
     "troubleshooting_output": {
       "ja": [
@@ -467,41 +457,17 @@
         "1. marimo edit learning-path/01_getting_started.py で起動",
         "2. wandas[marimo,io,psychoacoustic] がインストールされているか確認",
         "3. ブラウザを再読み込みしてセルを再実行",
-        "現在のMatplotlibバックエンド: {backend}",
-        "✅ marimoバージョン: {version}"
+        "現在のMatplotlibバックエンド: [[backend]]",
+        "✅ marimoバージョン: [[version]]"
       ],
       "en": [
         "Troubleshooting marimo display:",
         "1. Start with marimo edit learning-path/01_getting_started.py",
         "2. Confirm that wandas[marimo,io,psychoacoustic] is installed",
         "3. Reload the browser and run the cell again",
-        "Current Matplotlib backend: {backend}",
-        "✅ marimo version: {version}"
+        "Current Matplotlib backend: [[backend]]",
+        "✅ marimo version: [[version]]"
       ]
-    },
-    "navigation.heading": {
-      "ja": ["📚 次のステップ"],
-      "en": ["📚 Next steps"]
-    },
-    "navigation.previous": {
-      "ja": ["前のmarimoアプリ"],
-      "en": ["Previous marimo app"]
-    },
-    "navigation.next": {
-      "ja": ["次のmarimoアプリ"],
-      "en": ["Next marimo app"]
-    },
-    "navigation.japanese_only": {
-      "ja": ["日本語のみ"],
-      "en": ["Japanese only"]
-    },
-    "language.ja": {
-      "ja": ["日本語"],
-      "en": ["Japanese"]
-    },
-    "language.en": {
-      "ja": ["English"],
-      "en": ["English"]
     }
   }
 }

--- a/learning-path/translations/01_getting_started.json
+++ b/learning-path/translations/01_getting_started.json
@@ -1,0 +1,507 @@
+{
+  "lesson": "01_getting_started",
+  "messages": {
+    "title": {
+      "ja": ["01 環境構築とウォームアップ"],
+      "en": ["01 Getting Started with Wandas"]
+    },
+    "intro": {
+      "ja": [
+        "## Wandasを動かしてみよう",
+        "",
+        "このmarimoアプリでは、Wandasをインストールし、基本的な環境設定を行って、最初の信号処理を体験します。",
+        "",
+        "**学習目標:**",
+        "- Wandasのインストールと環境設定",
+        "- marimo環境でのインタラクティブな操作",
+        "- 最初の信号生成と可視化",
+        "- 基本的な操作の習得",
+        "",
+        "**前提条件:**",
+        "- Python 3.10+（3.10以上）",
+        "- marimo環境"
+      ],
+      "en": [
+        "## Try Wandas",
+        "",
+        "In this marimo app, you will install Wandas, configure a basic environment, and run your first signal-processing workflow.",
+        "",
+        "**Learning goals:**",
+        "- Install Wandas and configure the environment",
+        "- Explore an interactive workflow in marimo",
+        "- Generate and visualize your first signal",
+        "- Learn the basic Wandas operations",
+        "",
+        "**Prerequisites:**",
+        "- Python 3.10 or later",
+        "- A working marimo environment"
+      ]
+    },
+    "why_environment": {
+      "ja": [
+        "## 🎯 なぜ環境構築が重要か",
+        "",
+        "### 信号処理のワークフロー",
+        "",
+        "信号処理の作業では、以下のようなサイクルを繰り返します：",
+        "",
+        "1. **データ収集** → 2. **前処理** → 3. **分析** → 4. **可視化** → 5. **解釈**",
+        "",
+        "このサイクルを効率的に回すためには、適切な環境設定が不可欠です。Wandasは、このワークフローを**1つの統合された環境**で実現します。",
+        "",
+        "### インタラクティブな探索の重要性",
+        "",
+        "信号処理では、**試行錯誤**が不可欠です：",
+        "- フィルタのパラメータを調整しながら効果を確認",
+        "- 異なる可視化方法を比較",
+        "- 処理結果をリアルタイムで評価",
+        "",
+        "marimo + Wandasの組み合わせで、これを可能にします。"
+      ],
+      "en": [
+        "## 🎯 Why the environment matters",
+        "",
+        "### The signal-processing workflow",
+        "",
+        "Signal-processing work follows a cycle like this:",
+        "",
+        "1. **Collect data** → 2. **Preprocess** → 3. **Analyze** → 4. **Visualize** → 5. **Interpret**",
+        "",
+        "A well-configured environment makes this cycle efficient. Wandas brings the workflow together in **one integrated environment**.",
+        "",
+        "### Why interactive exploration matters",
+        "",
+        "Signal processing depends on **experimentation**:",
+        "- Adjust filter parameters and inspect the effect",
+        "- Compare different visualizations",
+        "- Evaluate results as you work",
+        "",
+        "The combination of marimo and Wandas supports this workflow."
+      ]
+    },
+    "installation_pypi": {
+      "ja": [
+        "## 📦 インストール",
+        "",
+        "### 方法1: PyPIからインストール（推奨）",
+        "",
+        "最新の安定版をインストールします。"
+      ],
+      "en": [
+        "## 📦 Install Wandas",
+        "",
+        "### Option 1: Install from PyPI (recommended)",
+        "",
+        "Install the latest stable release."
+      ]
+    },
+    "installation_dev": {
+      "ja": [
+        "### 方法2: 開発環境の場合",
+        "",
+        "このリポジトリをクローンしている場合は："
+      ],
+      "en": [
+        "### Option 2: Use a development checkout",
+        "",
+        "If you have cloned this repository:"
+      ]
+    },
+    "installation_visualization": {
+      "ja": [
+        "### 可視化ライブラリのインストール",
+        "",
+        "marimo 表示と学習パス内の WDF/音響解析セルのために必要です。"
+      ],
+      "en": [
+        "### Install visualization dependencies",
+        "",
+        "These extras support marimo output and the WDF and acoustics examples in the Learning Path."
+      ]
+    },
+    "imports": {
+      "ja": [
+        "## 🔧 基本的なインポートと確認",
+        "",
+        "### 必要なライブラリのインポート"
+      ],
+      "en": [
+        "## 🔧 Import and verify the basics",
+        "",
+        "### Import the required libraries"
+      ]
+    },
+    "plot_config": {
+      "ja": [
+        "## 🎨 marimo環境の設定",
+        "",
+        "### プロット表示の設定",
+        "",
+        "信号処理では、**グラフを見ながら探索的に確認**することが重要です：",
+        "- 時間範囲や周波数範囲を絞って詳細を確認",
+        "- 複数の処理結果を並べて比較",
+        "- ラベルや凡例で注目点を確認",
+        "",
+        "この学習パスでは、marimo上でMatplotlibの静的な図を確認しながら進めます。"
+      ],
+      "en": [
+        "## 🎨 Configure the marimo environment",
+        "",
+        "### Configure plot display",
+        "",
+        "In signal processing, it is important to **inspect the graphs while exploring**:",
+        "- Zoom in on a time or frequency range",
+        "- Compare several processing results side by side",
+        "- Use labels and legends to focus on the important details",
+        "",
+        "In this Learning Path, you will inspect static Matplotlib figures in marimo as you go."
+      ]
+    },
+    "marimo_check": {
+      "ja": [
+        "### marimoの確認",
+        "",
+        "marimoアプリとして実行できる環境か確認します。"
+      ],
+      "en": [
+        "### Verify marimo",
+        "",
+        "Confirm that the environment can run a marimo app."
+      ]
+    },
+    "signal_generation": {
+      "ja": [
+        "## 🎵 最初の信号生成",
+        "",
+        "### なぜ信号生成から始めるのか",
+        "",
+        "実際のデータ分析に入る前に、**既知の信号を生成**することで：",
+        "- Wandasの基本操作を学ぶ",
+        "- 期待される結果を確認できる",
+        "- トラブルシューティングが容易",
+        "",
+        "これは信号処理の**「Hello, World!」**のようなものです。"
+      ],
+      "en": [
+        "## 🎵 Generate your first signal",
+        "",
+        "### Why start with a generated signal?",
+        "",
+        "Before analyzing real data, **generate a known signal** so that you can:",
+        "- Learn the basic Wandas operations",
+        "- Check the expected result",
+        "- Troubleshoot with a predictable input",
+        "",
+        "This is the signal-processing equivalent of **Hello, World!**."
+      ]
+    },
+    "visualization": {
+      "ja": [
+        "### 信号の可視化",
+        "",
+        "Wandasの最も強力な機能の一つが、**一つのメソッドで包括的な可視化**ができることです。"
+      ],
+      "en": [
+        "### Visualize the signal",
+        "",
+        "One of Wandas's most useful features is **comprehensive visualization from a single method**."
+      ]
+    },
+    "describe_result": {
+      "ja": [
+        "**🎉 `describe()`メソッドで:**",
+        "- **時間領域**: 波形の形状を確認",
+        "- **周波数領域**: スペクトル（周波数成分）を確認",
+        "- **時間周波数領域**: スペクトログラム（時間変化）を確認",
+        "",
+        "が一度に表示されました。"
+      ],
+      "en": [
+        "**🎉 With `describe()`:**",
+        "- **Time domain**: inspect the waveform shape",
+        "- **Frequency domain**: inspect the spectrum (frequency components)",
+        "- **Time-frequency domain**: inspect the spectrogram over time",
+        "",
+        "all three views are displayed together."
+      ]
+    },
+    "method_chain": {
+      "ja": [
+        "## 🔄 メソッドチェーンの体験",
+        "",
+        "### Wandasの核心機能",
+        "",
+        "Wandasの最大の特徴は、**メソッドチェーン**による直感的な処理です。",
+        "",
+        "これはpandasのようなAPIで、処理を**自然言語のように**連鎖できます。"
+      ],
+      "en": [
+        "## 🔄 Try method chaining",
+        "",
+        "### A core Wandas idea",
+        "",
+        "Wandas makes processing intuitive through **method chaining**.",
+        "",
+        "Like the pandas API, operations can be chained in a **readable sequence**."
+      ]
+    },
+    "interactive_experiment": {
+      "ja": [
+        "## 🎮 インタラクティブな実験",
+        "",
+        "### パラメータを変更して実験",
+        "",
+        "信号処理の面白さは、**パラメータを変更しながら結果を確認**できることです。",
+        "",
+        "以下のセルで、さまざまなパラメータを試してみましょう。"
+      ],
+      "en": [
+        "## 🎮 Run an interactive experiment",
+        "",
+        "### Experiment by changing parameters",
+        "",
+        "Signal processing becomes practical when you can **change parameters and inspect the result**.",
+        "",
+        "Try different values in the cells below."
+      ]
+    },
+    "troubleshooting": {
+      "ja": [
+        "## 🛠️ トラブルシューティング",
+        "",
+        "### よくある問題と解決法",
+        "",
+        "#### 1. marimoアプリが起動しない",
+        "```python",
+        "# 解決法",
+        "!pip install \"wandas[marimo,io,psychoacoustic]\" --upgrade",
+        "marimo edit learning-path/01_getting_started.py",
+        "```",
+        "",
+        "#### 2. バージョン互換性の問題",
+        "- Python 3.10+（3.10以上）を使用してください",
+        "- 最新版のWandasを使用してください",
+        "",
+        "#### 3. メモリ不足",
+        "- 時間を短くする",
+        "- サンプリングレートを下げる",
+        "",
+        "#### 4. プロットが表示されない",
+        "- `marimo edit learning-path/01_getting_started.py` で起動しているか確認",
+        "- ブラウザを再読み込みしてセルを再実行"
+      ],
+      "en": [
+        "## 🛠️ Troubleshooting",
+        "",
+        "### Common problems and solutions",
+        "",
+        "#### 1. The marimo app does not start",
+        "```python",
+        "# Upgrade the installation",
+        "!pip install \"wandas[marimo,io,psychoacoustic]\" --upgrade",
+        "marimo edit learning-path/01_getting_started.py",
+        "```",
+        "",
+        "#### 2. Version compatibility problems",
+        "- Use Python 3.10 or later",
+        "- Use the latest Wandas release",
+        "",
+        "#### 3. Not enough memory",
+        "- Shorten the signal duration",
+        "- Lower the sampling rate",
+        "",
+        "#### 4. The plot is not visible",
+        "- Confirm that you started `marimo edit learning-path/01_getting_started.py`",
+        "- Reload the browser and run the cell again"
+      ]
+    },
+    "s3": {
+      "ja": [
+        "## ☁️ S3からWAVを読み込む",
+        "",
+        "S3から取得したバイト列をそのまま`wd.read()`に渡せます。",
+        "ファイル保存は不要です。"
+      ],
+      "en": [
+        "## ☁️ Read a WAV file from S3",
+        "",
+        "Bytes retrieved from S3 can be passed directly to `wd.read()`.",
+        "No temporary file is required."
+      ]
+    },
+    "next_steps": {
+      "ja": [
+        "## 📚 次のステップ",
+        "",
+        "環境構築と基本操作が完了しました！",
+        "",
+        "ここでは、実際のデータファイル（WAV, CSVなど）を読み込んで、Wandasのデータ構造について紹介します。",
+        "",
+        "### 🎯 これまでに学んだこと",
+        "- ✅ Wandasのインストールと環境設定",
+        "- ✅ インタラクティブなmarimo環境の構築",
+        "- ✅ 信号生成と基本的な可視化",
+        "- ✅ メソッドチェーンによる直感的な処理",
+        "- ✅ パラメータ変更による実験",
+        "",
+        "### 🚀 次の学習目標",
+        "- 実際のデータファイルの読み込み",
+        "- ChannelFrameデータ構造の理解",
+        "- チャンネル操作とインデックスアクセス",
+        "- メタデータの管理",
+        "",
+        "---",
+        "",
+        "**準備はできましたか？次のmarimoアプリへ進みましょう！** 🎵"
+      ],
+      "en": [
+        "## 📚 Next steps",
+        "",
+        "You have completed the environment setup and the basic workflow.",
+        "",
+        "Next, load real data files such as WAV and CSV files and learn how Wandas represents the data.",
+        "",
+        "### 🎯 What you learned",
+        "- ✅ Install Wandas and configure the environment",
+        "- ✅ Set up an interactive marimo environment",
+        "- ✅ Generate signals and create basic visualizations",
+        "- ✅ Process signals with readable method chains",
+        "- ✅ Experiment by changing parameters",
+        "",
+        "### 🚀 Next learning goals",
+        "- Load real data files",
+        "- Understand the `ChannelFrame` data structure",
+        "- Select channels and use index access",
+        "- Manage metadata",
+        "",
+        "---",
+        "",
+        "**Ready to continue? Open the next marimo app.** 🎵"
+      ]
+    },
+    "install_recommended": {
+      "ja": ["Wandas learning path の推奨インストールコマンド:"],
+      "en": ["Recommended installation command for the Wandas Learning Path:"]
+    },
+    "development_install": {
+      "ja": ["開発インストールコマンド:"],
+      "en": ["Development installation command:"]
+    },
+    "visualization_install": {
+      "ja": ["marimo環境のインストール:"],
+      "en": ["Install the marimo extras:"]
+    },
+    "library_versions": {
+      "ja": [
+        "Wandas: {wandas}",
+        "NumPy: {numpy}",
+        "Matplotlib: {matplotlib}"
+      ],
+      "en": [
+        "Wandas: {wandas}",
+        "NumPy: {numpy}",
+        "Matplotlib: {matplotlib}"
+      ]
+    },
+    "libraries_ready": {
+      "ja": ["✅ すべてのライブラリが正常にインポートされました！"],
+      "en": ["✅ All libraries were imported successfully!"]
+    },
+    "plot_configuration_complete": {
+      "ja": [
+        "✅ プロット表示の設定が完了しました！",
+        "",
+        "グラフ表示:",
+        "- 図は marimo のセル出力として表示されます",
+        "- 必要に応じて plot() の xlim/ylim などで表示範囲を調整します",
+        "- 比較したい結果は複数セルや複数軸に並べて確認します"
+      ],
+      "en": [
+        "✅ Plot display is configured.",
+        "",
+        "Working with graphs:",
+        "- Figures appear as marimo cell outputs",
+        "- Adjust the display range with plot() options such as xlim and ylim",
+        "- Compare results across cells or axes"
+      ]
+    },
+    "marimo_available": {
+      "ja": [
+        "✅ marimo: {version} - marimoアプリとして実行できます",
+        "   起動例: marimo edit learning-path/01_getting_started.py"
+      ],
+      "en": [
+        "✅ marimo: {version} - the environment can run a marimo app",
+        "   Example: marimo edit learning-path/01_getting_started.py"
+      ]
+    },
+    "signal_info": {
+      "ja": [
+        "生成された信号の情報:",
+        "  チャンネル数: {channels}",
+        "  サンプリングレート: {sampling_rate} Hz",
+        "  長さ: {duration} 秒",
+        "  サンプル数: {samples}",
+        "  チャンネル名: {labels}"
+      ],
+      "en": [
+        "Generated signal:",
+        "  Channels: {channels}",
+        "  Sampling rate: {sampling_rate} Hz",
+        "  Duration: {duration} seconds",
+        "  Samples: {samples}",
+        "  Channel labels: {labels}"
+      ]
+    },
+    "method_chain_complete": {
+      "ja": ["✅ メソッドチェーンによる処理が完了しました！"],
+      "en": ["✅ The method-chaining workflow is complete!"]
+    },
+    "spectrum_plot_title": {
+      "ja": ["元の信号とフィルタ後の信号のスペクトル"],
+      "en": ["Original and filtered signal spectrum"]
+    },
+    "troubleshooting_output": {
+      "ja": [
+        "marimo表示のトラブルシューティング:",
+        "1. marimo edit learning-path/01_getting_started.py で起動",
+        "2. wandas[marimo,io,psychoacoustic] がインストールされているか確認",
+        "3. ブラウザを再読み込みしてセルを再実行",
+        "現在のMatplotlibバックエンド: {backend}",
+        "✅ marimoバージョン: {version}"
+      ],
+      "en": [
+        "Troubleshooting marimo display:",
+        "1. Start with marimo edit learning-path/01_getting_started.py",
+        "2. Confirm that wandas[marimo,io,psychoacoustic] is installed",
+        "3. Reload the browser and run the cell again",
+        "Current Matplotlib backend: {backend}",
+        "✅ marimo version: {version}"
+      ]
+    },
+    "navigation.heading": {
+      "ja": ["📚 次のステップ"],
+      "en": ["📚 Next steps"]
+    },
+    "navigation.previous": {
+      "ja": ["前のmarimoアプリ"],
+      "en": ["Previous marimo app"]
+    },
+    "navigation.next": {
+      "ja": ["次のmarimoアプリ"],
+      "en": ["Next marimo app"]
+    },
+    "navigation.japanese_only": {
+      "ja": ["日本語のみ"],
+      "en": ["Japanese only"]
+    },
+    "language.ja": {
+      "ja": ["日本語"],
+      "en": ["Japanese"]
+    },
+    "language.en": {
+      "ja": ["English"],
+      "en": ["English"]
+    }
+  }
+}

--- a/learning-path/translations/06_reusable_pipeline_recipes.json
+++ b/learning-path/translations/06_reusable_pipeline_recipes.json
@@ -1,0 +1,234 @@
+{
+  "lesson": "06_reusable_pipeline_recipes",
+  "messages": {
+    "title": {
+      "ja": ["同じ信号処理をRecipeとして再利用する"],
+      "en": ["Reuse the same signal processing as a Recipe"]
+    },
+    "intro": {
+      "ja": [
+        "複数の録音へ同じ前処理を適用するとき、メソッドチェーンを各所へコピーすると、",
+        "パラメータ変更や処理順の確認が難しくなります。`RecipePlan` は、通常のFrame操作から",
+        "「どの公開操作を、どの順番とパラメータで適用するか」を取り出します。",
+        "",
+        "Recipeは波形データそのものを保存しません。別のFrameを名前付き入力として渡すと、",
+        "同じ処理をlazyなFrameグラフとして組み立て直します。",
+        "",
+        "この教材では次を確認します。",
+        "",
+        "1. 通常のFrame操作からRecipeを作る",
+        "2. JSONとして保存できるschemaへ変換し、読み戻す",
+        "3. 別のFrameへ適用し、直接呼び出した結果と一致することを確かめる",
+        "4. 複数Frameを使う処理でも入力名が明示されることを確かめる"
+      ],
+      "en": [
+        "When the same preprocessing is applied to several recordings, copying a method chain makes parameter changes and operation order difficult to review. `RecipePlan` extracts",
+        "which public operations should run, in what order, and with which parameters, from ordinary Frame operations.",
+        "",
+        "A Recipe does not store waveform data. Give it another Frame as a named input and it rebuilds the same processing as a lazy Frame graph.",
+        "",
+        "In this lesson you will:",
+        "",
+        "1. Create a Recipe from ordinary Frame operations",
+        "2. Convert it to a JSON-compatible schema and load it again",
+        "3. Apply it to another Frame and verify that it matches a direct call",
+        "4. Verify that operations using several Frames keep their input names explicit"
+      ]
+    },
+    "record_frame": {
+      "ja": [
+        "## 1. 普通のFrame操作を記録する",
+        "",
+        "Recipe専用のbuilderは使いません。代表入力に対して、再利用したい公開Frame操作を",
+        "そのまま呼び出します。ここではDC成分を除き、振幅を正規化します。"
+      ],
+      "en": [
+        "## 1. Record ordinary Frame operations",
+        "",
+        "There is no Recipe-specific builder here. Call the public Frame operations you want to reuse",
+        "directly on a representative input. This example removes the DC component and normalizes the amplitude."
+      ]
+    },
+    "lineage_explanation": {
+      "ja": [
+        "`RecipePlan.from_frame()` は結果Frameのsemantic lineageを読みます。公開操作1回が",
+        "Recipe node 1件になり、元のサンプル値はplanへ入りません。`input_names` は、あとで",
+        "runtime dataを渡すための名前です。"
+      ],
+      "en": [
+        "`RecipePlan.from_frame()` reads the semantic lineage of the result Frame. Each public operation",
+        "becomes one Recipe node, while the original sample values stay out of the plan. `input_names`",
+        "are the names used to provide runtime data later."
+      ]
+    },
+    "recipe_schema": {
+      "ja": [
+        "## 2. JSONで保存できる形へ変換する",
+        "",
+        "`to_dict()` の結果はschema version付きのJSON-compatible valueです。",
+        "payloadはliveなPython operation objectを保存せず、stable operation IDを保持します。",
+        "`RecipePlan.from_dict()` はIDをbuilt-in registryで解決し、未知のfield、operation、version、",
+        "不正なgraphを拒否します。extensionではextract/load/applyに同じregistryを渡します。"
+      ],
+      "en": [
+        "## 2. Convert to a JSON-compatible form",
+        "",
+        "`to_dict()` returns a JSON-compatible value with a schema version.",
+        "The payload stores stable operation IDs instead of live Python operation objects.",
+        "`RecipePlan.from_dict()` resolves those IDs through the built-in registry and rejects unknown",
+        "fields, operations, or versions and invalid graphs. Extensions pass the same registry to extract,",
+        "load, and apply."
+      ]
+    },
+    "recipe_table": {
+      "ja": [
+        "| Recipeの確認項目 | 値 |",
+        "| --- | --- |",
+        "| 入力名 | `{input_name}` |",
+        "| ノード数 | `{node_count}` |",
+        "| 操作ID | `{operations}` |"
+      ],
+      "en": [
+        "| Recipe check | Value |",
+        "| --- | --- |",
+        "| Input name | `{input_name}` |",
+        "| Node count | `{node_count}` |",
+        "| Operation IDs | `{operations}` |"
+      ]
+    },
+    "json_round_trip": {
+      "ja": [
+        "## 3. 別のFrameへ適用する",
+        "",
+        "planに記録されるのは操作intentです。サンプル、metadata、label、sampling rateは",
+        "`apply()` へ渡すruntime Frameが所有します。`apply()` 自体はlazy graphを作るだけで、",
+        "このセルでは検証のため最後に `frame.data` からNumPy値を取得します。"
+      ],
+      "en": [
+        "## 3. Apply the plan to another Frame",
+        "",
+        "The plan records operation intent. The runtime Frame passed to `apply()` owns the samples, metadata,",
+        "labels, and sampling rate. `apply()` only builds a lazy graph; this cell reads `frame.data` at the end",
+        "to verify the result with NumPy values."
+      ]
+    },
+    "multiple_inputs": {
+      "ja": [
+        "## 4. 複数入力も名前で区別する",
+        "",
+        "Frame同士の演算、`mix()`、NumPy/Dask operandは、追加のruntime inputになります。",
+        "値やNumPy/Daskというcontainer種別はschemaへ埋め込まれません。",
+        "",
+        "次の例では `base` と `other` を明示し、別の2つのFrameへmix Recipeを適用します。",
+        "`mix()` はsource timeではなく現在のarray indexで信号を重ねます。"
+      ],
+      "en": [
+        "## 4. Name multiple inputs explicitly",
+        "",
+        "Frame-to-Frame operations, `mix()`, and NumPy/Dask operands become additional runtime inputs.",
+        "The values and the NumPy/Dask container type are not embedded in the schema.",
+        "",
+        "The next example names `base` and `other` explicitly and applies a mix Recipe to a different pair of Frames.",
+        "`mix()` overlays signals by their current array index rather than by source time."
+      ]
+    },
+    "summary": {
+      "ja": [
+        "## まとめ",
+        "",
+        "- いつもどおりFrameメソッドを呼び、結果から`RecipePlan`を作る",
+        "- Recipeは操作intentとgraphだけを持ち、波形やDask graphを保存しない",
+        "- 実行時のoperation behaviorはstable IDに対応するregistry handlerが供給する",
+        "- `to_dict()` / `from_dict()` でstrictなschemaを往復する",
+        "- `apply()` では抽出時に決めた名前でruntime inputを渡す",
+        "- replay後もruntime Frameのmetadataを保持し、入力Frameは変更しない",
+        "- 任意の`Frame.apply(callable)`はruntime-onlyで、portable Recipeにはならない",
+        "",
+        "詳細な入力形状と制約は [RecipePlan how-to]({how_to_href}) を、API signatureは",
+        "[Pipeline API reference]({api_href}) を参照してください。"
+      ],
+      "en": [
+        "## Summary",
+        "",
+        "- Call Frame methods as usual, then create a `RecipePlan` from the result",
+        "- A Recipe stores operation intent and a graph, not waveform data or a Dask graph",
+        "- A registry handler for each stable ID supplies the runtime operation behavior",
+        "- Round-trip a strict schema with `to_dict()` / `from_dict()`",
+        "- Provide runtime inputs using the names chosen during extraction",
+        "- Replay preserves runtime Frame metadata and does not mutate the input Frame",
+        "- An arbitrary `Frame.apply(callable)` is runtime-only and cannot become a portable Recipe",
+        "",
+        "See the [RecipePlan how-to]({how_to_href}) for input shapes and constraints, and the",
+        "[Pipeline API reference]({api_href}) for API signatures."
+      ]
+    },
+    "template_history": {
+      "ja": ["代表入力の履歴: {operations}"],
+      "en": ["Representative input history: {operations}"]
+    },
+    "recipe_inputs": {
+      "ja": ["入力名: {input_name}"],
+      "en": ["Input name: {input_name}"]
+    },
+    "recipe_operations": {
+      "ja": ["Recipe operations: {operations}"],
+      "en": ["Recipe operations: {operations}"]
+    },
+    "schema_info": {
+      "ja": [
+        "Schema: {schema} {version}",
+        "JSON size: {size} bytes"
+      ],
+      "en": [
+        "Schema: {schema} {version}",
+        "JSON size: {size} bytes"
+      ]
+    },
+    "direct_result": {
+      "ja": [
+        "直接呼び出しと一致: yes",
+        "runtime metadata: {metadata}",
+        "元のruntime Frameの履歴: {history}"
+      ],
+      "en": [
+        "Matches the direct call: yes",
+        "Runtime metadata: {metadata}",
+        "Original runtime Frame history: {history}"
+      ]
+    },
+    "mix_result": {
+      "ja": [
+        "mix入力: {inputs}",
+        "replay結果: {values}"
+      ],
+      "en": [
+        "Mix inputs: {inputs}",
+        "Replay result: {values}"
+      ]
+    },
+    "navigation.heading": {
+      "ja": ["次のステップ"],
+      "en": ["Next steps"]
+    },
+    "navigation.previous": {
+      "ja": ["前のmarimoアプリ"],
+      "en": ["Previous marimo app"]
+    },
+    "navigation.next": {
+      "ja": ["次のmarimoアプリ"],
+      "en": ["Next marimo app"]
+    },
+    "navigation.japanese_only": {
+      "ja": ["日本語のみ"],
+      "en": ["Japanese only"]
+    },
+    "language.ja": {
+      "ja": ["日本語"],
+      "en": ["Japanese"]
+    },
+    "language.en": {
+      "ja": ["English"],
+      "en": ["English"]
+    }
+  }
+}

--- a/learning-path/translations/06_reusable_pipeline_recipes.json
+++ b/learning-path/translations/06_reusable_pipeline_recipes.json
@@ -84,16 +84,16 @@
       "ja": [
         "| Recipeの確認項目 | 値 |",
         "| --- | --- |",
-        "| 入力名 | `{input_name}` |",
-        "| ノード数 | `{node_count}` |",
-        "| 操作ID | `{operations}` |"
+        "| 入力名 | `[[input_name]]` |",
+        "| ノード数 | `[[node_count]]` |",
+        "| 操作ID | `[[operations]]` |"
       ],
       "en": [
         "| Recipe check | Value |",
         "| --- | --- |",
-        "| Input name | `{input_name}` |",
-        "| Node count | `{node_count}` |",
-        "| Operation IDs | `{operations}` |"
+        "| Input name | `[[input_name]]` |",
+        "| Node count | `[[node_count]]` |",
+        "| Operation IDs | `[[operations]]` |"
       ]
     },
     "json_round_trip": {
@@ -144,8 +144,7 @@
         "- replay後もruntime Frameのmetadataを保持し、入力Frameは変更しない",
         "- 任意の`Frame.apply(callable)`はruntime-onlyで、portable Recipeにはならない",
         "",
-        "詳細な入力形状と制約は [RecipePlan how-to]({how_to_href}) を、API signatureは",
-        "[Pipeline API reference]({api_href}) を参照してください。"
+        "詳細な入力形状と制約は [[how_to_link]] を、API signatureは [[api_link]] を参照してください。"
       ],
       "en": [
         "## Summary",
@@ -158,77 +157,44 @@
         "- Replay preserves runtime Frame metadata and does not mutate the input Frame",
         "- An arbitrary `Frame.apply(callable)` is runtime-only and cannot become a portable Recipe",
         "",
-        "See the [RecipePlan how-to]({how_to_href}) for input shapes and constraints, and the",
-        "[Pipeline API reference]({api_href}) for API signatures."
+        "See [[how_to_link]] for input shapes and constraints, and [[api_link]] for API signatures."
       ]
     },
     "template_history": {
-      "ja": ["代表入力の履歴: {operations}"],
-      "en": ["Representative input history: {operations}"]
-    },
-    "recipe_inputs": {
-      "ja": ["入力名: {input_name}"],
-      "en": ["Input name: {input_name}"]
-    },
-    "recipe_operations": {
-      "ja": ["Recipe operations: {operations}"],
-      "en": ["Recipe operations: {operations}"]
+      "ja": ["代表入力の履歴: [[operations]]"],
+      "en": ["Representative input history: [[operations]]"]
     },
     "schema_info": {
       "ja": [
-        "Schema: {schema} {version}",
-        "JSON size: {size} bytes"
+        "Schema: [[schema]] [[version]]",
+        "JSON size: [[size]] bytes"
       ],
       "en": [
-        "Schema: {schema} {version}",
-        "JSON size: {size} bytes"
+        "Schema: [[schema]] [[version]]",
+        "JSON size: [[size]] bytes"
       ]
     },
     "direct_result": {
       "ja": [
         "直接呼び出しと一致: yes",
-        "runtime metadata: {metadata}",
-        "元のruntime Frameの履歴: {history}"
+        "runtime metadata: [[metadata]]",
+        "元のruntime Frameの履歴: [[history]]"
       ],
       "en": [
         "Matches the direct call: yes",
-        "Runtime metadata: {metadata}",
-        "Original runtime Frame history: {history}"
+        "Runtime metadata: [[metadata]]",
+        "Original runtime Frame history: [[history]]"
       ]
     },
     "mix_result": {
       "ja": [
-        "mix入力: {inputs}",
-        "replay結果: {values}"
+        "mix入力: [[inputs]]",
+        "replay結果: [[values]]"
       ],
       "en": [
-        "Mix inputs: {inputs}",
-        "Replay result: {values}"
+        "Mix inputs: [[inputs]]",
+        "Replay result: [[values]]"
       ]
-    },
-    "navigation.heading": {
-      "ja": ["次のステップ"],
-      "en": ["Next steps"]
-    },
-    "navigation.previous": {
-      "ja": ["前のmarimoアプリ"],
-      "en": ["Previous marimo app"]
-    },
-    "navigation.next": {
-      "ja": ["次のmarimoアプリ"],
-      "en": ["Next marimo app"]
-    },
-    "navigation.japanese_only": {
-      "ja": ["日本語のみ"],
-      "en": ["Japanese only"]
-    },
-    "language.ja": {
-      "ja": ["日本語"],
-      "en": ["Japanese"]
-    },
-    "language.en": {
-      "ja": ["English"],
-      "en": ["English"]
     }
   }
 }

--- a/learning-path/translations/common.json
+++ b/learning-path/translations/common.json
@@ -1,0 +1,29 @@
+{
+  "catalog": "common",
+  "messages": {
+    "navigation.heading": {
+      "ja": ["教材間の移動"],
+      "en": ["Navigate between lessons"]
+    },
+    "navigation.previous": {
+      "ja": ["前の教材"],
+      "en": ["Previous lesson"]
+    },
+    "navigation.next": {
+      "ja": ["次の教材"],
+      "en": ["Next lesson"]
+    },
+    "navigation.japanese_only": {
+      "ja": ["日本語のみ"],
+      "en": ["Japanese only"]
+    },
+    "language.ja": {
+      "ja": ["日本語"],
+      "en": ["Japanese"]
+    },
+    "language.en": {
+      "ja": ["English"],
+      "en": ["English"]
+    }
+  }
+}

--- a/scripts/export_learning_path.py
+++ b/scripts/export_learning_path.py
@@ -1,29 +1,36 @@
-"""Export the Learning Path through one manifest-driven command."""
+"""Plan and export Learning Path HTML through one manifest-driven command."""
 
 from __future__ import annotations
 
 import argparse
+import shlex
 import subprocess
 import sys
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 try:
-    from .learning_path_i18n import REPO_ROOT, LearningPathI18nError, Lesson, load_manifest, output_path, poc_lessons
-except ImportError:  # Running this file directly keeps the existing `python scripts/foo.py` workflow.
-    from learning_path_i18n import REPO_ROOT, LearningPathI18nError, Lesson, load_manifest, output_path, poc_lessons
-
-
-@dataclass(frozen=True)
-class ExportTarget:
-    lesson: Lesson
-    locale: str
-    output_root: Path
-
-    @property
-    def output_path(self) -> Path:
-        return output_path(self.output_root, self.lesson, self.locale)
+    from .learning_path_i18n import (
+        REPO_ROOT,
+        SUPPORTED_LOCALES,
+        ExportPlanItem,
+        LearningPathI18nError,
+        Lesson,
+        build_export_plan,
+        load_manifest,
+        poc_lessons,
+    )
+except ImportError:  # Running this file directly keeps the existing python scripts/foo.py workflow.
+    from learning_path_i18n import (
+        REPO_ROOT,
+        SUPPORTED_LOCALES,
+        ExportPlanItem,
+        LearningPathI18nError,
+        Lesson,
+        build_export_plan,
+        load_manifest,
+        poc_lessons,
+    )
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -32,16 +39,19 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     selection.add_argument("--all", action="store_true", help="export every lesson in every available locale")
     selection.add_argument("--poc", action="store_true", help="export the two manifest entries marked for the PoC")
     selection.add_argument("--lesson", help="export one lesson by manifest id")
-    parser.add_argument("--locale", choices=("ja", "en"), help="export only this locale")
+    parser.add_argument("--locale", choices=SUPPORTED_LOCALES, help="export only this locale")
     parser.add_argument("--output", type=Path, default=Path("docs/site"), help="site output directory")
-    parser.add_argument("--jobs", type=int, default=2, help="number of marimo exports to run concurrently")
+    parser.add_argument("--jobs", type=int, default=1, help="number of marimo exports to run concurrently")
+    parser.add_argument("--dry-run", action="store_true", help="print the deterministic plan without exporting")
     args = parser.parse_args(argv)
     if args.jobs < 1:
         parser.error("--jobs must be at least 1")
     return args
 
 
-def _select_lessons(args: argparse.Namespace) -> tuple[Lesson, ...]:
+def select_lessons(args: argparse.Namespace) -> tuple[Lesson, ...]:
+    """Select lessons without changing their manifest order."""
+
     lessons = load_manifest()
     if args.poc:
         selected = poc_lessons()
@@ -59,18 +69,15 @@ def _select_lessons(args: argparse.Namespace) -> tuple[Lesson, ...]:
     return selected
 
 
-def _targets(args: argparse.Namespace) -> tuple[ExportTarget, ...]:
-    output_root = args.output.resolve()
-    targets = []
-    for lesson in _select_lessons(args):
-        locales = (args.locale,) if args.locale is not None else lesson.locales
-        for locale in locales:
-            targets.append(ExportTarget(lesson=lesson, locale=locale, output_root=output_root))
-    return tuple(targets)
+def export_plan(args: argparse.Namespace) -> tuple[ExportPlanItem, ...]:
+    """Return a deterministic export plan for parsed CLI arguments."""
+
+    return build_export_plan(select_lessons(args), args.output.resolve())
 
 
-def _export(target: ExportTarget) -> None:
-    target.output_path.parent.mkdir(parents=True, exist_ok=True)
+def marimo_export_command(target: ExportPlanItem) -> tuple[str, ...]:
+    """Build the exact public marimo command for one plan item."""
+
     command = [
         sys.executable,
         "-m",
@@ -81,12 +88,16 @@ def _export(target: ExportTarget) -> None:
         "-o",
         str(target.output_path),
         "-f",
-        "--",
-        "--locale",
-        target.locale,
     ]
+    if target.pass_locale:
+        command.extend(("--", "--locale", target.locale))
+    return tuple(command)
+
+
+def _export(target: ExportPlanItem) -> None:
+    target.output_path.parent.mkdir(parents=True, exist_ok=True)
     completed = subprocess.run(
-        command,
+        marimo_export_command(target),
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
@@ -102,16 +113,27 @@ def _export(target: ExportTarget) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
-    targets = _targets(args)
+    targets = export_plan(args)
     print(f"Exporting {len(targets)} Learning Path page(s) to {args.output.resolve()}")
 
-    failures: list[str] = []
+    if args.dry_run:
+        for target in targets:
+            print(f"  {target.lesson.lesson_id} [{target.locale}] -> {target.output_path}")
+            print(f"    {shlex.join(marimo_export_command(target))}")
+        return 0
+
+    if not targets:
+        return 0
+
+    futures = {}
     with ThreadPoolExecutor(max_workers=min(args.jobs, len(targets))) as executor:
-        futures = {executor.submit(_export, target): target for target in targets}
-        for future in as_completed(futures):
-            target = futures[future]
+        for target in targets:
+            futures[target] = executor.submit(_export, target)
+
+        failures: list[str] = []
+        for target in targets:
             try:
-                future.result()
+                futures[target].result()
             except Exception as exc:  # noqa: BLE001 - preserve lesson and locale context for CI.
                 failures.append(str(exc))
             else:

--- a/scripts/export_learning_path.py
+++ b/scripts/export_learning_path.py
@@ -72,7 +72,7 @@ def select_lessons(args: argparse.Namespace) -> tuple[Lesson, ...]:
 def export_plan(args: argparse.Namespace) -> tuple[ExportPlanItem, ...]:
     """Return a deterministic export plan for parsed CLI arguments."""
 
-    return build_export_plan(select_lessons(args), args.output.resolve())
+    return build_export_plan(select_lessons(args), args.output.resolve(), locale=args.locale)
 
 
 def marimo_export_command(target: ExportPlanItem) -> tuple[str, ...]:

--- a/scripts/export_learning_path.py
+++ b/scripts/export_learning_path.py
@@ -1,0 +1,129 @@
+"""Export the Learning Path through one manifest-driven command."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from .learning_path_i18n import REPO_ROOT, LearningPathI18nError, Lesson, load_manifest, output_path, poc_lessons
+except ImportError:  # Running this file directly keeps the existing `python scripts/foo.py` workflow.
+    from learning_path_i18n import REPO_ROOT, LearningPathI18nError, Lesson, load_manifest, output_path, poc_lessons
+
+
+@dataclass(frozen=True)
+class ExportTarget:
+    lesson: Lesson
+    locale: str
+    output_root: Path
+
+    @property
+    def output_path(self) -> Path:
+        return output_path(self.output_root, self.lesson, self.locale)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    selection = parser.add_mutually_exclusive_group(required=True)
+    selection.add_argument("--all", action="store_true", help="export every lesson in every available locale")
+    selection.add_argument("--poc", action="store_true", help="export the two manifest entries marked for the PoC")
+    selection.add_argument("--lesson", help="export one lesson by manifest id")
+    parser.add_argument("--locale", choices=("ja", "en"), help="export only this locale")
+    parser.add_argument("--output", type=Path, default=Path("docs/site"), help="site output directory")
+    parser.add_argument("--jobs", type=int, default=2, help="number of marimo exports to run concurrently")
+    args = parser.parse_args(argv)
+    if args.jobs < 1:
+        parser.error("--jobs must be at least 1")
+    return args
+
+
+def _select_lessons(args: argparse.Namespace) -> tuple[Lesson, ...]:
+    lessons = load_manifest()
+    if args.poc:
+        selected = poc_lessons()
+    elif args.lesson:
+        selected = tuple(lesson for lesson in lessons if lesson.lesson_id == args.lesson)
+        if not selected:
+            raise LearningPathI18nError(f"Unknown lesson id: {args.lesson}")
+    else:
+        selected = lessons
+
+    if args.locale is not None:
+        selected = tuple(lesson for lesson in selected if args.locale in lesson.locales)
+        if not selected:
+            raise LearningPathI18nError(f"No selected lesson is available in locale {args.locale!r}")
+    return selected
+
+
+def _targets(args: argparse.Namespace) -> tuple[ExportTarget, ...]:
+    output_root = args.output.resolve()
+    targets = []
+    for lesson in _select_lessons(args):
+        locales = (args.locale,) if args.locale is not None else lesson.locales
+        for locale in locales:
+            targets.append(ExportTarget(lesson=lesson, locale=locale, output_root=output_root))
+    return tuple(targets)
+
+
+def _export(target: ExportTarget) -> None:
+    target.output_path.parent.mkdir(parents=True, exist_ok=True)
+    command = [
+        sys.executable,
+        "-m",
+        "marimo",
+        "export",
+        "html",
+        str(target.lesson.source_path),
+        "-o",
+        str(target.output_path),
+        "-f",
+        "--",
+        "--locale",
+        target.locale,
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        details = (completed.stdout + completed.stderr).strip()
+        raise RuntimeError(
+            f"marimo export failed for {target.lesson.lesson_id} ({target.locale}) "
+            f"with exit code {completed.returncode}:\n{details}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    targets = _targets(args)
+    print(f"Exporting {len(targets)} Learning Path page(s) to {args.output.resolve()}")
+
+    failures: list[str] = []
+    with ThreadPoolExecutor(max_workers=min(args.jobs, len(targets))) as executor:
+        futures = {executor.submit(_export, target): target for target in targets}
+        for future in as_completed(futures):
+            target = futures[future]
+            try:
+                future.result()
+            except Exception as exc:  # noqa: BLE001 - preserve lesson and locale context for CI.
+                failures.append(str(exc))
+            else:
+                print(f"  {target.lesson.lesson_id} [{target.locale}] -> {target.output_path}")
+
+    if failures:
+        print("Learning Path export failed:", file=sys.stderr)
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/learning_path_i18n.py
+++ b/scripts/learning_path_i18n.py
@@ -1,0 +1,413 @@
+"""Shared metadata and translation helpers for the Learning Path.
+
+The notebooks import this module at runtime, while the export and validation
+scripts use it to resolve the same lesson manifest and locale paths.  The
+module intentionally uses only the Python standard library so that opening a
+lesson locally does not add a translation-specific dependency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import posixpath
+import sys
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from string import Formatter
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LEARNING_PATH_ROOT = REPO_ROOT / "learning-path"
+MANIFEST_PATH = LEARNING_PATH_ROOT / "manifest.json"
+CATALOG_ROOT = LEARNING_PATH_ROOT / "translations"
+SUPPORTED_LOCALES = ("ja", "en")
+DEFAULT_LOCALE = "ja"
+
+# These keys are used by ``navigation_markdown`` rather than by a notebook's
+# direct ``t("...")`` calls.  Including them in the validator's used-key set
+# keeps unused-key detection honest without asking authors to duplicate
+# navigation text in every notebook.
+NAVIGATION_KEYS = frozenset(
+    {
+        "navigation.heading",
+        "navigation.previous",
+        "navigation.next",
+        "navigation.japanese_only",
+        "language.ja",
+        "language.en",
+    }
+)
+
+
+class LearningPathI18nError(ValueError):
+    """Raised when Learning Path metadata or translations are invalid."""
+
+
+@dataclass(frozen=True)
+class Lesson:
+    """A lesson entry from the central Learning Path manifest."""
+
+    lesson_id: str
+    source: str
+    locales: tuple[str, ...]
+    previous: str | None
+    next: str | None
+    catalog: str | None
+    poc: bool
+
+    @property
+    def source_path(self) -> Path:
+        return REPO_ROOT / self.source
+
+    @property
+    def catalog_path(self) -> Path | None:
+        if self.catalog is None:
+            return None
+        return CATALOG_ROOT / self.catalog
+
+
+@dataclass(frozen=True)
+class TranslationCatalog:
+    """A line-oriented JSON catalog for one lesson."""
+
+    lesson_id: str
+    messages: Mapping[str, Mapping[str, tuple[str, ...]]]
+    locale: str = DEFAULT_LOCALE
+
+    def text(self, key: str, **values: object) -> str:
+        """Return a translated message, formatting only declared placeholders."""
+
+        try:
+            localized = self.messages[key]
+        except KeyError as exc:
+            raise LearningPathI18nError(f"Unknown translation key {key!r} for {self.lesson_id}") from exc
+
+        locale = self.locale
+        try:
+            lines = localized[locale]
+        except KeyError as exc:
+            raise LearningPathI18nError(f"Missing locale {locale!r} for key {key!r}") from exc
+
+        try:
+            return "\n".join(line.format(**values) for line in lines)
+        except KeyError as exc:
+            raise LearningPathI18nError(
+                f"Missing placeholder {exc.args[0]!r} while rendering {self.lesson_id}:{key}"
+            ) from exc
+        except ValueError as exc:
+            raise LearningPathI18nError(f"Invalid placeholder syntax in {self.lesson_id}:{key}") from exc
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise LearningPathI18nError(f"Missing Learning Path metadata file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise LearningPathI18nError(f"Invalid JSON in {path}: {exc}") from exc
+
+
+def load_manifest() -> tuple[Lesson, ...]:
+    """Load and validate the central lesson manifest."""
+
+    raw = _read_json(MANIFEST_PATH)
+    if not isinstance(raw, dict) or not isinstance(raw.get("lessons"), list):
+        raise LearningPathI18nError("manifest.json must contain a lessons array")
+
+    manifest_locales = raw.get("locales")
+    if not isinstance(manifest_locales, dict) or set(manifest_locales) != set(SUPPORTED_LOCALES):
+        raise LearningPathI18nError("manifest.json locales must be exactly ja and en")
+    if raw.get("default_locale") != DEFAULT_LOCALE:
+        raise LearningPathI18nError(f"manifest.json default_locale must be {DEFAULT_LOCALE!r}")
+
+    lessons: list[Lesson] = []
+    ids: set[str] = set()
+    for raw_lesson in raw["lessons"]:
+        if not isinstance(raw_lesson, dict):
+            raise LearningPathI18nError("Every manifest lesson must be an object")
+
+        lesson_id = raw_lesson.get("id")
+        source = raw_lesson.get("source")
+        locales = raw_lesson.get("locales")
+        if not isinstance(lesson_id, str) or not lesson_id:
+            raise LearningPathI18nError("Every lesson needs a non-empty id")
+        if lesson_id in ids:
+            raise LearningPathI18nError(f"Duplicate lesson id: {lesson_id}")
+        if not isinstance(source, str) or not source:
+            raise LearningPathI18nError(f"Lesson {lesson_id} needs a source path")
+        if not isinstance(locales, list) or not locales:
+            raise LearningPathI18nError(f"Lesson {lesson_id} needs at least one locale")
+        if any(locale not in SUPPORTED_LOCALES for locale in locales):
+            raise LearningPathI18nError(f"Lesson {lesson_id} has an unknown locale: {locales}")
+        if len(set(locales)) != len(locales):
+            raise LearningPathI18nError(f"Lesson {lesson_id} repeats a locale")
+
+        lesson = Lesson(
+            lesson_id=lesson_id,
+            source=source,
+            locales=tuple(locales),
+            previous=_optional_string(raw_lesson.get("previous"), f"{lesson_id}.previous"),
+            next=_optional_string(raw_lesson.get("next"), f"{lesson_id}.next"),
+            catalog=_optional_string(raw_lesson.get("catalog"), f"{lesson_id}.catalog"),
+            poc=raw_lesson.get("poc", False) is True,
+        )
+        if not lesson.source_path.exists():
+            raise LearningPathI18nError(f"Lesson source does not exist: {lesson.source}")
+        if "en" in lesson.locales and lesson.catalog is None:
+            raise LearningPathI18nError(f"English lesson {lesson_id} needs a translation catalog")
+        lessons.append(lesson)
+        ids.add(lesson_id)
+
+    for lesson in lessons:
+        for relation, target in (("previous", lesson.previous), ("next", lesson.next)):
+            if target is not None and target not in ids:
+                raise LearningPathI18nError(f"{lesson.lesson_id}.{relation} points to unknown lesson {target}")
+
+    return tuple(lessons)
+
+
+def _optional_string(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise LearningPathI18nError(f"{field} must be a non-empty string or null")
+    return value
+
+
+def lesson_by_id(lesson_id: str) -> Lesson:
+    """Return one manifest lesson or raise a useful error."""
+
+    for lesson in load_manifest():
+        if lesson.lesson_id == lesson_id:
+            return lesson
+    raise LearningPathI18nError(f"Unknown lesson id: {lesson_id}")
+
+
+def locale_from_argv(argv: Sequence[str] | None = None) -> str:
+    """Read the locale passed after marimo's ``--`` separator."""
+
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--locale", choices=SUPPORTED_LOCALES, default=DEFAULT_LOCALE)
+    args, _unknown = parser.parse_known_args(sys.argv[1:] if argv is None else argv)
+    return str(args.locale)
+
+
+def load_catalog(lesson_id: str, locale: str) -> TranslationCatalog:
+    """Load a lesson catalog for ``locale`` without adding runtime dependencies."""
+
+    if locale not in SUPPORTED_LOCALES:
+        raise LearningPathI18nError(f"Unsupported locale {locale!r}; expected one of {SUPPORTED_LOCALES}")
+    lesson = lesson_by_id(lesson_id)
+    if locale not in lesson.locales:
+        raise LearningPathI18nError(f"Lesson {lesson_id} is not available in locale {locale!r}")
+    if lesson.catalog_path is None:
+        raise LearningPathI18nError(f"Lesson {lesson_id} has no translation catalog")
+
+    raw = _read_json(lesson.catalog_path)
+    if not isinstance(raw, dict) or raw.get("lesson") != lesson_id or not isinstance(raw.get("messages"), dict):
+        raise LearningPathI18nError(f"Catalog {lesson.catalog_path} has an invalid lesson or messages field")
+
+    messages: dict[str, dict[str, tuple[str, ...]]] = {}
+    for key, raw_locales in raw["messages"].items():
+        if not isinstance(key, str) or not key:
+            raise LearningPathI18nError(f"Catalog {lesson.catalog_path} has an invalid message key")
+        if not isinstance(raw_locales, dict):
+            raise LearningPathI18nError(f"Catalog key {key!r} must map to locale objects")
+        if set(raw_locales) - set(SUPPORTED_LOCALES):
+            unknown = sorted(set(raw_locales) - set(SUPPORTED_LOCALES))
+            raise LearningPathI18nError(f"Catalog {lesson.catalog_path} has unknown locales: {unknown}")
+
+        localized: dict[str, tuple[str, ...]] = {}
+        for candidate_locale, raw_lines in raw_locales.items():
+            if not isinstance(raw_lines, list) or not raw_lines or any(not isinstance(line, str) for line in raw_lines):
+                raise LearningPathI18nError(
+                    f"Catalog {lesson.catalog_path}:{key}:{candidate_locale} is not a string array"
+                )
+            if not "\n".join(raw_lines).strip():
+                raise LearningPathI18nError(f"Catalog {lesson.catalog_path}:{key}:{candidate_locale} is empty")
+            localized[candidate_locale] = tuple(raw_lines)
+        messages[key] = localized
+
+    catalog = TranslationCatalog(lesson_id=lesson_id, messages=messages, locale=locale)
+    return catalog
+
+
+def output_path(output_root: Path, lesson: Lesson, locale: str) -> Path:
+    """Return the static HTML path for one lesson and locale."""
+
+    if locale not in lesson.locales:
+        raise LearningPathI18nError(f"Lesson {lesson.lesson_id} is not available in locale {locale!r}")
+    relative = Path("learning-path") / f"{lesson.lesson_id}.html"
+    if locale == "en":
+        relative = Path("en") / relative
+    return output_root / relative
+
+
+def _site_relative_href(current_locale: str, target_locale: str, target_relative: str) -> str:
+    current_dir = Path("en/learning-path" if current_locale == "en" else "learning-path")
+    target_path = Path(target_relative)
+    if target_locale == "en":
+        target_path = Path("en") / target_path
+    return posixpath.relpath(target_path.as_posix(), current_dir.as_posix())
+
+
+def docs_relative_href(locale: str, target: str) -> str:
+    """Return a link from a Learning Path page to the Japanese MkDocs site."""
+
+    current_dir = Path("en/learning-path" if locale == "en" else "learning-path")
+    return posixpath.relpath(Path(target).as_posix(), current_dir.as_posix())
+
+
+def navigation_markdown(lesson_id: str, locale: str) -> str:
+    """Build locale-aware navigation using only manifest metadata and catalog labels."""
+
+    lesson = lesson_by_id(lesson_id)
+    catalog = load_catalog(lesson_id, locale)
+    lines = [
+        f"## {catalog.text('navigation.heading')}",
+        "",
+        f"{catalog.text('language.ja')} | {catalog.text('language.en')}",
+        "",
+    ]
+
+    language_links = []
+    for target_locale in SUPPORTED_LOCALES:
+        if target_locale not in lesson.locales:
+            continue
+        target = Path("learning-path") / f"{lesson.lesson_id}.html"
+        href = _site_relative_href(locale, target_locale, target.as_posix())
+        language_links.append(f"[{catalog.text(f'language.{target_locale}')}]({href})")
+    lines[2] = " | ".join(language_links)
+
+    for relation, label_key in (("previous", "navigation.previous"), ("next", "navigation.next")):
+        target_id = getattr(lesson, relation)
+        if target_id is None:
+            continue
+        target = lesson_by_id(target_id)
+        target_locale = locale if locale in target.locales else DEFAULT_LOCALE
+        suffix = "" if target_locale == locale else f" ({catalog.text('navigation.japanese_only')})"
+        target_path = Path("learning-path") / f"{target.lesson_id}.html"
+        href = _site_relative_href(locale, target_locale, target_path.as_posix())
+        lines.append(f"**{catalog.text(label_key)}{suffix}**: [{target.lesson_id}]({href})")
+
+    return "\n".join(lines)
+
+
+def translation_keys_in_source(source_path: Path) -> set[str]:
+    """Collect literal ``t("key")`` references from a notebook source."""
+
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    keys: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name) or node.func.id != "t":
+            continue
+        if not node.args or not isinstance(node.args[0], ast.Constant) or not isinstance(node.args[0].value, str):
+            raise LearningPathI18nError(f"Translation calls in {source_path} must use literal keys")
+        keys.add(node.args[0].value)
+    return keys
+
+
+def _placeholder_names(value: str) -> set[str]:
+    names: set[str] = set()
+    try:
+        parsed = Formatter().parse(value)
+        for _literal, field_name, _format_spec, _conversion in parsed:
+            if field_name is None:
+                continue
+            if not field_name.isidentifier():
+                raise LearningPathI18nError(f"Only simple named placeholders are supported: {{{field_name}}}")
+            names.add(field_name)
+    except ValueError as exc:
+        raise LearningPathI18nError(f"Invalid placeholder syntax in catalog value: {value!r}") from exc
+    return names
+
+
+def _validate_markdown(value: str, location: str) -> None:
+    if value.count("```") % 2:
+        raise LearningPathI18nError(f"Unbalanced Markdown code fence in {location}")
+    for target in _markdown_targets(value):
+        if target.startswith(("http://", "https://", "#", "mailto:")):
+            continue
+        if "{" in target or "}" in target:
+            continue
+        if not target.endswith((".html", "/")):
+            raise LearningPathI18nError(f"Suspicious internal Markdown link in {location}: {target}")
+
+
+def _markdown_targets(value: str) -> Iterable[str]:
+    marker = "]("
+    start = 0
+    while True:
+        position = value.find(marker, start)
+        if position < 0:
+            return
+        end = value.find(")", position + len(marker))
+        if end < 0:
+            raise LearningPathI18nError(f"Unclosed Markdown link in catalog value: {value!r}")
+        yield value[position + len(marker) : end]
+        start = end + 1
+
+
+def validate_catalogs() -> None:
+    """Validate every catalog, source reference, and navigation link."""
+
+    for lesson in load_manifest():
+        if lesson.catalog_path is None:
+            continue
+        if not lesson.catalog_path.exists():
+            raise LearningPathI18nError(f"Missing catalog for {lesson.lesson_id}: {lesson.catalog_path}")
+        catalogs = {locale: load_catalog(lesson.lesson_id, locale) for locale in lesson.locales}
+        key_sets = {locale: set(catalog.messages) for locale, catalog in catalogs.items()}
+        if len({frozenset(keys) for keys in key_sets.values()}) != 1:
+            raise LearningPathI18nError(f"Locale key sets differ for {lesson.lesson_id}: {key_sets}")
+
+        used_keys = translation_keys_in_source(lesson.source_path) | NAVIGATION_KEYS
+        catalog_keys = next(iter(key_sets.values()))
+        missing = used_keys - catalog_keys
+        unused = catalog_keys - used_keys
+        if missing:
+            raise LearningPathI18nError(f"Missing translation keys in {lesson.lesson_id}: {sorted(missing)}")
+        if unused:
+            raise LearningPathI18nError(f"Unused translation keys in {lesson.lesson_id}: {sorted(unused)}")
+
+        for key in sorted(catalog_keys):
+            for locale, catalog in catalogs.items():
+                if set(catalog.messages[key]) != set(lesson.locales):
+                    raise LearningPathI18nError(
+                        f"Locale coverage differs for {lesson.lesson_id}:{key}; "
+                        f"{locale} has {sorted(catalog.messages[key])}"
+                    )
+            localized_values = [catalogs[locale].messages[key][locale] for locale in lesson.locales]
+            for locale, lines in ((locale, catalogs[locale].messages[key][locale]) for locale in lesson.locales):
+                value = "\n".join(lines)
+                _validate_markdown(value, f"{lesson.lesson_id}:{key}:{locale}")
+            placeholder_sets = [frozenset(_placeholder_names("\n".join(value))) for value in localized_values]
+            if len(set(placeholder_sets)) != 1:
+                raise LearningPathI18nError(f"Placeholder sets differ for {lesson.lesson_id}:{key}")
+
+        for locale in lesson.locales:
+            navigation = navigation_markdown(lesson.lesson_id, locale)
+            for target in _markdown_targets(navigation):
+                if target.startswith("http"):
+                    continue
+                candidate = posixpath.normpath((output_path(Path(""), lesson, locale).parent / target).as_posix())
+                if not any(
+                    candidate == posixpath.normpath(output_path(Path(""), target_lesson, target_locale).as_posix())
+                    for target_lesson in load_manifest()
+                    for target_locale in target_lesson.locales
+                ):
+                    raise LearningPathI18nError(
+                        f"Navigation link from {lesson.lesson_id}:{locale} does not target a manifest export: {target}"
+                    )
+
+
+def poc_lessons() -> tuple[Lesson, ...]:
+    """Return the manifest entries required for the two-lesson PoC."""
+
+    lessons = tuple(lesson for lesson in load_manifest() if lesson.poc)
+    if not lessons:
+        raise LearningPathI18nError("The manifest does not define any PoC lessons")
+    return lessons

--- a/scripts/learning_path_i18n.py
+++ b/scripts/learning_path_i18n.py
@@ -609,11 +609,12 @@ def validate_catalogs() -> None:
                     )
 
 
-def poc_lessons() -> tuple[Lesson, ...]:
+def poc_lessons(lessons: Iterable[Lesson] | None = None) -> tuple[Lesson, ...]:
     """Return the two manifest entries required for the PoC."""
 
-    lessons = tuple(lesson for lesson in load_manifest() if lesson.poc)
+    available_lessons = load_manifest() if lessons is None else tuple(lessons)
+    poc = tuple(lesson for lesson in available_lessons if lesson.poc)
     expected = {"01_getting_started", "06_reusable_pipeline_recipes"}
-    if {lesson.lesson_id for lesson in lessons} != expected:
+    if {lesson.lesson_id for lesson in poc} != expected:
         raise LearningPathI18nError(f"PoC lessons must be exactly {sorted(expected)}")
-    return lessons
+    return poc

--- a/scripts/learning_path_i18n.py
+++ b/scripts/learning_path_i18n.py
@@ -343,25 +343,37 @@ def output_path(output_root: Path, lesson: Lesson, locale: str) -> Path:
     return output_root / relative
 
 
-def build_export_plan(lessons: Iterable[Lesson], output_root: Path) -> tuple[ExportPlanItem, ...]:
-    """Build a deterministic, duplicate-free export plan."""
+def build_export_plan(
+    lessons: Iterable[Lesson],
+    output_root: Path,
+    locale: str | None = None,
+) -> tuple[ExportPlanItem, ...]:
+    """Build a deterministic, duplicate-free export plan.
+
+    When ``locale`` is supplied, each selected lesson contributes only that
+    locale.  Without it, every locale declared by each lesson is retained.
+    """
+
+    if locale is not None and locale not in SUPPORTED_LOCALES:
+        raise LearningPathI18nError(f"Unsupported locale {locale!r}; expected one of {SUPPORTED_LOCALES}")
 
     items: list[ExportPlanItem] = []
     seen_outputs: dict[str, tuple[str, str]] = {}
     for lesson in lessons:
-        for locale in lesson.locales:
-            path = output_path(output_root, lesson, locale)
+        target_locales = (locale,) if locale is not None else lesson.locales
+        for target_locale in target_locales:
+            path = output_path(output_root, lesson, target_locale)
             key = path.as_posix()
             if key in seen_outputs:
                 previous = seen_outputs[key]
                 raise LearningPathI18nError(
-                    f"Duplicate export path {key}: {previous[0]}:{previous[1]} and {lesson.lesson_id}:{locale}"
+                    f"Duplicate export path {key}: {previous[0]}:{previous[1]} and {lesson.lesson_id}:{target_locale}"
                 )
-            seen_outputs[key] = (lesson.lesson_id, locale)
+            seen_outputs[key] = (lesson.lesson_id, target_locale)
             items.append(
                 ExportPlanItem(
                     lesson=lesson,
-                    locale=locale,
+                    locale=target_locale,
                     output_path=path,
                     pass_locale=lesson.catalog_path is not None,
                 )

--- a/scripts/learning_path_i18n.py
+++ b/scripts/learning_path_i18n.py
@@ -1,9 +1,8 @@
-"""Shared metadata and translation helpers for the Learning Path.
+"""Shared manifest, catalog, navigation, and export-plan helpers.
 
-The notebooks import this module at runtime, while the export and validation
-scripts use it to resolve the same lesson manifest and locale paths.  The
-module intentionally uses only the Python standard library so that opening a
-lesson locally does not add a translation-specific dependency.
+The Learning Path uses a deliberately small, standard-library-only layer.  The
+lesson source remains the single executable source, while catalogs provide the
+locale-specific prose rendered during a static export.
 """
 
 from __future__ import annotations
@@ -12,25 +11,30 @@ import argparse
 import ast
 import json
 import posixpath
+import re
+import subprocess
 import sys
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
-from string import Formatter
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 LEARNING_PATH_ROOT = REPO_ROOT / "learning-path"
 MANIFEST_PATH = LEARNING_PATH_ROOT / "manifest.json"
 CATALOG_ROOT = LEARNING_PATH_ROOT / "translations"
+COMMON_CATALOG_PATH = CATALOG_ROOT / "common.json"
 SUPPORTED_LOCALES = ("ja", "en")
 DEFAULT_LOCALE = "ja"
 
-# These keys are used by ``navigation_markdown`` rather than by a notebook's
-# direct ``t("...")`` calls.  Including them in the validator's used-key set
-# keeps unused-key detection honest without asking authors to duplicate
-# navigation text in every notebook.
-NAVIGATION_KEYS = frozenset(
+_LESSON_SOURCE_RE = re.compile(r"learning-path/[0-9]{2}_[^/]+\.py\Z")
+_PLACEHOLDER_RE = re.compile(r"\[\[([A-Za-z_][A-Za-z0-9_]*)\]\]")
+_PLACEHOLDER_TOKEN_RE = re.compile(r"\[\[([^\[\]]*)\]\]")
+
+# These keys are used by helpers rather than direct notebook ``t(...)`` calls.
+# They belong to common.json and are deliberately never copied into lesson
+# catalogs.
+COMMON_KEYS = frozenset(
     {
         "navigation.heading",
         "navigation.previous",
@@ -41,9 +45,23 @@ NAVIGATION_KEYS = frozenset(
     }
 )
 
+_I18N_HELPER_NAMES = frozenset(
+    {
+        "catalog",
+        "docs_reference_links",
+        "docs_relative_href",
+        "language_switch_markdown",
+        "load_catalog",
+        "locale",
+        "locale_from_argv",
+        "navigation_markdown",
+        "t",
+    }
+)
+
 
 class LearningPathI18nError(ValueError):
-    """Raised when Learning Path metadata or translations are invalid."""
+    """Raised when Learning Path metadata, translations, or plans are invalid."""
 
 
 @dataclass(frozen=True)
@@ -70,35 +88,47 @@ class Lesson:
 
 
 @dataclass(frozen=True)
+class ExportPlanItem:
+    """One deterministic source/locale/output item in an export plan."""
+
+    lesson: Lesson
+    locale: str
+    output_path: Path
+    pass_locale: bool
+
+
+@dataclass(frozen=True)
 class TranslationCatalog:
-    """A line-oriented JSON catalog for one lesson."""
+    """A line-oriented JSON catalog merged with the common catalog."""
 
     lesson_id: str
     messages: Mapping[str, Mapping[str, tuple[str, ...]]]
     locale: str = DEFAULT_LOCALE
 
     def text(self, key: str, **values: object) -> str:
-        """Return a translated message, formatting only declared placeholders."""
+        """Render a message using only explicit ``[[name]]`` placeholders."""
 
+        location = f"{self.lesson_id}:{key}:{self.locale}"
         try:
             localized = self.messages[key]
         except KeyError as exc:
-            raise LearningPathI18nError(f"Unknown translation key {key!r} for {self.lesson_id}") from exc
-
-        locale = self.locale
-        try:
-            lines = localized[locale]
-        except KeyError as exc:
-            raise LearningPathI18nError(f"Missing locale {locale!r} for key {key!r}") from exc
+            raise LearningPathI18nError(f"Unknown translation key at {location}") from exc
 
         try:
-            return "\n".join(line.format(**values) for line in lines)
+            lines = localized[self.locale]
         except KeyError as exc:
-            raise LearningPathI18nError(
-                f"Missing placeholder {exc.args[0]!r} while rendering {self.lesson_id}:{key}"
-            ) from exc
-        except ValueError as exc:
-            raise LearningPathI18nError(f"Invalid placeholder syntax in {self.lesson_id}:{key}") from exc
+            raise LearningPathI18nError(f"Missing locale at {location}") from exc
+
+        value = "\n".join(lines)
+        names = _placeholder_names(value, location)
+        provided = set(values)
+        missing = names - provided
+        unused = provided - names
+        if missing:
+            raise LearningPathI18nError(f"Missing placeholder(s) {sorted(missing)} at {location}")
+        if unused:
+            raise LearningPathI18nError(f"Unused value(s) {sorted(unused)} at {location}")
+        return _PLACEHOLDER_RE.sub(lambda match: str(values[match.group(1)]), value)
 
 
 def _read_json(path: Path) -> Any:
@@ -110,63 +140,30 @@ def _read_json(path: Path) -> Any:
         raise LearningPathI18nError(f"Invalid JSON in {path}: {exc}") from exc
 
 
-def load_manifest() -> tuple[Lesson, ...]:
-    """Load and validate the central lesson manifest."""
+def tracked_numbered_lesson_sources() -> tuple[str, ...]:
+    """Return tracked numbered lesson sources without seeing ignored scratch files.
 
-    raw = _read_json(MANIFEST_PATH)
-    if not isinstance(raw, dict) or not isinstance(raw.get("lessons"), list):
-        raise LearningPathI18nError("manifest.json must contain a lessons array")
+    The manifest contract is meaningful only in a Git checkout.  If Git is not
+    available or the command fails, fail explicitly instead of silently falling
+    back to ``Path.glob`` and treating an ignored scratch notebook as a public
+    lesson.
+    """
 
-    manifest_locales = raw.get("locales")
-    if not isinstance(manifest_locales, dict) or set(manifest_locales) != set(SUPPORTED_LOCALES):
-        raise LearningPathI18nError("manifest.json locales must be exactly ja and en")
-    if raw.get("default_locale") != DEFAULT_LOCALE:
-        raise LearningPathI18nError(f"manifest.json default_locale must be {DEFAULT_LOCALE!r}")
-
-    lessons: list[Lesson] = []
-    ids: set[str] = set()
-    for raw_lesson in raw["lessons"]:
-        if not isinstance(raw_lesson, dict):
-            raise LearningPathI18nError("Every manifest lesson must be an object")
-
-        lesson_id = raw_lesson.get("id")
-        source = raw_lesson.get("source")
-        locales = raw_lesson.get("locales")
-        if not isinstance(lesson_id, str) or not lesson_id:
-            raise LearningPathI18nError("Every lesson needs a non-empty id")
-        if lesson_id in ids:
-            raise LearningPathI18nError(f"Duplicate lesson id: {lesson_id}")
-        if not isinstance(source, str) or not source:
-            raise LearningPathI18nError(f"Lesson {lesson_id} needs a source path")
-        if not isinstance(locales, list) or not locales:
-            raise LearningPathI18nError(f"Lesson {lesson_id} needs at least one locale")
-        if any(locale not in SUPPORTED_LOCALES for locale in locales):
-            raise LearningPathI18nError(f"Lesson {lesson_id} has an unknown locale: {locales}")
-        if len(set(locales)) != len(locales):
-            raise LearningPathI18nError(f"Lesson {lesson_id} repeats a locale")
-
-        lesson = Lesson(
-            lesson_id=lesson_id,
-            source=source,
-            locales=tuple(locales),
-            previous=_optional_string(raw_lesson.get("previous"), f"{lesson_id}.previous"),
-            next=_optional_string(raw_lesson.get("next"), f"{lesson_id}.next"),
-            catalog=_optional_string(raw_lesson.get("catalog"), f"{lesson_id}.catalog"),
-            poc=raw_lesson.get("poc", False) is True,
+    try:
+        completed = subprocess.run(
+            ["git", "ls-files", "-z", "--", "learning-path"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
         )
-        if not lesson.source_path.exists():
-            raise LearningPathI18nError(f"Lesson source does not exist: {lesson.source}")
-        if "en" in lesson.locales and lesson.catalog is None:
-            raise LearningPathI18nError(f"English lesson {lesson_id} needs a translation catalog")
-        lessons.append(lesson)
-        ids.add(lesson_id)
+    except FileNotFoundError as exc:
+        raise LearningPathI18nError("Cannot verify tracked lessons: git is required for manifest validation") from exc
+    if completed.returncode != 0:
+        details = completed.stderr.strip() or "git ls-files failed"
+        raise LearningPathI18nError(f"Cannot verify tracked lessons: {details}")
 
-    for lesson in lessons:
-        for relation, target in (("previous", lesson.previous), ("next", lesson.next)):
-            if target is not None and target not in ids:
-                raise LearningPathI18nError(f"{lesson.lesson_id}.{relation} points to unknown lesson {target}")
-
-    return tuple(lessons)
+    return tuple(sorted(path for path in completed.stdout.split("\0") if _LESSON_SOURCE_RE.fullmatch(path)))
 
 
 def _optional_string(value: object, field: str) -> str | None:
@@ -175,6 +172,96 @@ def _optional_string(value: object, field: str) -> str | None:
     if not isinstance(value, str) or not value:
         raise LearningPathI18nError(f"{field} must be a non-empty string or null")
     return value
+
+
+def load_manifest() -> tuple[Lesson, ...]:
+    """Load, validate, and derive navigation from the manifest order."""
+
+    raw = _read_json(MANIFEST_PATH)
+    if not isinstance(raw, dict) or not isinstance(raw.get("lessons"), list):
+        raise LearningPathI18nError("manifest.json must contain a lessons array")
+
+    manifest_locales = raw.get("locales")
+    if not isinstance(manifest_locales, dict) or set(manifest_locales) != set(SUPPORTED_LOCALES):
+        raise LearningPathI18nError("manifest.json locales must be exactly ja and en")
+    if any(not isinstance(label, str) or not label for label in manifest_locales.values()):
+        raise LearningPathI18nError("manifest.json locale labels must be non-empty strings")
+    if raw.get("default_locale") != DEFAULT_LOCALE:
+        raise LearningPathI18nError(f"manifest.json default_locale must be {DEFAULT_LOCALE!r}")
+
+    lessons: list[Lesson] = []
+    ids: set[str] = set()
+    sources: set[str] = set()
+    for raw_lesson in raw["lessons"]:
+        if not isinstance(raw_lesson, dict):
+            raise LearningPathI18nError("Every manifest lesson must be an object")
+        if "previous" in raw_lesson or "next" in raw_lesson:
+            raise LearningPathI18nError("previous/next are derived from manifest lesson order; remove those fields")
+
+        lesson_id = raw_lesson.get("id")
+        source = raw_lesson.get("source")
+        locales = raw_lesson.get("locales")
+        if not isinstance(lesson_id, str) or not lesson_id:
+            raise LearningPathI18nError("Every lesson needs a non-empty id")
+        if lesson_id in ids:
+            raise LearningPathI18nError(f"Duplicate lesson id: {lesson_id}")
+        if not isinstance(source, str) or not source or not _LESSON_SOURCE_RE.fullmatch(source):
+            raise LearningPathI18nError(f"Lesson {lesson_id} needs a numbered learning-path source")
+        if Path(source).stem != lesson_id:
+            raise LearningPathI18nError(f"Lesson id/source stem mismatch: {lesson_id!r} != {Path(source).stem!r}")
+        if source in sources:
+            raise LearningPathI18nError(f"Duplicate lesson source: {source}")
+        if not isinstance(locales, list) or not locales:
+            raise LearningPathI18nError(f"Lesson {lesson_id} needs at least one locale")
+        if any(locale not in SUPPORTED_LOCALES for locale in locales):
+            raise LearningPathI18nError(f"Lesson {lesson_id} has an unknown locale: {locales}")
+        if len(set(locales)) != len(locales):
+            raise LearningPathI18nError(f"Lesson {lesson_id} repeats a locale")
+        if DEFAULT_LOCALE not in locales:
+            raise LearningPathI18nError(f"Lesson {lesson_id} must provide the default locale {DEFAULT_LOCALE!r}")
+
+        catalog = _optional_string(raw_lesson.get("catalog"), f"{lesson_id}.catalog")
+        if ("en" in locales) != (catalog is not None):
+            raise LearningPathI18nError(f"Lesson {lesson_id} needs a catalog exactly when English is available")
+        if catalog is not None and (Path(catalog).is_absolute() or Path(catalog).name != catalog):
+            raise LearningPathI18nError(f"Lesson {lesson_id}.catalog must be a file name below translations/")
+
+        poc = raw_lesson.get("poc", False)
+        if not isinstance(poc, bool):
+            raise LearningPathI18nError(f"Lesson {lesson_id}.poc must be boolean")
+        lesson = Lesson(
+            lesson_id=lesson_id,
+            source=source,
+            locales=tuple(locales),
+            previous=None,
+            next=None,
+            catalog=catalog,
+            poc=poc,
+        )
+        if not lesson.source_path.exists():
+            raise LearningPathI18nError(f"Lesson source does not exist: {lesson.source}")
+        lessons.append(lesson)
+        ids.add(lesson_id)
+        sources.add(source)
+
+    tracked_sources = set(tracked_numbered_lesson_sources())
+    if sources != tracked_sources:
+        missing = sorted(tracked_sources - sources)
+        extra = sorted(sources - tracked_sources)
+        raise LearningPathI18nError(f"Manifest/tracked lesson mismatch; missing={missing}, untracked={extra}")
+
+    derived = []
+    for index, lesson in enumerate(lessons):
+        derived.append(
+            replace(
+                lesson,
+                previous=lessons[index - 1].lesson_id if index else None,
+                next=lessons[index + 1].lesson_id if index + 1 < len(lessons) else None,
+            )
+        )
+    lessons_tuple = tuple(derived)
+    build_export_plan(lessons_tuple, Path())
+    return lessons_tuple
 
 
 def lesson_by_id(lesson_id: str) -> Lesson:
@@ -195,8 +282,38 @@ def locale_from_argv(argv: Sequence[str] | None = None) -> str:
     return str(args.locale)
 
 
+def _load_messages(path: Path, identity_key: str, identity: str) -> dict[str, dict[str, tuple[str, ...]]]:
+    raw = _read_json(path)
+    if not isinstance(raw, dict) or raw.get(identity_key) != identity or not isinstance(raw.get("messages"), dict):
+        raise LearningPathI18nError(f"Catalog {path} has an invalid {identity_key} or messages field")
+
+    messages: dict[str, dict[str, tuple[str, ...]]] = {}
+    for key, raw_locales in raw["messages"].items():
+        if not isinstance(key, str) or not key:
+            raise LearningPathI18nError(f"Catalog {path} has an invalid message key")
+        if not isinstance(raw_locales, dict):
+            raise LearningPathI18nError(f"Catalog {path}:{key} must map to locale objects")
+        unknown_locales = set(raw_locales) - set(SUPPORTED_LOCALES)
+        if unknown_locales:
+            raise LearningPathI18nError(f"Catalog {path}:{key} has unknown locales: {sorted(unknown_locales)}")
+
+        localized: dict[str, tuple[str, ...]] = {}
+        for locale, raw_lines in raw_locales.items():
+            if not isinstance(raw_lines, list) or not raw_lines or any(not isinstance(line, str) for line in raw_lines):
+                raise LearningPathI18nError(f"Catalog {path}:{key}:{locale} is not a non-empty string array")
+            if not "\n".join(raw_lines).strip():
+                raise LearningPathI18nError(f"Catalog {path}:{key}:{locale} is empty")
+            localized[locale] = tuple(raw_lines)
+        messages[key] = localized
+    return messages
+
+
+def _common_messages() -> dict[str, dict[str, tuple[str, ...]]]:
+    return _load_messages(COMMON_CATALOG_PATH, "catalog", "common")
+
+
 def load_catalog(lesson_id: str, locale: str) -> TranslationCatalog:
-    """Load a lesson catalog for ``locale`` without adding runtime dependencies."""
+    """Load common and lesson-specific messages for one locale."""
 
     if locale not in SUPPORTED_LOCALES:
         raise LearningPathI18nError(f"Unsupported locale {locale!r}; expected one of {SUPPORTED_LOCALES}")
@@ -206,33 +323,13 @@ def load_catalog(lesson_id: str, locale: str) -> TranslationCatalog:
     if lesson.catalog_path is None:
         raise LearningPathI18nError(f"Lesson {lesson_id} has no translation catalog")
 
-    raw = _read_json(lesson.catalog_path)
-    if not isinstance(raw, dict) or raw.get("lesson") != lesson_id or not isinstance(raw.get("messages"), dict):
-        raise LearningPathI18nError(f"Catalog {lesson.catalog_path} has an invalid lesson or messages field")
-
-    messages: dict[str, dict[str, tuple[str, ...]]] = {}
-    for key, raw_locales in raw["messages"].items():
-        if not isinstance(key, str) or not key:
-            raise LearningPathI18nError(f"Catalog {lesson.catalog_path} has an invalid message key")
-        if not isinstance(raw_locales, dict):
-            raise LearningPathI18nError(f"Catalog key {key!r} must map to locale objects")
-        if set(raw_locales) - set(SUPPORTED_LOCALES):
-            unknown = sorted(set(raw_locales) - set(SUPPORTED_LOCALES))
-            raise LearningPathI18nError(f"Catalog {lesson.catalog_path} has unknown locales: {unknown}")
-
-        localized: dict[str, tuple[str, ...]] = {}
-        for candidate_locale, raw_lines in raw_locales.items():
-            if not isinstance(raw_lines, list) or not raw_lines or any(not isinstance(line, str) for line in raw_lines):
-                raise LearningPathI18nError(
-                    f"Catalog {lesson.catalog_path}:{key}:{candidate_locale} is not a string array"
-                )
-            if not "\n".join(raw_lines).strip():
-                raise LearningPathI18nError(f"Catalog {lesson.catalog_path}:{key}:{candidate_locale} is empty")
-            localized[candidate_locale] = tuple(raw_lines)
-        messages[key] = localized
-
-    catalog = TranslationCatalog(lesson_id=lesson_id, messages=messages, locale=locale)
-    return catalog
+    common = _common_messages()
+    lesson_messages = _load_messages(lesson.catalog_path, "lesson", lesson_id)
+    collisions = sorted(set(common) & set(lesson_messages))
+    if collisions:
+        raise LearningPathI18nError(f"Common catalog keys are duplicated in {lesson_id}: {collisions}")
+    merged = {**common, **lesson_messages}
+    return TranslationCatalog(lesson_id=lesson_id, messages=merged, locale=locale)
 
 
 def output_path(output_root: Path, lesson: Lesson, locale: str) -> Path:
@@ -246,6 +343,32 @@ def output_path(output_root: Path, lesson: Lesson, locale: str) -> Path:
     return output_root / relative
 
 
+def build_export_plan(lessons: Iterable[Lesson], output_root: Path) -> tuple[ExportPlanItem, ...]:
+    """Build a deterministic, duplicate-free export plan."""
+
+    items: list[ExportPlanItem] = []
+    seen_outputs: dict[str, tuple[str, str]] = {}
+    for lesson in lessons:
+        for locale in lesson.locales:
+            path = output_path(output_root, lesson, locale)
+            key = path.as_posix()
+            if key in seen_outputs:
+                previous = seen_outputs[key]
+                raise LearningPathI18nError(
+                    f"Duplicate export path {key}: {previous[0]}:{previous[1]} and {lesson.lesson_id}:{locale}"
+                )
+            seen_outputs[key] = (lesson.lesson_id, locale)
+            items.append(
+                ExportPlanItem(
+                    lesson=lesson,
+                    locale=locale,
+                    output_path=path,
+                    pass_locale=lesson.catalog_path is not None,
+                )
+            )
+    return tuple(items)
+
+
 def _site_relative_href(current_locale: str, target_locale: str, target_relative: str) -> str:
     current_dir = Path("en/learning-path" if current_locale == "en" else "learning-path")
     target_path = Path(target_relative)
@@ -257,31 +380,33 @@ def _site_relative_href(current_locale: str, target_locale: str, target_relative
 def docs_relative_href(locale: str, target: str) -> str:
     """Return a link from a Learning Path page to the Japanese MkDocs site."""
 
+    if locale not in SUPPORTED_LOCALES:
+        raise LearningPathI18nError(f"Unsupported locale {locale!r}; expected one of {SUPPORTED_LOCALES}")
     current_dir = Path("en/learning-path" if locale == "en" else "learning-path")
     return posixpath.relpath(Path(target).as_posix(), current_dir.as_posix())
 
 
-def navigation_markdown(lesson_id: str, locale: str) -> str:
-    """Build locale-aware navigation using only manifest metadata and catalog labels."""
+def language_switch_markdown(lesson_id: str, locale: str) -> str:
+    """Build the static language switch shown directly below a lesson title."""
 
     lesson = lesson_by_id(lesson_id)
     catalog = load_catalog(lesson_id, locale)
-    lines = [
-        f"## {catalog.text('navigation.heading')}",
-        "",
-        f"{catalog.text('language.ja')} | {catalog.text('language.en')}",
-        "",
-    ]
-
-    language_links = []
+    links = []
     for target_locale in SUPPORTED_LOCALES:
         if target_locale not in lesson.locales:
             continue
         target = Path("learning-path") / f"{lesson.lesson_id}.html"
         href = _site_relative_href(locale, target_locale, target.as_posix())
-        language_links.append(f"[{catalog.text(f'language.{target_locale}')}]({href})")
-    lines[2] = " | ".join(language_links)
+        links.append(f"[{catalog.text(f'language.{target_locale}')}]({href})")
+    return " | ".join(links)
 
+
+def navigation_markdown(lesson_id: str, locale: str) -> str:
+    """Build previous/next navigation from the manifest order."""
+
+    lesson = lesson_by_id(lesson_id)
+    catalog = load_catalog(lesson_id, locale)
+    lines = [f"## {catalog.text('navigation.heading')}", ""]
     for relation, label_key in (("previous", "navigation.previous"), ("next", "navigation.next")):
         target_id = getattr(lesson, relation)
         if target_id is None:
@@ -292,8 +417,17 @@ def navigation_markdown(lesson_id: str, locale: str) -> str:
         target_path = Path("learning-path") / f"{target.lesson_id}.html"
         href = _site_relative_href(locale, target_locale, target_path.as_posix())
         lines.append(f"**{catalog.text(label_key)}{suffix}**: [{target.lesson_id}]({href})")
-
     return "\n".join(lines)
+
+
+def docs_reference_links(locale: str, catalog: TranslationCatalog) -> dict[str, str]:
+    """Create 06's docs links and annotate English links to Japanese docs."""
+
+    suffix = f" ({catalog.text('navigation.japanese_only')})" if locale == "en" else ""
+    return {
+        "how_to_link": (f"[RecipePlan how-to{suffix}]({docs_relative_href(locale, 'how-to/pipeline-recipes/')})"),
+        "api_link": f"[Pipeline API reference{suffix}]({docs_relative_href(locale, 'api/pipeline/')})",
+    }
 
 
 def translation_keys_in_source(source_path: Path) -> set[str]:
@@ -310,18 +444,15 @@ def translation_keys_in_source(source_path: Path) -> set[str]:
     return keys
 
 
-def _placeholder_names(value: str) -> set[str]:
+def _placeholder_names(value: str, location: str) -> set[str]:
+    if value.count("[[") != value.count("]]"):
+        raise LearningPathI18nError(f"Unbalanced placeholder brackets at {location}")
     names: set[str] = set()
-    try:
-        parsed = Formatter().parse(value)
-        for _literal, field_name, _format_spec, _conversion in parsed:
-            if field_name is None:
-                continue
-            if not field_name.isidentifier():
-                raise LearningPathI18nError(f"Only simple named placeholders are supported: {{{field_name}}}")
-            names.add(field_name)
-    except ValueError as exc:
-        raise LearningPathI18nError(f"Invalid placeholder syntax in catalog value: {value!r}") from exc
+    for match in _PLACEHOLDER_TOKEN_RE.finditer(value):
+        name = match.group(1)
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+            raise LearningPathI18nError(f"Invalid placeholder {name!r} at {location}")
+        names.add(name)
     return names
 
 
@@ -331,7 +462,7 @@ def _validate_markdown(value: str, location: str) -> None:
     for target in _markdown_targets(value):
         if target.startswith(("http://", "https://", "#", "mailto:")):
             continue
-        if "{" in target or "}" in target:
+        if "[[" in target or "]]" in target:
             continue
         if not target.endswith((".html", "/")):
             raise LearningPathI18nError(f"Suspicious internal Markdown link in {location}: {target}")
@@ -351,42 +482,104 @@ def _markdown_targets(value: str) -> Iterable[str]:
         start = end + 1
 
 
+def _validate_message_collection(
+    messages: Mapping[str, Mapping[str, tuple[str, ...]]],
+    locales: Sequence[str],
+    location_prefix: str,
+) -> None:
+    for key, localized in messages.items():
+        if set(localized) != set(locales):
+            raise LearningPathI18nError(
+                f"Locale coverage differs for {location_prefix}:{key}; found {sorted(localized)}"
+            )
+        placeholder_sets = []
+        for locale in locales:
+            location = f"{location_prefix}:{key}:{locale}"
+            value = "\n".join(localized[locale])
+            _validate_markdown(value, location)
+            placeholder_sets.append(frozenset(_placeholder_names(value, location)))
+        if len(set(placeholder_sets)) != 1:
+            raise LearningPathI18nError(f"Placeholder sets differ for {location_prefix}:{key}")
+
+
+def _attribute_path(node: ast.AST) -> tuple[str, ...] | None:
+    if isinstance(node, ast.Name):
+        return (node.id,)
+    if isinstance(node, ast.Attribute):
+        parent = _attribute_path(node.value)
+        return (*parent, node.attr) if parent else None
+    return None
+
+
+def _is_hidden_cell(node: ast.FunctionDef) -> bool:
+    for decorator in node.decorator_list:
+        if not isinstance(decorator, ast.Call) or _attribute_path(decorator.func) != ("app", "cell"):
+            continue
+        for keyword in decorator.keywords:
+            if keyword.arg == "hide_code":
+                return isinstance(keyword.value, ast.Constant) and keyword.value.value is True
+        return False
+    return False
+
+
+def validate_visible_source(source_path: Path) -> None:
+    """Reject i18n implementation details in learner-visible cells."""
+
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef) or not any(
+            _attribute_path(decorator.func if isinstance(decorator, ast.Call) else decorator) == ("app", "cell")
+            for decorator in node.decorator_list
+        ):
+            continue
+        if _is_hidden_cell(node):
+            continue
+        for child in ast.walk(node):
+            if isinstance(child, ast.Name) and child.id in _I18N_HELPER_NAMES:
+                raise LearningPathI18nError(
+                    f"i18n helper {child.id!r} appears in visible cell {source_path}:{node.lineno}"
+                )
+            if isinstance(child, ast.Call) and isinstance(child.func, ast.Name) and child.func.id == "t":
+                raise LearningPathI18nError(f"translation call appears in visible cell {source_path}:{node.lineno}")
+            if isinstance(child, ast.Call):
+                for keyword in child.keywords:
+                    if keyword.arg not in {"label", "title", "xlabel", "ylabel"}:
+                        continue
+                    if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
+                        if not keyword.value.value.isascii():
+                            raise LearningPathI18nError(
+                                f"localized plot label must be ASCII in {source_path}:{node.lineno}"
+                            )
+            if isinstance(child, ast.ImportFrom) and child.module == "scripts.learning_path_i18n":
+                raise LearningPathI18nError(f"i18n import appears in visible cell {source_path}:{node.lineno}")
+
+
 def validate_catalogs() -> None:
-    """Validate every catalog, source reference, and navigation link."""
+    """Validate manifest, common/lesson catalogs, sources, and navigation."""
+
+    common = _common_messages()
+    if set(common) != COMMON_KEYS:
+        raise LearningPathI18nError(f"common.json keys must be exactly {sorted(COMMON_KEYS)}; found {sorted(common)}")
+    _validate_message_collection(common, SUPPORTED_LOCALES, "common")
 
     for lesson in load_manifest():
         if lesson.catalog_path is None:
             continue
-        if not lesson.catalog_path.exists():
-            raise LearningPathI18nError(f"Missing catalog for {lesson.lesson_id}: {lesson.catalog_path}")
-        catalogs = {locale: load_catalog(lesson.lesson_id, locale) for locale in lesson.locales}
-        key_sets = {locale: set(catalog.messages) for locale, catalog in catalogs.items()}
-        if len({frozenset(keys) for keys in key_sets.values()}) != 1:
-            raise LearningPathI18nError(f"Locale key sets differ for {lesson.lesson_id}: {key_sets}")
+        lesson_messages = _load_messages(lesson.catalog_path, "lesson", lesson.lesson_id)
+        collisions = sorted(set(common) & set(lesson_messages))
+        if collisions:
+            raise LearningPathI18nError(f"Common catalog keys are duplicated in {lesson.lesson_id}: {collisions}")
+        _validate_message_collection(lesson_messages, lesson.locales, lesson.lesson_id)
+        validate_visible_source(lesson.source_path)
 
-        used_keys = translation_keys_in_source(lesson.source_path) | NAVIGATION_KEYS
-        catalog_keys = next(iter(key_sets.values()))
-        missing = used_keys - catalog_keys
-        unused = catalog_keys - used_keys
+        used_keys = translation_keys_in_source(lesson.source_path)
+        lesson_keys = set(lesson_messages)
+        missing = (used_keys - COMMON_KEYS) - lesson_keys
+        unused = lesson_keys - used_keys
         if missing:
             raise LearningPathI18nError(f"Missing translation keys in {lesson.lesson_id}: {sorted(missing)}")
         if unused:
             raise LearningPathI18nError(f"Unused translation keys in {lesson.lesson_id}: {sorted(unused)}")
-
-        for key in sorted(catalog_keys):
-            for locale, catalog in catalogs.items():
-                if set(catalog.messages[key]) != set(lesson.locales):
-                    raise LearningPathI18nError(
-                        f"Locale coverage differs for {lesson.lesson_id}:{key}; "
-                        f"{locale} has {sorted(catalog.messages[key])}"
-                    )
-            localized_values = [catalogs[locale].messages[key][locale] for locale in lesson.locales]
-            for locale, lines in ((locale, catalogs[locale].messages[key][locale]) for locale in lesson.locales):
-                value = "\n".join(lines)
-                _validate_markdown(value, f"{lesson.lesson_id}:{key}:{locale}")
-            placeholder_sets = [frozenset(_placeholder_names("\n".join(value))) for value in localized_values]
-            if len(set(placeholder_sets)) != 1:
-                raise LearningPathI18nError(f"Placeholder sets differ for {lesson.lesson_id}:{key}")
 
         for locale in lesson.locales:
             navigation = navigation_markdown(lesson.lesson_id, locale)
@@ -405,9 +598,10 @@ def validate_catalogs() -> None:
 
 
 def poc_lessons() -> tuple[Lesson, ...]:
-    """Return the manifest entries required for the two-lesson PoC."""
+    """Return the two manifest entries required for the PoC."""
 
     lessons = tuple(lesson for lesson in load_manifest() if lesson.poc)
-    if not lessons:
-        raise LearningPathI18nError("The manifest does not define any PoC lessons")
+    expected = {"01_getting_started", "06_reusable_pipeline_recipes"}
+    if {lesson.lesson_id for lesson in lessons} != expected:
+        raise LearningPathI18nError(f"PoC lessons must be exactly {sorted(expected)}")
     return lessons

--- a/scripts/validate_learning_path_i18n.py
+++ b/scripts/validate_learning_path_i18n.py
@@ -1,4 +1,4 @@
-"""Validate Learning Path translation catalogs and PoC HTML exports."""
+"""Validate Learning Path catalogs, export plans, and static HTML."""
 
 from __future__ import annotations
 
@@ -6,27 +6,33 @@ import argparse
 import json
 import posixpath
 import re
+from collections.abc import Mapping
 from pathlib import Path
+from typing import cast
 
 try:
     from .learning_path_i18n import (
         LearningPathI18nError,
         _markdown_targets,
-        docs_relative_href,
-        lesson_by_id,
+        build_export_plan,
+        docs_reference_links,
+        language_switch_markdown,
         load_catalog,
+        load_manifest,
         navigation_markdown,
         output_path,
         poc_lessons,
         validate_catalogs,
     )
-except ImportError:  # Running this file directly keeps the existing `python scripts/foo.py` workflow.
+except ImportError:  # Running this file directly keeps the existing python scripts/foo.py workflow.
     from learning_path_i18n import (
         LearningPathI18nError,
         _markdown_targets,
-        docs_relative_href,
-        lesson_by_id,
+        build_export_plan,
+        docs_reference_links,
+        language_switch_markdown,
         load_catalog,
+        load_manifest,
         navigation_markdown,
         output_path,
         poc_lessons,
@@ -49,65 +55,190 @@ def _serialized_text(value: str) -> tuple[str, str]:
     return value, json.dumps(value, ensure_ascii=True)[1:-1]
 
 
-def validate_exported_site(site_root: Path) -> None:
-    """Check the generated PoC HTML without using snapshots or pixel comparison."""
+def _first_position(html: str, value: str) -> int:
+    positions = [html.find(candidate) for candidate in _serialized_text(value)]
+    positions = [position for position in positions if position >= 0]
+    return min(positions, default=-1)
+
+
+def _first_href_position(html: str, hrefs: set[str]) -> int:
+    positions = [html.find(href) for href in hrefs]
+    positions = [position for position in positions if position >= 0]
+    return min(positions, default=-1)
+
+
+def _exported_notebook_cells(html: str, page: Path) -> list[dict[str, object]]:
+    """Read marimo's exported cell metadata without snapshotting the HTML."""
+
+    marker = '"notebook": '
+    marker_position = html.find(marker)
+    if marker_position < 0:
+        raise LearningPathI18nError(f"Exported marimo notebook metadata is missing: {page}")
+    try:
+        notebook, _ = json.JSONDecoder().raw_decode(html[marker_position + len(marker) :])
+    except json.JSONDecodeError as exc:
+        raise LearningPathI18nError(f"Exported marimo notebook metadata is invalid: {page}") from exc
+    if not isinstance(notebook, dict) or not isinstance(notebook.get("cells"), list):
+        raise LearningPathI18nError(f"Exported marimo notebook cells are missing: {page}")
+    cells = notebook["cells"]
+    if not all(isinstance(cell, dict) for cell in cells):
+        raise LearningPathI18nError(f"Exported marimo notebook contains an invalid cell: {page}")
+    return cells
+
+
+def _validate_visible_exported_code(html: str, page: Path) -> None:
+    """Ensure exported visible cells do not expose the translation machinery."""
+
+    leaked_markers = (
+        "scripts.learning_path_i18n",
+        "locale_from_argv",
+        "load_catalog",
+        "language_switch_markdown",
+        "navigation_markdown",
+        "docs_reference_links",
+    )
+    for cell in _exported_notebook_cells(html, page):
+        code = cell.get("code")
+        config = cell.get("config")
+        if not isinstance(code, str) or not isinstance(config, Mapping):
+            raise LearningPathI18nError(f"Exported marimo cell metadata is invalid: {page}")
+        config_mapping = cast(Mapping[str, object], config)
+        if config_mapping.get("hide_code") is True:
+            continue
+        if any(marker in code for marker in leaked_markers) or re.search(r"\bt\s*\(\s*['\"]", code):
+            raise LearningPathI18nError(f"Translation implementation leaked into visible code: {page}")
+
+
+def _validate_exported_layout(html: str, page: Path) -> None:
+    """Check the title/switch/navigation cell order without a full snapshot."""
+
+    cells = _exported_notebook_cells(html, page)
+    marker_indices: dict[str, list[int]] = {"title": [], "switch": [], "navigation": []}
+    for index, cell in enumerate(cells):
+        code = cell.get("code")
+        if not isinstance(code, str):
+            continue
+        if "t('title')" in code or 't("title")' in code:
+            marker_indices["title"].append(index)
+        if "language_switch_markdown(" in code:
+            marker_indices["switch"].append(index)
+        if "navigation_markdown(" in code:
+            marker_indices["navigation"].append(index)
+
+    if any(len(indices) != 1 for indices in marker_indices.values()):
+        raise LearningPathI18nError(f"Exported title/switch/navigation cells are ambiguous: {page}")
+    title_index = marker_indices["title"][0]
+    switch_index = marker_indices["switch"][0]
+    navigation_index = marker_indices["navigation"][0]
+    if switch_index != title_index + 1:
+        raise LearningPathI18nError(f"Language switch is not immediately below the title cell: {page}")
+    if navigation_index != len(cells) - 1:
+        raise LearningPathI18nError(f"Navigation is not the final cell: {page}")
+
+    for index in (title_index, switch_index, navigation_index):
+        config = cells[index].get("config")
+        if not isinstance(config, Mapping) or cast(Mapping[str, object], config).get("hide_code") is not True:
+            raise LearningPathI18nError(f"Title, switch, and navigation cells must hide code: {page}")
+
+
+def validate_exported_site(site_root: Path, *, validate_all: bool = False) -> None:
+    """Check planned files and PoC HTML without snapshots or pixel comparison."""
+
+    planned_lessons = load_manifest() if validate_all else poc_lessons()
+    plan = build_export_plan(planned_lessons, site_root)
+    for target in plan:
+        if not target.output_path.exists():
+            raise LearningPathI18nError(f"Missing planned export: {target.output_path}")
 
     for lesson in poc_lessons():
         for locale in lesson.locales:
             page = output_path(site_root, lesson, locale)
-            if not page.exists():
-                raise LearningPathI18nError(f"Missing exported page: {page}")
             html = page.read_text(encoding="utf-8")
-            if "Traceback (most recent call last)" in html or "ModuleNotFoundError" in html:
+            if any(
+                marker in html
+                for marker in ("Traceback (most recent call last)", "ModuleNotFoundError", "ImportError:")
+            ):
                 raise LearningPathI18nError(f"Python error text found in exported page: {page}")
+            _validate_visible_exported_code(html, page)
+            _validate_exported_layout(html, page)
 
-            title = load_catalog(lesson.lesson_id, locale).text("title")
-            if not any(candidate in html for candidate in _serialized_text(title)):
+            catalog = load_catalog(lesson.lesson_id, locale)
+            title = catalog.text("title")
+            if _first_position(html, title) < 0:
                 raise LearningPathI18nError(f"Missing {locale} title in {page}: {title}")
             for marker in _CODE_MARKERS[lesson.lesson_id]:
                 if marker not in html:
                     raise LearningPathI18nError(f"Missing shared code marker {marker!r} in {page}")
 
-            expected_hrefs = set(_markdown_targets(navigation_markdown(lesson.lesson_id, locale)))
-            if locale == "en":
-                for relation in ("previous", "next"):
-                    target_id = getattr(lesson, relation)
-                    if target_id is None or "en" in lesson_by_id(target_id).locales:
-                        continue
-                    japanese_only = load_catalog(lesson.lesson_id, locale).text("navigation.japanese_only")
-                    if not any(candidate in html for candidate in _serialized_text(japanese_only)):
-                        raise LearningPathI18nError(
-                            f"Missing Japanese-only fallback label in {page} for {relation} link"
-                        )
+            switch = language_switch_markdown(lesson.lesson_id, locale)
+            navigation = navigation_markdown(lesson.lesson_id, locale)
+            expected_hrefs = set(_markdown_targets(switch)) | set(_markdown_targets(navigation))
+            navigation_hrefs = set(_markdown_targets(navigation))
+            summary = ""
             if lesson.lesson_id == "06_reusable_pipeline_recipes":
-                summary = load_catalog(lesson.lesson_id, locale).text(
-                    "summary",
-                    how_to_href=docs_relative_href(locale, "how-to/pipeline-recipes/"),
-                    api_href=docs_relative_href(locale, "api/pipeline/"),
-                )
+                summary = catalog.text("summary", **docs_reference_links(locale, catalog))
                 expected_hrefs.update(_markdown_targets(summary))
             missing_hrefs = {href for href in expected_hrefs if href not in html}
             if missing_hrefs:
-                raise LearningPathI18nError(f"Missing navigation links in {page}: {sorted(missing_hrefs)}")
+                raise LearningPathI18nError(f"Missing links in {page}: {sorted(missing_hrefs)}")
+
+            switch_position = _first_href_position(html, set(_markdown_targets(switch)))
+            navigation_position = _first_href_position(html, navigation_hrefs)
+            title_position = _first_position(html, title)
+            if switch_position < 0 or title_position < 0 or not title_position < switch_position:
+                raise LearningPathI18nError(f"Language switch is not below the title in {page}")
+            if navigation_hrefs and (navigation_position < 0 or navigation_position <= switch_position):
+                raise LearningPathI18nError(f"Previous/next navigation is not below the language switch in {page}")
+
+            if not summary and "summary" in catalog.messages:
+                summary = catalog.text("summary")
+            summary_heading = summary.splitlines()[0] if summary else ""
+            navigation_heading = navigation.splitlines()[0]
+            if summary_heading == navigation_heading:
+                raise LearningPathI18nError(f"Summary and navigation headings are duplicated in {page}")
+            if summary_heading and _first_position(html, summary_heading.lstrip("# ")) < 0:
+                raise LearningPathI18nError(f"Missing summary heading in {page}")
+            if _first_position(html, navigation_heading.lstrip("# ")) < 0:
+                raise LearningPathI18nError(f"Missing navigation heading in {page}")
+
+            if locale == "en":
+                for relation in ("previous", "next"):
+                    target_id = getattr(lesson, relation)
+                    if (
+                        target_id is None
+                        or "en"
+                        in next(candidate for candidate in load_manifest() if candidate.lesson_id == target_id).locales
+                    ):
+                        continue
+                    japanese_only = catalog.text("navigation.japanese_only")
+                    if _first_position(html, japanese_only) < 0:
+                        raise LearningPathI18nError(
+                            f"Missing Japanese-only fallback label in {page} for {relation} link"
+                        )
+                if (
+                    lesson.lesson_id == "06_reusable_pipeline_recipes"
+                    and _first_position(html, catalog.text("navigation.japanese_only")) < 0
+                ):
+                    raise LearningPathI18nError(f"Missing Japanese-only docs-link note in {page}")
 
             exported_hrefs = re.findall(r'href=\\?"([^"\\\s]*learning-path[^"\\\s]*)\\?"', html)
             for href in exported_hrefs:
                 target = _normalized_site_target(page.relative_to(site_root), href)
-                if "en/learning-path" in target:
-                    target_path = site_root / target
-                    if not target_path.exists():
-                        raise LearningPathI18nError(f"English link points to a missing page: {page} -> {href}")
+                if "en/learning-path" in target and not (site_root / target).exists():
+                    raise LearningPathI18nError(f"English link points to a missing page: {page} -> {href}")
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--site", type=Path, help="validate exported PoC HTML below this directory")
+    parser.add_argument("--site", type=Path, help="validate exported HTML below this directory")
+    parser.add_argument("--all", action="store_true", help="validate every manifest export, not only the PoC pages")
     args = parser.parse_args(argv)
     validate_catalogs()
-    print("Learning Path translation catalogs are valid.")
+    print("Learning Path manifest and translation catalogs are valid.")
     if args.site is not None:
-        validate_exported_site(args.site.resolve())
-        print(f"Learning Path PoC HTML is valid below {args.site.resolve()}.")
+        validate_exported_site(args.site.resolve(), validate_all=args.all)
+        scope = "all planned" if args.all else "PoC"
+        print(f"Learning Path {scope} HTML is valid below {args.site.resolve()}.")
     return 0
 
 

--- a/scripts/validate_learning_path_i18n.py
+++ b/scripts/validate_learning_path_i18n.py
@@ -1,0 +1,115 @@
+"""Validate Learning Path translation catalogs and PoC HTML exports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import posixpath
+import re
+from pathlib import Path
+
+try:
+    from .learning_path_i18n import (
+        LearningPathI18nError,
+        _markdown_targets,
+        docs_relative_href,
+        lesson_by_id,
+        load_catalog,
+        navigation_markdown,
+        output_path,
+        poc_lessons,
+        validate_catalogs,
+    )
+except ImportError:  # Running this file directly keeps the existing `python scripts/foo.py` workflow.
+    from learning_path_i18n import (
+        LearningPathI18nError,
+        _markdown_targets,
+        docs_relative_href,
+        lesson_by_id,
+        load_catalog,
+        navigation_markdown,
+        output_path,
+        poc_lessons,
+        validate_catalogs,
+    )
+
+_CODE_MARKERS = {
+    "01_getting_started": ("wd.generate_sin", "combined_signal.fft().plot"),
+    "06_reusable_pipeline_recipes": ("RecipePlan.from_frame", "loaded_recipe.apply"),
+}
+
+
+def _normalized_site_target(current: Path, href: str) -> str:
+    return posixpath.normpath((current.parent / href).as_posix())
+
+
+def _serialized_text(value: str) -> tuple[str, str]:
+    """Return the literal and JSON-escaped forms used by a marimo export."""
+
+    return value, json.dumps(value, ensure_ascii=True)[1:-1]
+
+
+def validate_exported_site(site_root: Path) -> None:
+    """Check the generated PoC HTML without using snapshots or pixel comparison."""
+
+    for lesson in poc_lessons():
+        for locale in lesson.locales:
+            page = output_path(site_root, lesson, locale)
+            if not page.exists():
+                raise LearningPathI18nError(f"Missing exported page: {page}")
+            html = page.read_text(encoding="utf-8")
+            if "Traceback (most recent call last)" in html or "ModuleNotFoundError" in html:
+                raise LearningPathI18nError(f"Python error text found in exported page: {page}")
+
+            title = load_catalog(lesson.lesson_id, locale).text("title")
+            if not any(candidate in html for candidate in _serialized_text(title)):
+                raise LearningPathI18nError(f"Missing {locale} title in {page}: {title}")
+            for marker in _CODE_MARKERS[lesson.lesson_id]:
+                if marker not in html:
+                    raise LearningPathI18nError(f"Missing shared code marker {marker!r} in {page}")
+
+            expected_hrefs = set(_markdown_targets(navigation_markdown(lesson.lesson_id, locale)))
+            if locale == "en":
+                for relation in ("previous", "next"):
+                    target_id = getattr(lesson, relation)
+                    if target_id is None or "en" in lesson_by_id(target_id).locales:
+                        continue
+                    japanese_only = load_catalog(lesson.lesson_id, locale).text("navigation.japanese_only")
+                    if not any(candidate in html for candidate in _serialized_text(japanese_only)):
+                        raise LearningPathI18nError(
+                            f"Missing Japanese-only fallback label in {page} for {relation} link"
+                        )
+            if lesson.lesson_id == "06_reusable_pipeline_recipes":
+                summary = load_catalog(lesson.lesson_id, locale).text(
+                    "summary",
+                    how_to_href=docs_relative_href(locale, "how-to/pipeline-recipes/"),
+                    api_href=docs_relative_href(locale, "api/pipeline/"),
+                )
+                expected_hrefs.update(_markdown_targets(summary))
+            missing_hrefs = {href for href in expected_hrefs if href not in html}
+            if missing_hrefs:
+                raise LearningPathI18nError(f"Missing navigation links in {page}: {sorted(missing_hrefs)}")
+
+            exported_hrefs = re.findall(r'href=\\?"([^"\\\s]*learning-path[^"\\\s]*)\\?"', html)
+            for href in exported_hrefs:
+                target = _normalized_site_target(page.relative_to(site_root), href)
+                if "en/learning-path" in target:
+                    target_path = site_root / target
+                    if not target_path.exists():
+                        raise LearningPathI18nError(f"English link points to a missing page: {page} -> {href}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--site", type=Path, help="validate exported PoC HTML below this directory")
+    args = parser.parse_args(argv)
+    validate_catalogs()
+    print("Learning Path translation catalogs are valid.")
+    if args.site is not None:
+        validate_exported_site(args.site.resolve())
+        print(f"Learning Path PoC HTML is valid below {args.site.resolve()}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_learning_path_i18n.py
+++ b/scripts/validate_learning_path_i18n.py
@@ -144,13 +144,15 @@ def _validate_exported_layout(html: str, page: Path) -> None:
 def validate_exported_site(site_root: Path, *, validate_all: bool = False) -> None:
     """Check planned files and PoC HTML without snapshots or pixel comparison."""
 
-    planned_lessons = load_manifest() if validate_all else poc_lessons()
+    manifest_lessons = load_manifest()
+    planned_lessons = manifest_lessons if validate_all else poc_lessons(manifest_lessons)
+    lessons_by_id = {lesson.lesson_id: lesson for lesson in manifest_lessons}
     plan = build_export_plan(planned_lessons, site_root)
     for target in plan:
         if not target.output_path.exists():
             raise LearningPathI18nError(f"Missing planned export: {target.output_path}")
 
-    for lesson in poc_lessons():
+    for lesson in poc_lessons(manifest_lessons):
         for locale in lesson.locales:
             page = output_path(site_root, lesson, locale)
             html = page.read_text(encoding="utf-8")
@@ -204,11 +206,7 @@ def validate_exported_site(site_root: Path, *, validate_all: bool = False) -> No
             if locale == "en":
                 for relation in ("previous", "next"):
                     target_id = getattr(lesson, relation)
-                    if (
-                        target_id is None
-                        or "en"
-                        in next(candidate for candidate in load_manifest() if candidate.lesson_id == target_id).locales
-                    ):
+                    if target_id is None or "en" in lessons_by_id[target_id].locales:
                         continue
                     japanese_only = catalog.text("navigation.japanese_only")
                     if _first_position(html, japanese_only) < 0:

--- a/tests/docs/test_learning_path_i18n.py
+++ b/tests/docs/test_learning_path_i18n.py
@@ -1,0 +1,57 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.learning_path_i18n import (
+    LearningPathI18nError,
+    locale_from_argv,
+    poc_lessons,
+    validate_catalogs,
+)
+from scripts.validate_learning_path_i18n import validate_exported_site
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_learning_path_translation_catalog_contract() -> None:
+    validate_catalogs()
+
+    source_paths = [lesson.source_path for lesson in poc_lessons()]
+    assert len(source_paths) == len(set(source_paths))
+    for source_path in source_paths:
+        assert not source_path.with_name(f"{source_path.stem}.ja.py").exists()
+        assert not source_path.with_name(f"{source_path.stem}.en.py").exists()
+
+    with pytest.raises(SystemExit):
+        locale_from_argv(["--locale", "fr"])
+
+
+def test_learning_path_poc_exports_are_static_and_cross_linked(tmp_path: Path) -> None:
+    site_root = tmp_path / "site"
+    environment = {**os.environ, "MPLBACKEND": "Agg"}
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/export_learning_path.py",
+            "--poc",
+            "--output",
+            str(site_root),
+            "--jobs",
+            "2",
+        ],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=600,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    try:
+        validate_exported_site(site_root)
+    except LearningPathI18nError as exc:
+        pytest.fail(str(exc))

--- a/tests/docs/test_learning_path_i18n.py
+++ b/tests/docs/test_learning_path_i18n.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 import sys
@@ -5,10 +6,17 @@ from pathlib import Path
 
 import pytest
 
+from scripts.export_learning_path import _parse_args, export_plan, marimo_export_command
 from scripts.learning_path_i18n import (
+    COMMON_CATALOG_PATH,
+    COMMON_KEYS,
     LearningPathI18nError,
+    TranslationCatalog,
+    build_export_plan,
+    load_catalog,
+    load_manifest,
     locale_from_argv,
-    poc_lessons,
+    tracked_numbered_lesson_sources,
     validate_catalogs,
 )
 from scripts.validate_learning_path_i18n import validate_exported_site
@@ -16,17 +24,100 @@ from scripts.validate_learning_path_i18n import validate_exported_site
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+def test_learning_path_manifest_matches_tracked_sources(tmp_path: Path) -> None:
+    lessons = load_manifest()
+    manifest_sources = {lesson.source for lesson in lessons}
+    tracked_sources = set(tracked_numbered_lesson_sources())
+
+    assert manifest_sources == tracked_sources
+    assert len({lesson.lesson_id for lesson in lessons}) == len(lessons)
+    assert len(manifest_sources) == len(lessons)
+    assert all(lesson.lesson_id == Path(lesson.source).stem for lesson in lessons)
+    assert all(lesson.source_path.exists() for lesson in lessons)
+    manifest = json.loads((REPO_ROOT / "learning-path/manifest.json").read_text(encoding="utf-8"))
+    assert all("previous" not in lesson and "next" not in lesson for lesson in manifest["lessons"])
+
+    for index, lesson in enumerate(lessons):
+        assert lesson.previous == (lessons[index - 1].lesson_id if index else None)
+        assert lesson.next == (lessons[index + 1].lesson_id if index + 1 < len(lessons) else None)
+
+    plan = build_export_plan(lessons, tmp_path)
+    output_paths = [target.output_path for target in plan]
+    assert len(output_paths) == len(set(output_paths))
+    assert [target.lesson.lesson_id for target in plan if target.locale == "ja"] == [
+        lesson.lesson_id for lesson in lessons
+    ]
+
+
 def test_learning_path_translation_catalog_contract() -> None:
     validate_catalogs()
 
-    source_paths = [lesson.source_path for lesson in poc_lessons()]
-    assert len(source_paths) == len(set(source_paths))
-    for source_path in source_paths:
+    common = json.loads(COMMON_CATALOG_PATH.read_text(encoding="utf-8"))
+    assert set(common["messages"]) == COMMON_KEYS
+    for lesson in load_manifest():
+        if lesson.catalog_path is None:
+            continue
+        catalog = json.loads(lesson.catalog_path.read_text(encoding="utf-8"))
+        assert not COMMON_KEYS.intersection(catalog["messages"])
+
+    for lesson in load_manifest():
+        source_path = lesson.source_path
         assert not source_path.with_name(f"{source_path.stem}.ja.py").exists()
         assert not source_path.with_name(f"{source_path.stem}.en.py").exists()
 
     with pytest.raises(SystemExit):
         locale_from_argv(["--locale", "fr"])
+    with pytest.raises(LearningPathI18nError, match="Unsupported locale"):
+        load_catalog("01_getting_started", "fr")
+
+
+def test_translation_catalog_uses_explicit_placeholders_and_literal_braces() -> None:
+    catalog = TranslationCatalog(
+        "placeholder_test",
+        {
+            "literal": {"ja": ('config = {"sampling_rate": 48000}',)},
+            "message": {"ja": ("Hello [[name]]",)},
+            "invalid": {"ja": ("Value [[name.attr]]",)},
+        },
+    )
+
+    assert catalog.text("literal") == 'config = {"sampling_rate": 48000}'
+    assert catalog.text("message", name="Wandas") == "Hello Wandas"
+    with pytest.raises(LearningPathI18nError, match="placeholder_test:message:ja"):
+        catalog.text("message")
+    with pytest.raises(LearningPathI18nError, match="placeholder_test:message:ja"):
+        catalog.text("message", name="Wandas", unused="value")
+    with pytest.raises(LearningPathI18nError, match="placeholder_test:invalid:ja"):
+        catalog.text("invalid", name="Wandas")
+    with pytest.raises(LearningPathI18nError, match="placeholder_test:missing:ja"):
+        catalog.text("missing")
+
+
+def test_learning_path_export_plan_is_deterministic_and_preserves_legacy_commands() -> None:
+    args = _parse_args(["--all", "--dry-run"])
+    plan = export_plan(args)
+    assert plan == export_plan(args)
+
+    lessons = load_manifest()
+    expected = [(lesson.lesson_id, locale) for lesson in lessons for locale in lesson.locales]
+    assert [(target.lesson.lesson_id, target.locale) for target in plan] == expected
+    assert len({target.output_path for target in plan}) == len(plan)
+
+    for target in plan:
+        command = marimo_export_command(target)
+        if target.lesson.catalog_path is None:
+            assert "--" not in command
+            assert target.locale == "ja"
+        else:
+            assert command[-3:] == ("--", "--locale", target.locale)
+
+    poc_plan = export_plan(_parse_args(["--poc", "--jobs", "2"]))
+    assert [(target.lesson.lesson_id, target.locale) for target in poc_plan] == [
+        ("01_getting_started", "ja"),
+        ("01_getting_started", "en"),
+        ("06_reusable_pipeline_recipes", "ja"),
+        ("06_reusable_pipeline_recipes", "en"),
+    ]
 
 
 def test_learning_path_poc_exports_are_static_and_cross_linked(tmp_path: Path) -> None:

--- a/tests/docs/test_learning_path_i18n.py
+++ b/tests/docs/test_learning_path_i18n.py
@@ -1,8 +1,12 @@
+import ast
 import json
 import os
+import re
 import subprocess
 import sys
+from collections.abc import Mapping
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -19,9 +23,47 @@ from scripts.learning_path_i18n import (
     tracked_numbered_lesson_sources,
     validate_catalogs,
 )
-from scripts.validate_learning_path_i18n import validate_exported_site
+from scripts.validate_learning_path_i18n import _exported_notebook_cells, validate_exported_site
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _app_cell_decorator(decorator: ast.expr) -> ast.Attribute | None:
+    target = decorator.func if isinstance(decorator, ast.Call) else decorator
+    if not isinstance(target, ast.Attribute) or not isinstance(target.value, ast.Name):
+        return None
+    if target.value.id != "app" or target.attr != "cell":
+        return None
+    return target
+
+
+def _source_cell_code(source_path: Path) -> tuple[tuple[str, bool], ...]:
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    cells: list[tuple[str, bool]] = []
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if not any(_app_cell_decorator(decorator) is not None for decorator in node.decorator_list):
+            continue
+        hidden = any(
+            isinstance(decorator, ast.Call)
+            and any(
+                keyword.arg == "hide_code" and isinstance(keyword.value, ast.Constant) and keyword.value.value is True
+                for keyword in decorator.keywords
+            )
+            for decorator in node.decorator_list
+        )
+        cells.append((ast.unparse(node), hidden))
+    return tuple(cells)
+
+
+def _exported_cell_code(cell: dict[str, object]) -> tuple[str, bool]:
+    code = cell.get("code")
+    config = cell.get("config")
+    assert isinstance(code, str)
+    assert isinstance(config, Mapping)
+    config_mapping = cast(Mapping[str, object], config)
+    return code, config_mapping.get("hide_code") is True
 
 
 def test_learning_path_manifest_matches_tracked_sources(tmp_path: Path) -> None:
@@ -103,6 +145,26 @@ def test_learning_path_export_plan_is_deterministic_and_preserves_legacy_command
     assert [(target.lesson.lesson_id, target.locale) for target in plan] == expected
     assert len({target.output_path for target in plan}) == len(plan)
 
+    en_plan = export_plan(_parse_args(["--lesson", "01_getting_started", "--locale", "en", "--dry-run"]))
+    assert [(target.lesson.lesson_id, target.locale) for target in en_plan] == [("01_getting_started", "en")]
+
+    ja_plan = export_plan(_parse_args(["--lesson", "01_getting_started", "--locale", "ja", "--dry-run"]))
+    assert [(target.lesson.lesson_id, target.locale) for target in ja_plan] == [("01_getting_started", "ja")]
+
+    all_en_plan = export_plan(_parse_args(["--all", "--locale", "en", "--dry-run"]))
+    assert [(target.lesson.lesson_id, target.locale) for target in all_en_plan] == [
+        ("01_getting_started", "en"),
+        ("06_reusable_pipeline_recipes", "en"),
+    ]
+
+    all_ja_plan = export_plan(_parse_args(["--all", "--locale", "ja", "--dry-run"]))
+    assert [(target.lesson.lesson_id, target.locale) for target in all_ja_plan] == [
+        (lesson.lesson_id, "ja") for lesson in lessons
+    ]
+
+    with pytest.raises(LearningPathI18nError, match="No selected lesson is available"):
+        export_plan(_parse_args(["--lesson", "00_why_wandas", "--locale", "en", "--dry-run"]))
+
     for target in plan:
         command = marimo_export_command(target)
         if target.lesson.catalog_path is None:
@@ -118,6 +180,25 @@ def test_learning_path_export_plan_is_deterministic_and_preserves_legacy_command
         ("06_reusable_pipeline_recipes", "ja"),
         ("06_reusable_pipeline_recipes", "en"),
     ]
+
+
+def test_learning_path_06_public_imports_are_visible_and_i18n_setup_is_hidden() -> None:
+    source_cells = _source_cell_code(REPO_ROOT / "learning-path/06_reusable_pipeline_recipes.py")
+    visible_source = "\n".join(code for code, hidden in source_cells if not hidden)
+    hidden_source = "\n".join(code for code, hidden in source_cells if hidden)
+
+    for statement in (
+        "import json",
+        "import numpy as np",
+        "import wandas as wd",
+        "from wandas import pipeline as pipeline_api",
+    ):
+        assert statement in visible_source
+    assert "from scripts.learning_path_i18n import" in hidden_source
+    assert "scripts.learning_path_i18n" not in visible_source
+    assert "load_catalog" not in visible_source
+    assert "locale_from_argv" not in visible_source
+    assert re.search(r"\bt\s*\(\s*['\"]", visible_source) is None
 
 
 def test_learning_path_poc_exports_are_static_and_cross_linked(tmp_path: Path) -> None:
@@ -146,3 +227,25 @@ def test_learning_path_poc_exports_are_static_and_cross_linked(tmp_path: Path) -
         validate_exported_site(site_root)
     except LearningPathI18nError as exc:
         pytest.fail(str(exc))
+
+    for locale in ("ja", "en"):
+        page = (
+            site_root
+            / ("en/learning-path" if locale == "en" else "learning-path")
+            / ("06_reusable_pipeline_recipes.html")
+        )
+        cells = [_exported_cell_code(cell) for cell in _exported_notebook_cells(page.read_text(encoding="utf-8"), page)]
+        visible_html = "\n".join(code for code, hidden in cells if not hidden)
+        hidden_html = "\n".join(code for code, hidden in cells if hidden)
+        for statement in (
+            "import json",
+            "import numpy as np",
+            "import wandas as wd",
+            "from wandas import pipeline as pipeline_api",
+        ):
+            assert statement in visible_html
+        assert "from scripts.learning_path_i18n import" in hidden_html
+        assert "scripts.learning_path_i18n" not in visible_html
+        assert "load_catalog" not in visible_html
+        assert "locale_from_argv" not in visible_html
+        assert re.search(r"\bt\s*\(\s*['\"]", visible_html) is None


### PR DESCRIPTION
## Summary

- Organize the existing RecipePlan/Learning Path navigation and documentation links.
- Add a minimal Japanese/English internationalization PoC for Learning Path 01 and 06.
- Keep one marimo source per lesson and select translated catalog content with `-- --locale ja|en`.
- Preserve the existing Japanese URLs and add English pages under `/en/learning-path/`.
- Add a manifest-driven export path shared by local runs, CI, and deployment.
- Add catalog, placeholder, navigation, static HTML, and shared-source validation.

## Design

The PoC compares duplicated marimo sources, bilingual pages, catalog-driven export, and gettext/generated-source/MkDocs-plugin approaches. It adopts one Python source plus JSON line-array catalogs, with Japanese fallback links for lessons that are not translated yet.

The design record is in `docs/design/learning-path-internationalization.md`.

## Validation

- `uv run --no-sync marimo check --strict learning-path/01_getting_started.py learning-path/06_reusable_pipeline_recipes.py` ✅
- `uv run --no-sync python scripts/validate_learning_path_i18n.py` ✅
- locale plan regression tests: `--lesson ... --locale en` and `ja` each produce one item; `--all --locale en` produces only 01/06 English items ✅
- `uv run --no-sync pytest tests/docs/test_learning_path_i18n.py -q --no-cov` — 6 passed ✅
- PoC export (`--jobs 2`) and generated HTML validation for 01/06 in Japanese and English ✅
- locale-limited export produced only `en/learning-path/01_getting_started.html` ✅
- `uv run --no-sync mkdocs build --strict` ✅
- `uv run --no-sync ruff check ...`, `ruff format --check ...`, `ty check ...`, and `git diff --check` ✅
- Review follow-up: HTML validation reuses one manifest load, and deploy export sets `MPLBACKEND=Agg` ✅
- PR CI checks on commit `1c31ad21` all pass, including CI Gate.
