### PR TITLE
docs: generalize Learning Path i18n validation

### DIFF
--- a/.agents/skills/wandas-learning-material-authoring/SKILL.md
+++ b/.agents/skills/wandas-learning-material-authoring/SKILL.md
@@ -52,6 +52,21 @@ Do not encode static explanation as executable code. Do not prescribe a particul
 - Run `uv run marimo check <notebook>` after adding, splitting, merging, or renaming cells. Do not rely only on export execution to detect reactive-definition conflicts.
 - Make output explain what it proves. Avoid unexplained counts, dumps, and intermediate state.
 
+## Standard Learning Path internationalization procedure
+
+For a lesson that is being prepared for Japanese and English static export:
+
+1. Make visible code language-neutral: keep Python names, Wandas API names, units, and short ASCII plot labels stable.
+2. Put locale setup, catalog loading, navigation helpers, and translated display cells in `hide_code=True` cells.
+3. Keep public imports that a learner needs in visible cells so copied code remains executable.
+4. Move learner-facing prose, headings, tables, output descriptions, and figure explanations into the lesson catalog.
+5. Use only `[[name]]` for dynamic values; keep the placeholder set identical in Japanese and English.
+6. Reuse common catalog keys instead of copying common navigation or language strings into the lesson catalog.
+7. Declare `en` and the lesson catalog in `learning-path/manifest.json`; do not create locale-specific Python source files.
+8. Export the same source once for `ja` and once for `en` through `scripts/export_learning_path.py`.
+9. Validate both generated pages, including title, language switch, navigation, links, visible-cell i18n leakage, and shared visible code.
+10. Do not add new Japanese text to Matplotlib titles, legends, or axis labels; put localized explanation next to the figure to avoid missing-glyph warnings.
+
 ## Choose examples at the right abstraction
 
 - Demonstrate the primary public workflow a learner should normally adopt.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -130,17 +129,17 @@ jobs:
       - name: Learning Path全体のexport planを検証
         run: uv run --no-sync python scripts/export_learning_path.py --all --dry-run
 
-      - name: Learning Path PoCを日英export
+      - name: Learning Path翻訳済み教材を日英export
         env:
           MPLBACKEND: Agg
         run: >-
           uv run --no-sync python scripts/export_learning_path.py
-          --poc --output "$RUNNER_TEMP/wandas-learning-path-poc" --jobs 2
+          --translated --output "$RUNNER_TEMP/wandas-learning-path-translated" --jobs 2
 
-      - name: Learning Path PoCの生成HTMLを検証
+      - name: Learning Path翻訳済み教材の生成HTMLを検証
         run: >-
           uv run --no-sync python scripts/validate_learning_path_i18n.py
-          --site "$RUNNER_TEMP/wandas-learning-path-poc"
+          --site "$RUNNER_TEMP/wandas-learning-path-translated" --translated
 
       - name: Documentation contract tests
         run: uv run --no-sync pytest tests/docs -q --no-cov

--- a/docs/design/learning-path-internationalization.md
+++ b/docs/design/learning-path-internationalization.md
@@ -72,13 +72,16 @@ Dはgettext自体を否定しないが、現在の小規模な教材数では、
 `scripts/export_learning_path.py --all --dry-run` は、manifestの全日本語ページと、
 manifestで `en` を宣言したページだけの英語ページを、決定的な順序で表示する。項目数は
 manifestのlesson数とlocale宣言に従って増減する。CIはこの全planをdry-runで検査し、重い
-実行はPoCの4ページに限定する。
+`--translated` はmanifestで `en` とcatalogを宣言した全教材を日英でexportする。
+CIではこのscopeを実行し、新しい英語教材を追加するたびに教材IDをworkflowへ追加しない。
+`poc_lessons()` は01/06の軽量な代表exportをローカル確認用に残す。
 
 HTMLの詳細検証対象はexport選択とは分離する。`translated_lessons()` はmanifestで `en`
 とlesson catalogを宣言した全教材を、manifest順で返す。validatorの
 `validate_exported_site(..., validate_all=True)` は全manifest exportの存在を確認したうえで、
-このtranslated lesson集合の日英HTMLを詳細検証する。`poc_lessons()` は01/06の代表exportを
-軽量なCIで選ぶためだけに残し、新しい日英教材を追加するたびにvalidatorへ教材IDを追加しない。
+このtranslated lesson集合の日英HTMLを詳細検証する。`--translated` は翻訳済みlessonの
+exportを対象とし、CIの全translated siteだけでなく、ローカルの単一lesson siteも検証できる。
+新しい日英教材を追加するたびにvalidatorへ教材IDを追加しない。
 
 ## 翻訳カタログ
 
@@ -223,8 +226,9 @@ AST検査も併用する。
 - translated lessonのsourceに日英別 `.ja.py`/`.en.py` がなく、visible cellに翻訳実装がない。
 - `marimo check --strict`、日本語export、英語export、offline executionでエラーやtracebackがない。
 - `--all --dry-run` が全日本語lesson、英語を宣言したlesson、決定的順序だけを計画する。
-- `validate_exported_site(..., validate_all=True)` は全manifest exportの存在と、catalogを持つ全translated lessonの日英HTMLを検証する。タイトル、switch、navigation、visible codeへのi18n漏出、traceback/import error、英語リンク切れ、summary/navigation見出し重複を確認し、hidden cellを除いたvisible cell code列がja/enで順序を含め一致することを確認する。
-- CIの実exportは01/06の4ページを `--jobs 2` で行い、生成HTMLのPoC固有マーカー、タイトル、switch、navigation、fallback、Japanese-only注記、リンク存在を検証する。全translated lessonの詳細検証は全siteをexportするdeploy経路（`--all --jobs 1`）で行う。
+- `validate_exported_site(..., validate_all=True)` は全manifest exportの存在と、catalogを持つ全translated lessonの日英HTMLを検証する。`--translated` は同じ共通検証を翻訳済みlessonへ適用する。タイトル、switch、navigation、visible codeへの実際のi18n呼び出し、traceback/import error、英語リンク切れ、summary/navigation見出し重複を確認し、hidden cellを除いたvisible cell code列がja/enで順序を含め一致することを確認する。`t`、`locale`、`catalog` という一般的なidentifierだけでは失敗させない。
+- CIの実exportは`--translated --jobs 2`でmanifest上の翻訳済みlesson全件の日英ページを生成し、同じscopeのHTML検証を行う。デプロイは`--all --jobs 1`で全siteをexportし、`--all`検証を通過してから公開する。
+- stacked PRでもdocs jobが起動するよう、workflowの`pull_request`はbase branchで絞り込まない。`push`は`main`限定のままとする。
 
 CI jobはdocs変更時に次を実行する。
 
