### PR TITLE
docs: translate Learning Path 05

### DIFF
--- a/learning-path/05_custom_functions.py
+++ b/learning-path/05_custom_functions.py
@@ -128,20 +128,23 @@ def _(input_frame):
 
 @app.cell(hide_code=True)
 def _(input_frame, mo, np, normalized_frame, same_shape, scaled_frame, signal_data, t):
+    import dask
+
     execution_counter = {"calls": 0}
 
     def probe(data):
         execution_counter["calls"] += 1
         return data
 
-    lazy_probe_frame = input_frame.apply(
-        probe,
-        output_shape_func=same_shape,
-        dask_pure=False,
-    )
-    probe_calls_after_apply = execution_counter["calls"]
-    _probe_values = lazy_probe_frame.data
-    probe_calls_after_data = execution_counter["calls"]
+    with dask.config.set(scheduler="synchronous"):
+        lazy_probe_frame = input_frame.apply(
+            probe,
+            output_shape_func=same_shape,
+            dask_pure=False,
+        )
+        probe_calls_after_apply = execution_counter["calls"]
+        _probe_values = lazy_probe_frame.data
+        probe_calls_after_data = execution_counter["calls"]
     assert probe_calls_after_apply == 0
     assert probe_calls_after_data > probe_calls_after_apply
 

--- a/learning-path/05_custom_functions.py
+++ b/learning-path/05_custom_functions.py
@@ -134,7 +134,11 @@ def _(input_frame, mo, np, normalized_frame, same_shape, scaled_frame, signal_da
         execution_counter["calls"] += 1
         return data
 
-    lazy_probe_frame = input_frame.apply(probe, output_shape_func=same_shape)
+    lazy_probe_frame = input_frame.apply(
+        probe,
+        output_shape_func=same_shape,
+        dask_pure=False,
+    )
     probe_calls_after_apply = execution_counter["calls"]
     _probe_values = lazy_probe_frame.data
     probe_calls_after_data = execution_counter["calls"]

--- a/learning-path/05_custom_functions.py
+++ b/learning-path/05_custom_functions.py
@@ -1,596 +1,364 @@
 import marimo
 
-__generated_with = "0.23.1"
+__generated_with = "0.23.9"
 app = marimo.App()
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _():
     import marimo as mo
 
-    return (mo,)
+    from scripts.learning_path_i18n import (
+        language_switch_markdown,
+        load_catalog,
+        locale_from_argv,
+        navigation_markdown,
+    )
+
+    locale = locale_from_argv()
+    catalog = load_catalog("05_custom_functions", locale)
+
+    def t(key, **values):
+        return catalog.text(key, **values)
+
+    return language_switch_markdown, locale, mo, navigation_markdown, t
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 🎯 なぜカスタム関数が必要か
-
-    ### Wandasの標準機能だけでは足りない場合
-
-    Wandasには豊富な信号処理機能が組み込まれていますが、
-    実際のプロジェクトでは以下のようなニーズが生じます：
-
-    1. **独自のアルゴリム**: 研究開発や特殊な分析手法
-    2. **ドメイン固有の処理**: 業界特有の計算や変換
-    3. **プロトタイピング**: 新しい処理を試す前段階
-    4. **統合**: 既存のNumPy/SciPy関数を組み込む
-
-    ### `apply()` メソッドの利点
-
-    - **統一されたインターフェース**: 標準機能と同じように使える
-    - **メタデータの自動管理**: サンプリングレートや処理履歴を保持
-    - **遅延評価対応**: Daskによる効率的な処理
-    - **メソッドチェーン可能**: 他の処理と組み合わせやすい
-    """)
+def _(mo, t):
+    mo.md(f"# {t('title')}\n\n{t('intro')}")
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 📦 準備
-    """)
+def _(language_switch_markdown, locale, mo):
+    mo.md(language_switch_markdown("05_custom_functions", locale))
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, t):
+    mo.md(t("choice_guide"))
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, t):
+    mo.md(t("input_section"))
     return
 
 
 @app.cell
 def _():
-    # 必要なライブラリをインポート
     import matplotlib.pyplot as plt
     import numpy as np
     from scipy import signal as scipy_signal
 
     import wandas as wd
 
-    # プロット設定
-    # '%matplotlib inline' command supported automatically in marimo
     plt.rcParams["figure.figsize"] = (12, 6)
-
-    print(f"Wandas: {wd.__version__}")
-    print("✅ 準備完了")
     return np, plt, scipy_signal, wd
 
 
 @app.cell
 def _(np, wd):
-    # デモ用の信号を作成
-    np.random.seed(42)
-    sampling_rate = 1000  # 1kHz
-    duration = 2.0
-    time = np.arange(int(duration * sampling_rate)) / sampling_rate
-
-    # 複数の周波数成分を持つ信号
-    signal_data = (
-        1.0 * np.sin(2 * np.pi * 50 * time)  # 50Hz
-        + 0.7 * np.sin(2 * np.pi * 120 * time)  # 120Hz
-        + 0.5 * np.sin(2 * np.pi * 200 * time)  # 200Hz
-        + 0.1 * np.random.randn(len(time))  # ノイズ
-    )
-
-    # ChannelFrameを作成
-    demo_signal = wd.from_numpy(data=signal_data.reshape(1, -1), sampling_rate=sampling_rate, ch_labels=["Demo Signal"])
-
-    print("デモ信号作成完了:")
-    print(f"  サンプリングレート: {demo_signal.sampling_rate} Hz")
-    print(f"  信号長: {demo_signal.duration:.2f} 秒")
-    print(f"  サンプル数: {demo_signal.n_samples}")
-    return demo_signal, sampling_rate
+    rng = np.random.default_rng(7)
+    sampling_rate = 1000.0
+    sample_count = 200
+    time_axis = np.arange(sample_count, dtype=np.float64) / sampling_rate
+    signal_data = np.vstack(
+        [
+            np.sin(2 * np.pi * 25 * time_axis) + 0.02 * rng.normal(size=sample_count),
+            0.5 * np.cos(2 * np.pi * 40 * time_axis) + 0.02 * rng.normal(size=sample_count),
+        ]
+    ).astype(np.float32)
+    input_frame = wd.from_numpy(
+        data=signal_data,
+        sampling_rate=sampling_rate,
+        metadata={"source": "lesson_05", "unit": "V"},
+        ch_labels=["left", "right"],
+        ch_units=["V", "V"],
+    ).with_source_time_offset(0.25)
+    return input_frame, sampling_rate, signal_data, time_axis
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 🔰 基本的な使い方
+def _(input_frame, mo, signal_data, t):
+    mo.md(
+        t(
+            "input_result",
+            shape=input_frame.shape,
+            dtype=signal_data.dtype,
+            channels=input_frame.n_channels,
+            samples=input_frame.n_samples,
+            sampling_rate=input_frame.sampling_rate,
+            duration=f"{input_frame.duration:.3f}",
+            offset=input_frame.source_time_offset.tolist(),
+            labels=input_frame.labels,
+            units=[channel.unit for channel in input_frame.channels],
+            metadata=input_frame.metadata,
+        )
+    )
+    return
 
-    ### 最もシンプルな例：スケーリング
 