@@ -232,9 +236,9 @@ CI jobはdocs変更時に次を実行する。
 uv run --no-sync python scripts/validate_learning_path_i18n.py
 uv run --no-sync python scripts/export_learning_path.py --all --dry-run
 uv run --no-sync python scripts/export_learning_path.py \
-  --poc --output "$RUNNER_TEMP/wandas-learning-path-poc" --jobs 2
+  --translated --output "$RUNNER_TEMP/wandas-learning-path-translated" --jobs 2
 uv run --no-sync python scripts/validate_learning_path_i18n.py \
-  --site "$RUNNER_TEMP/wandas-learning-path-poc"
+  --site "$RUNNER_TEMP/wandas-learning-path-translated" --translated
 ```
 
 既存の `tests/docs/test_learning_path_executable_contracts.py` は全教材のoffline

--- a/docs/design/learning-path-internationalization.md
+++ b/docs/design/learning-path-internationalization.md
@@ -69,11 +69,10 @@ Dはgettext自体を否定しないが、現在の小規模な教材数では、
 - manifestに書かれた `previous`/`next` は拒否する。
 - `build_export_plan()` が各localeの出力先を決定し、重複を拒否する。
 
-`scripts/export_learning_path.py --all --dry-run` は、manifestの全日本語ページと、
-manifestで `en` を宣言したページだけの英語ページを、決定的な順序で表示する。項目数は
-manifestのlesson数とlocale宣言に従って増減する。CIはこの全planをdry-runで検査し、重い
-`--translated` はmanifestで `en` とcatalogを宣言した全教材を日英でexportする。
-CIではこのscopeを実行し、新しい英語教材を追加するたびに教材IDをworkflowへ追加しない。
+`scripts/export_learning_path.py --all --dry-run` は、manifestの全日本語ページと、manifestで
+`en` を宣言した英語ページを決定的な順序で表示する。CIはこの全planをdry-runで検査する。
+実際のexportでは `--translated` を使い、manifestで `en` とcatalogを宣言した全教材を
+日本語・英語の両方で生成する。新しい英語教材を追加するたびに教材IDをworkflowへ追加しない。
 `poc_lessons()` は01/06の軽量な代表exportをローカル確認用に残す。
 
 HTMLの詳細検証対象はexport選択とは分離する。`translated_lessons()` はmanifestで `en`

--- a/docs/design/learning-path-internationalization.md
+++ b/docs/design/learning-path-internationalization.md
@@ -74,6 +74,12 @@ manifestで `en` を宣言したページだけの英語ページを、決定的
 日本語9ページ、英語2ページの11項目である。CIはこの全planをdry-runで検査し、重い実行
 はPoCの4ページに限定する。
 
+HTMLの詳細検証対象はexport選択とは分離する。`translated_lessons()` はmanifestで `en`
+とlesson catalogを宣言した全教材を、manifest順で返す。validatorの
+`validate_exported_site(..., validate_all=True)` は全manifest exportの存在を確認したうえで、
+このtranslated lesson集合の日英HTMLを詳細検証する。`poc_lessons()` は01/06の代表exportを
+軽量なCIで選ぶためだけに残し、新しい日英教材を追加するたびにvalidatorへ教材IDを追加しない。
+
 ## 翻訳カタログ
 
 カタログは標準ライブラリの `json` だけで読める行配列JSONとする。
@@ -215,7 +221,8 @@ AST検査も併用する。
 - 01/06のsourceに日英別 `.ja.py`/`.en.py` がなく、visible cellに翻訳実装がない。
 - `marimo check --strict`、日本語export、英語export、offline executionでエラーやtracebackがない。
 - `--all --dry-run` が全日本語lesson、英語を宣言したlesson、決定的順序だけを計画する。
-- CIの実exportは01/06の4ページを `--jobs 2` で行い、生成HTMLのタイトル、switch、navigation、主要Wandasコード、fallback、Japanese-only注記、リンク存在を検証する。
+- `validate_exported_site(..., validate_all=True)` は全manifest exportの存在と、catalogを持つ全translated lessonの日英HTMLを検証する。タイトル、switch、navigation、visible codeへのi18n漏出、traceback/import error、英語リンク切れ、summary/navigation見出し重複を確認し、hidden cellを除いたvisible cell code列がja/enで順序を含め一致することを確認する。
+- CIの実exportは01/06の4ページを `--jobs 2` で行い、生成HTMLのPoC固有マーカー、タイトル、switch、navigation、fallback、Japanese-only注記、リンク存在を検証する。全translated lessonの詳細検証は全siteをexportするdeploy経路（`--all --jobs 1`）で行う。
 
 CI jobはdocs変更時に次を実行する。
 

--- a/docs/design/learning-path-internationalization.md
+++ b/docs/design/learning-path-internationalization.md
@@ -50,7 +50,7 @@ learning-path/06_reusable_pipeline_recipes.py
 Cは、Pythonコード重複、API変更時の修正箇所、静的HTML配信、未翻訳教材の混在、CIでの
 不一致検出を同時に満たす。Aは短期的には分かりやすいが、今回の「API変更を1箇所だけ
 直す」という条件に反する。Bは表示言語を選べず、Cより翻訳漏れを明確に検出しにくい。
-Dはgettext自体を否定しないが、現在の9教材規模では、marimo実行・図・前後リンクまで
+Dはgettext自体を否定しないが、現在の小規模な教材数では、marimo実行・図・前後リンクまで
 含む契約を保つための生成基盤が過剰である。
 
 ## manifest、順序、export plan
@@ -70,9 +70,9 @@ Dはgettext自体を否定しないが、現在の9教材規模では、marimo�
 - `build_export_plan()` が各localeの出力先を決定し、重複を拒否する。
 
 `scripts/export_learning_path.py --all --dry-run` は、manifestの全日本語ページと、
-manifestで `en` を宣言したページだけの英語ページを、決定的な順序で表示する。現在は
-日本語9ページ、英語2ページの11項目である。CIはこの全planをdry-runで検査し、重い実行
-はPoCの4ページに限定する。
+manifestで `en` を宣言したページだけの英語ページを、決定的な順序で表示する。項目数は
+manifestのlesson数とlocale宣言に従って増減する。CIはこの全planをdry-runで検査し、重い
+実行はPoCの4ページに限定する。
 
 HTMLの詳細検証対象はexport選択とは分離する。`translated_lessons()` はmanifestで `en`
 とlesson catalogを宣言した全教材を、manifest順で返す。validatorの
@@ -89,6 +89,8 @@ learning-path/translations/common.json
 learning-path/translations/01_getting_started.json
 learning-path/translations/06_reusable_pipeline_recipes.json
 ```