-    `apply()` メソッドの基本構文：
-
-    ```python
-    result = frame.apply(func, **params)
-    ```
-
-    - `func`: 適用する関数（第1引数は配列）
-    - `**params`: 関数に渡す追加パラメータ
-    """)
+@app.cell(hide_code=True)
+def _(mo, t):
+    mo.md(t("apply_section"))
     return
 
 
 @app.cell
-def _(demo_signal):
-    # 例1: シンプルなスケーリング関数
-    def scale(x, factor):
-        """信号を指定倍率でスケーリング"""
-        return x * factor
+def _(input_frame):
+    def scale_channels(data, factor):
+        return data * factor
 
-    # カスタム関数を適用（2倍にスケール）
-    scaled = demo_signal.apply(
-        scale,
-        output_shape_func=lambda shape: shape,  # 出力形状は入力と同じ
-        factor=2.0,
-    )
+    def same_shape(input_shape):
+        return input_shape
 
-    print("スケーリング適用:")
-    print(f"  元の信号の最大値: {demo_signal.data.max():.3f}")
-    print(f"  スケール後の最大値: {scaled.data.max():.3f}")
-    print(f"  チャンネルラベル: {scaled.labels}")
-    return (scaled,)
+    scaled_frame = input_frame.apply(scale_channels, output_shape_func=same_shape, factor=1.5)
+    return same_shape, scale_channels, scaled_frame
+
+
+@app.cell
+def _(input_frame):
+    normalized_frame = input_frame.normalize()
+    return (normalized_frame,)
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### `apply(callable)` はruntime-only
+def _(input_frame, mo, np, normalized_frame, same_shape, scaled_frame, signal_data, t):
+    execution_counter = {"calls": 0}
 
-    `apply()` は元Frameを変更せず、新しいFrameのlineageと表示用の処理履歴にcustom処理を
-    追加します。ただしPython callableそのものはRecipe JSONへ保存できないため、この経路は
-    **現在のPython process内だけで再実行できるruntime-only処理**です。
+    def probe(data):
+        execution_counter["calls"] += 1
+        return data
 
-    別環境で再生できるRecipeが必要なら、公開の拡張経路に従って`AudioOperation`と薄いFrame
-    methodを作り、methodを`@recipe_operation`で宣言します。詳細は
-    [Frame・Operation拡張ガイド](../contributing/frame-operation-extensions/)を参照してください。
-    """)
+    lazy_probe_frame = input_frame.apply(probe, output_shape_func=same_shape)
+    probe_calls_after_apply = execution_counter["calls"]
+    _probe_values = lazy_probe_frame.data
+    probe_calls_after_data = execution_counter["calls"]
+    assert probe_calls_after_apply == 0
+    assert probe_calls_after_data > probe_calls_after_apply
+
+    input_data_before = input_frame.data.copy()
+    scaled_values = scaled_frame.data
+    normalized_values = normalized_frame.data
+    assert scaled_frame.shape == input_frame.shape
+    assert scaled_frame.sampling_rate == input_frame.sampling_rate
+    assert scaled_frame.previous is input_frame
+    assert normalized_frame.previous is input_frame
+    assert scaled_frame.lineage is not input_frame.lineage
+    assert scaled_frame.operation_history[-1]["operation"] == "wandas.custom.apply"
+    assert normalized_frame.operation_history[-1]["operation"] == "wandas.audio.normalize"
+    assert scaled_values.dtype == signal_data.dtype
+    assert normalized_values.dtype == signal_data.dtype
+    assert scaled_frame.metadata == input_frame.metadata
+    assert [channel.unit for channel in scaled_frame.channels] == ["V", "V"]
+    assert scaled_frame.labels == ["scale_channels(left)", "scale_channels(right)"]
+    np.testing.assert_array_equal(input_data_before, signal_data)
+    assert input_frame.labels == ["left", "right"]
+    assert input_frame.metadata == {"source": "lesson_05", "unit": "V"}
+    mo.md(
+        t(
+            "apply_result",
+            materialized_type=type(scaled_values).__name__,
+            input_shape=input_frame.shape,
+            output_shape=scaled_frame.shape,
+            input_dtype=signal_data.dtype,
+            output_dtype=scaled_values.dtype,
+            lazy_calls_after_apply=probe_calls_after_apply,
+            lazy_calls_after_data=probe_calls_after_data,
+            sampling_rate=scaled_frame.sampling_rate,
+            metadata=scaled_frame.metadata,
+            input_labels=input_frame.labels,
+            output_labels=scaled_frame.labels,
+            channel_units=[channel.unit for channel in scaled_frame.channels],
+            custom_operation=scaled_frame.operation_history[-1]["operation"],
+            standard_operation=normalized_frame.operation_history[-1]["operation"],
+            lineage_status=scaled_frame.lineage is not None,
+            previous_status=scaled_frame.previous is input_frame,
+        )
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, t):
+    mo.md(t("runtime_only_section"))
     return
 
 
 @app.cell
-def _(scaled):
-    # runtime lineageは残るが、任意callableはportable Recipeへ抽出できないことを確認する
-    from wandas.pipeline import RecipeExtractionError, RecipePlan
+def _(normalized_frame):
+    from wandas.pipeline import RecipePlan
 
-    assert scaled.operation_history[-1]["operation"] == "wandas.custom.apply"
+    standard_recipe = RecipePlan.from_frame(normalized_frame, input_names=("signal",))
+    standard_recipe_payload = standard_recipe.to_dict()
+    return (standard_recipe_payload,)
+
+
+@app.cell(hide_code=True)
+def _(mo, scaled_frame, standard_recipe_payload, t):
+    from wandas.pipeline import RecipeExtractionError as _RecipeExtractionError
+    from wandas.pipeline import RecipePlan as _RecipePlan
+
+    runtime_recipe_error = ""
     try:
-        RecipePlan.from_frame(scaled)
-    except RecipeExtractionError as error:
-        print("Recipe portability: runtime-only")
-        print(f"抽出拒否理由: {error}")
+        _RecipePlan.from_frame(scaled_frame)
+    except _RecipeExtractionError as error:
+        runtime_recipe_error = str(error)
     else:
-        raise AssertionError("Frame.apply(callable) must not become a portable Recipe")
+        raise AssertionError("Frame.apply(callable) must remain runtime-only")
+
+    portable_operation_ids = [node["operation"] for node in standard_recipe_payload["nodes"]]
+    assert "Frame.apply(callable) is runtime-only" in runtime_recipe_error
+    assert scaled_frame.operation_history[-1]["operation"] == "wandas.custom.apply"
+    assert "wandas.audio.normalize" in portable_operation_ids
+    mo.md(
+        t(
+            "recipe_result",
+            rejected_operation=scaled_frame.operation_history[-1]["operation"],
+            error=runtime_recipe_error,
+            portable_operations=portable_operation_ids,
+            schema=standard_recipe_payload["schema"],
+            version=standard_recipe_payload["version"],
+            node_count=len(standard_recipe_payload["nodes"]),
+        )
+    )
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 📐 出力形状の制御
-
-    ### `output_shape_func` パラメータ
-
-    カスタム関数を使う際、`output_shape_func`で出力形状を指定することでパフォーマンスが向上します。
-    `output_shape_func`は、入力形状を受け取り、出力形状を返す関数です。
-    指定しない場合、Wandasは自動推論を試みますが、関数を実行するためのコストがかかります。
-
-    ```python
-
-    # 自動推論（関数が1回実行される）
-    result = demo_signal.apply(some_func)
-
-    # 明示的に指定（推奨：推論コストを回避）
-    result = demo_signal.apply(
-        some_func,
-        output_shape_func=lambda shape: shape
-    )
-
-    **なぜ必要？**
-    - Daskの遅延評価では、実際に計算する前に出力形状を知る必要がある
-    - 効率的なメモリ管理とタスクグラフ構築のため
-    """)
+def _(mo, t):
+    mo.md(t("shape_section"))
     return
 
 
 @app.cell
-def _(demo_signal):
-    # 例2: 前半区間の抽出（サンプル数を半分に）
-    def take_first_half(x):
-        """入力の前半区間のみを返す"""
-        return x[:, : x.shape[1] // 2]
+def _(input_frame):
+    def take_first_half(data):
+        return data[:, : data.shape[1] // 2]
 
-    # 出力形状を計算する関数
     def half_shape(input_shape):
-        """入力形状から出力形状を計算"""
-        channels, samples = input_shape
-        return (channels, samples // 2)
+        return (input_shape[0], input_shape[1] // 2)
 
-    # sampling rateは変えず、前半区間だけを取り出す
-    first_half = demo_signal.apply(take_first_half, output_shape_func=half_shape)
+    first_half_frame = input_frame.apply(take_first_half, output_shape_func=half_shape)
+    semantic_trimmed_frame = input_frame.trim(start=0.05, end=0.15)
+    return first_half_frame, half_shape, semantic_trimmed_frame, take_first_half
 
-    print("前半区間の抽出:")
-    print(f"  元のサンプル数: {demo_signal.n_samples}")
-    print(f"  抽出後: {first_half.n_samples}")
-    print(f"  sampling rate（不変）: {first_half.sampling_rate} Hz")
-    print(f"  チャンネルラベル: {first_half.labels}")
+
+@app.cell(hide_code=True)
+def _(first_half_frame, input_frame, mo, np, semantic_trimmed_frame, t):
+    assert first_half_frame.shape == (2, 100)
+    assert semantic_trimmed_frame.shape == (2, 100)
+    assert first_half_frame.sampling_rate == input_frame.sampling_rate
+    assert semantic_trimmed_frame.sampling_rate == input_frame.sampling_rate
+    assert first_half_frame.duration == 0.1
+    assert semantic_trimmed_frame.duration == 0.1
+    np.testing.assert_allclose(first_half_frame.source_time_offset, [0.25, 0.25])
+    np.testing.assert_allclose(semantic_trimmed_frame.source_time_offset, [0.30, 0.30])
+    np.testing.assert_allclose(first_half_frame.source_time[:, 0], [0.25, 0.25])
+    np.testing.assert_allclose(semantic_trimmed_frame.source_time[:, 0], [0.30, 0.30])
+    assert first_half_frame.metadata == input_frame.metadata
+    assert semantic_trimmed_frame.metadata == input_frame.metadata
+    assert first_half_frame.previous is input_frame
+    assert semantic_trimmed_frame.previous is input_frame
+    assert first_half_frame.operation_history[-1]["operation"] == "wandas.custom.apply"
+    assert semantic_trimmed_frame.operation_history[-1]["operation"] == "wandas.frame.time_slice"
+    mo.md(
+        t(
+            "shape_result",
+            apply_shape=first_half_frame.shape,
+            apply_samples=first_half_frame.n_samples,
+            apply_sampling_rate=first_half_frame.sampling_rate,
+            apply_duration=f"{first_half_frame.duration:.3f}",
+            apply_offset=first_half_frame.source_time_offset.tolist(),
+            apply_source_time=first_half_frame.source_time[:, 0].tolist(),
+            apply_metadata=first_half_frame.metadata,
+            trim_shape=semantic_trimmed_frame.shape,
+            trim_samples=semantic_trimmed_frame.n_samples,
+            trim_sampling_rate=semantic_trimmed_frame.sampling_rate,
+            trim_duration=f"{semantic_trimmed_frame.duration:.3f}",
+            trim_offset=semantic_trimmed_frame.source_time_offset.tolist(),
+            trim_source_time=semantic_trimmed_frame.source_time[:, 0].tolist(),
+            trim_metadata=semantic_trimmed_frame.metadata,
+        )
+    )
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 🔗 既存ライブラリとの統合
-
-    ### SciPyの関数を組み込む
-
-    SciPyなど既存のライブラリの関数も `apply()` で簡単に使えます。
-    """)
+def _(mo, t):
+    mo.md(t("scipy_section"))
     return
 
 
 @app.cell
-def _(demo_signal, plt, scipy_signal):
-    # 例3: SciPyのメディアンフィルタを使う
-    def median_filter(x, kernel_size):
-        """メディアンフィルタを各チャンネルに適用"""
-        result = scipy_signal.medfilt(x, kernel_size=(1, kernel_size))
-        return result
+def _(input_frame, plt, scipy_signal):
+    def median_filter_channel_first(data, kernel_size):
+        return scipy_signal.medfilt(data, kernel_size=(1, kernel_size))
 
-    filtered = demo_signal.apply(median_filter, output_shape_func=lambda shape: shape, kernel_size=11)
-    # メディアンフィルタを適用（ノイズ除去）
-    (_fig, _axes) = plt.subplots(2, 1, figsize=(12, 8))
-    demo_signal.plot(ax=_axes[0], time_range=(0, 0.2))
-    _axes[0].set_title("元の信号（ノイズあり）")
-    _axes[0].set_xlabel("時間 [s]")
-    _axes[0].grid(True, alpha=0.3)
-    filtered.plot(ax=_axes[1], time_range=(0, 0.2))
-    # 結果を比較
-    _axes[1].set_title("メディアンフィルタ適用後（ノイズ除去）")
-    _axes[1].set_xlabel("時間 [s]")
-    # 元の信号
-    _axes[1].grid(True, alpha=0.3)
+    median_frame = input_frame.apply(
+        median_filter_channel_first,
+        output_shape_func=lambda input_shape: input_shape,
+        kernel_size=5,
+    )
+    (_fig, _axes) = plt.subplots(2, 1, figsize=(12, 7), sharex=True)
+    input_frame.plot(ax=_axes[0], title="Input signal", overlay=True)
+    median_frame.plot(ax=_axes[1], title="Median filtered signal", overlay=True)
+    _axes[1].set_xlabel("Time [s]")
     plt.tight_layout()
     plt.show()
-    print("メディアンフィルタ適用完了")
-    # フィルタ後
-    print(f"  チャンネルラベル: {filtered.labels}")
-    return
+    return median_filter_channel_first, median_frame
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## ⛓️ メソッドチェーンへの統合
-
-    ### カスタム関数も標準機能と組み合わせられる
-
-    `apply()` の戻り値は通常の `ChannelFrame` なので、
-    他のメソッドと自由にチェーンできます。
-    """)
-    return
-
-
-@app.cell
-def _(demo_signal, np):
-    # 例4: カスタム関数と標準機能を組み合わせる
-    def clip_amplitude(x, threshold):
-        """振幅を指定値でクリップ"""
-        return np.clip(x, -threshold, threshold)
-
-    # メソッドチェーン：カスタム関数 → 正規化 → ローパスフィルタ
-    processed = (
-        demo_signal.apply(clip_amplitude, output_shape_func=lambda shape: shape, threshold=0.5)
-        .normalize()
-        .low_pass_filter(cutoff=150)
+def _(input_frame, median_filter_channel_first, median_frame, mo, np, scipy_signal, t):
+    input_values = input_frame.data
+    filtered_values = median_frame.data
+    expected_values = scipy_signal.medfilt(input_values, kernel_size=(1, 5))
+    channelwise_expected = np.vstack(
+        [median_filter_channel_first(input_values[index : index + 1], 5)[0] for index in range(input_values.shape[0])]
     )
-
-    print("複数処理のチェーン適用:")
-    print(f"  処理履歴の長さ: {len(processed.operation_history)}")
-    print(f"  最終チャンネルラベル: {processed.labels}")
-    print("\n処理履歴:")
-    for i, op in enumerate(processed.operation_history, 1):
-        print(f"  {i}. {op['operation']} - {op.get('params', {})}")
-
-    demo_signal.describe()
-    processed.describe()
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 🚀 実践的な例
-
-    ### 例1: 移動平均フィルタ
-
-    シンプルですが実用的な移動平均フィルタを実装します。
-    """)
-    return
-
-
-@app.cell
-def _(demo_signal, np, plt):
-    def moving_average(x, window_size):
-        """移動平均フィルタ"""
-        result = np.zeros_like(x)
-        for i in range(x.shape[0]):
-            kernel = np.ones(window_size) / window_size  # 畳み込みで移動平均を計算
-            result[i] = np.convolve(x[i], kernel, mode="same")
-        return result
-
-    smoothed = demo_signal.apply(moving_average, output_shape_func=lambda shape: shape, window_size=51)
-    (_fig, _ax) = plt.subplots(figsize=(12, 5))
-    # 移動平均を適用
-    demo_signal.plot(ax=_ax, time_range=(0.5, 1.0), label="元の信号", alpha=0.5)
-    smoothed.plot(ax=_ax, time_range=(0.5, 1.0), label="移動平均適用後", linewidth=2)
-    _ax.set_title("移動平均フィルタの効果")
-    _ax.set_xlabel("時間 [s]")  # 51サンプルの窓
-    _ax.legend()
-    _ax.grid(True, alpha=0.3)
-    # 結果を可視化
-    plt.tight_layout()
-    plt.show()
-    print("移動平均フィルタ適用完了")
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### 例2: エンベロープ抽出
-
-    信号のエンベロープ（包絡線）を抽出します。
-    """)
-    return
-
-
-@app.cell
-def _(demo_signal, np, plt):
-    def extract_envelope(x, window_size):
-        """Hilbert変換によるエンベロープ抽出"""
-        from scipy.signal import hilbert
-
-        result = np.zeros_like(x)
-        for i in range(x.shape[0]):
-            analytic_signal = hilbert(x[i])
-            envelope = np.abs(analytic_signal)  # Hilbert変換で解析信号を取得
-            kernel = np.ones(window_size) / window_size
-            result[i] = np.convolve(envelope, kernel, mode="same")  # 振幅（エンベロープ）を計算
-        return result
-
-    envelope = demo_signal.apply(
-        extract_envelope, output_shape_func=lambda shape: shape, window_size=101
-    )  # 移動平均でスムージング
-    (_fig, _ax) = plt.subplots(figsize=(12, 5))
-    demo_signal.plot(ax=_ax, label="元の信号", alpha=0.6)
-    envelope.plot(ax=_ax, label="エンベロープ", linewidth=2, color="red")
-    _ax.set_title("信号のエンベロープ抽出")
-    # エンベロープを抽出
-    _ax.set_xlabel("時間 [s]")
-    _ax.legend()
-    _ax.grid(True, alpha=0.3)
-    plt.tight_layout()
-    plt.show()
-    print("エンベロープ抽出完了")
-    # 可視化
-    print(f"  チャンネルラベル: {envelope.labels}")
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### 例3: カスタムゲイン関数
-
-    周波数依存のゲインカーブを適用します。
-    """)
-    return
-
-
-@app.cell
-def _(demo_signal, np, plt, sampling_rate):
-    def frequency_dependent_gain(x, sr, gain_curve):
-        """
-        周波数依存のゲインを適用
-
-        Args:
-            x: ndarray. 入力信号
-            sr: float. サンプリングレート（Wandasから自動取得不可のため明示的に渡す）
-            gain_curve: callable. 周波数を受け取りゲインを返す関数
-        """
-        result = np.zeros_like(x, dtype=complex)
-        spectrum = np.fft.rfft(x, axis=1)
-        freqs = np.fft.rfftfreq(x.shape[1], d=1 / sr)  # FFT
-        gains = np.array([gain_curve(f) for f in freqs])
-        spectrum *= gains[np.newaxis, :]
-        result = np.fft.irfft(spectrum, n=x.shape[1], axis=1)
-        return result.real  # ゲインカーブを適用（ベクトル化）
-
-    def low_freq_emphasis(freq):  # ブロードキャストで全チャンネルに適用
-        """低周波を強調するゲインカーブ"""
-        if freq < 80:  # 逆FFT
-            return 2.0
-        elif freq < 150:
-            return 1.5
-        else:
-            # ゲインカーブを定義（低周波を強調）
-            return 0.5
-
-    gained = demo_signal.apply(
-        frequency_dependent_gain, output_shape_func=lambda shape: shape, sr=sampling_rate, gain_curve=low_freq_emphasis
+    boundary_probe = np.array([[1, 2, 3, 4, 5]], dtype=input_values.dtype)
+    boundary_result = median_filter_channel_first(boundary_probe, 5)
+    np.testing.assert_array_equal(filtered_values, expected_values)
+    np.testing.assert_array_equal(filtered_values, channelwise_expected)
+    assert filtered_values.shape == input_values.shape
+    assert filtered_values.dtype == input_values.dtype
+    np.testing.assert_array_equal(boundary_result, scipy_signal.medfilt(boundary_probe, kernel_size=(1, 5)))
+    mo.md(
+        t(
+            "scipy_result",
+            axis="axis=1",
+            kernel_shape=(1, 5),
+            input_shape=input_values.shape,
+            output_shape=filtered_values.shape,
+            input_dtype=input_values.dtype,
+            output_dtype=filtered_values.dtype,
+            channel_independent=True,
+            boundary_result=boundary_result.tolist(),
+        )
     )
-    (_fig, _axes) = plt.subplots(1, 2, figsize=(14, 5))
-    demo_signal.fft().plot(ax=_axes[0], freq_range=(0, 300))
-    _axes[0].set_title("元の信号のスペクトル")
-    _axes[0].set_xlabel("周波数 [Hz]")
-    _axes[0].grid(True, alpha=0.3)
-    gained.fft().plot(ax=_axes[1], freq_range=(0, 300))
-    _axes[1].set_title("カスタムゲイン適用後のスペクトル")
-    # カスタムゲインを適用
-    _axes[1].set_xlabel("周波数 [Hz]")
-    _axes[1].grid(True, alpha=0.3)
-    plt.tight_layout()
-    plt.show()  # サンプリングレートを明示的に渡す
-    print("カスタムゲイン適用完了")
-    print("  低周波（<80Hz）を2倍に強調")
-    print("  中周波（80-150Hz）を1.5倍に強調")
-    # スペクトルで比較
-    # 元の信号のスペクトル
-    # ゲイン適用後のスペクトル
-    print("  高周波（>150Hz）を0.5倍に減衰")
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 💡 ベストプラクティス
-
-    ### 1. 出力形状は明示的に指定する
-
-    ```python
-    # ❌ 推奨しない：形状推論に頼る
-    result = frame.apply(some_func)
-
-    # ✅ 推奨：明示的に指定
-    result = frame.apply(
-        some_func,
-        output_shape_func=lambda shape: shape
-    )
-    ```
-
-    **理由**: 形状推論は関数を1回実行するため、副作用がある関数や重い処理では問題になる可能性があります。
-
-    ### 2. 関数に名前を付ける
-
-    ```python
-    # ❌ 推奨しない：ラムダ式
-    result = frame.apply(lambda x: x * 2, output_shape_func=lambda s: s)
-
-    # ✅ 推奨：名前付き関数
-    def double(x):
-        return x * 2
-
-    result = frame.apply(double, output_shape_func=lambda s: s)
-    ```
-
-    **理由**: チャンネルラベルに関数名が表示され、処理履歴が分かりやすくなります。
-
-    ### 3. パラメータは明示的に渡す
-
-    ```python
-    # ❌ 推奨しない：グローバル変数を参照
-    threshold = 1.5
-    def clip(x):
-        return np.clip(x, -threshold, threshold)
-
-    # ✅ 推奨：パラメータとして渡す
-    def clip(x, threshold):
-        return np.clip(x, -threshold, threshold)
-
-    result = frame.apply(clip, output_shape_func=lambda s: s, threshold=1.5)
-    ```
-
-    **理由**: パラメータが処理履歴に記録され、再現性が向上します。
-
-    ### 4. 配列の形状に注意
-
-    ```python
-    # Wandasの配列形状は (channels, samples)
-    def process_each_channel(x):
-        result = np.zeros_like(x)
-        for i in range(x.shape[0]):  # チャンネルごとにループ
-            result[i] = some_operation(x[i])
-        return result
-    ```
-
-    ### 5. ドキュメンテーション
-
-    ```python
-    def custom_filter(x, cutoff, order):
-        \"\"\"
-        カスタムフィルタを適用
-
-        Args:
-            x: ndarray, shape (channels, samples). 入力信号
-            cutoff: float. カットオフ周波数 [Hz]
-            order: int. フィルタ次数
-
-        Returns:
-            ndarray: フィルタ適用後の信号
-        \"\"\"
-        # 実装...
-    ```
-    """)
+def _(mo, t):
+    mo.md(t("extension_section"))
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## ⚠️ 制限事項と注意点
-
-    ### 1. サンプリングレートへのアクセス
-
-    カスタム関数内からはサンプリングレートに直接アクセスできません。
-    必要な場合はパラメータとして渡してください。
-
-    ```python
-    def needs_sr(x, sr):
-        # sampling_rateを使った処理
-        pass
-
-    result = frame.apply(
-        needs_sr,
-        output_shape_func=lambda s: s,
-        sr=frame.sampling_rate
-    )
-    ```
-
-    ### 2. メタデータの更新
-
-    カスタム関数はサンプリングレートを変更できません。
-    リサンプリングが必要な場合は公開の `ChannelFrame.resampling()` メソッドを使用してください。
-
-    ### 3. 複数チャンネルの処理
-
-    チャンネル数を変更する処理（例：ステレオ→モノラル変換）は、
-    `output_shape_func` で正しい形状を返すようにしてください。
-    """)
+def _(mo, t):
+    mo.md(t("summary"))
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 📝 まとめ
-
-    このmarimoアプリでは、以下を学びました：
-
-    ✅ **`apply()` メソッドの基本的な使い方**
-    - カスタム関数を信号処理パイプラインに統合
-    - パラメータの渡し方
-
-    ✅ **出力形状の制御**
-    - `output_shape_func` による明示的な形状指定
-    - 前半区間の抽出など、sampling rateを変えずに形状が変わる処理への対応
-
-    ✅ **既存ライブラリとの統合**
-    - SciPyなど外部ライブラリの関数を組み込む
-    - NumPy/SciPyの豊富な機能を活用
-
-    ✅ **メソッドチェーン**
-    - カスタム関数と標準機能を自由に組み合わせ
-    - 処理履歴の自動記録
-    - `apply(callable)`はruntime-onlyで、portable Recipeにはならない
-
-    ✅ **実践的な例**
-    - 移動平均、エンベロープ抽出、周波数依存ゲイン
-    - ベストプラクティスと注意点
-
-    カスタム関数を活用することで、Wandasの機能を自由に拡張できます！
-
-    **前のmarimoアプリ**: [04_advanced_processing](04_advanced_processing.html)
-
-    **次のmarimoアプリ**: [06_reusable_pipeline_recipes](06_reusable_pipeline_recipes.html)
-    """)
+def _(locale, mo, navigation_markdown):
+    mo.md(navigation_markdown("05_custom_functions", locale))
     return
 
 

--- a/learning-path/manifest.json
+++ b/learning-path/manifest.json
@@ -38,7 +38,8 @@
     {
       "id": "05_custom_functions",
       "source": "learning-path/05_custom_functions.py",
-      "locales": ["ja"]
+      "locales": ["ja", "en"],
+      "catalog": "05_custom_functions.json"
     },
     {
       "id": "06_reusable_pipeline_recipes",

--- a/learning-path/translations/05_custom_functions.json
+++ b/learning-path/translations/05_custom_functions.json
@@ -1,0 +1,353 @@
+{
+  "lesson": "05_custom_functions",
+  "messages": {
+    "title": {
+      "ja": ["05 カスタム処理をFrameへ組み込む"],
+      "en": ["05 Add Custom Processing to a Frame"]
+    },
+    "intro": {
+      "ja": [
+        "## 不足している処理を、適切な境界で追加する",
+        "",
+        "Wandasに標準operationがあるなら、それを使うのが最初の候補です。標準APIにない処理を試すときは、`Frame.apply(callable)`で現在のPython processへ短く組み込めます。複数の環境で再利用する処理は、公開Frameメソッドと`AudioOperation`を拡張し、`@recipe_operation`でportableなoperationとして宣言します。",
+        "",
+        "この教材では、任意のNumPy/SciPy callableをchannel-firstのFrameへ適用し、shape・dtype・Daskの遅延グラフ・Frame stateを確認します。そのうえで、単なる配列処理と意味を持つFrame operation、runtime-onlyのcallableとportableなRecipe-capable拡張を区別します。",
+        "",
+        "**学習目標:**",
+        "- `Frame.apply(callable)`の入力shape、出力shape、dtype、lazy境界を説明する",
+        "- metadata、channel metadata、`previous`、`lineage`、`operation_history`、immutabilityを確認する",
+        "- sample数を変える処理で、sampling rate・duration・source timeの意味を検証する",
+        "- 標準operationとportable Operation拡張を選ぶ判断基準を持つ",
+        "",
+        "**前提条件:**",
+        "- `03_signal_processing_basics.py`を完了していること"
+      ],
+      "en": [
+        "## Add missing behavior at the right boundary",
+        "",
+        "When Wandas already provides an operation, it is the first option to consider. When a needed operation is not part of the standard API, `Frame.apply(callable)` can add it briefly to the current Python process. For behavior that must be reused across environments, extend the public Frame/Operation path and declare a portable operation with `@recipe_operation`.",
+        "",
+        "This lesson applies NumPy and SciPy callables to a channel-first Frame and checks shape, dtype, Dask laziness, and Frame state. It also separates an array-only transformation from a semantic Frame operation, and a runtime-only callable from a portable Recipe-capable extension.",
+        "",
+        "**Learning goals:**",
+        "- Explain the input shape, output shape, dtype, and lazy boundary of `Frame.apply(callable)`",
+        "- Inspect metadata, channel metadata, `previous`, `lineage`, `operation_history`, and immutability",
+        "- Verify the meaning of sampling rate, duration, and source time when sample count changes",
+        "- Choose between a standard operation and a portable Operation extension",
+        "",
+        "**Prerequisite:**",
+        "- Complete `03_signal_processing_basics.py` first"
+      ]
+    },
+    "choice_guide": {
+      "ja": [
+        "## どの拡張経路を選ぶか",
+        "",
+        "| 経路 | 選ぶ場面 | portability |",
+        "| --- | --- | --- |",
+        "| `Frame.apply(callable)` | 探索、1回限りのPython処理、標準APIにない小さな変換 | runtime-only。任意callableはRecipeへ保存できない |",
+        "| 標準Wandas operation | `normalize()`、`trim()`、filterなど、既に意味とmetadata契約がある処理 | built-in Recipe対応を利用できる |",
+        "| portable Operation拡張 | 複数の環境・入力で再利用する新しい公開処理 | `AudioOperation`、薄いFrameメソッド、`@recipe_operation`、registry、testsが必要 |",
+        "",
+        "迷ったら、まず標準operationを検索します。探索段階なら`apply()`、長期利用する公開機能なら拡張ガイドに沿ってOperationを追加します。"
+      ],
+      "en": [
+        "## Choose an extension path",
+        "",
+        "| Path | Choose it for | Portability |",
+        "| --- | --- | --- |",
+        "| `Frame.apply(callable)` | Exploration, one-off Python work, or a small transform missing from the standard API | Runtime-only. An arbitrary callable cannot be stored in a Recipe |",
+        "| Standard Wandas operation | A process such as `normalize()`, `trim()`, or a filter that already has a semantic and metadata contract | Use the built-in Recipe support |",
+        "| Portable Operation extension | A new public behavior that must be reused across environments and inputs | Requires `AudioOperation`, a thin Frame method, `@recipe_operation`, a registry, and tests |",
+        "",
+        "When unsure, search the standard operations first. Use `apply()` while exploring; for a long-lived public feature, follow the extension guide and add an Operation."
+      ]
+    },
+    "input_section": {
+      "ja": [
+        "## channel-first入力とlazyなFrame",
+        "",
+        "`Frame.apply(callable)`は、Frame内部のDask配列をcallableへ渡します。callableの入力は`(channels, samples)`のchannel-first 2D shapeです。公開のsingle-channel `.data`がsingleton channel axisを省略する場合でも、`apply()`のcallable契約はchannel-firstです。",
+        "",
+        "`output_shape_func`は入力shapeを受け取り、compute前に出力shapeを返します。shapeを変えるcallableでは明示してください。現行の`Frame.apply()`には`output_dtype_func`がないため、Daskのdtype metadataは入力dtypeから決まります。callableはそのdtype契約に合わせて返す必要があり、dtypeを本当に変えるportable Operationでは`calculate_output_dtype()`を実装します。",
+        "",
+        "この例は`np.random.default_rng(seed)`で決定的な2-channel信号を作ります。`Frame.apply()`、標準operation、Recipe抽出、shape変更の比較で同じ入力を使います。"
+      ],
+      "en": [
+        "## Channel-first input and a lazy Frame",
+        "",
+        "`Frame.apply(callable)` passes the Frame's internal Dask array to the callable. The callable input follows the channel-first 2D shape `(channels, samples)`. Even when public single-channel `.data` suppresses a singleton channel axis, the `apply()` callable contract is channel-first.",
+        "",
+        "`output_shape_func` receives the input shape and returns the output shape before compute. Supply it explicitly when the callable changes shape. Current `Frame.apply()` has no `output_dtype_func`, so Dask dtype metadata is derived from the input dtype. The callable should honor that dtype contract; a portable Operation that truly changes dtype must implement `calculate_output_dtype()`.",
+        "",
+        "This example creates a deterministic two-channel signal with `np.random.default_rng(seed)`. The same input is used for `Frame.apply()`, a standard operation, Recipe extraction, and the shape-change comparison."
+      ]
+    },
+    "input_result": {
+      "ja": [
+        "**入力Frameの確認**",
+        "",
+        "- shape: `[[shape]]`（channels, samples）",
+        "- channels / samples: [[channels]] / [[samples]]",
+        "- dtype: `[[dtype]]`",
+        "- sampling rate: [[sampling_rate]] Hz",
+        "- duration: [[duration]] s",
+        "- source time offset: `[[offset]]`",
+        "- labels: `[[labels]]`",
+        "- channel units: `[[units]]`",
+        "- metadata: `[[metadata]]`"
+      ],
+      "en": [
+        "**Inspect the input Frame**",
+        "",
+        "- Shape: `[[shape]]` (channels, samples)",
+        "- Channels / samples: [[channels]] / [[samples]]",
+        "- dtype: `[[dtype]]`",
+        "- Sampling rate: [[sampling_rate]] Hz",
+        "- Duration: [[duration]] s",
+        "- Source-time offset: `[[offset]]`",
+        "- Labels: `[[labels]]`",
+        "- Channel units: `[[units]]`",
+        "- Metadata: `[[metadata]]`"
+      ]
+    },
+    "apply_section": {
+      "ja": [
+        "## callableをapplyし、標準operationと比較する",
+        "",
+        "`scale_channels()`は入力shapeとdtypeを保つ名前付きcallableです。`output_shape_func=same_shape`を指定すると、Dask graphを作る前にshapeが確定します。関数名は結果のchannel label表示に使われます。",
+        "",
+        "同じ入力に標準の`normalize()`も適用します。標準operationはWandasが数値処理、metadata、lineage、Recipe宣言をまとめて管理するため、該当する処理がある場合の通常の選択です。",
+        "",
+        "どちらも入力Frameを変更せず、新しいFrameを返します。Wandasは処理をlazyに組み立てます。publicな`.data`を読む操作やplotはmaterialization boundaryになり、必要なときにDask graphを実行します。"
+      ],
+      "en": [
+        "## Apply a callable and compare a standard operation",
+        "",
+        "`scale_channels()` is a named callable that preserves input shape and dtype. Setting `output_shape_func=same_shape` lets Wandas know the shape before it builds the Dask graph. The function name is used in the result channel-label display.",
+        "",
+        "The same input also receives the standard `normalize()` operation. A standard operation is the usual choice when it exists because Wandas owns its numerical behavior, metadata, lineage, and Recipe declaration.",
+        "",
+        "Both calls leave the input Frame unchanged and return a new Frame. Wandas builds the operation lazily; reading public `.data` or plotting is a materialization boundary that executes the Dask graph when needed."
+      ]
+    },
+    "apply_result": {
+      "ja": [
+        "**`apply()`と標準operationのruntime契約**",
+        "",
+        "- type after reading public `.data`: `[[materialized_type]]`",
+        "- input / output shape: `[[input_shape]]` → `[[output_shape]]`",
+        "- input / output dtype: `[[input_dtype]]` → `[[output_dtype]]`",
+        "- apply直後 / publicな`.data`読取後のprobe呼出し回数: [[lazy_calls_after_apply]] / [[lazy_calls_after_data]]",
+        "- sampling rate: [[sampling_rate]] Hz",
+        "- metadata: `[[metadata]]`",
+        "- input labels: `[[input_labels]]`",
+        "- custom output labels: `[[output_labels]]`",
+        "- channel units: `[[channel_units]]`",
+        "- custom history operation: `[[custom_operation]]`",
+        "- standard history operation: `[[standard_operation]]`",
+        "- lineage present: [[lineage_status]]",
+        "- previous points to input: [[previous_status]]",
+        "",
+        "`operation_history`は`lineage`から作られる表示用のderived viewです。`previous`は直前のreceiverへのprocess-local参照であり、完全なprovenanceの代わりにはなりません。"
+      ],
+      "en": [
+        "**Runtime contract for `apply()` and the standard operation**",
+        "",
+        "- Type after reading public `.data`: `[[materialized_type]]`",
+        "- Input / output shape: `[[input_shape]]` → `[[output_shape]]`",
+        "- Input / output dtype: `[[input_dtype]]` → `[[output_dtype]]`",
+        "- Probe calls immediately after `apply()` / after public `.data`: [[lazy_calls_after_apply]] / [[lazy_calls_after_data]]",
+        "- Sampling rate: [[sampling_rate]] Hz",
+        "- Metadata: `[[metadata]]`",
+        "- Input labels: `[[input_labels]]`",
+        "- Custom output labels: `[[output_labels]]`",
+        "- Channel units: `[[channel_units]]`",
+        "- Custom history operation: `[[custom_operation]]`",
+        "- Standard history operation: `[[standard_operation]]`",
+        "- Lineage present: [[lineage_status]]",
+        "- Previous points to input: [[previous_status]]",
+        "",
+        "`operation_history` is a derived display view of `lineage`. `previous` is a process-local reference to the immediate receiver; it is not a substitute for complete provenance."
+      ]
+    },
+    "runtime_only_section": {
+      "ja": [
+        "## `Frame.apply(callable)`とRecipe抽出の境界",
+        "",
+        "`Frame.apply()`のcallableとPython closureは、現在のprocessでDask graphを実行するためのruntime stateです。任意のPython callableをJSONへ保存してimport pathやclosureを勝手に復元することはしません。",
+        "",
+        "そのため`RecipePlan.from_frame()`は`wandas.custom.apply`のnodeで`RecipeExtractionError`を送出します。これはグラフの一部を黙って捨てるfallbackではなく、portableでない処理を明示的に知らせる契約です。"
+      ],
+      "en": [
+        "## The `Frame.apply(callable)` and Recipe boundary",
+        "",
+        "The callable and any Python closure passed to `Frame.apply()` are runtime state for executing a Dask graph in the current process. Wandas does not store an arbitrary Python callable in JSON or guess how to restore an import path or closure.",
+        "",
+        "Therefore `RecipePlan.from_frame()` raises `RecipeExtractionError` at the `wandas.custom.apply` node. This is an explicit portability failure, not a fallback that silently drops part of the graph."
+      ]
+    },
+    "recipe_result": {
+      "ja": [
+        "**Recipe抽出の結果**",
+        "",
+        "- rejected operation: `[[rejected_operation]]`",
+        "- exception: `[[error]]`",
+        "- standard operation IDs: `[[portable_operations]]`",
+        "- schema / version: `[[schema]]` / [[version]]",
+        "- standard Recipe node count: [[node_count]]",
+        "",
+        "標準operationはstable IDを持つためRecipeへ抽出できます。`RecipePlan`は入力データやDask graphを保存せず、operation intentとnamed inputを保存します。"
+      ],
+      "en": [
+        "**Recipe extraction result**",
+        "",
+        "- Rejected operation: `[[rejected_operation]]`",
+        "- Exception: `[[error]]`",
+        "- Standard operation IDs: `[[portable_operations]]`",
+        "- Schema / version: `[[schema]]` / [[version]]",
+        "- Standard Recipe node count: [[node_count]]",
+        "",
+        "A standard operation has a stable ID and can be extracted into a Recipe. `RecipePlan` stores operation intent and named inputs, not input samples or a Dask graph."
+      ]
+    },
+    "shape_section": {
+      "ja": [
+        "## shapeが変わるcallableと意味付きsliceを区別する",
+        "",
+        "`take_first_half()`は`data[:, :data.shape[1] // 2]`という配列切り出しです。`half_shape()`で`(channels, samples // 2)`を宣言しますが、任意callableに対してWandasがsampling rate、source offset、time axisの意味を自動補正することは保証されません。",
+        "",
+        "今回の入力は0.25 sのsource offsetを持ちます。単なる前半切り出しではsampling rateは1000 Hzのまま、durationはサンプル数から0.1 sになり、source offsetは0.25 sのままです。",
+        "",
+        "一方、`trim(start=0.05, end=0.15)`はWandasの意味付きFrame operationです。shapeは同じ100 samplesですが、最初のsource timeは0.25 + 0.05 = 0.30 sへ進み、`wandas.frame.time_slice`としてlineage/historyに記録されます。実際の処理の意味に合う標準operationを選び、標準APIがなければdomain stateを扱うOperation拡張を設計してください。"
+      ],
+      "en": [
+        "## Separate a shape-changing callable from a semantic slice",
+        "",
+        "`take_first_half()` performs the array slice `data[:, :data.shape[1] // 2]`. `half_shape()` declares `(channels, samples // 2)`, but Wandas does not promise to infer or automatically correct the sampling rate, source offset, or time-axis meaning for an arbitrary callable.",
+        "",
+        "This input has a 0.25 s source-time offset. The plain half-slice keeps the sampling rate at 1000 Hz, derives a 0.1 s duration from its sample count, and leaves the source offset at 0.25 s.",
+        "",
+        "By contrast, `trim(start=0.05, end=0.15)` is a semantic Wandas Frame operation. It also produces 100 samples, but its first source time advances from 0.25 + 0.05 to 0.30 s and it records `wandas.frame.time_slice` in lineage/history. Choose the standard operation that matches the meaning; if none exists, design an Operation extension that owns the domain-state change."
+      ]
+    },
+    "shape_result": {
+      "ja": [
+        "**shape変更の比較**",
+        "",
+        "| 項目 | `apply(take_first_half)` | `trim(0.05, 0.15)` |",
+        "| --- | --- | --- |",
+        "| shape | `[[apply_shape]]` | `[[trim_shape]]` |",
+        "| samples | [[apply_samples]] | [[trim_samples]] |",
+        "| sampling rate | [[apply_sampling_rate]] Hz | [[trim_sampling_rate]] Hz |",
+        "| duration | [[apply_duration]] s | [[trim_duration]] s |",
+        "| source offset | `[[apply_offset]]` | `[[trim_offset]]` |",
+        "| first source time | `[[apply_source_time]]` | `[[trim_source_time]]` |",
+        "| metadata | `[[apply_metadata]]` | `[[trim_metadata]]` |",
+        "",
+        "同じsample数でも、単なる配列切り出しと意味付きFrame operationではsource timeの契約が異なります。"
+      ],
+      "en": [
+        "**Compare the shape-changing results**",
+        "",
+        "| Field | `apply(take_first_half)` | `trim(0.05, 0.15)` |",
+        "| --- | --- | --- |",
+        "| Shape | `[[apply_shape]]` | `[[trim_shape]]` |",
+        "| Samples | [[apply_samples]] | [[trim_samples]] |",
+        "| Sampling rate | [[apply_sampling_rate]] Hz | [[trim_sampling_rate]] Hz |",
+        "| Duration | [[apply_duration]] s | [[trim_duration]] s |",
+        "| Source offset | `[[apply_offset]]` | `[[trim_offset]]` |",
+        "| First source time | `[[apply_source_time]]` | `[[trim_source_time]]` |",
+        "| Metadata | `[[apply_metadata]]` | `[[trim_metadata]]` |",
+        "",
+        "The same sample count can have different source-time contracts: an array slice is not automatically a semantic Frame operation."
+      ]
+    },
+    "scipy_section": {
+      "ja": [
+        "## SciPy callableのshape・axis・境界を確認する",
+        "",
+        "`scipy.signal.medfilt`へ`kernel_size=(1, 5)`を渡します。最初のaxisのkernel幅を1にしてchannel間を混ぜず、`axis=1`のtime axisだけへ長さ5の奇数kernelを適用します。出力shapeは入力と同じで、今回のfloat32入力ではdtypeもfloat32です。",
+        "",
+        "`medfilt`の境界はSciPyの現行契約に従うzero paddingです。kernel shape、channel独立性、output shape、dtype、境界の小さなprobeを実行結果で確認します。別のSciPy関数を渡す場合も、axis、kernel shape、dtype、境界条件、shapeをその関数の仕様で確認してください。"
+      ],
+      "en": [
+        "## Check shape, axis, and boundaries for a SciPy callable",
+        "",
+        "The example passes `kernel_size=(1, 5)` to `scipy.signal.medfilt`. A kernel width of 1 on the first axis prevents mixing channels, while the length-5 odd kernel runs along the time axis (`axis=1`). The output shape is unchanged, and this float32 input keeps a float32 result.",
+        "",
+        "`medfilt` uses the current SciPy contract of zero padding at the boundaries. The runtime check covers kernel shape, channel independence, output shape, dtype, and a small boundary probe. For another SciPy function, verify its axis, kernel shape, dtype, boundary behavior, and output shape from that function's contract."
+      ]
+    },
+    "scipy_result": {
+      "ja": [
+        "**SciPy median filterの確認**",
+        "",
+        "- axis: `[[axis]]`",
+        "- kernel shape: `[[kernel_shape]]`",
+        "- input / output shape: `[[input_shape]]` → `[[output_shape]]`",
+        "- input / output dtype: `[[input_dtype]]` → `[[output_dtype]]`",
+        "- channel independent: [[channel_independent]]",
+        "- boundary probe result: `[[boundary_result]]`"
+      ],
+      "en": [
+        "**SciPy median-filter check**",
+        "",
+        "- Axis: `[[axis]]`",
+        "- Kernel shape: `[[kernel_shape]]`",
+        "- Input / output shape: `[[input_shape]]` → `[[output_shape]]`",
+        "- Input / output dtype: `[[input_dtype]]` → `[[output_dtype]]`",
+        "- Channel independent: [[channel_independent]]",
+        "- Boundary-probe result: `[[boundary_result]]`"
+      ]
+    },
+    "extension_section": {
+      "ja": [
+        "## portable Operation拡張の境界",
+        "",
+        "新しい処理をportableにする場合、Python callableをRecipeへ埋め込むのではなく、次の責務を分けます。",
+        "",
+        "1. 数値アルゴリズムとparameter validationを`wandas/processing/`の`AudioOperation`へ置く。全channelが対応する入力channelだけに依存する場合だけ`ChannelIndependentAudioOperation`を選び、shapeやdtypeが変わるなら`calculate_output_shape()`と`calculate_output_dtype()`を実装する。",
+        "2. Frame-levelの整合、metadata、axis、出力Frameを薄い公開Frameメソッドで扱う。sampling rateや`source_time_offset`の変更はdomainの意味として明示する。",
+        "3. 公開methodを`@recipe_operation(\"wandas.audio.example\")`で宣言し、stable ID・binding・handler・registryを通して`RecipePlan.from_frame()` → `to_dict()` → `from_dict()` → `apply()`をテストする。",
+        "",
+        "この教材の`Frame.apply(callable)`はこの拡張経路の代わりではありません。実装・metadata・Recipe・testの責務を確認するときは、[Frame・Operation拡張ガイド](../contributing/frame-operation-extensions/)を参照してください。"
+      ],
+      "en": [
+        "## The portable Operation extension boundary",
+        "",
+        "To make new behavior portable, do not embed a Python callable in a Recipe. Separate the responsibilities:",
+        "",
+        "1. Put the numerical algorithm and parameter validation in an `AudioOperation` under `wandas/processing/`. Choose `ChannelIndependentAudioOperation` only when every output channel depends on the corresponding input channel; implement `calculate_output_shape()` and `calculate_output_dtype()` when shape or dtype changes.",
+        "2. Keep Frame-level compatibility, metadata, axes, and output Frame selection in a thin public Frame method. Make a sampling-rate or `source_time_offset` change explicit as domain meaning.",
+        "3. Declare the public method with `@recipe_operation(\"wandas.audio.example\")`, then test the stable ID, bindings, handler, registry, and the full `RecipePlan.from_frame()` → `to_dict()` → `from_dict()` → `apply()` path.",
+        "",
+        "This lesson's `Frame.apply(callable)` is not a substitute for that extension path. For the implementation, metadata, Recipe, and test responsibilities, see the [Frame and Operation extension guide (Japanese only)](../contributing/frame-operation-extensions/)."
+      ]
+    },
+    "summary": {
+      "ja": [
+        "## まとめ",
+        "",
+        "- callableの入力は`(channels, samples)`で、`output_shape_func`はcompute前のshape契約を示す",
+        "- `Frame.apply()`はDask lazy graphと新しいFrameを作るが、任意callableのdtype・sampling rate・source timeを自動補正しない",
+        "- metadata、channel units、`previous`、`lineage`、`operation_history`、入力immutabilityを実行結果で確認した",
+        "- sample数を変える配列sliceと、source offsetを更新する`trim()`は異なる意味を持つ",
+        "- SciPy callableではaxis、kernel shape、channel独立性、境界、shape、dtypeを確認する",
+        "- 標準operationはまず再利用し、長期portable化には`AudioOperation` + 公開Frame method + `@recipe_operation`を使う",
+        "- 任意の`Frame.apply(callable)`は`RecipeExtractionError`でportable Recipeから拒否される"
+      ],
+      "en": [
+        "## Summary",
+        "",
+        "- A callable receives `(channels, samples)`, and `output_shape_func` declares the shape contract before compute",
+        "- `Frame.apply()` builds a lazy Dask graph and a new Frame, but it does not automatically correct an arbitrary callable's dtype, sampling rate, or source time",
+        "- The runtime evidence checked metadata, channel units, `previous`, `lineage`, `operation_history`, and input immutability",
+        "- An array slice that changes sample count has a different meaning from `trim()`, which updates the source offset",
+        "- A SciPy callable requires checks for axis, kernel shape, channel independence, boundaries, shape, and dtype",
+        "- Prefer a standard operation first; for long-lived portability use `AudioOperation` + a public Frame method + `@recipe_operation`",
+        "- An arbitrary `Frame.apply(callable)` is rejected from a portable Recipe with `RecipeExtractionError`"
+      ]
+    }
+  }
+}