+
+上のlesson catalogはPoCの代表例であり、英語対応するlessonごとに対応するcatalogを追加する。
 
 `common.json` は次のhelper所有キーだけを持ち、教材カタログへ複製しない。
 
@@ -155,7 +157,7 @@ uv run --no-sync python scripts/export_learning_path.py \
 ```
 
 `--locale` を省略した場合は従来どおり各lessonの全available localeを計画し、
-`--all --locale en` は現在英語対応している01と06の英語版だけを計画する。
+`--all --locale en` はmanifestで `en` を宣言した全教材の英語版だけを計画する。
 
 marimoのstatic HTML exportには、0.23.9のCLI上、ページ全体の `lang` をlocale別に設定
 する公開引数/APIがない。実測では日本語・英語の両HTMLとも `<html lang="en">` になった。
@@ -218,7 +220,7 @@ AST検査も併用する。
 - tracked numbered lesson集合とmanifest source集合が一致する。
 - ID/source stem、source存在、locale、catalog、出力先、配列順navigationが妥当である。
 - common/lesson key、ja/en coverage、空値、unknown locale/key、placeholder集合、literal brace、コードフェンス、内部リンクを検査する。
-- 01/06のsourceに日英別 `.ja.py`/`.en.py` がなく、visible cellに翻訳実装がない。
+- translated lessonのsourceに日英別 `.ja.py`/`.en.py` がなく、visible cellに翻訳実装がない。
 - `marimo check --strict`、日本語export、英語export、offline executionでエラーやtracebackがない。
 - `--all --dry-run` が全日本語lesson、英語を宣言したlesson、決定的順序だけを計画する。
 - `validate_exported_site(..., validate_all=True)` は全manifest exportの存在と、catalogを持つ全translated lessonの日英HTMLを検証する。タイトル、switch、navigation、visible codeへのi18n漏出、traceback/import error、英語リンク切れ、summary/navigation見出し重複を確認し、hidden cellを除いたvisible cell code列がja/enで順序を含め一致することを確認する。

--- a/scripts/export_learning_path.py
+++ b/scripts/export_learning_path.py
@@ -43,7 +43,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     selection.add_argument(
         "--translated",
         action="store_true",
-        help="export every lesson with an English translation catalog in Japanese and English",
+        help="export every lesson with an English translation catalog in both locales unless --locale is set",
     )
     selection.add_argument("--lesson", help="export one lesson by manifest id")
     parser.add_argument("--locale", choices=SUPPORTED_LOCALES, help="export only this locale")

--- a/scripts/export_learning_path.py
+++ b/scripts/export_learning_path.py
@@ -19,6 +19,7 @@ try:
         build_export_plan,
         load_manifest,
         poc_lessons,
+        translated_lessons,
     )
 except ImportError:  # Running this file directly keeps the existing python scripts/foo.py workflow.
     from learning_path_i18n import (
@@ -30,6 +31,7 @@ except ImportError:  # Running this file directly keeps the existing python scri
         build_export_plan,
         load_manifest,
         poc_lessons,
+        translated_lessons,
     )
 
 
@@ -38,6 +40,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     selection = parser.add_mutually_exclusive_group(required=True)
     selection.add_argument("--all", action="store_true", help="export every lesson in every available locale")
     selection.add_argument("--poc", action="store_true", help="export the two manifest entries marked for the PoC")
+    selection.add_argument(
+        "--translated",
+        action="store_true",
+        help="export every lesson with an English translation catalog in Japanese and English",
+    )
     selection.add_argument("--lesson", help="export one lesson by manifest id")
     parser.add_argument("--locale", choices=SUPPORTED_LOCALES, help="export only this locale")
     parser.add_argument("--output", type=Path, default=Path("docs/site"), help="site output directory")
@@ -55,6 +62,10 @@ def select_lessons(args: argparse.Namespace) -> tuple[Lesson, ...]:
     lessons = load_manifest()
     if args.poc:
         selected = poc_lessons()
+    elif args.translated:
+        selected = translated_lessons(lessons)
+        if not selected:
+            raise LearningPathI18nError("No translated lessons are available")
     elif args.lesson:
         selected = tuple(lesson for lesson in lessons if lesson.lesson_id == args.lesson)
         if not selected:

--- a/scripts/learning_path_i18n.py
+++ b/scripts/learning_path_i18n.py
@@ -273,6 +273,19 @@ def lesson_by_id(lesson_id: str) -> Lesson:
     raise LearningPathI18nError(f"Unknown lesson id: {lesson_id}")
 
 
+def translated_lessons(lessons: Iterable[Lesson] | None = None) -> tuple[Lesson, ...]:
+    """Return manifest lessons that have an English translation catalog.
+
+    ``poc_lessons`` intentionally remains a small export-selection helper for
+    representative CI exports.  HTML validation should use this manifest
+    driven predicate instead, so adding an English lesson automatically adds
+    it to the detailed validation scope.
+    """
+
+    available_lessons = load_manifest() if lessons is None else tuple(lessons)
+    return tuple(lesson for lesson in available_lessons if "en" in lesson.locales and lesson.catalog is not None)
+
+
 def locale_from_argv(argv: Sequence[str] | None = None) -> str:
     """Read the locale passed after marimo's ``--`` separator."""
 

--- a/scripts/learning_path_i18n.py
+++ b/scripts/learning_path_i18n.py
@@ -47,15 +47,12 @@ COMMON_KEYS = frozenset(
 
 _I18N_HELPER_NAMES = frozenset(
     {
-        "catalog",
         "docs_reference_links",
         "docs_relative_href",
         "language_switch_markdown",
         "load_catalog",
-        "locale",
         "locale_from_argv",
         "navigation_markdown",
-        "t",
     }
 )
 
@@ -547,6 +544,54 @@ def _is_hidden_cell(node: ast.FunctionDef) -> bool:
     return False
 
 
+def _reject_visible_i18n_ast(tree: ast.AST, location: str) -> None:
+    """Reject actual i18n machinery while allowing ordinary identifiers.
+
+    ``t``, ``locale``, and ``catalog`` are useful names in learning material,
+    so their mere presence is not evidence of leaked implementation details.
+    This check deliberately looks at Python syntax instead of searching source
+    text.  The same function is used for source cells and exported cell
+    metadata so the two validation paths cannot drift apart.
+    """
+
+    for child in ast.walk(tree):
+        if isinstance(child, ast.Import):
+            if any(alias.name.startswith("scripts.learning_path_i18n") for alias in child.names):
+                raise LearningPathI18nError(f"i18n import appears in visible code {location}")
+        elif isinstance(child, ast.ImportFrom):
+            if child.module and child.module.startswith("scripts.learning_path_i18n"):
+                raise LearningPathI18nError(f"i18n import appears in visible code {location}")
+        elif isinstance(child, ast.Call):
+            function_path = _attribute_path(child.func)
+            if function_path and function_path[-1] in _I18N_HELPER_NAMES:
+                raise LearningPathI18nError(f"i18n helper {function_path[-1]!r} is called in visible code {location}")
+            if function_path == ("catalog", "text"):
+                raise LearningPathI18nError(f"catalog.text() is called in visible code {location}")
+            if (
+                function_path == ("t",)
+                and child.args
+                and isinstance(child.args[0], ast.Constant)
+                and isinstance(child.args[0].value, str)
+            ):
+                raise LearningPathI18nError(f"translation call appears in visible code {location}")
+            for keyword in child.keywords:
+                if keyword.arg not in {"label", "title", "xlabel", "ylabel"}:
+                    continue
+                if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
+                    if not keyword.value.value.isascii():
+                        raise LearningPathI18nError(f"localized plot label must be ASCII in {location}")
+
+
+def validate_visible_code(code: str, location: str | Path) -> None:
+    """Validate one learner-visible cell using the source AST contract."""
+
+    try:
+        tree = ast.parse(code, filename=str(location))
+    except SyntaxError as exc:
+        raise LearningPathI18nError(f"Invalid visible Python code in {location}: {exc}") from exc
+    _reject_visible_i18n_ast(tree, str(location))
+
+
 def validate_visible_source(source_path: Path) -> None:
     """Reject i18n implementation details in learner-visible cells."""
 
@@ -559,24 +604,7 @@ def validate_visible_source(source_path: Path) -> None:
             continue
         if _is_hidden_cell(node):
             continue
-        for child in ast.walk(node):
-            if isinstance(child, ast.Name) and child.id in _I18N_HELPER_NAMES:
-                raise LearningPathI18nError(
-                    f"i18n helper {child.id!r} appears in visible cell {source_path}:{node.lineno}"
-                )
-            if isinstance(child, ast.Call) and isinstance(child.func, ast.Name) and child.func.id == "t":
-                raise LearningPathI18nError(f"translation call appears in visible cell {source_path}:{node.lineno}")
-            if isinstance(child, ast.Call):
-                for keyword in child.keywords:
-                    if keyword.arg not in {"label", "title", "xlabel", "ylabel"}:
-                        continue
-                    if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
-                        if not keyword.value.value.isascii():
-                            raise LearningPathI18nError(
-                                f"localized plot label must be ASCII in {source_path}:{node.lineno}"
-                            )
-            if isinstance(child, ast.ImportFrom) and child.module == "scripts.learning_path_i18n":
-                raise LearningPathI18nError(f"i18n import appears in visible cell {source_path}:{node.lineno}")
+        _reject_visible_i18n_ast(node, f"{source_path}:{node.lineno}")
 
 
 def validate_catalogs() -> None:

--- a/scripts/validate_learning_path_i18n.py
+++ b/scripts/validate_learning_path_i18n.py
@@ -12,8 +12,8 @@ from typing import cast
 
 try:
     from .learning_path_i18n import (
-        _I18N_HELPER_NAMES,
         LearningPathI18nError,
+        Lesson,
         _markdown_targets,
         build_export_plan,
         docs_reference_links,
@@ -25,11 +25,12 @@ try:
         poc_lessons,
         translated_lessons,
         validate_catalogs,
+        validate_visible_code,
     )
 except ImportError:  # Running this file directly keeps the existing python scripts/foo.py workflow.
     from learning_path_i18n import (
-        _I18N_HELPER_NAMES,
         LearningPathI18nError,
+        Lesson,
         _markdown_targets,
         build_export_plan,
         docs_reference_links,
@@ -41,6 +42,7 @@ except ImportError:  # Running this file directly keeps the existing python scri
         poc_lessons,
         translated_lessons,
         validate_catalogs,
+        validate_visible_code,
     )
 
 # These are deliberately kept as PoC-specific regression checks. The general
@@ -112,9 +114,25 @@ def _validate_visible_exported_code(html: str, page: Path) -> None:
     """Ensure exported visible cells do not expose the translation machinery."""
 
     for code in _visible_exported_code(html, page):
-        leaked_helper = any(re.search(rf"\b{re.escape(name)}\b", code) for name in _I18N_HELPER_NAMES)
-        if "scripts.learning_path_i18n" in code or leaked_helper:
-            raise LearningPathI18nError(f"Translation implementation leaked into visible code: {page}")
+        validate_visible_code(code, page)
+
+
+_PYTHON_ERROR_PATTERNS = (
+    re.compile(r"Traceback \(most recent call last\)"),
+    re.compile(r"(?<!except )\bModuleNotFoundError:\s+\S"),
+    re.compile(r"(?<!except )\bImportError:\s+\S"),
+)
+
+
+def _contains_python_error_text(html: str) -> bool:
+    """Return whether HTML contains an actual traceback/error line.
+
+    A lesson may legitimately show ``except ImportError:`` as source code;
+    that is not an execution failure.  Error markers therefore require a
+    traceback heading or an exception name followed by an error message.
+    """
+
+    return any(pattern.search(html) for pattern in _PYTHON_ERROR_PATTERNS)
 
 
 def _validate_shared_visible_code(
@@ -179,12 +197,44 @@ def _validate_exported_layout(html: str, page: Path) -> None:
             raise LearningPathI18nError(f"Title, switch, and navigation cells must hide code: {page}")
 
 
-def validate_exported_site(site_root: Path, *, validate_all: bool = False) -> None:
+def _translated_site_lessons(site_root: Path, manifest_lessons: tuple[Lesson, ...]) -> tuple[Lesson, ...]:
+    """Select translated lessons represented by a full or lesson-sized site.
+
+    CI passes a site containing every translated lesson.  Local lesson-focused
+    checks often export one lesson, so a translated validation accepts a
+    non-empty manifest subset and still requires both locales for each lesson
+    represented by the site.
+    """
+
+    candidates = []
+    for lesson in translated_lessons(manifest_lessons):
+        if any(output_path(site_root, lesson, locale).exists() for locale in lesson.locales):
+            candidates.append(lesson)
+    if not candidates:
+        raise LearningPathI18nError(f"No translated lesson export found below {site_root}")
+    return tuple(candidates)
+
+
+def validate_exported_site(
+    site_root: Path,
+    *,
+    validate_all: bool = False,
+    validate_translated: bool = False,
+) -> None:
     """Check planned files and translated HTML without snapshots or pixel comparison."""
 
+    if validate_all and validate_translated:
+        raise LearningPathI18nError("--all and --translated are mutually exclusive site scopes")
     manifest_lessons = load_manifest()
-    planned_lessons = manifest_lessons if validate_all else poc_lessons(manifest_lessons)
-    detailed_lessons = translated_lessons(manifest_lessons) if validate_all else planned_lessons
+    if validate_all:
+        planned_lessons = manifest_lessons
+        detailed_lessons = translated_lessons(manifest_lessons)
+    elif validate_translated:
+        detailed_lessons = _translated_site_lessons(site_root, manifest_lessons)
+        planned_lessons = detailed_lessons
+    else:
+        planned_lessons = poc_lessons(manifest_lessons)
+        detailed_lessons = planned_lessons
     lessons_by_id = {lesson.lesson_id: lesson for lesson in manifest_lessons}
     plan = build_export_plan(planned_lessons, site_root)
     for target in plan:
@@ -197,9 +247,7 @@ def validate_exported_site(site_root: Path, *, validate_all: bool = False) -> No
             page = output_path(site_root, lesson, locale)
             html = page.read_text(encoding="utf-8")
             pages[locale] = (page, html)
-            if any(
-                marker in html for marker in ("Traceback (most recent call last)", "ModuleNotFoundError", "ImportError")
-            ):
+            if _contains_python_error_text(html):
                 raise LearningPathI18nError(f"Python error text found in exported page: {page}")
             _validate_visible_exported_code(html, page)
             _validate_exported_layout(html, page)
@@ -273,12 +321,19 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--site", type=Path, help="validate exported HTML below this directory")
     parser.add_argument("--all", action="store_true", help="validate every manifest export, not only the PoC pages")
+    parser.add_argument(
+        "--translated",
+        action="store_true",
+        help="validate all translated lesson exports present below the site directory",
+    )
     args = parser.parse_args(argv)
+    if args.all and args.translated:
+        parser.error("--all and --translated are mutually exclusive")
     validate_catalogs()
     print("Learning Path manifest and translation catalogs are valid.")
     if args.site is not None:
-        validate_exported_site(args.site.resolve(), validate_all=args.all)
-        scope = "all planned" if args.all else "PoC"
+        validate_exported_site(args.site.resolve(), validate_all=args.all, validate_translated=args.translated)
+        scope = "all planned" if args.all else "translated" if args.translated else "PoC"
         print(f"Learning Path {scope} HTML is valid below {args.site.resolve()}.")
     return 0
 

--- a/scripts/validate_learning_path_i18n.py
+++ b/scripts/validate_learning_path_i18n.py
@@ -12,6 +12,7 @@ from typing import cast
 
 try:
     from .learning_path_i18n import (
+        _I18N_HELPER_NAMES,
         LearningPathI18nError,
         _markdown_targets,
         build_export_plan,
@@ -22,10 +23,12 @@ try:
         navigation_markdown,
         output_path,
         poc_lessons,
+        translated_lessons,
         validate_catalogs,
     )
 except ImportError:  # Running this file directly keeps the existing python scripts/foo.py workflow.
     from learning_path_i18n import (
+        _I18N_HELPER_NAMES,
         LearningPathI18nError,
         _markdown_targets,
         build_export_plan,
@@ -36,10 +39,13 @@ except ImportError:  # Running this file directly keeps the existing python scri
         navigation_markdown,
         output_path,
         poc_lessons,
+        translated_lessons,
         validate_catalogs,
     )
 
-_CODE_MARKERS = {
+# These are deliberately kept as PoC-specific regression checks. The general
+# validator compares every translated lesson's exported visible cells.
+_POC_CODE_MARKERS = {
     "01_getting_started": ("wd.generate_sin", "combined_signal.fft().plot"),
     "06_reusable_pipeline_recipes": ("RecipePlan.from_frame", "loaded_recipe.apply"),
 }
@@ -86,17 +92,10 @@ def _exported_notebook_cells(html: str, page: Path) -> list[dict[str, object]]:
     return cells
 
 
-def _validate_visible_exported_code(html: str, page: Path) -> None:
-    """Ensure exported visible cells do not expose the translation machinery."""
+def _visible_exported_code(html: str, page: Path) -> tuple[str, ...]:
+    """Return exported visible cell source, excluding hidden implementation cells."""
 
-    leaked_markers = (
-        "scripts.learning_path_i18n",
-        "locale_from_argv",
-        "load_catalog",
-        "language_switch_markdown",
-        "navigation_markdown",
-        "docs_reference_links",
-    )
+    visible_code: list[str] = []
     for cell in _exported_notebook_cells(html, page):
         code = cell.get("code")
         config = cell.get("config")
@@ -105,8 +104,47 @@ def _validate_visible_exported_code(html: str, page: Path) -> None:
         config_mapping = cast(Mapping[str, object], config)
         if config_mapping.get("hide_code") is True:
             continue
-        if any(marker in code for marker in leaked_markers) or re.search(r"\bt\s*\(\s*['\"]", code):
+        visible_code.append(code)
+    return tuple(visible_code)
+
+
+def _validate_visible_exported_code(html: str, page: Path) -> None:
+    """Ensure exported visible cells do not expose the translation machinery."""
+
+    for code in _visible_exported_code(html, page):
+        leaked_helper = any(re.search(rf"\b{re.escape(name)}\b", code) for name in _I18N_HELPER_NAMES)
+        if "scripts.learning_path_i18n" in code or leaked_helper:
             raise LearningPathI18nError(f"Translation implementation leaked into visible code: {page}")
+
+
+def _validate_shared_visible_code(
+    japanese_html: str,
+    japanese_page: Path,
+    english_html: str,
+    english_page: Path,
+) -> None:
+    """Ensure ja/en exports preserve the same visible source-cell sequence."""
+
+    japanese_code = _visible_exported_code(japanese_html, japanese_page)
+    english_code = _visible_exported_code(english_html, english_page)
+    if japanese_code == english_code:
+        return
+
+    for index in range(max(len(japanese_code), len(english_code))):
+        ja_cell = japanese_code[index] if index < len(japanese_code) else "<missing>"
+        en_cell = english_code[index] if index < len(english_code) else "<missing>"
+        if ja_cell != en_cell:
+            raise LearningPathI18nError(
+                f"Visible cell code differs between locale exports at cell {index}: {japanese_page} != {english_page}"
+            )
+
+
+def _validate_poc_code_markers(lesson_id: str, html: str, page: Path) -> None:
+    """Run legacy fixed markers only for the two PoC lessons."""
+
+    for marker in _POC_CODE_MARKERS.get(lesson_id, ()):
+        if marker not in html:
+            raise LearningPathI18nError(f"Missing shared code marker {marker!r} in {page}")
 
 
 def _validate_exported_layout(html: str, page: Path) -> None:
@@ -142,35 +180,35 @@ def _validate_exported_layout(html: str, page: Path) -> None:
 
 
 def validate_exported_site(site_root: Path, *, validate_all: bool = False) -> None:
-    """Check planned files and PoC HTML without snapshots or pixel comparison."""
+    """Check planned files and translated HTML without snapshots or pixel comparison."""
 
     manifest_lessons = load_manifest()
     planned_lessons = manifest_lessons if validate_all else poc_lessons(manifest_lessons)
+    detailed_lessons = translated_lessons(manifest_lessons) if validate_all else planned_lessons
     lessons_by_id = {lesson.lesson_id: lesson for lesson in manifest_lessons}
     plan = build_export_plan(planned_lessons, site_root)
     for target in plan:
         if not target.output_path.exists():
             raise LearningPathI18nError(f"Missing planned export: {target.output_path}")
 
-    for lesson in poc_lessons(manifest_lessons):
+    for lesson in detailed_lessons:
+        pages: dict[str, tuple[Path, str]] = {}
         for locale in lesson.locales:
             page = output_path(site_root, lesson, locale)
             html = page.read_text(encoding="utf-8")
+            pages[locale] = (page, html)
             if any(
-                marker in html
-                for marker in ("Traceback (most recent call last)", "ModuleNotFoundError", "ImportError:")
+                marker in html for marker in ("Traceback (most recent call last)", "ModuleNotFoundError", "ImportError")
             ):
                 raise LearningPathI18nError(f"Python error text found in exported page: {page}")
             _validate_visible_exported_code(html, page)
             _validate_exported_layout(html, page)
+            _validate_poc_code_markers(lesson.lesson_id, html, page)
 
             catalog = load_catalog(lesson.lesson_id, locale)
             title = catalog.text("title")
             if _first_position(html, title) < 0:
                 raise LearningPathI18nError(f"Missing {locale} title in {page}: {title}")
-            for marker in _CODE_MARKERS[lesson.lesson_id]:
-                if marker not in html:
-                    raise LearningPathI18nError(f"Missing shared code marker {marker!r} in {page}")
 
             switch = language_switch_markdown(lesson.lesson_id, locale)
             navigation = navigation_markdown(lesson.lesson_id, locale)
@@ -193,7 +231,7 @@ def validate_exported_site(site_root: Path, *, validate_all: bool = False) -> No
                 raise LearningPathI18nError(f"Previous/next navigation is not below the language switch in {page}")
 
             if not summary and "summary" in catalog.messages:
-                summary = catalog.text("summary")
+                summary = "\n".join(catalog.messages["summary"][locale])
             summary_heading = summary.splitlines()[0] if summary else ""
             navigation_heading = navigation.splitlines()[0]
             if summary_heading == navigation_heading:
@@ -224,6 +262,11 @@ def validate_exported_site(site_root: Path, *, validate_all: bool = False) -> No
                 target = _normalized_site_target(page.relative_to(site_root), href)
                 if "en/learning-path" in target and not (site_root / target).exists():
                     raise LearningPathI18nError(f"English link points to a missing page: {page} -> {href}")
+
+        if "ja" in pages and "en" in pages:
+            japanese_page, japanese_html = pages["ja"]
+            english_page, english_html = pages["en"]
+            _validate_shared_visible_code(japanese_html, japanese_page, english_html, english_page)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/docs/test_learning_path_i18n.py
+++ b/tests/docs/test_learning_path_i18n.py
@@ -199,8 +199,9 @@ def test_learning_path_export_plan_is_deterministic_and_preserves_legacy_command
         (lesson.lesson_id, "ja") for lesson in lessons
     ]
 
+    legacy_lesson = next(lesson for lesson in lessons if "en" not in lesson.locales)
     with pytest.raises(LearningPathI18nError, match="No selected lesson is available"):
-        export_plan(_parse_args(["--lesson", "00_why_wandas", "--locale", "en", "--dry-run"]))
+        export_plan(_parse_args(["--lesson", legacy_lesson.lesson_id, "--locale", "en", "--dry-run"]))
 
     for target in plan:
         command = marimo_export_command(target)

--- a/tests/docs/test_learning_path_i18n.py
+++ b/tests/docs/test_learning_path_i18n.py
@@ -191,8 +191,7 @@ def test_learning_path_export_plan_is_deterministic_and_preserves_legacy_command
 
     all_en_plan = export_plan(_parse_args(["--all", "--locale", "en", "--dry-run"]))
     assert [(target.lesson.lesson_id, target.locale) for target in all_en_plan] == [
-        ("01_getting_started", "en"),
-        ("06_reusable_pipeline_recipes", "en"),
+        (lesson.lesson_id, "en") for lesson in translated_lessons(lessons)
     ]
 
     all_ja_plan = export_plan(_parse_args(["--all", "--locale", "ja", "--dry-run"]))

--- a/tests/docs/test_learning_path_i18n.py
+++ b/tests/docs/test_learning_path_i18n.py
@@ -265,9 +265,10 @@ def test_learning_path_export_plan_is_deterministic_and_preserves_legacy_command
         (lesson.lesson_id, "ja") for lesson in lessons
     ]
 
-    legacy_lesson = next(lesson for lesson in lessons if "en" not in lesson.locales)
-    with pytest.raises(LearningPathI18nError, match="No selected lesson is available"):
-        export_plan(_parse_args(["--lesson", legacy_lesson.lesson_id, "--locale", "en", "--dry-run"]))
+    legacy_lessons = tuple(lesson for lesson in lessons if "en" not in lesson.locales)
+    if legacy_lessons:
+        with pytest.raises(LearningPathI18nError, match="No selected lesson is available"):
+            export_plan(_parse_args(["--lesson", legacy_lessons[0].lesson_id, "--locale", "en", "--dry-run"]))
 
     for target in plan:
         command = marimo_export_command(target)

--- a/tests/docs/test_learning_path_i18n.py
+++ b/tests/docs/test_learning_path_i18n.py
@@ -23,10 +23,13 @@ from scripts.learning_path_i18n import (
     tracked_numbered_lesson_sources,
     translated_lessons,
     validate_catalogs,
+    validate_visible_source,
 )
 from scripts.validate_learning_path_i18n import (
+    _contains_python_error_text,
     _exported_notebook_cells,
     _validate_shared_visible_code,
+    _validate_visible_exported_code,
     validate_exported_site,
 )
 
@@ -151,6 +154,69 @@ def test_shared_visible_code_ignores_hidden_locale_implementation() -> None:
         _validate_shared_visible_code(japanese, Path("ja.html"), changed_english, Path("en.html"))
 
 
+def _visible_cell_source(body: str, *, hidden: bool = False) -> str:
+    decorator = "@app.cell(hide_code=True)" if hidden else "@app.cell"
+    indented = "\n".join(f"    {line}" for line in body.splitlines())
+    return f"import marimo\n\napp = marimo.App()\n\n{decorator}\ndef _():\n{indented}\n"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "import numpy as np\nt = np.arange(4)",
+        "locale = 'C'",
+        "catalog = {'name': 'sensor'}",
+    ],
+)
+def test_visible_general_identifiers_are_not_i18n_leakage(tmp_path: Path, body: str) -> None:
+    source = tmp_path / "lesson.py"
+    source.write_text(_visible_cell_source(body), encoding="utf-8")
+
+    validate_visible_source(source)
+    html = _exported_notebook_html({"code": body, "config": {"hide_code": False}})
+    _validate_visible_exported_code(html, source)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "load_catalog('lesson', 'ja')",
+        "catalog.text('title')",
+        "t('title')",
+        "from scripts.learning_path_i18n import load_catalog",
+        "import scripts.learning_path_i18n",
+    ],
+)
+def test_visible_i18n_implementation_is_rejected(tmp_path: Path, body: str) -> None:
+    source = tmp_path / "lesson.py"
+    source.write_text(_visible_cell_source(body), encoding="utf-8")
+
+    with pytest.raises(LearningPathI18nError):
+        validate_visible_source(source)
+    html = _exported_notebook_html({"code": body, "config": {"hide_code": False}})
+    with pytest.raises(LearningPathI18nError):
+        _validate_visible_exported_code(html, source)
+
+
+def test_hidden_i18n_setup_is_allowed_by_both_validation_paths(tmp_path: Path) -> None:
+    body = (
+        "from scripts.learning_path_i18n import load_catalog\nlocale = 'ja'\ncatalog = load_catalog('lesson', locale)"
+    )
+    source = tmp_path / "lesson.py"
+    source.write_text(_visible_cell_source(body, hidden=True), encoding="utf-8")
+
+    validate_visible_source(source)
+    html = _exported_notebook_html({"code": body, "config": {"hide_code": True}})
+    _validate_visible_exported_code(html, source)
+
+
+def test_error_text_detection_does_not_reject_importerror_example() -> None:
+    assert not _contains_python_error_text("try:\n    import optional\nexcept ImportError:\n    pass")
+    assert _contains_python_error_text("Traceback (most recent call last):")
+    assert _contains_python_error_text("ModuleNotFoundError: missing")
+    assert _contains_python_error_text("ImportError: missing")
+
+
 def test_translation_catalog_uses_explicit_placeholders_and_literal_braces() -> None:
     catalog = TranslationCatalog(
         "placeholder_test",
@@ -218,6 +284,12 @@ def test_learning_path_export_plan_is_deterministic_and_preserves_legacy_command
         ("06_reusable_pipeline_recipes", "ja"),
         ("06_reusable_pipeline_recipes", "en"),
     ]
+
+    translated_plan = export_plan(_parse_args(["--translated", "--dry-run"]))
+    assert [(target.lesson.lesson_id, target.locale) for target in translated_plan] == [
+        (lesson.lesson_id, locale) for lesson in translated_lessons(lessons) for locale in lesson.locales
+    ]
+    assert translated_plan == export_plan(_parse_args(["--translated", "--dry-run"]))
 
 
 def test_learning_path_06_public_imports_are_visible_and_i18n_setup_is_hidden() -> None:

--- a/tests/docs/test_learning_path_i18n.py
+++ b/tests/docs/test_learning_path_i18n.py
@@ -21,9 +21,14 @@ from scripts.learning_path_i18n import (
     load_manifest,
     locale_from_argv,
     tracked_numbered_lesson_sources,
+    translated_lessons,
     validate_catalogs,
 )
-from scripts.validate_learning_path_i18n import _exported_notebook_cells, validate_exported_site
+from scripts.validate_learning_path_i18n import (
+    _exported_notebook_cells,
+    _validate_shared_visible_code,
+    validate_exported_site,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -64,6 +69,10 @@ def _exported_cell_code(cell: dict[str, object]) -> tuple[str, bool]:
     assert isinstance(config, Mapping)
     config_mapping = cast(Mapping[str, object], config)
     return code, config_mapping.get("hide_code") is True
+
+
+def _exported_notebook_html(*cells: dict[str, object]) -> str:
+    return f'<script>"notebook": {json.dumps({"cells": list(cells)})}</script>'
 
 
 def test_learning_path_manifest_matches_tracked_sources(tmp_path: Path) -> None:
@@ -111,6 +120,35 @@ def test_learning_path_translation_catalog_contract() -> None:
         locale_from_argv(["--locale", "fr"])
     with pytest.raises(LearningPathI18nError, match="Unsupported locale"):
         load_catalog("01_getting_started", "fr")
+
+
+def test_translated_lessons_are_manifest_driven() -> None:
+    lessons = load_manifest()
+
+    assert [lesson.lesson_id for lesson in translated_lessons(lessons)] == [
+        lesson.lesson_id for lesson in lessons if "en" in lesson.locales and lesson.catalog is not None
+    ]
+    assert all("en" in lesson.locales and lesson.catalog is not None for lesson in translated_lessons(lessons))
+
+
+def test_shared_visible_code_ignores_hidden_locale_implementation() -> None:
+    japanese = _exported_notebook_html(
+        {"code": "locale = 'ja'", "config": {"hide_code": True}},
+        {"code": "signal = wd.generate_sin()", "config": {"hide_code": False}},
+    )
+    english = _exported_notebook_html(
+        {"code": "locale = 'en'", "config": {"hide_code": True}},
+        {"code": "signal = wd.generate_sin()", "config": {"hide_code": False}},
+    )
+
+    _validate_shared_visible_code(japanese, Path("ja.html"), english, Path("en.html"))
+
+    changed_english = _exported_notebook_html(
+        {"code": "locale = 'en'", "config": {"hide_code": True}},
+        {"code": "signal = wd.generate_cos()", "config": {"hide_code": False}},
+    )
+    with pytest.raises(LearningPathI18nError, match="Visible cell code differs"):
+        _validate_shared_visible_code(japanese, Path("ja.html"), changed_english, Path("en.html"))
 
 
 def test_translation_catalog_uses_explicit_placeholders_and_literal_braces() -> None:


### PR DESCRIPTION
## Summary

- Generalize exported Learning Path validation from fixed 01/06 checks to every manifest lesson that declares both `en` and a catalog.
- Use AST-based visible-code checks, translated export/validation scopes, and stacked-PR documentation CI.
- Complete the interrupted manifest/export-plan explanation in the design document.

## Scope and stack

- Base branch: `main`
- Head commit: `9515c12768557a3e7581d4a5dcb3597bab18ff72`
- This update changes the design document only; no Python implementation, workflow, test, lesson, catalog, or manifest changes were added.
- Foundation for #427, #428, and #429.
- This PR remains Draft and has not been merged.

## Documentation wording fix

The design now states that `scripts/export_learning_path.py --all --dry-run` displays all Japanese pages and declared English pages in deterministic order, that CI checks the complete plan, and that `--translated` generates both locales for every lesson declaring `en` and a catalog.

## Validation and CI

- `python scripts/validate_learning_path_i18n.py`: passed.
- `mkdocs build --strict -f docs/mkdocs.yml`: passed.
- `git diff --check`: passed.
- GitHub CI: Determine required checks, Build Documentation, Lint and Type Check, native matrix, Core-only wheel smoke, Pyodide, CI Gate, and codecov all succeeded.

Existing unrelated Matplotlib Japanese-glyph warnings remain documented; no implementation change was made here.