--- a/learning-path/translations/05_custom_functions.json
+++ b/learning-path/translations/05_custom_functions.json
@@ -67,7 +67,7 @@
       "ja": [
         "## channel-first入力とlazyなFrame",
         "",
-        "`Frame.apply(callable)`は、Frame内部のDask配列をcallableへ渡します。callableの入力は`(channels, samples)`のchannel-first 2D shapeです。公開のsingle-channel `.data`がsingleton channel axisを省略する場合でも、`apply()`のcallable契約はchannel-firstです。",
+        "`Frame.apply(callable)`はDask graphをlazyに構築しますが、materialization時にはFrameの依存を解決してから、callableへeagerなchannel-firstのNumPy配列を渡します。callableの入力は`(channels, samples)`の2D shapeです。公開のsingle-channel `.data`がsingleton channel axisを省略する場合でも、`apply()`のcallable契約はchannel-firstです。この教材の呼出し回数probeは、親processの辞書を観測するため、in-processの`synchronous` schedulerへ明示的に限定しています。",
         "",
         "`output_shape_func`は入力shapeを受け取り、compute前に出力shapeを返します。shapeを変えるcallableでは明示してください。現行の`Frame.apply()`には`output_dtype_func`がないため、Daskのdtype metadataは入力dtypeから決まります。callableはそのdtype契約に合わせて返す必要があり、dtypeを本当に変えるportable Operationでは`calculate_output_dtype()`を実装します。",
         "",
@@ -76,7 +76,7 @@
       "en": [
         "## Channel-first input and a lazy Frame",
         "",
-        "`Frame.apply(callable)` passes the Frame's internal Dask array to the callable. The callable input follows the channel-first 2D shape `(channels, samples)`. Even when public single-channel `.data` suppresses a singleton channel axis, the `apply()` callable contract is channel-first.",
+        "`Frame.apply(callable)` builds the Dask graph lazily, but at materialization Wandas resolves the Frame dependency first and passes the callable an eager channel-first NumPy array. The callable input follows the 2D shape `(channels, samples)`. Even when public single-channel `.data` suppresses a singleton channel axis, the `apply()` callable contract is channel-first. This lesson's call-count probe is explicitly scoped to the in-process `synchronous` scheduler so it can observe the parent process's dictionary.",
         "",
         "`output_shape_func` receives the input shape and returns the output shape before compute. Supply it explicitly when the callable changes shape. Current `Frame.apply()` has no `output_dtype_func`, so Dask dtype metadata is derived from the input dtype. The callable should honor that dtype contract; a portable Operation that truly changes dtype must implement `calculate_output_dtype()`.",
         "",
@@ -322,7 +322,7 @@
         "2. Keep Frame-level compatibility, metadata, axes, and output Frame selection in a thin public Frame method. Make a sampling-rate or `source_time_offset` change explicit as domain meaning.",
         "3. Declare the public method with `@recipe_operation(\"wandas.audio.example\")`, then test the stable ID, bindings, handler, registry, and the full `RecipePlan.from_frame()` → `to_dict()` → `from_dict()` → `apply()` path.",
         "",
-        "This lesson's `Frame.apply(callable)` is not a substitute for that extension path. For the implementation, metadata, Recipe, and test responsibilities, see the [Frame and Operation extension guide (Japanese only)](../contributing/frame-operation-extensions/)."
+        "This lesson's `Frame.apply(callable)` is not a substitute for that extension path. For the implementation, metadata, Recipe, and test responsibilities, see the [Frame and Operation extension guide (Japanese only)](../../contributing/frame-operation-extensions/)."
       ]
     },
     "summary": {


### PR DESCRIPTION
## Teaching contract

Learning Path 05 teaches learners to choose the right extension boundary:

- `Frame.apply(callable)` for exploratory/runtime-only processing.
- A standard Wandas operation when a semantic, metadata-aware public operation already exists.
- A portable `AudioOperation`/Frame extension for reusable behavior.
- Channel-first callable input, output-shape declaration, dtype behavior, Dask laziness, and execution boundaries.
- Shape-changing callables versus semantic Frame operations.
- Runtime-only processing versus Recipe portability.

The lesson displays executable evidence for each decision.

## Technical audit and corrections

- Verified the current `Frame.apply()` signature and channel-first `(channels, samples)` contract, including `output_shape_func`, current dtype behavior, lazy graph construction, metadata/channel metadata, `previous`, lineage, derived `operation_history`, and input immutability.
- Kept the public standard Recipe example visible, while moving runtime-only rejection, assertions, and Recipe payload inspection into hidden cells.
- Added a hidden side-effect probe showing that the callable has zero calls immediately after `apply()` and runs after public `.data` access. The catalog also identifies plotting as a materialization boundary.
- Demonstrated that an array half-slice changes sample count without automatically changing sampling semantics/source offset, while semantic `trim()` updates source time and records a semantic operation.
- Verified SciPy `medfilt` with `kernel_size=(1, 5)`, channel independence, dtype/shape preservation, and zero-padding boundary behavior.
- Confirmed that arbitrary `Frame.apply(callable)` extraction raises the current `RecipeExtractionError`; standard `normalize()` extraction remains portable.

## apply(callable) runtime contract

The lesson uses the current public path:

`apply(func, output_shape_func=None, output_frame_class=None, output_frame_kwargs=None, *, dask_pure=True, **kwargs)`

Graph construction is lazy, and at materialization the callable receives an eager channel-first `numpy.ndarray` after Wandas resolves the Frame dependency. The lesson's counter probe is explicitly scoped to Dask's in-process `synchronous` scheduler. `output_shape_func` is required for shape-changing examples. The lesson does not promise automatic dtype, sampling-rate, or source-time correction beyond the current implementation.

## Runtime-only versus portable Operation

- `Frame.apply(callable)` stores process-local Python callable/closure state in the lazy runtime graph and is not serialized into a portable Recipe.
- A reusable extension belongs in `AudioOperation`/processing, a thin public Frame method, `@recipe_operation`, registry/handler contracts, and tests.
- `RecipePlan.from_frame()` is shown extracting a standard operation and explicitly rejecting `wandas.custom.apply`.

## Shape-changing example and Recipe extraction

The `take_first_half()` example verifies shape `(2, 100)`, unchanged sampling rate, duration derived from sample count, and unchanged source offset. The semantic `trim(0.05, 0.15)` example has the same shape but advances source time and records `wandas.frame.time_slice`.

## Japanese/English implementation

- One Python source is used for both locales.
- Lesson-specific catalog: `learning-path/translations/05_custom_functions.json`.
- Manifest entry adds `locales: ["ja", "en"]` and the catalog; `common.json` is unchanged.
- Visible code is locale-neutral and identical in both exports. Translation machinery and translated/dynamic Markdown remain hidden.

## URLs and navigation

Expected deployed pages:

- Japanese: https://kasahart.github.io/wandas/learning-path/05_custom_functions.html
- English: https://kasahart.github.io/wandas/en/learning-path/05_custom_functions.html

Manifest-driven navigation currently resolves:

- JA: previous 04 JA; next 06 according to locale.
- EN: previous 04 Japanese fallback marked `Japanese only` on this independent base; next 06 EN.

After Learning Path 04 is merged, rebase this branch onto the updated `main`; the previous EN link will automatically become 04 EN.

## Local validation

- `marimo check --strict`: passed.
- Catalog/source validation: passed.
- JA/EN lesson export to `/tmp/wandas-lp05-review`: passed.
- Translated HTML validation: passed.
- `pytest tests/docs -q --no-cov`: 54 passed.
- PoC export and validator: passed; the focused PoC cross-link test passed 1/1 in this worktree.
- `mkdocs build --strict -f docs/mkdocs.yml`: passed; only existing unlisted-page warnings remain.
- Ruff check/format, Ty, git diff check: passed.
- JA/EN exported visible code comparison: identical.
- Independent content/API/translation review: substantive lesson findings were addressed; the remaining PoC concern was not reproducible in the worktree (focused test passed).

## Known limitations

- marimo 0.23.9 keeps the exported HTML `lang`/browser title metadata shared between locales; visible page content, language switch, and navigation are translated. Fixing that would require a shared exporter contract change outside this PR.
- The current branch intentionally has 04 English unavailable, so EN previous navigation uses the safe Japanese fallback until the required rebase.
- Generated HTML is validation output only and is not committed.

## Review fix

- Updated the hidden side-effecting lazy probe to pass `dask_pure=False`. This makes Dask avoid treating the task as pure while keeping `dask_pure` out of the callable arguments and derived `operation_history` parameters.
- The probe still verifies `probe_calls_after_apply == 0` and that the call count increases after public `.data` materialization.
- Post-fix GitHub Actions run `31118487970` passed after a runner-availability retry: `Determine required checks`, `Lint and Type Check`, `Build Documentation`, and `CI Gate` all succeeded. Build Documentation completed the Learning applications source check, catalog validation, full export plan, JA/EN export, generated HTML validation, documentation contract tests, and MkDocs build.
- This PR must be rebased onto the latest `main` after #432 is merged, preserving both manifest entries and rechecking the English navigation.

## Follow-up review fixes

- Clarified in both catalogs that graph construction is lazy but the callable executes with an eager channel-first NumPy array at materialization.
- Corrected the English extension-guide link to the documentation root (`../../contributing/frame-operation-extensions/`).
- Scoped the side-effect probe to the in-process `synchronous` scheduler so the parent-process counter is valid; `dask_pure=False` remains explicit and is not recorded as a callable or history parameter.
- GitHub Actions CI run `31146329768` succeeded: `Determine required checks`, `Build Documentation`, `Lint and Type Check`, and `CI Gate`; Build Documentation completed source/catalog/full-plan checks, JA/EN export, generated HTML validation, documentation contract tests, and MkDocs.

## Status

This pull request is Ready for review, targets `main`, and has not been merged.

Latest head after the review fixes: `3463b8242c9ba02aac2bee44ca2b78fbe07a60d3`.


