### PR TITLE
docs: translate Learning Path 04

### DIFF
--- a/learning-path/04_advanced_processing.py
+++ b/learning-path/04_advanced_processing.py
@@ -63,7 +63,7 @@ def _(np, wd):
     time_varying_values[time < 1.0] = np.sin(2 * np.pi * 400 * time[time < 1.0])
     time_varying_values[(time >= 1.0) & (time < 2.0)] = np.sin(2 * np.pi * 800 * time[(time >= 1.0) & (time < 2.0)])
     time_varying_values[time >= 2.0] = 0.8 * np.sin(2 * np.pi * 1_200 * time[time >= 2.0]) + 0.5 * np.sin(
-        2 * np.pi * 1_500 * time[time >= 2.0]
+        2 * np.pi * 1_240 * time[time >= 2.0]
     )
     time_varying_values += 0.03 * rng_time.standard_normal(time.size)
     time_varying_signal = wd.from_numpy(
@@ -82,8 +82,18 @@ def _(plt, time_varying_signal):
 
 
 @app.cell(hide_code=True)
-def _(mo, stft_short_window, t):
-    mo.md(t("stft_parameters", last_time=f"{stft_short_window.times[-1]:.3f}"))
+def _(mo, stft_long_window, stft_short_window, stft_zero_padded, t):
+    mo.md(
+        t(
+            "stft_parameters",
+            short_first_time=f"{stft_short_window.times[0]:.3f}",
+            short_last_time=f"{stft_short_window.times[-1]:.3f}",
+            padded_first_time=f"{stft_zero_padded.times[0]:.3f}",
+            padded_last_time=f"{stft_zero_padded.times[-1]:.3f}",
+            long_first_time=f"{stft_long_window.times[0]:.3f}",
+            long_last_time=f"{stft_long_window.times[-1]:.3f}",
+        )
+    )
     return
 
 
@@ -153,8 +163,12 @@ def _(mo, sampling_rate, stft_long_window, stft_short_window, stft_zero_padded, 
             long_window_scale=f"{sampling_rate / stft_long_window.win_length:.2f}",
             short_time_step=f"{stft_short_window.hop_length / sampling_rate * 1_000:.1f}",
             long_time_step=f"{stft_long_window.hop_length / sampling_rate * 1_000:.1f}",
-            first_time=f"{stft_short_window.times[0]:.3f}",
-            last_time=f"{stft_short_window.times[-1]:.3f}",
+            short_first_time=f"{stft_short_window.times[0]:.3f}",
+            short_last_time=f"{stft_short_window.times[-1]:.3f}",
+            padded_first_time=f"{stft_zero_padded.times[0]:.3f}",
+            padded_last_time=f"{stft_zero_padded.times[-1]:.3f}",
+            long_first_time=f"{stft_long_window.times[0]:.3f}",
+            long_last_time=f"{stft_long_window.times[-1]:.3f}",
         )
     )
     return
@@ -219,10 +233,28 @@ def _(plt, window_boxcar_frame, window_hann_frame):
 
 @app.cell(hide_code=True)
 def _(mo, np, t, window_boxcar_frame, window_hann_frame):
-    boxcar_db = np.asarray(window_boxcar_frame.dB)
-    hann_db = np.asarray(window_hann_frame.dB)
-    boxcar_off_peak = float(np.max(boxcar_db[(window_boxcar_frame.freqs < 425) | (window_boxcar_frame.freqs > 465)]))
-    hann_off_peak = float(np.max(hann_db[(window_hann_frame.freqs < 425) | (window_hann_frame.freqs > 465)]))
+    def single_channel_spectrum(frame):
+        frequencies = np.asarray(frame.freqs).reshape(-1)
+        values = np.asarray(frame.dB)
+        if values.ndim == 2:
+            values = values[0]
+        values = values.reshape(-1)
+        if values.shape != frequencies.shape:
+            raise ValueError("spectrum values and frequencies must have matching shapes")
+        return frequencies, values
+
+    boxcar_freqs, boxcar_db = single_channel_spectrum(window_boxcar_frame)
+    hann_freqs, hann_db = single_channel_spectrum(window_hann_frame)
+    tone_frequencies = (437.0, 451.0)
+    exclusion_half_width = 5.0
+    boxcar_off_peak_mask = np.logical_and.reduce(
+        [np.abs(boxcar_freqs - frequency) > exclusion_half_width for frequency in tone_frequencies]
+    )
+    hann_off_peak_mask = np.logical_and.reduce(
+        [np.abs(hann_freqs - frequency) > exclusion_half_width for frequency in tone_frequencies]
+    )
+    boxcar_off_peak = float(np.max(boxcar_db[boxcar_off_peak_mask]))
+    hann_off_peak = float(np.max(hann_db[hann_off_peak_mask]))
     mo.md(
         t(
             "window_evidence",
@@ -450,7 +482,7 @@ def _(np, sampling_rate, wd):
         ch_labels=["sound_pressure"],
         ch_units=["Pa"],
     )
-    return level_db, level_reference, level_time, sound_data
+    return level_time, sound_data
 
 
 @app.cell
@@ -536,10 +568,12 @@ def _(mo, t):
 
 @app.cell
 def _(np, sampling_rate, wavfile):
+    import atexit
     import tempfile
     from pathlib import Path
 
     temporary_directory = tempfile.TemporaryDirectory(prefix="wandas-learning-path-04-")
+    atexit.register(temporary_directory.cleanup)
     comparison_root = Path(temporary_directory.name)
     comparison_time = np.arange(2 * sampling_rate) / sampling_rate
     comparison_values = {
@@ -578,7 +612,6 @@ def _(comparison_root, wd):
         )
     )
     comparison_frames = [comparison_dataset[index] for index in range(len(comparison_dataset))]
-    comparison_materialized_values = [frame.data for frame in comparison_frames]
     comparison_contract = {
         "sampling_rates": sorted({float(frame.sampling_rate) for frame in comparison_frames}),
         "units": sorted({tuple(channel.unit for channel in frame.channels) for frame in comparison_frames}),
@@ -589,7 +622,6 @@ def _(comparison_root, wd):
         comparison_contract,
         comparison_dataset,
         comparison_frames,
-        comparison_materialized_values,
         dataset,
         dataset_state_before,
         selected_frame,

--- a/learning-path/04_advanced_processing.py
+++ b/learning-path/04_advanced_processing.py
@@ -246,7 +246,7 @@ def _(mo, np, t, window_boxcar_frame, window_hann_frame):
     boxcar_freqs, boxcar_db = single_channel_spectrum(window_boxcar_frame)
     hann_freqs, hann_db = single_channel_spectrum(window_hann_frame)
     tone_frequencies = (437.0, 451.0)
-    exclusion_half_width = 5.0
+    exclusion_half_width = 20.0
     boxcar_off_peak_mask = np.logical_and.reduce(
         [np.abs(boxcar_freqs - frequency) > exclusion_half_width for frequency in tone_frequencies]
     )
@@ -262,6 +262,7 @@ def _(mo, np, t, window_boxcar_frame, window_hann_frame):
             hann_peak=f"{float(np.max(hann_db)):.1f}",
             boxcar_off_peak=f"{boxcar_off_peak:.1f}",
             hann_off_peak=f"{hann_off_peak:.1f}",
+            exclusion_half_width=f"{exclusion_half_width:.0f}",
         )
     )
     return

--- a/learning-path/04_advanced_processing.py
+++ b/learning-path/04_advanced_processing.py
@@ -1,1079 +1,662 @@
 import marimo
 
-__generated_with = "0.23.1"
+__generated_with = "0.23.9"
 app = marimo.App()
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _():
     import marimo as mo
 
-    return (mo,)
+    from scripts.learning_path_i18n import (
+        language_switch_markdown,
+        load_catalog,
+        locale_from_argv,
+        navigation_markdown,
+    )
+
+    locale = locale_from_argv()
+    catalog = load_catalog("04_advanced_processing", locale)
+
+    def t(key, **values):
+        return catalog.text(key, **values)
+
+    return language_switch_markdown, locale, mo, navigation_markdown, t
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    # 04 高度な信号処理
-    """)
+def _(mo, t):
+    mo.md(f"# {t('title')}\n\n{t('intro')}")
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 高度な信号処理手法の実践
+def _(language_switch_markdown, locale, mo):
+    mo.md(language_switch_markdown("04_advanced_processing", locale))
+    return
 
-    このmarimoアプリでは、前回までに学んだ基本的な信号処理手法を発展させ、
-    **実務で使えるパラメータ調整と比較分析**を行います。
 
-    ### これまでに学んだ基礎
-    - **FFT**: 全体の周波数成分を一度に解析（03で学習）
-    - **基本的なフィルタリング**: ローパス、ハイパス、バンドパス（03で学習）
-    - **Welch法の基本**: ノイズを低減したスペクトル推定（02・03で学習）
-
-    ### 目次（このmarimoアプリで扱う内容）
-    1. **STFT（短時間フーリエ変換）のパラメータチューニング**
-       - 時間-周波数分解能のトレードオフ
-       - 窓サイズ変更による結果比較
-    2. **Welch法によるパラメータ最適化**
-       - 低SNR信号での分解能比較
-       - セグメント数と推定安定性の関係
-    3. **N-octave分析の実践**
-       - 1/3-octaveバンドによる対数周波数分析
-       - 音響評価に適した見方
-    4. **A特性・時間重み付けレベル実装の解析**
-       - Fast（125 ms）とSlow（1 s）の応答差
-       - 周波数重み付けと実装時定数の実践的解釈
-    5. **FrameDatasetへの一括処理適用**
-       - 複数条件データへの同一処理適用
-       - Welch法とN-octave分析の重ね合わせ比較
-
-    ### 学習目標
-    - STFTとWelch法のパラメータ選定を目的別に使い分けられるようになる
-    - N-octave分析と、基準を明記したA特性・時間重み付けレベルの読み方を習得する
-    - FrameDatasetを使った複数条件の比較分析フローを実装できるようになる
-
-    **注意**: Wandasは現在開発中のため、ウェーブレット変換など一部の高度な機能は
-    今後実装予定です。このmarimoアプリでは**現在利用可能な手法**に焦点を当てます。
-    """)
+@app.cell(hide_code=True)
+def _(mo, t):
+    mo.md(t("stft_section"))
     return
 
 
 @app.cell
 def _():
-    # 必要なライブラリをインポート
     import matplotlib.pyplot as plt
     import numpy as np
+    from scipy.io import wavfile
 
     import wandas as wd
-    from scripts import documentation_audio_examples as audio_contract
 
-    # インタラクティブプロット設定
-    # '%matplotlib inline' command supported automatically in marimo
     plt.rcParams["figure.figsize"] = (12, 6)
-
-    print(f"Wandas: {wd.__version__}")
-    print("✅ 準備完了")
-    return (
-        audio_contract,
-        np,
-        plt,
-        wd,
-    )
+    return np, plt, wavfile, wd
 
 
 @app.cell
 def _(np, wd):
-    np.random.seed(42)
-    sampling_rate = 48000
-    _duration = 4.0
-    time = np.arange(int(_duration * sampling_rate)) / sampling_rate
-    time_varying_signal = np.zeros_like(time)
-    _mask1 = (time >= 0) & (time < 1)
-    time_varying_signal[_mask1] = 2.0 * np.sin(2 * np.pi * 10 * time[_mask1])
-    _mask2 = (time >= 1) & (time < 2)
-    time_varying_signal[_mask2] = 1.5 * np.sin(2 * np.pi * 50 * time[_mask2])
-    _mask3 = (time >= 2) & (time < 3)
-    time_varying_signal[_mask3] = 1.0 * np.sin(2 * np.pi * 150 * time[_mask3])
-    _mask4 = (time >= 3) & (time < 4)
-    time_varying_signal[_mask4] = 0.8 * np.sin(2 * np.pi * 80 * time[_mask4]) + 0.6 * np.sin(
-        2 * np.pi * 120 * time[_mask4]
+    sampling_rate = 8_000
+    time = np.arange(3 * sampling_rate) / sampling_rate
+    rng_time = np.random.default_rng(404)
+    time_varying_values = np.zeros_like(time)
+    time_varying_values[time < 1.0] = np.sin(2 * np.pi * 400 * time[time < 1.0])
+    time_varying_values[(time >= 1.0) & (time < 2.0)] = np.sin(2 * np.pi * 800 * time[(time >= 1.0) & (time < 2.0)])
+    time_varying_values[time >= 2.0] = 0.8 * np.sin(2 * np.pi * 1_200 * time[time >= 2.0]) + 0.5 * np.sin(
+        2 * np.pi * 1_500 * time[time >= 2.0]
     )
-    time_varying_signal = time_varying_signal + 0.1 * np.random.randn(len(time))
-    time_varying_data = wd.from_numpy(
-        data=time_varying_signal.reshape(1, -1), sampling_rate=sampling_rate, ch_labels=["Time-Varying Signal"]
+    time_varying_values += 0.03 * rng_time.standard_normal(time.size)
+    time_varying_signal = wd.from_numpy(
+        data=time_varying_values.reshape(1, -1),
+        sampling_rate=sampling_rate,
+        ch_labels=["time_varying"],
     )
-    print(f"信号作成: {time_varying_data.shape}, {time_varying_data.sampling_rate} Hz")
-    print(f"継続時間: {time_varying_data.duration:.1f} 秒")
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## STFT（短時間フーリエ変換）のパラメータチューニング
-
-    ### なぜSTFTのパラメータ調整が重要か
-
-    **STFT（Short-Time Fourier Transform）**は、信号を短い時間窓で区切り、
-    各窓ごとにFFTを適用する手法です。これにより、
-    **時間とともに変化する周波数成分**を捉えることができます。
-
-    STFTには**時間分解能と周波数分解能のトレードオフ**が存在し、分析目的に応じた適切なパラメータ設定が必要です。
-
-    ### 時間-周波数分解能のトレードオフ
-
-    **窓サイズ（`n_fft`）が大きい場合**:
-    - ✅ 周波数分解能が高い（細かい周波数成分を区別できる）
-    - ❌ 時間分解能が低い（瞬間的な変化を捉えにくい）
-
-    **窓サイズ（`n_fft`）が小さい場合**:
-    - ✅ 時間分解能が高い（瞬間的な変化を捉えやすい）
-    - ❌ 周波数分解能が低い（近接する周波数成分を区別しにくい）
-
-    ### 実践的なパラメータ選択
-
-    **48kHzサンプリングレートでの目安**:
-    - **周波数分解能** = `sampling_rate / n_fft`
-      - `n_fft=2048` → 約23.4 Hz（粗い）
-      - `n_fft=4096` → 約11.7 Hz（中程度）
-      - `n_fft=8192` → 約5.9 Hz（細かい）
-
-    - **時間分解能** = `hop_length / sampling_rate`
-      - `hop_length=512` → 約10.7 ms（細かい）
-      - `hop_length=1024` → 約21.3 ms（中程度）
-      - `hop_length=2048` → 約42.7 ms（粗い）
-
-    このセクションでは、**パラメータ変更が結果に与える影響**を実践的に確認します。
-    """)
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### デモ信号の作成
-
-    時間とともに周波数が変化する信号を作成し、STFTの効果を視覚的に確認します。
-
-    **信号の構成**（4秒間）:
-    - **0〜1秒**: 10Hz（低周波振動）
-    - **1〜2秒**: 50Hz（電源周波数成分）
-    - **2〜3秒**: 150Hz（機械の固有振動数）
-    - **3〜4秒**: 80Hz + 120Hzの複合振動
-
-    この信号により、STFTが**時間変化する周波数成分を捉える能力**を確認できます。
-    """)
-    return
+    return sampling_rate, time, time_varying_signal, time_varying_values
 
 
 @app.cell
-def _(np, wd):
-    np.random.seed(42)
-    sampling_rate_1 = 48000
-    _duration = 4.0
-    time_1 = np.arange(int(sampling_rate_1 * _duration)) / sampling_rate_1
-    _signal = np.zeros_like(time_1)
-    _mask1 = (time_1 >= 0) & (time_1 < 1)
-    _signal[_mask1] = 1.0 * np.sin(2 * np.pi * 10 * time_1[_mask1])
-    _mask2 = (time_1 >= 1) & (time_1 < 2)
-    _signal[_mask2] = 1.0 * np.sin(2 * np.pi * 50 * time_1[_mask2])
-    _mask3 = (time_1 >= 2) & (time_1 < 3)
-    _signal[_mask3] = 1.0 * np.sin(2 * np.pi * 150 * time_1[_mask3])
-    _mask4 = time_1 >= 3
-    _signal[_mask4] = 0.7 * np.sin(2 * np.pi * 80 * time_1[_mask4]) + 0.7 * np.sin(2 * np.pi * 120 * time_1[_mask4])
-    _signal = _signal + 0.05 * np.random.randn(len(time_1))
-    time_varying_data_1 = wd.from_numpy(
-        data=_signal.reshape(1, -1), sampling_rate=sampling_rate_1, ch_labels=["Time-Varying Signal"]
-    )
-    print("✅ 時間変化信号を作成:")
-    print(f"  サンプリングレート: {time_varying_data_1.sampling_rate} Hz")
-    print(f"  長さ: {time_varying_data_1.duration:.1f} 秒")
-    print(f"  サンプル数: {time_varying_data_1.n_samples}")
-    return sampling_rate_1, time_varying_data_1
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### 時間領域での確認
-
-    まず、作成した信号を時間領域で観察します。
-    """)
-    return
-
-
-@app.cell
-def _(plt, time_varying_data_1):
-    (_fig, _ax) = plt.subplots(figsize=(12, 4))
-    time_varying_data_1.plot(ax=_ax, title="Time-Varying Frequency Signal", xlabel="Time [s]", ylabel="Amplitude")
-    plt.tight_layout()
+def _(plt, time_varying_signal):
+    time_varying_signal.plot(title="Time-varying signal", xlabel="Time [s]", ylabel="Amplitude")
     plt.show()
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    **波形の観察**:
-    - 4つの異なる区間で振幅と周波数が明確に変化している
-    - 周波数が高いほど波の間隔が狭くなる（2-3秒の区間）
-    - 3-4秒の区間では複数の周波数が混在し、複雑な波形になる
-
-    この波形だけでは「どの周波数成分がいつ現れたか」は定量的に判断できません。次にSTFTを適用して、時間-周波数平面での分析を行います。
-    """)
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### STFTの実行
-
-    それでは、STFTを適用してスペクトログラムを作成します。
-
-    **使用するパラメータ**（48kHzサンプリングレート）:
-    - **`n_fft=2048`**: 周波数分解能 約23.4 Hz
-    - **`hop_length=512`**: 時間分解能 約10.7 ms
-    - **`window='hann'`**: Hann窓（スペクトル漏れと分解能のバランス）
-
-    これらのパラメータは、**瞬時的な周波数変化を捉える**ために時間分解能を優先した設定です。
-    """)
+def _(mo, stft_short_window, t):
+    mo.md(t("stft_parameters", last_time=f"{stft_short_window.times[-1]:.3f}"))
     return
 
 
 @app.cell
-def _(plt, time_varying_data_1):
-    _spec = time_varying_data_1.stft(n_fft=2048, hop_length=512, window="hann")
-    print("📊 STFT結果:")
-    _spec.info()
-    (_fig, _ax) = plt.subplots(figsize=(12, 6))
-    _spec.plot(ax=_ax, title="Spectrogram (STFT)", ylim=(0, 200), vmin=-60, vmax=20)
-    plt.tight_layout()
-    plt.show()
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### スペクトログラムの読み方と結果解釈
-
-    **スペクトログラムの構成**:
-    - **横軸**: 時間（秒） - 信号の時間進行
-    - **縦軸**: 周波数（Hz） - 各時刻に含まれる周波数成分
-    - **色**: 振幅レベル（dB、チャンネル基準値に対する値） - 明るい色ほど強い周波数成分
-
-    **観察される結果**:
-    - **0-1秒**: 10Hz付近に明るい水平線 → 低周波振動が支配的
-    - **1-2秒**: 50Hz付近に明るい水平線 → 電源周波数成分が現れる
-    - **2-3秒**: 150Hz付近に明るい水平線 → より高い周波数成分
-    - **3-4秒**: 80Hzと120Hz付近に2本の明るい線 → 複合振動を明確に分離
-
-    **STFTの利点**:
-    - 通常のFFTでは全時間の平均的なスペクトルしか得られないが、**STFTは時間変化を捉えられる**
-    - 各時間窓での周波数成分を個別に分析できる
-    - 過渡現象や非定常信号の分析に不可欠
-
-    次に、パラメータを変更して分解能のトレードオフを体験します。
-    """)
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### パラメータ変更による分解能比較
-
-    STFTの**窓サイズ（`n_fft`）**を変えることで、時間-周波数分解能のトレードオフを実際に確認します。
-
-    **比較する3つの設定**:
-    1. **小窓（`n_fft=1024`）**: 時間分解能優先 - 瞬時的変化に強い
-    2. **中窓（`n_fft=2048`）**: バランス型 - 一般的な用途
-    3. **大窓（`n_fft=4096`）**: 周波数分解能優先 - 近接周波数の分離に強い
-
-    それぞれのスペクトログラムを並べて比較します。
-    """)
-    return
-
-
-@app.cell
-def _(plt, sampling_rate_1, time_varying_data_1):
-    n_fft_sizes = [1024, 2048, 4096]
-    spectrograms = {}
-    for _n_fft in n_fft_sizes:
-        _hop_length = _n_fft // 4
-        _freq_res = sampling_rate_1 / _n_fft
-        time_res = _hop_length / sampling_rate_1 * 1000
-        _spec = time_varying_data_1.stft(n_fft=_n_fft, hop_length=_hop_length)
-        spectrograms[_n_fft] = _spec
-        print(f"n_fft={_n_fft}: 周波数分解能={_freq_res:.1f} Hz, 時間分解能={time_res:.1f} ms")
-    (_fig, _axes) = plt.subplots(1, 3, figsize=(18, 5))
-    for _ax, (_n_fft, _spec) in zip(_axes, spectrograms.items()):
-        _freq_res = sampling_rate_1 / _n_fft
-        time_res = _n_fft // 4 / sampling_rate_1 * 1000
-        _spec.plot(
-            ax=_ax,
-            title=f"n_fft={_n_fft}\n(f_res={_freq_res:.1f}Hz, t_res={time_res:.1f}ms)",
-            ylim=(0, 200),
-            vmin=-60,
-            vmax=20,
-        )
-    plt.tight_layout()
-    plt.show()
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    **パラメータ比較の結果**:
-
-    **小窓（`n_fft=1024`）**:
-    - ✅ 時間的な区切りがシャープ（各区間の境界がはっきり）
-    - ❌ 周波数軸方向にぼやけている（80Hzと120Hzの分離が不明瞭）
-    - **用途**: 急激な周波数変化や過渡現象の検出
-
-    **中窓（`n_fft=2048`）**:
-    - ✅ 時間と周波数のバランスが良い
-    - ✅ 大抵のケースで十分な分解能
-    - **用途**: 一般的な音響・振動分析（デフォルトとして推奨）
-
-    **大窓（`n_fft=4096`）**:
-    - ✅ 80Hzと120Hzを明確に分離できる
-    - ❌ 時間方向にぼやけ（区間の境界が不明瞭）
-    - **用途**: 近接する周波数成分の精密分離、定常信号の分析
-
-    **実践的な選択指針**:
-    - **過渡現象・衝撃音分析**: 小窓（高時間分解能）
-    - **音声・音楽分析**: 中窓（バランス型）
-    - **機械診断・周波数同定**: 大窓（高周波数分解能）
-
-    次のセクションでは、Welch法によるスペクトル推定のパラメータ最適化を学びます。
-    """)
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## Welch法によるパラメータ最適化
-
-    ### なぜWelch法のパラメータ調整が重要か
-
-    **Welch法**は、信号を重複する区間に分割し、各区間のパワースペクトルを平均化することで、
-    ノイズの影響を低減します。Wandasはその平均をピーク振幅へ変換して返すため、
-    結果は入力と同じ単位の振幅スペクトルであり、PSD（単位あたりHz）ではありません。
-
-    **02のmarimoアプリ**では、Welch法の基本的な使い方とFFTとの違いを学びました。このセクションでは、**パラメータ調整による推定精度の最適化**を実践します。
-
-    ### Welch法のパラメータとその役割
-
-    **主要パラメータ**:
-    - **`n_fft`**: 各セグメントのFFTサイズ - 周波数分解能を決定
-    - **`hop_length`**: セグメント間のオーバーラップ - 推定の安定性に影響
-    - **`window`**: 窓関数の種類 - スペクトル漏れの抑制
-
-    **パラメータ間のトレードオフ**:
-    - **`n_fft`が大きい**: 周波数分解能↑、セグメント数↓（平均化効果↓）
-    - **`hop_length`が小さい**: セグメント数↑（平均化効果↑）、計算時間↑
-    - **窓関数の選択**: スペクトル漏れ vs メインローブ幅
-
-    ### 実践的な最適化戦略
-
-    このセクションでは、**低SNR信号**に対して3つの異なる分解能設定を比較し、適切なパラメータ選択の指針を学びます。
-    """)
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### 低SNR信号の作成
-
-    まず、ノイズの多い信号を作成し、Welch法のパラメータ最適化の効果を確認します。
-
-    **信号の構成**:
-    - **信号成分**: 100Hz（振幅0.5）+ 150Hz（振幅0.3）
-    - **ノイズ**: 強いガウシアンノイズ（標準偏差2.0）
-    - **SNR**: マイナスのSNR（信号よりノイズが強い）
-
-    この厳しい条件下で、Welch法のパラメータ調整によって信号成分を検出できるかを検証します。
-    """)
-    return
-
-
-@app.cell
-def _(np, sampling_rate_1, wd):
-    np.random.seed(123)
-    _duration = 10.0
-    time_2 = np.arange(int(sampling_rate_1 * _duration)) / sampling_rate_1
-    _signal = 0.5 * np.sin(2 * np.pi * 100 * time_2) + 0.3 * np.sin(2 * np.pi * 150 * time_2)
-    noise = 2.0 * np.random.randn(len(time_2))
-    noisy_signal = _signal + noise
-    noisy_data = wd.from_numpy(
-        data=noisy_signal.reshape(1, -1), sampling_rate=sampling_rate_1, ch_labels=["Low SNR Signal"]
+def _(time_varying_signal):
+    stft_short_window = time_varying_signal.stft(
+        n_fft=256,
+        win_length=256,
+        hop_length=64,
+        window="hann",
     )
-    signal_power = _signal.var()
-    noise_power = noise.var()
-    snr_db = 10 * np.log10(signal_power / noise_power)
-    print("✅ 低SNR信号を作成:")
-    print(f"  理論SNR: {snr_db:.1f} dB")
-    print("  信号周波数: 100Hz, 150Hz")
-    print("  ノイズレベル: 強（σ=2.0）")
-    print(f"  信号長: {noisy_data.duration:.1f} 秒")
-    return noisy_data, time_2
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### 3つの分解能設定で比較
-
-    異なるパラメータ設定でWelch法を実行し、**推定精度の違い**を確認します。
-
-    **比較する3つの設定**:
-    1. **低分解能（高速）**: `n_fft=2048`, `hop_length=1024`
-       - 周波数分解能: 約23.4 Hz
-       - セグメント数: 多い（平均化効果大）
-
-    2. **中分解能（バランス）**: `n_fft=4096`, `hop_length=2048`
-       - 周波数分解能: 約11.7 Hz
-       - セグメント数: 中程度
-
-    3. **高分解能（精密）**: `n_fft=8192`, `hop_length=4096`
-       - 周波数分解能: 約5.9 Hz
-       - セグメント数: 少ない（平均化効果小）
-
-    それぞれのスペクトルを比較して、信号検出能力の差を確認します。
-    """)
-    return
-
-
-@app.cell
-def _(noisy_data, plt, sampling_rate_1):
-    configs = [
-        {"n_fft": 2048, "hop_length": 1024, "label": "低分解能（高速）"},
-        {"n_fft": 4096, "hop_length": 2048, "label": "中分解能（バランス）"},
-        {"n_fft": 8192, "hop_length": 4096, "label": "高分解能（精密）"},
-    ]
-    _welch_results = {}
-    print("🔧 Welch法パラメータ比較:")
-    for config in configs:
-        _n_fft = config["n_fft"]
-        _hop_length = config["hop_length"]
-        label = config["label"]
-        amplitude_spectrum = noisy_data.welch(n_fft=_n_fft, hop_length=_hop_length)
-        _welch_results[label] = amplitude_spectrum
-        _freq_res = sampling_rate_1 / _n_fft
-        n_segments = int((noisy_data.n_samples - _n_fft) / _hop_length) + 1
-        print(f"\n{label}:")
-        print(f"  n_fft={_n_fft}, hop_length={_hop_length}")
-        print(f"  周波数分解能: {_freq_res:.2f} Hz")
-        print(f"  セグメント数: {n_segments} (平均化)")
-    (_fig, _axes) = plt.subplots(1, 3, figsize=(18, 5))
-    for _ax, (label, amplitude_spectrum) in zip(_axes, _welch_results.items()):
-        amplitude_spectrum.plot(ax=_ax, title=label, xlim=(0, 300), ylim=(-30, 0))
-        _ax.axvline(100, color="red", linestyle="--", alpha=0.7, linewidth=1, label="100Hz")
-        _ax.axvline(150, color="orange", linestyle="--", alpha=0.7, linewidth=1, label="150Hz")
-        _ax.legend()
-    plt.tight_layout()
-    plt.show()
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### パラメータ比較の結果解釈
-
-    **低分解能（`n_fft=2048`）**:
-    - ✅ 多数のセグメントによる平均化効果でノイズが滑らか
-    - ✅ 100Hzと150Hzのピークが明確に検出できる
-    - ❌ 周波数分解能が粗いため、ピークが広がっている
-    - **用途**: ノイズが多く、大まかな周波数成分を知りたい場合
-
-    **中分解能（`n_fft=4096`）**:
-    - ✅ 周波数分解能と平均化のバランスが良い
-    - ✅ ピークが適度にシャープで、ノイズレベルも許容範囲
-    - ✅ 一般的な用途に最適
-    - **用途**: 標準的な信号分析（推奨デフォルト設定）
-
-    **高分解能（`n_fft=8192`）**:
-    - ✅ 最も高い周波数分解能でピークがシャープ
-    - ✅ 近接周波数の精密分離に優れている
-    - ❌ セグメント数が少ないと、ノイズの変動が大きくなり、弱い信号が埋もれやすい
-    - **用途**: 音が長く、精密な周波数分析が必要な場合
-
-    **実践的な選択指針**:
-    - **ノイズが多い場合**: 低〜中分解能（平均化を優先）
-    - **信号が安定している場合**: 中〜高分解能（分解能を優先）
-    - **データ長が短い場合**: 低分解能（セグメント数を確保）
-    - **データ長が十分ある場合**: 中〜高分解能
-
-    次のセクションでは、N-octave分析によるオーディオ/建築音響に特化した分析手法を学びます。
-    """)
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## N-octave分析
-
-    ### なぜN-octave分析が必要か
-
-    **N-octave分析**は、音響工学や建築音響で広く使われる周波数分析手法です。通常のFFTが**等間隔の周波数ビン**を使うのに対し、N-octave分析は**対数的に配置された周波数帯域**を使用します。
-
-    ### 人間の聴覚特性との対応
-
-    **人間の耳は対数的**に周波数を知覚します：
-    - 100Hzと200Hzの差（100Hz）と、1000Hzと2000Hzの差（1000Hz）は**同じ音程差**（1オクターブ）として聞こえる
-    - 音楽や音響では、等間隔ではなく**倍数関係**で周波数を扱う
-
-    N-octave分析は、この人間の聴覚特性に合わせた周波数分割を提供します。
-
-    ### 1/N-octaveバンドとは
-
-    **1/N-octaveバンド**は、各帯域の中心周波数が以下の関係を持ちます：
-    $$f_{\text{center},k+1} = f_{\text{center},k} \times 2^{1/N}$$
-
-    一般的な設定:
-    - **1-octave**: 粗い分析（建築音響の評価、規格に基づく一般的な騒音評価、簡易的な騒音源特定）
-    - **1/3-octave**: 中程度の分解能（環境騒音の詳細分析、騒音対策の効果検証、機械の異音解析など精密な評価）
-    - **1/12-octave**: 細かい分析（音楽の半音に対応）
-
-    このセクションでは、**1/3-octave分析**を実践し、各帯域のRMS振幅レベルを視覚化します。
-    """)
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### 広帯域信号の作成
-
-    N-octave分析の効果を確認するため、**広い周波数範囲**にわたる信号を作成します。
-
-    **信号の構成**:
-    - **63 Hz**: 低音（バスドラム相当）
-    - **250 Hz**: 中低音（男性の声相当）
-    - **1000 Hz**: 中音（基準周波数）
-    - **4000 Hz**: 高音（シンバル相当）
-    - **ノイズ**: 現実的な環境ノイズを模擬
-
-    この信号により、N-octave分析が**広帯域信号をどのように帯域分割するか**を確認できます。
-    """)
-    return
-
-
-@app.cell
-def _(np, sampling_rate_1, time_2, wd):
-    # N-オクターブ分析用の複合周波数信号を作成
-    np.random.seed(456)
-    composite_signal = (
-        1.0 * np.sin(2 * np.pi * 63 * time_2)
-        + 0.8 * np.sin(2 * np.pi * 250 * time_2)
-        + 0.6 * np.sin(2 * np.pi * 1000 * time_2)
-        + 0.5 * np.sin(2 * np.pi * 4000 * time_2)
-        + 0.3 * np.sin(2 * np.pi * 8000 * time_2)
+    stft_zero_padded = time_varying_signal.stft(
+        n_fft=1_024,
+        win_length=256,
+        hop_length=64,
+        window="hann",
     )
-    # 複数の周波数成分を持つ信号
-    # 48kHzサンプリングレートでは、より広い周波数範囲が利用可能
-    composite_signal = composite_signal + 0.05 * np.random.randn(len(time_2))
-    composite_data = wd.from_numpy(
-        data=composite_signal.reshape(1, -1), sampling_rate=sampling_rate_1, ch_labels=["Multi-Frequency Signal"]
-    )  # 低域
-    print(f"複合周波数信号作成: {composite_data.shape}")  # 中域
-    print("含まれる周波数: 63Hz, 250Hz, 1kHz, 4kHz, 8kHz")  # 中高域
-    # 軽いノイズを追加
-    # ChannelFrame作成
-    print(f"Nyquist周波数: {sampling_rate_1 / 2} Hz")  # 高域  # 超高域（48kHzだからこそ可能）
-    return (composite_data,)
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### 1/3-octave分析の実行
-
-    それでは、作成した信号に対して1/3-octave分析を実行します。
-
-    **パラメータ**:
-    - **`n=3`**: 1/3-octaveバンド（建築音響で一般的）
-    - **`G=10`**（既定値）: 中心周波数を定めるbase-10比率規約。dB gainではない
-    - 各帯域の帯域幅は中心周波数に比例する
-    """)
-    return
-
-
-@app.cell
-def _(composite_data, plt, sampling_rate_1):
-    _noct_result = composite_data.noct_spectrum(fmin=25, fmax=20000, n=3)
-    print("N-オクターブ分析結果:")
-    print(f"  バンド数: {len(_noct_result.freqs)}")
-    print(f"  周波数範囲: {_noct_result.freqs[0]:.1f} - {_noct_result.freqs[-1]:.1f} Hz")
-    print(f"  サンプリングレート: {_noct_result.sampling_rate} Hz")
-    print(f"  Nyquist周波数: {sampling_rate_1 / 2} Hz")
-    (_fig, (_ax1, _ax2)) = plt.subplots(2, 1, figsize=(12, 10))
-    composite_data.plot(ax=_ax1, title="Original Multi-Frequency Signal")
-    _noct_result.plot(ax=_ax2, title="1/3 Octave Band Spectrum")
-    _ax2.set_xscale("log")
-    _ax2.grid(True, which="both", alpha=0.3)
-    for freq in [63, 250, 1000, 4000, 8000]:
-        _ax2.axvline(freq, color="red", linestyle="--", alpha=0.5)
-    plt.tight_layout()
-    plt.show()
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### N-octave分析結果の読み方
-
-    **1/3-octaveスペクトルの特徴**:
-    - **横軸**: 中心周波数（対数スケール）
-    - **縦軸**: 各帯域のRMS振幅をチャンネル基準値で表したレベル（dB）
-    - **帯域幅**: 低周波数では狭く、高周波数では広い
-
-    **観察される結果**:
-    - **63 Hz付近**: 低音成分が明確にピークとして現れる
-    - **250 Hz付近**: 中低音成分のピーク
-    - **1000 Hz付近**: 中音成分のピーク（最も強い）
-    - **4000 Hz付近**: 高音成分のピーク
-
-    **FFTスペクトルとの違い**:
-    - FFTは等間隔の周波数ビン → 高周波数帯域の分解能が相対的に高い
-    - N-octaveは対数的な帯域 → 全周波数範囲で均等な相対分解能
-    - N-octaveは人間の聴覚特性に合っている → 音響評価に適している
-
-    **実用例**:
-    - **建築音響**: 室内の音響特性評価
-    - **騒音測定**: 環境騒音の周波数分布
-    - **音楽分析**: 楽器の周波数特性
-    - **機械診断**: 回転機械の振動評価
-    """)
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## A特性・時間重み付けレベルの応答を比較
-
-    振幅が段階的に変化する信号を使い、FastとSlowの応答差を観察します。
-    API固有の引数・単位・基準値の契約は、生成されるAPIリファレンスで確認し、
-    このアプリでは信号の作り方とグラフの読み方に集中します。
-
-    この例で比較する時間重み付けは次のとおりです：
-
-    | 設定 | 時定数 | この例での表記 |
-    |------|--------|------|
-    | **Fast（F）** | 125 ms | A/F重み付けレベル |
-    | **Slow（S）** | 1000 ms | A/S重み付けレベル |
-
-    **時定数の効果**：
-    - **Fast**: 短い時定数により、入力の変化に素早く応答
-    - **Slow**: 長い時定数により、レベル変動をより強く平滑化
-
-    ここで確認するのはWandasのデジタルフィルタと時定数の実装です。認証機器の
-    完全な適合性を判定する測定手順ではありません。
-    """)
-    return
-
-
-@app.cell
-def _(np, wd):
-    # A特性・時間重み付けレベル解析用のPa信号を作成
-    # 突然レベルが変化する信号で時定数の効果を確認
-    np.random.seed(789)
-    sr_sl = 48000
-    duration_sl = 6.0
-    time_sl = np.arange(int(sr_sl * duration_sl)) / sr_sl
-
-    # 段階的に音圧レベルが変化する信号（音響信号を模擬）
-    # 0-2秒: 低レベル（60 dB SPL re 20 µPa）
-    # 2-4秒: 高レベル（80 dB SPL re 20 µPa、突然増大）
-    # 4-6秒: 再び低レベル（60 dB SPL re 20 µPa）
-    p_ref = 2e-5  # 音圧の基準値 [Pa]
-
-    # 各区間の実効音圧
-    p_low = p_ref * 10 ** (60 / 20)  # 60 dB SPL re 20 µPa → 約 0.02 Pa
-    p_high = p_ref * 10 ** (80 / 20)  # 80 dB SPL re 20 µPa → 約 0.20 Pa
-
-    sound_signal = np.zeros(len(time_sl))
-    mask_low1 = time_sl < 2.0
-    mask_high = (time_sl >= 2.0) & (time_sl < 4.0)
-    mask_low2 = time_sl >= 4.0
-
-    # 1000 Hz正弦波（純音）に各レベルの振幅を設定
-    sound_signal[mask_low1] = p_low * np.sqrt(2) * np.sin(2 * np.pi * 1000 * time_sl[mask_low1])
-    sound_signal[mask_high] = p_high * np.sqrt(2) * np.sin(2 * np.pi * 1000 * time_sl[mask_high])
-    sound_signal[mask_low2] = p_low * np.sqrt(2) * np.sin(2 * np.pi * 1000 * time_sl[mask_low2])
-
-    # ChannelFrame作成（ch_units='Pa' により基準音圧 2e-5 Pa が自動設定される）
-    sound_data = wd.from_numpy(
-        data=sound_signal.reshape(1, -1), sampling_rate=sr_sl, ch_labels=["Sound Pressure"], ch_units=["Pa"]
+    stft_long_window = time_varying_signal.stft(
+        n_fft=1_024,
+        win_length=1_024,
+        hop_length=256,
+        window="hann",
     )
-
-    print("✅ 音圧信号を作成:")
-    print(f"  サンプリングレート: {sound_data.sampling_rate} Hz")
-    print(f"  継続時間: {sound_data.duration:.1f} 秒")
-    print(f"  基準音圧（公開channel metadata）: {sound_data.channels[0].ref} Pa")
-    print(f"  0-2秒: {20 * np.log10(p_low / p_ref):.0f} dB SPL (re {p_ref:g} Pa)")
-    print(f"  2-4秒: {20 * np.log10(p_high / p_ref):.0f} dB SPL (re {p_ref:g} Pa、突然増大)")
-    print(f"  4-6秒: {20 * np.log10(p_low / p_ref):.0f} dB SPL (re {p_ref:g} Pa、突然減少)")
-    return (sound_data,)
+    return stft_long_window, stft_short_window, stft_zero_padded
 
 
 @app.cell
-def _(plt, sound_data):
-    # 基準音圧20 µPaに対するA特性・Fast/Slow実装値を比較
-    # Fast（F）: 時定数 125ms、Slow（S）: 時定数 1000ms
-    laf = sound_data.sound_level(freq_weighting="A", time_weighting="Fast", dB=True)
-    # Fast時定数（125ms）でのA特性重み付けレベル
-    las = sound_data.sound_level(freq_weighting="A", time_weighting="Slow", dB=True)
-    reference_pressure_pa = sound_data.channels[0].ref
-    print(f"A/F重み付けレベル（実装値）- 時定数: 125 ms、基準: {reference_pressure_pa:g} Pa")
-    print(f"  出力形状: {laf.data.shape}")
-    print(f"A/S重み付けレベル（実装値）- 時定数: 1000 ms、基準: {reference_pressure_pa:g} Pa")
-    print(f"  出力形状: {las.data.shape}")
-    (_fig, _axes) = plt.subplots(2, 1, figsize=(12, 8), sharex=True)
-    # Slow時定数（1000ms）でのA特性重み付けレベル
-    laf.plot(
+def _(plt, stft_long_window, stft_short_window, stft_zero_padded):
+    _fig, _axes = plt.subplots(1, 3, figsize=(18, 5), sharey=True)
+    stft_short_window.plot(
         ax=_axes[0],
-        title="A/F重み付けレベル（実装値、Fast: 125 ms）",
-        ylabel=f"Level [dB SPL re {reference_pressure_pa:g} Pa]",
-        ylim=(20, 90),
+        title="Short window",
+        ylim=(0, 2_000),
+        vmin=-70,
+        vmax=5,
     )
-    _axes[0].axvline(x=2.0, color="red", linestyle="--", alpha=0.7, label="レベル変化点")
-    _axes[0].axvline(x=4.0, color="red", linestyle="--", alpha=0.7)
-    _axes[0].axhline(y=60, color="gray", linestyle=":", alpha=0.5, label="60 dB SPL re 20 µPa")
-    _axes[0].axhline(y=80, color="orange", linestyle=":", alpha=0.5, label="80 dB SPL re 20 µPa")
-    _axes[0].legend(loc="upper right")
-    las.plot(
+    stft_zero_padded.plot(
         ax=_axes[1],
-        title="A/S重み付けレベル（実装値、Slow: 1000 ms）",
-        ylabel=f"Level [dB SPL re {reference_pressure_pa:g} Pa]",
-        ylim=(20, 90),
+        title="Same window, zero-padded FFT",
+        ylim=(0, 2_000),
+        vmin=-70,
+        vmax=5,
     )
-    _axes[1].axvline(x=2.0, color="red", linestyle="--", alpha=0.7, label="レベル変化点")
-    _axes[1].axvline(x=4.0, color="red", linestyle="--", alpha=0.7)
-    _axes[1].axhline(y=60, color="gray", linestyle=":", alpha=0.5, label="60 dB SPL re 20 µPa")
-    _axes[1].axhline(y=80, color="orange", linestyle=":", alpha=0.5, label="80 dB SPL re 20 µPa")
-    # プロット比較
-    _axes[1].legend(loc="upper right")
+    stft_long_window.plot(
+        ax=_axes[2],
+        title="Long window",
+        ylim=(0, 2_000),
+        vmin=-70,
+        vmax=5,
+    )
     plt.tight_layout()
-    # A/F（Fast）
     plt.show()
-    print("\n📊 定常状態での最大値（高レベル区間）:")
-    print(f"  A/F最大値: {laf.data.max():.1f} dB SPL (re {reference_pressure_pa:g} Pa)")
-    # A/S（Slow）
-    print(f"  A/S最大値: {las.data.max():.1f} dB SPL (re {reference_pressure_pa:g} Pa)")
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### 解析結果の読み方
-
-    **Fast（F）とSlow（S）の違い**:
-
-    | 特性 | Fast（A/F実装値） | Slow（A/S実装値） |
-    |------|------------|------------|
-    | **時定数** | 125 ms | 1000 ms |
-    | **応答速度** | 速い（瞬時変動を追跡） | 遅い（変動を平滑化） |
-    | **レベル上昇時** | 素早く定常値へ到達 | ゆっくり定常値へ収束 |
-    | **レベル下降時** | 素早く低下 | ゆっくり減衰 |
-
-    **観察される結果**:
-    - **A/F（Fast）**: 2秒と4秒の変化点へ素早く応答
-    - **A/S（Slow）**: 変化点での立ち上がり・立ち下がりが緩やか
-
-    **実用的な使い分け**:
-    - **Fast**: 短時間の変化を追跡する実装比較
-    - **Slow**: より長い時間で平滑化する実装比較
-    """)
+def _(mo, sampling_rate, stft_long_window, stft_short_window, stft_zero_padded, t):
+    mo.md(
+        t(
+            "stft_evidence",
+            short_shape=stft_short_window.shape,
+            padded_shape=stft_zero_padded.shape,
+            long_shape=stft_long_window.shape,
+            short_bin_spacing=f"{sampling_rate / stft_short_window.n_fft:.2f}",
+            padded_bin_spacing=f"{sampling_rate / stft_zero_padded.n_fft:.2f}",
+            short_window_scale=f"{sampling_rate / stft_short_window.win_length:.2f}",
+            long_window_scale=f"{sampling_rate / stft_long_window.win_length:.2f}",
+            short_time_step=f"{stft_short_window.hop_length / sampling_rate * 1_000:.1f}",
+            long_time_step=f"{stft_long_window.hop_length / sampling_rate * 1_000:.1f}",
+            first_time=f"{stft_short_window.times[0]:.3f}",
+            last_time=f"{stft_short_window.times[-1]:.3f}",
+        )
+    )
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## データセットへの一括処理適用
-
-    FrameDatasetを使用すると、**全データに同じ処理を一度に適用**できます。
-
-    ここでは、**Welch法とN-octave分析を一括適用**し、結果を重ねて比較することで、
-    **異なる分析手法の特徴と相補性を視覚的に確認**します。
-
-    **実践例**: 正常・軽度異常・重度異常の3つの条件の振動データを比較分析
-
-    3条件は相対差を保つ共通係数で `[-0.95, 0.95]` に収め、明示的なPCM16 WAVとして保存します。
-    再読込値の単位は full scale（FS）で、スペクトルの0 dB基準は `1 FS` です。
-    """)
+def _(mo, t):
+    mo.md(t("window_section"))
     return
 
 
 @app.cell
-def _(audio_contract):
-    # 3条件を共通係数で0.95 FS以下に収め、PCM16 WAVとして保存・再読込する
+def _(np, sampling_rate, wd):
+    steady_time = np.arange(int(1.5 * sampling_rate)) / sampling_rate
+    steady_values = 0.8 * np.sin(2 * np.pi * 437 * steady_time) + 0.5 * np.sin(2 * np.pi * 451 * steady_time)
+    steady_signal = wd.from_numpy(
+        data=steady_values.reshape(1, -1),
+        sampling_rate=sampling_rate,
+        ch_labels=["steady"],
+    )
+    return steady_signal
+
+
+@app.cell
+def _(steady_signal):
+    window_boxcar_spectrogram = steady_signal.stft(
+        n_fft=1_024,
+        win_length=1_024,
+        hop_length=256,
+        window="boxcar",
+    )
+    window_hann_spectrogram = steady_signal.stft(
+        n_fft=1_024,
+        win_length=1_024,
+        hop_length=256,
+        window="hann",
+    )
+    window_boxcar_frame = window_boxcar_spectrogram.get_frame_at(window_boxcar_spectrogram.n_frames // 2)
+    window_hann_frame = window_hann_spectrogram.get_frame_at(window_hann_spectrogram.n_frames // 2)
+    return window_boxcar_frame, window_hann_frame
+
+
+@app.cell
+def _(plt, window_boxcar_frame, window_hann_frame):
+    _fig, (_ax_boxcar, _ax_hann) = plt.subplots(1, 2, figsize=(14, 4), sharey=True)
+    window_boxcar_frame.plot(
+        ax=_ax_boxcar,
+        title="Boxcar window",
+        xlim=(350, 550),
+        ylim=(-80, 5),
+    )
+    window_hann_frame.plot(
+        ax=_ax_hann,
+        title="Hann window",
+        xlim=(350, 550),
+        ylim=(-80, 5),
+    )
+    plt.tight_layout()
+    plt.show()
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, np, t, window_boxcar_frame, window_hann_frame):
+    boxcar_db = np.asarray(window_boxcar_frame.dB)
+    hann_db = np.asarray(window_hann_frame.dB)
+    boxcar_off_peak = float(np.max(boxcar_db[(window_boxcar_frame.freqs < 425) | (window_boxcar_frame.freqs > 465)]))
+    hann_off_peak = float(np.max(hann_db[(window_hann_frame.freqs < 425) | (window_hann_frame.freqs > 465)]))
+    mo.md(
+        t(
+            "window_evidence",
+            boxcar_peak=f"{float(np.max(boxcar_db)):.1f}",
+            hann_peak=f"{float(np.max(hann_db)):.1f}",
+            boxcar_off_peak=f"{boxcar_off_peak:.1f}",
+            hann_off_peak=f"{hann_off_peak:.1f}",
+        )
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, t):
+    mo.md(t("welch_section"))
+    return
+
+
+@app.cell
+def _(np, sampling_rate, wd):
+    welch_time = np.arange(4 * sampling_rate) / sampling_rate
+    rng_welch = np.random.default_rng(405)
+    welch_values = (
+        0.8 * np.sin(2 * np.pi * 600 * welch_time)
+        + 0.5 * np.sin(2 * np.pi * 660 * welch_time)
+        + 0.2 * rng_welch.standard_normal(welch_time.size)
+    )
+    welch_signal = wd.from_numpy(
+        data=welch_values.reshape(1, -1),
+        sampling_rate=sampling_rate,
+        ch_labels=["noisy_tone"],
+    )
+    return welch_signal
+
+
+@app.cell
+def _(welch_signal):
+    welch_reference = welch_signal.welch(
+        n_fft=512,
+        win_length=512,
+        hop_length=256,
+        window="hann",
+        average="mean",
+    )
+    welch_more_overlap = welch_signal.welch(
+        n_fft=512,
+        win_length=512,
+        hop_length=128,
+        window="hann",
+        average="mean",
+    )
+    welch_zero_padded = welch_signal.welch(
+        n_fft=1_024,
+        win_length=512,
+        hop_length=256,
+        window="hann",
+        average="mean",
+    )
+    return welch_more_overlap, welch_reference, welch_zero_padded
+
+
+@app.cell
+def _(plt, welch_more_overlap, welch_reference, welch_zero_padded):
+    _fig, _axes = plt.subplots(1, 3, figsize=(18, 5), sharey=True)
+    welch_reference.plot(
+        ax=_axes[0],
+        title="50% overlap",
+        xlim=(450, 800),
+        ylim=(-70, 5),
+    )
+    welch_more_overlap.plot(
+        ax=_axes[1],
+        title="75% overlap",
+        xlim=(450, 800),
+        ylim=(-70, 5),
+    )
+    welch_zero_padded.plot(
+        ax=_axes[2],
+        title="Welch with zero-padded FFT",
+        xlim=(450, 800),
+        ylim=(-70, 5),
+    )
+    plt.tight_layout()
+    plt.show()
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, np, sampling_rate, t, welch_more_overlap, welch_reference, welch_signal, welch_zero_padded):
+    reference_segment_count = 1 + (welch_signal.n_samples - 512) // 256
+    overlap_segment_count = 1 + (welch_signal.n_samples - 512) // 128
+    padded_segment_count = 1 + (welch_signal.n_samples - 512) // 256
+    reference_db = np.asarray(welch_reference.dB)
+    reference_linear = np.asarray(welch_reference.data)
+    mo.md(
+        t(
+            "welch_evidence",
+            reference_shape=welch_reference.shape,
+            overlap_shape=welch_more_overlap.shape,
+            padded_shape=welch_zero_padded.shape,
+            reference_segments=reference_segment_count,
+            overlap_segments=overlap_segment_count,
+            padded_segments=padded_segment_count,
+            reference_overlap=f"{512 - 256}",
+            more_overlap=f"{512 - 128}",
+            bin_spacing=f"{sampling_rate / welch_reference.n_fft:.2f}",
+            padded_bin_spacing=f"{sampling_rate / welch_zero_padded.n_fft:.2f}",
+            linear_peak=f"{float(np.max(reference_linear)):.3f}",
+            db_peak=f"{float(np.max(reference_db)):.1f}",
+            unit=welch_signal.channels[0].unit,
+            reference=f"{welch_signal.channels[0].ref:g}",
+        )
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, t):
+    mo.md(t("noct_section"))
+    return
+
+
+@app.cell
+def _(np, wd):
+    acoustic_sampling_rate = 16_000
+    acoustic_time = np.arange(3 * acoustic_sampling_rate) / acoustic_sampling_rate
+    acoustic_values = (
+        0.020 * np.sqrt(2) * np.sin(2 * np.pi * 125 * acoustic_time)
+        + 0.010 * np.sqrt(2) * np.sin(2 * np.pi * 250 * acoustic_time)
+        + 0.006 * np.sqrt(2) * np.sin(2 * np.pi * 1_000 * acoustic_time)
+        + 0.004 * np.sqrt(2) * np.sin(2 * np.pi * 4_000 * acoustic_time)
+    )
+    acoustic_signal = wd.from_numpy(
+        data=acoustic_values.reshape(1, -1),
+        sampling_rate=acoustic_sampling_rate,
+        ch_labels=["acoustic"],
+        ch_units=["Pa"],
+    )
+    return acoustic_signal
+
+
+@app.cell
+def _(acoustic_signal, np):
+    noct_result = acoustic_signal.noct_spectrum(
+        fmin=63,
+        fmax=6_300,
+        n=3,
+        G=10,
+        fr=1_000,
+    )
+    noct_band_centers = noct_result.freqs
+    noct_ratio = 10 ** (3 / (10 * noct_result.n)) if noct_result.G == 10 else 2 ** (1 / noct_result.n)
+    noct_band_widths = noct_band_centers * (np.sqrt(noct_ratio) - 1 / np.sqrt(noct_ratio))
+    return noct_band_centers, noct_band_widths, noct_result
+
+
+@app.cell
+def _(noct_result, plt):
+    _fig, (_ax_raw, _ax_weighted) = plt.subplots(1, 2, figsize=(15, 4), sharey=True)
+    _raw_axis = noct_result.plot(
+        ax=_ax_raw,
+        title="Third-octave band level",
+        xlabel="Band center [Hz]",
+        ylabel="Level [dB SPL re 20 uPa]",
+    )
+    _weighted_axis = noct_result.plot(
+        ax=_ax_weighted,
+        title="A-weighted third-octave level",
+        xlabel="Band center [Hz]",
+        ylabel="Level [dB SPL re 20 uPa]",
+        Aw=True,
+    )
+    _raw_axis.set_xscale("log")
+    _weighted_axis.set_xscale("log")
+    plt.tight_layout()
+    plt.show()
+    return
+
+
+@app.cell(hide_code=True)
+def _(acoustic_signal, mo, noct_band_centers, noct_band_widths, noct_result, np, t):
+    noct_db = np.asarray(noct_result.dB)[0]
+    noct_dba = np.asarray(noct_result.dBA)[0]
+    reference_band_index = int(np.argmin(np.abs(noct_band_centers - noct_result.fr)))
+    mo.md(
+        t(
+            "noct_evidence",
+            band_count=len(noct_band_centers),
+            center_start=f"{noct_band_centers[0]:.1f}",
+            center_end=f"{noct_band_centers[-1]:.1f}",
+            first_width=f"{noct_band_widths[0]:.1f}",
+            reference_center=f"{noct_band_centers[reference_band_index]:.1f}",
+            reference_level=f"{noct_db[reference_band_index]:.1f}",
+            reference_a_level=f"{noct_dba[reference_band_index]:.1f}",
+            n=noct_result.n,
+            G=noct_result.G,
+            fr=noct_result.fr,
+            unit=acoustic_signal.channels[0].unit,
+            reference=f"{acoustic_signal.channels[0].ref:g}",
+        )
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, t):
+    mo.md(t("level_section"))
+    return
+
+
+@app.cell
+def _(np, sampling_rate, wd):
+    level_time = np.arange(4 * sampling_rate) / sampling_rate
+    level_reference = 2e-5
+    level_db = np.where(
+        level_time < 2.0,
+        60.0,
+        np.where(level_time < 3.0, 80.0, 60.0),
+    )
+    level_rms = level_reference * 10 ** (level_db / 20)
+    level_values = np.sqrt(2) * level_rms * np.sin(2 * np.pi * 1_000 * level_time)
+    sound_data = wd.from_numpy(
+        data=level_values.reshape(1, -1),
+        sampling_rate=sampling_rate,
+        ch_labels=["sound_pressure"],
+        ch_units=["Pa"],
+    )
+    return level_db, level_reference, level_time, sound_data
+
+
+@app.cell
+def _(sound_data):
+    sound_level_linear = sound_data.sound_level(
+        freq_weighting="A",
+        time_weighting="Fast",
+        dB=False,
+    )
+    sound_level_fast = sound_data.sound_level(
+        freq_weighting="A",
+        time_weighting="Fast",
+        dB=True,
+    )
+    sound_level_slow = sound_data.sound_level(
+        freq_weighting="A",
+        time_weighting="Slow",
+        dB=True,
+    )
+    return sound_level_fast, sound_level_linear, sound_level_slow
+
+
+@app.cell
+def _(plt, sound_level_fast, sound_level_linear, sound_level_slow):
+    _fig, (_ax_linear, _ax_fast, _ax_slow) = plt.subplots(3, 1, figsize=(12, 8), sharex=True)
+    sound_level_linear.plot(
+        ax=_ax_linear,
+        title="Linear A/F RMS",
+        ylabel="RMS [Pa]",
+        ylim=(0, 0.25),
+    )
+    sound_level_fast.plot(
+        ax=_ax_fast,
+        title="A/F level",
+        ylabel="Level [dB SPL re 20 uPa]",
+        ylim=(40, 85),
+    )
+    sound_level_slow.plot(
+        ax=_ax_slow,
+        title="A/S level",
+        ylabel="Level [dB SPL re 20 uPa]",
+        ylim=(40, 85),
+    )
+    plt.tight_layout()
+    plt.show()
+    return
+
+
+@app.cell(hide_code=True)
+def _(level_time, mo, np, sound_data, sound_level_fast, sound_level_linear, sound_level_slow, t):
+    linear_values = np.asarray(sound_level_linear.data)
+    fast_values = np.asarray(sound_level_fast.data)
+    slow_values = np.asarray(sound_level_slow.data)
+    low_slice = (level_time >= 0.75) & (level_time < 1.75)
+    high_slice = (level_time >= 2.25) & (level_time < 2.75)
+    mo.md(
+        t(
+            "level_evidence",
+            linear_shape=sound_level_linear.shape,
+            fast_shape=sound_level_fast.shape,
+            slow_shape=sound_level_slow.shape,
+            sampling_rate=sound_level_fast.sampling_rate,
+            unit=sound_data.channels[0].unit,
+            reference=f"{sound_data.channels[0].ref:g}",
+            output_unit=sound_level_fast.channels[0].unit,
+            linear_low=f"{float(np.mean(linear_values[low_slice])):.4f}",
+            linear_high=f"{float(np.mean(linear_values[high_slice])):.4f}",
+            fast_low=f"{float(np.mean(fast_values[low_slice])):.1f}",
+            fast_high=f"{float(np.mean(fast_values[high_slice])):.1f}",
+            slow_high=f"{float(np.mean(slow_values[high_slice])):.1f}",
+            fast_peak=f"{float(np.max(fast_values)):.1f}",
+            slow_peak=f"{float(np.max(slow_values)):.1f}",
+        )
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, t):
+    mo.md(t("dataset_section"))
+    return
+
+
+@app.cell
+def _(np, sampling_rate, wavfile):
     import tempfile
     from pathlib import Path
 
-    temp_dir = Path(tempfile.mkdtemp(prefix="wandas_comparison_"))
-    comparison_paths = audio_contract.write_comparison_pcm16(temp_dir)
-    signals = audio_contract.read_comparison_pcm16(comparison_paths)
-    print("✅ PCM16で保存し、canonical float64 full-scale値として再読込:")
-    for _signal in signals:
-        print(f"  {_signal.labels[0]}: {_signal.shape}, {_signal.sampling_rate} Hz, dtype={_signal.data.dtype}")
-    return (temp_dir,)
+    temporary_directory = tempfile.TemporaryDirectory(prefix="wandas-learning-path-04-")
+    comparison_root = Path(temporary_directory.name)
+    comparison_time = np.arange(2 * sampling_rate) / sampling_rate
+    comparison_values = {
+        "baseline": 0.45 * np.sin(2 * np.pi * 440 * comparison_time),
+        "changed": 0.45 * np.sin(2 * np.pi * 660 * comparison_time) + 0.15 * np.sin(2 * np.pi * 880 * comparison_time),
+    }
+    for condition, values in comparison_values.items():
+        condition_directory = comparison_root / f"condition={condition}"
+        condition_directory.mkdir(parents=True, exist_ok=True)
+        pcm_values = np.asarray(values * np.iinfo(np.int16).max, dtype=np.int16)
+        wavfile.write(condition_directory / f"{condition}.wav", sampling_rate, pcm_values)
+    return comparison_root, temporary_directory
 
 
 @app.cell
+def _(comparison_root, wd):
+    dataset = wd.from_folder(
+        comparison_root,
+        recursive=True,
+        lazy_loading=True,
+        path_metadata=True,
+    )
+    dataset_state_before = dataset.get_metadata()
+    selected_dataset = dataset.select(condition="changed")
+    selected_state_before_load = selected_dataset.get_metadata()
+    selected_frame = selected_dataset[0]
+    selected_state_after_item = selected_dataset.get_metadata()
+    selected_materialized_values = selected_frame.data
+    comparison_dataset = dataset.apply(
+        lambda frame: frame.welch(
+            n_fft=512,
+            win_length=512,
+            hop_length=256,
+            window="hann",
+            average="mean",
+        )
+    )
+    comparison_frames = [comparison_dataset[index] for index in range(len(comparison_dataset))]
+    comparison_materialized_values = [frame.data for frame in comparison_frames]
+    comparison_contract = {
+        "sampling_rates": sorted({float(frame.sampling_rate) for frame in comparison_frames}),
+        "units": sorted({tuple(channel.unit for channel in frame.channels) for frame in comparison_frames}),
+        "references": sorted({tuple(float(channel.ref) for channel in frame.channels) for frame in comparison_frames}),
+        "shapes": [frame.shape for frame in comparison_frames],
+    }
+    return (
+        comparison_contract,
+        comparison_dataset,
+        comparison_frames,
+        comparison_materialized_values,
+        dataset,
+        dataset_state_before,
+        selected_frame,
+        selected_materialized_values,
+        selected_state_after_item,
+        selected_state_before_load,
+        selected_dataset,
+    )
+
+
+@app.cell
+def _(comparison_frames, plt):
+    _fig, _ax = plt.subplots(figsize=(12, 5))
+    for _frame in comparison_frames:
+        _frame.plot(
+            ax=_ax,
+            overlay=True,
+            label=str(_frame.metadata["condition"]),
+            xlim=(300, 1_100),
+            ylim=(-70, 5),
+        )
+    _ax.legend()
+    _ax.set_title("Collection-level Welch comparison")
+    plt.tight_layout()
+    plt.show()
+    return
+
+
+@app.cell(hide_code=True)
 def _(
-    audio_contract,
-    np,
-    plt,
-    temp_dir,
-    wd,
+    comparison_contract,
+    dataset_state_before,
+    mo,
+    selected_frame,
+    selected_materialized_values,
+    selected_state_after_item,
+    selected_state_before_load,
+    t,
 ):
-    # FrameDataset作成
-    dataset = wd.from_folder(temp_dir, lazy_loading=True)
-    print(f"✅ FrameDataset作成: {len(dataset)} ファイル")
-    _welch_results = dataset.apply(lambda x: x.welch(n_fft=2048, hop_length=1024))
-    # Welch法とN-octave分析を一括適用
-    noct_results = dataset.apply(lambda x: x.noct_spectrum(fmin=25, fmax=audio_contract.COMPARISON_NOCT_FMAX, n=3))
-    (fig1, _ax1) = plt.subplots(figsize=(12, 6))
-    for welch_result in _welch_results:
-        # Welch法とN-octave分析の結果を重ねて比較
-        # Welch法の結果を1つの図にまとめてプロット
-        welch_result.plot(ax=_ax1, alpha=0.8, label=welch_result.label)
-    _ax1.set_title("Welch Method Comparison Across Conditions", fontsize=14)
-    _ax1.set_xlim(20, 1000)
-    _ax1.set_ylabel("Amplitude level [dB re 1 FS]")
-    _ax1.set_ylim(*audio_contract.COMPARISON_WELCH_YLIM)
-    (fig2, _ax2) = plt.subplots(figsize=(12, 6))
-    for _noct_result in noct_results:
-        _noct_result.plot(ax=_ax2, alpha=0.8, label=_noct_result.label)
-    _ax2.set_title("N-Octave Analysis Comparison Across Conditions", fontsize=14)
-    # N-octave分析の結果を1つの図にまとめてプロット
-    _ax2.set_xlim(20, 10000)
-    _ax2.set_ylabel("Band RMS level [dB re 1 FS]")
-    _ax2.set_ylim(*audio_contract.COMPARISON_NOCT_YLIM)
-    _ax2.set_xscale("log")
-    assert audio_contract.DB_REFERENCE_FS == 1.0
-    for _result, _ylim in [
-        *[(_result, audio_contract.COMPARISON_WELCH_YLIM) for _result in _welch_results],
-        *[(_result, audio_contract.COMPARISON_NOCT_YLIM) for _result in noct_results],
-    ]:
-        _values_db = np.asarray(_result.dB)
-        assert np.isfinite(_values_db).all()
-        assert _ylim[0] < float(_values_db.max()) < _ylim[1]
-    return
-
-
-@app.cell
-def _(temp_dir):
-    # クリーンアップ
-    import shutil
-
-    shutil.rmtree(temp_dir)
-    print(f"一時ディレクトリを削除しました: {temp_dir}")
+    mo.md(
+        t(
+            "dataset_evidence",
+            file_count=dataset_state_before["file_count"],
+            loaded_before=dataset_state_before["loaded_count"],
+            selected_count=selected_state_before_load["file_count"],
+            selected_loaded_before=selected_state_before_load["loaded_count"],
+            selected_loaded_after_item=selected_state_after_item["loaded_count"],
+            materialized_type=type(selected_materialized_values).__name__,
+            selected_condition=selected_frame.metadata["condition"],
+            sampling_rates=comparison_contract["sampling_rates"],
+            units=comparison_contract["units"],
+            references=comparison_contract["references"],
+            shapes=comparison_contract["shapes"],
+        )
+    )
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### Welch法とN-octave分析の比較結果
-
-    **Welch法とN-octave分析の特徴比較**:
-
-    **Welch法の特徴**:
-    - **等間隔周波数ビン**: 高周波数帯域でも一定の分解能
-    - **詳細なピーク検出**: 100Hzと200Hzのピークを明確に分離
-    - **ノイズの影響**: 平均化により安定した推定が可能
-    - **用途**: 機械の固有周波数同定、精密な周波数分析
-
-    **N-octave分析の特徴**:
-    - **対数間隔周波数帯域**: 低周波数で広い帯域、高周波数で狭い帯域
-    - **人間聴覚特性対応**: 音響・振動の評価に適したスケール
-    - **広帯域特性評価**: 帯域ごとのRMS振幅分布を把握しやすい
-    - **用途**: 騒音評価、建築音響、環境振動測定
-
-    **実践的な使い分け**:
-    - **精密な周波数同定が必要**: Welch法
-    - **人間の感覚に合った評価**: N-octave分析
-    - **両方の特徴を活かす**: Welch法でピーク検出、N-octaveで全体評価
-
-    このように、FrameDatasetを使うことで**複数条件の系統的な比較と判定基準の設定**が可能になります。
-    """)
+def _(mo, t):
+    mo.md(t("summary"))
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## トラブルシューティング
-
-    ### よくある問題と実践的な解決策
-
-    #### 1. STFTパラメータ選択の迷い
-
-    **症状**: どのFFTサイズとホップ長を選べばいいかわからない
-
-    **解決策**:
-    ```python
-    # まず標準設定で試す（48kHz用）
-    spec = signal.stft(n_fft=2048, hop_length=512)
-
-    # 周波数分離を優先するなら
-    spec_high_res = signal.stft(n_fft=4096, hop_length=1024)
-
-    # 時間変化を細かく追いたいなら
-    spec_high_time = signal.stft(n_fft=1024, hop_length=256)
-    ```
-
-    **判断基準**:
-    - **近接周波数の分離が必要** -> FFTサイズを大きく（4096, 8192）
-    - **急激な時間変化を追跡** -> ホップ長を小さく（256, 128）
-    - **リアルタイム処理** -> 両方を小さく（1024/256）
-
-    #### 2. Welch法の計算が遅い
-
-    **原因**: FFTサイズと重複度が大きすぎる、またはセグメント数が多い
-
-    **対策**:
-    ```python
-    # 高速化のポイント
-    welch = signal.welch(
-        n_fft=2048,        # 小さめのFFTサイズ
-        hop_length=1024,   # 50%オーバーラップ（75%より軽い）
-        win_length=2048    # n_fftと同じにする
-    )
-    ```
-
-    **48kHzでの推奨設定**:
-    - **バランス型**: n_fft=2048, hop_length=1024（このmarimoアプリ採用）
-    - **高速型**: n_fft=1024, hop_length=512
-    - **高精度型**: n_fft=8192, hop_length=4096（長い信号のみ）
-
-    #### 3. N-octave分析の周波数範囲エラー
-
-    **症状**: `ValueError: fmax exceeds Nyquist frequency`
-
-    **原因**: 最大周波数がNyquist周波数（sampling_rate/2）を超えている
-
-    **解決策**:
-    ```python
-    nyquist = signal.sampling_rate / 2  # 48kHzなら24kHz
-
-    # 安全な設定
-    noct = signal.noct_spectrum(
-        fmin=25,
-        fmax=min(20000, nyquist * 0.9),  # Nyquistの90%まで
-        n=3  # 1/3オクターブ
-    )
-    ```
-
-    #### 4. A特性・時間重み付けレベルでFastとSlowの差が分かりにくい
-
-    **症状**: A/FとA/Sの実装値が似て、時定数の効果が見えない
-
-    **原因**:
-    - レベル変化の少ない定常信号を使っている
-    - 変化区間が短く、Slow（1000ms）の追従差が出にくい
-
-    **対策**:
-    ```python
-    # 単位Pa・基準20 µPaで、段階的にレベルが変化する信号を使う
-    reference_pressure_pa = signal.channels[0].ref
-    laf = signal.sound_level(freq_weighting="A", time_weighting="Fast", dB=True)
-    las = signal.sound_level(freq_weighting="A", time_weighting="Slow", dB=True)
-
-    # 変化点を可視化して比較
-    ax.axvline(2.0, linestyle="--", color="red")
-    ax.axvline(4.0, linestyle="--", color="red")
-    ```
-
-    #### 5. FrameDataset比較でプロットラベルが揃わない
-
-    **症状**: 重ね描きしたときに凡例名や系列対応が分かりにくい
-
-    **原因**: 入力ファイル名やチャンネルラベルが揃っていない
-
-    **対策**:
-    ```python
-    # 保存前にラベル命名規則を統一
-    signal = wd.from_numpy(
-        data=data,
-        sampling_rate=48000,
-        ch_labels=["Normal"]  # 条件名を明示
-    )
-
-    # あるいは読み込み後にラベルを確認してから比較
-    for frame in dataset:
-        print(frame.label)
-    ```
-
-    ### デバッグのヒント
-
-    **スペクトルが期待と異なる場合**:
-    1. 元信号を時間領域で確認（plot()）
-    2. サンプリングレートが正しいか確認
-    3. 窓関数の影響を考慮（Hann, Hamming, Blackmanで比較）
-    4. ゼロパディングの効果を確認（n_fft > データ長）
-    """)
-    return
-
-
-@app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 次のステップ
-
-    高度な信号処理手法を実践的に習得しました。
-
-    **前のmarimoアプリ**: [03_signal_processing_basics](03_signal_processing_basics.html)
-
-    **次のmarimoアプリ**: [05_custom_functions](05_custom_functions.html)
-
-    ここでは、Wandasの処理チェーンに**独自関数を組み込む方法**を学び、
-    現場課題に合わせた分析パイプラインを設計する実践に進みます。
-
-    ### このmarimoアプリで学んだこと
-
-    **理論と実践の両面**:
-    - STFTパラメータ調整: 時間-周波数分解能のトレードオフを体験
-    - Welch法の最適化: パラメータによる性能の違いを比較
-    - N-octaveバンド分析: 音響・振動解析で使う対数帯域分析
-    - A特性・時間重み付けレベル: 20 µPa基準のdB SPLとFast/Slow実装の比較
-    - FrameDataset応用: 条件別データの効率的な比較分析
-
-    **03との違い**: 基本的な処理方法から、パラメータ調整と比較評価の実践へ
-
-    ### 次の学習目標
-
-    05では以下を学びます:
-    - 独自処理関数の作成と適用
-    - 既存メソッドチェーンへの安全な組み込み
-    - 再利用しやすい分析処理の設計
-
-    ### 発展的なトピック（今後の実装予定）
-
-    Wandasは開発中のため、以下の機能は将来実装予定です:
-    - ウェーブレット変換: 時間-周波数-スケール解析
-    - 高度なフィルタ設計: カスタムFIR/IIRフィルタ
-    - 適応的信号処理: RLSアルゴリズムなど
-
-    ---
-
-    **高度な信号処理の実践スキルを習得しました。次は独自処理の実装に進みましょう。**
-    """)
+def _(locale, mo, navigation_markdown):
+    mo.md(navigation_markdown("04_advanced_processing", locale))
     return
 
 

--- a/learning-path/manifest.json
+++ b/learning-path/manifest.json
@@ -33,7 +33,8 @@
     {
       "id": "04_advanced_processing",
       "source": "learning-path/04_advanced_processing.py",
-      "locales": ["ja"]
+      "locales": ["ja", "en"],
+      "catalog": "04_advanced_processing.json"
     },
     {
       "id": "05_custom_functions",

--- a/learning-path/translations/04_advanced_processing.json
+++ b/learning-path/translations/04_advanced_processing.json
@@ -58,7 +58,7 @@
         "- `hop_length`: 連続frameに対応するサンプル間隔。時間軸の刻みを決めるが、フレーム間の情報を独立にはしない",
         "- `window`: Hannなどの窓関数。端の不連続を抑えて漏れを減らす一方、ピーク形状と振幅へ影響する",
         "",
-        "単一チャンネルのSTFT shapeは`(frequency, time)`で、図のx軸は`times`、y軸は`freqs`です。`freqs`は`n_fft`から作り、`times`は`hop_length / sampling_rate`刻みのローカル軸として公開します。現在のSTFTは境界をゼロパディングしてframeを端まで配置するため、この3秒入力でも最後のframe時刻は[[last_time]] sになります。これは元信号のdurationではありません。`dB`はチャンネル基準に対する一般的な振幅比で、Paの基準2e-5 Paを明示的に持つ音圧FrameでなければdB SPLとは呼びません。"
+        "単一チャンネルのSTFT shapeは`(frequency, time)`で、図のx軸は`times`、y軸は`freqs`です。`freqs`は`n_fft`から作り、`times`は`hop_length / sampling_rate`刻みのローカル軸として公開します。現在のSTFTは境界をゼロパディングしてframeを端まで配置するため、3秒入力でも設定ごとに異なる最後のframe時刻になります。短い窓は[[short_first_time]]〜[[short_last_time]] s、ゼロパディング版は[[padded_first_time]]〜[[padded_last_time]] s、長い窓は[[long_first_time]]〜[[long_last_time]] sです。これは元信号のdurationではありません。`dB`はチャンネル基準に対する一般的な振幅比で、Paの基準2e-5 Paを明示的に持つ音圧FrameでなければdB SPLとは呼びません。"
       ],
       "en": [
         "### Keep `win_length`, `n_fft`, and `hop_length` separate",
@@ -68,7 +68,7 @@
         "- `hop_length`: sample spacing between consecutive frames. It sets the time-axis spacing, but adjacent frames are not independent observations",
         "- `window`: a window such as Hann. It reduces edge discontinuities and leakage, while changing peak shape and amplitude",
         "",
-        "For a single channel, the STFT shape is `(frequency, time)`: the plot's x-axis is `times` and its y-axis is `freqs`. `freqs` is derived from `n_fft`, while `times` is a local axis spaced by `hop_length / sampling_rate`. The current STFT zero-pads boundaries to place frames through the signal edge, so this 3-second input ends at frame time [[last_time]] s; that is not the original signal duration. `dB` is a general amplitude ratio relative to the channel reference; call a result dB SPL only when the Pa Frame carries the explicit 2e-5 Pa reference."
+        "For a single channel, the STFT shape is `(frequency, time)`: the plot's x-axis is `times` and its y-axis is `freqs`. `freqs` is derived from `n_fft`, while `times` is a local axis spaced by `hop_length / sampling_rate`. The current STFT zero-pads boundaries to place frames through the signal edge, so the 3-second input has a different final frame time for each configuration: short [[short_first_time]]–[[short_last_time]] s, zero-padded [[padded_first_time]]–[[padded_last_time]] s, and long [[long_first_time]]–[[long_last_time]] s. These are not the original signal duration. `dB` is a general amplitude ratio relative to the channel reference; call a result dB SPL only when the Pa Frame carries the explicit 2e-5 Pa reference."
       ]
     },
     "stft_evidence": {
@@ -81,7 +81,7 @@
         "| 同じ窓をゼロパディング (`n_fft=1024`) | `[[padded_shape]]` | [[padded_bin_spacing]] Hz | 窓長による目安は同じ [[short_window_scale]] Hz | [[short_time_step]] ms |",
         "| 長い窓 (`n_fft=1024`, `win_length=1024`) | `[[long_shape]]` | [[padded_bin_spacing]] Hz | 窓長による目安 [[long_window_scale]] Hz | [[long_time_step]] ms |",
         "",
-        "ゼロパディングは表示グリッドを細かくしますが、短い窓の窓長による周波数スケールは変えません。長い窓は近い周波数を分けやすくなる代わりに時間変化を粗くします。`times`の範囲はローカル軸で、最初は [[first_time]] s、最後は [[last_time]] s です。"
+        "ゼロパディングは表示グリッドを細かくしますが、短い窓の窓長による周波数スケールは変えません。長い窓は、この例のように近い周波数を分けやすくなる代わりに時間変化を粗くします。`times`の範囲は設定ごとのローカル軸で、短い窓は [[short_first_time]]〜[[short_last_time]] s、ゼロパディング版は [[padded_first_time]]〜[[padded_last_time]] s、長い窓は [[long_first_time]]〜[[long_last_time]] s です。"
       ],
       "en": [
         "**STFT evidence**",
@@ -92,7 +92,7 @@
         "| Same window with zero padding (`n_fft=1024`) | `[[padded_shape]]` | [[padded_bin_spacing]] Hz | same window-length scale [[short_window_scale]] Hz | [[short_time_step]] ms |",
         "| Long window (`n_fft=1024`, `win_length=1024`) | `[[long_shape]]` | [[padded_bin_spacing]] Hz | window-length scale [[long_window_scale]] Hz | [[long_time_step]] ms |",
         "",
-        "Zero padding makes the display grid finer but does not change the short window's window-length scale. A long window separates nearby frequencies better at the cost of coarser time tracking. The `times` range is a local axis: it starts at [[first_time]] s and ends at [[last_time]] s."
+        "Zero padding makes the display grid finer but does not change the short window's window-length scale. In this example, the long window separates the nearby tones better at the cost of coarser time tracking. The `times` range is a local axis for each configuration: short [[short_first_time]]–[[short_last_time]] s, zero-padded [[padded_first_time]]–[[padded_last_time]] s, and long [[long_first_time]]–[[long_last_time]] s."
       ]
     },
     "window_section": {

--- a/learning-path/translations/04_advanced_processing.json
+++ b/learning-path/translations/04_advanced_processing.json
@@ -111,18 +111,18 @@
       "ja": [
         "**窓関数の証拠**",
         "",
-        "- boxcar: 最大 [[boxcar_peak]] dB、ピーク外の最大値 [[boxcar_off_peak]] dB",
-        "- Hann: 最大 [[hann_peak]] dB、ピーク外の最大値 [[hann_off_peak]] dB",
+        "- boxcar: 最大 [[boxcar_peak]] dB、各トーンから±[[exclusion_half_width]] Hzを除外した領域の最大値 [[boxcar_off_peak]] dB",
+        "- Hann: 最大 [[hann_peak]] dB、各トーンから±[[exclusion_half_width]] Hzを除外した領域の最大値 [[hann_off_peak]] dB",
         "",
-        "この例では、Hann窓のサイドローブが低くなり、近接成分の間の漏れを読みやすくします。ただし、狭いピークを分離したいか、漏れを抑えたいか、振幅をどう校正するかで窓を選びます。"
+        "主ローブを避けた領域でHann窓のサイドローブが低くなり、近接成分の漏れを読みやすくします。ただし、狭いピークを分離したいか、漏れを抑えたいか、振幅をどう校正するかで窓を選びます。"
       ],
       "en": [
         "**Window evidence**",
         "",
-        "- Boxcar: maximum [[boxcar_peak]] dB; maximum away from the peaks [[boxcar_off_peak]] dB",
-        "- Hann: maximum [[hann_peak]] dB; maximum away from the peaks [[hann_off_peak]] dB",
+        "- Boxcar: maximum [[boxcar_peak]] dB; maximum outside ±[[exclusion_half_width]] Hz around each tone [[boxcar_off_peak]] dB",
+        "- Hann: maximum [[hann_peak]] dB; maximum outside ±[[exclusion_half_width]] Hz around each tone [[hann_off_peak]] dB",
         "",
-        "In this example the Hann sidelobes are lower, making leakage between nearby components easier to interpret. Choose the window according to whether separation, leakage suppression, or calibrated amplitude matters most."
+        "Outside the main-lobe neighborhoods, the Hann sidelobes are lower in this example, making leakage from nearby components easier to interpret. Choose the window according to whether separation, leakage suppression, or calibrated amplitude matters most."
       ]
     },
     "welch_section": {

--- a/learning-path/translations/04_advanced_processing.json
+++ b/learning-path/translations/04_advanced_processing.json
@@ -268,7 +268,7 @@
         "- 比較したreferences: `[[references]]`",
         "- 変換後shape: `[[shapes]]`",
         "",
-        "`dataset.apply(callable)`はcollectionへ同じ公開Frame操作を遅延適用し、item取得時に変換Frameを作ります。ここでは各Frameの`data`を読んでから同じmetadata条件を確認しています。値が同じ単位・基準・sampling rate・shapeでなければ、スペクトルの差を処理差ではなく入力条件の差と誤解する可能性があります。"
+        "`dataset.apply(callable)`はcollectionへ同じ公開Frame操作を遅延適用し、item取得時に変換Frameを作ります。ここでは各Frameのsampling rate、unit、reference、shapeをサンプル値をmaterializeせずに確認し、plot cellで`frame.plot()`を呼ぶと比較用のサンプルがmaterializeされます。選択したFrameだけは先に`frame.data`を読んでmaterialization境界を示しています。値が同じ単位・基準・sampling rate・shapeでなければ、スペクトルの差を処理差ではなく入力条件の差と誤解する可能性があります。"
       ],
       "en": [
         "### Collection state and fair comparison conditions",
@@ -281,7 +281,7 @@
         "- References compared: `[[references]]`",
         "- Shapes after transformation: `[[shapes]]`",
         "",
-        "`dataset.apply(callable)` applies the same public Frame operation lazily across the collection and creates a transformed Frame when an item is requested. Here each Frame is read through `.data` before its metadata conditions are checked. If unit, reference, sampling rate, or shape differs, a spectral difference may be an input-condition difference rather than a processing difference."
+        "`dataset.apply(callable)` applies the same public Frame operation lazily across the collection and creates a transformed Frame when an item is requested. Here the sampling rate, unit, reference, and shape of each transformed Frame are checked without materializing sample values; the plot cell materializes the comparison samples when it calls `frame.plot()`. Only the selected Frame is read through `.data` earlier to show the materialization boundary. If unit, reference, sampling rate, or shape differs, a spectral difference may be an input-condition difference rather than a processing difference."
       ]
     },
     "summary": {

--- a/learning-path/translations/04_advanced_processing.json
+++ b/learning-path/translations/04_advanced_processing.json
@@ -1,0 +1,314 @@
+{
+  "lesson": "04_advanced_processing",
+  "messages": {
+    "title": {
+      "ja": ["04 高度な信号処理"],
+      "en": ["04 Advanced Signal Processing"]
+    },
+    "intro": {
+      "ja": [
+        "## 結果の証拠から処理を選ぶ",
+        "",
+        "各セクションでは、同じ入力を複数の表現や条件で調べます。STFT、Welch法、N-octave、周波数・時間重み付きレベル、FrameDatasetの結果を比較し、パラメータの意味と使いどころを判断します。",
+        "",
+        "**学習目標:**",
+        "- STFTで窓長、FFTサイズ、ホップ長、窓関数、軸を分けて読む",
+        "- Welch法の片側ピーク振幅スペクトルと平均化の効果を説明する",
+        "- N-octaveの帯域、単位、基準、A特性を確認し、FFT/Welchとの用途を使い分ける",
+        "- A特性とFast/Slow時間重み付けを線形値・dB SPL時系列として比較する",
+        "- FrameDatasetの遅延読み込み、materialization境界、metadata条件を使って公平に比較する",
+        "",
+        "**前提条件:**",
+        "- `03_signal_processing_basics.py`を完了していること"
+      ],
+      "en": [
+        "## Choose a representation from evidence",
+        "",
+        "Within each section, inspect the same input under several representations or parameter choices. Compare STFT, Welch analysis, N-octave bands, frequency and time weighted levels, and FrameDataset results so that you can choose parameters for a purpose instead of memorizing defaults.",
+        "",
+        "**Learning goals:**",
+        "- Separate the roles of window length, FFT size, hop length, window function, and axes in an STFT",
+        "- Explain that Welch returns a one-sided peak-amplitude spectrum and what segment averaging changes",
+        "- Read N-octave bands, units, references, and A-weighting, and distinguish their use from FFT/Welch",
+        "- Compare A-weighted Fast and Slow levels as linear values and dB SPL time series",
+        "- Use FrameDataset lazy loading, the materialization boundary, and metadata conditions for fair comparisons",
+        "",
+        "**Prerequisite:**",
+        "- Complete `03_signal_processing_basics.py` first"
+      ]
+    },
+    "stft_section": {
+      "ja": [
+        "## 1. STFT: 時間変化する周波数を見る",
+        "",
+        "STFTは、信号を短い区間に分けて各区間のスペクトルを並べます。下の信号は1秒ごとに主成分が変わるので、単一のFFTよりも「いつ何Hzが現れたか」を読むのに適しています。"
+      ],
+      "en": [
+        "## 1. STFT: inspect changing frequencies",
+        "",
+        "An STFT divides a signal into short sections and places their spectra on a time axis. The signal below changes its main components every second, so an STFT answers when a frequency appears in a way that one FFT cannot."
+      ]
+    },
+    "stft_parameters": {
+      "ja": [
+        "### `win_length`、`n_fft`、`hop_length`を分けて考える",
+        "",
+        "- `win_length`: 実際に1フレームへ掛ける窓のサンプル数。短いほど時間変化を追いやすく、窓長による周波数スケールの目安は粗くなる（実際の分離能力は窓の主ローブ幅にも依存）",
+        "- `n_fft`: FFTのサイズ。`n_fft > win_length`なら窓をゼロパディングして周波数軸の表示グリッドを細かくするが、新しい情報や真の分解能は増えない",
+        "- `hop_length`: 連続frameに対応するサンプル間隔。時間軸の刻みを決めるが、フレーム間の情報を独立にはしない",
+        "- `window`: Hannなどの窓関数。端の不連続を抑えて漏れを減らす一方、ピーク形状と振幅へ影響する",
+        "",
+        "単一チャンネルのSTFT shapeは`(frequency, time)`で、図のx軸は`times`、y軸は`freqs`です。`freqs`は`n_fft`から作り、`times`は`hop_length / sampling_rate`刻みのローカル軸として公開します。現在のSTFTは境界をゼロパディングしてframeを端まで配置するため、この3秒入力でも最後のframe時刻は[[last_time]] sになります。これは元信号のdurationではありません。`dB`はチャンネル基準に対する一般的な振幅比で、Paの基準2e-5 Paを明示的に持つ音圧FrameでなければdB SPLとは呼びません。"
+      ],
+      "en": [
+        "### Keep `win_length`, `n_fft`, and `hop_length` separate",
+        "",
+        "- `win_length`: samples in the window applied to each frame. A shorter window follows changes in time more closely but has a coarser window-length frequency scale; actual separation also depends on the window's main-lobe width",
+        "- `n_fft`: FFT size. When `n_fft > win_length`, the windowed frame is zero-padded to make a finer frequency-axis grid; it adds no information or true resolution",
+        "- `hop_length`: sample spacing between consecutive frames. It sets the time-axis spacing, but adjacent frames are not independent observations",
+        "- `window`: a window such as Hann. It reduces edge discontinuities and leakage, while changing peak shape and amplitude",
+        "",
+        "For a single channel, the STFT shape is `(frequency, time)`: the plot's x-axis is `times` and its y-axis is `freqs`. `freqs` is derived from `n_fft`, while `times` is a local axis spaced by `hop_length / sampling_rate`. The current STFT zero-pads boundaries to place frames through the signal edge, so this 3-second input ends at frame time [[last_time]] s; that is not the original signal duration. `dB` is a general amplitude ratio relative to the channel reference; call a result dB SPL only when the Pa Frame carries the explicit 2e-5 Pa reference."
+      ]
+    },
+    "stft_evidence": {
+      "ja": [
+        "**STFTの実行結果**",
+        "",
+        "| 設定 | shape | 周波数グリッド間隔 | 窓長による周波数スケール | 時間間隔 |",
+        "| --- | --- | ---: | ---: | ---: |",
+        "| 短い窓 (`n_fft=256`, `win_length=256`) | `[[short_shape]]` | [[short_bin_spacing]] Hz | 窓長による目安 [[short_window_scale]] Hz | [[short_time_step]] ms |",
+        "| 同じ窓をゼロパディング (`n_fft=1024`) | `[[padded_shape]]` | [[padded_bin_spacing]] Hz | 窓長による目安は同じ [[short_window_scale]] Hz | [[short_time_step]] ms |",
+        "| 長い窓 (`n_fft=1024`, `win_length=1024`) | `[[long_shape]]` | [[padded_bin_spacing]] Hz | 窓長による目安 [[long_window_scale]] Hz | [[long_time_step]] ms |",
+        "",
+        "ゼロパディングは表示グリッドを細かくしますが、短い窓の窓長による周波数スケールは変えません。長い窓は近い周波数を分けやすくなる代わりに時間変化を粗くします。`times`の範囲はローカル軸で、最初は [[first_time]] s、最後は [[last_time]] s です。"
+      ],
+      "en": [
+        "**STFT evidence**",
+        "",
+        "| Setting | shape | Frequency-grid spacing | Window-length frequency scale | Time spacing |",
+        "| --- | --- | ---: | ---: | ---: |",
+        "| Short window (`n_fft=256`, `win_length=256`) | `[[short_shape]]` | [[short_bin_spacing]] Hz | window-length scale [[short_window_scale]] Hz | [[short_time_step]] ms |",
+        "| Same window with zero padding (`n_fft=1024`) | `[[padded_shape]]` | [[padded_bin_spacing]] Hz | same window-length scale [[short_window_scale]] Hz | [[short_time_step]] ms |",
+        "| Long window (`n_fft=1024`, `win_length=1024`) | `[[long_shape]]` | [[padded_bin_spacing]] Hz | window-length scale [[long_window_scale]] Hz | [[long_time_step]] ms |",
+        "",
+        "Zero padding makes the display grid finer but does not change the short window's window-length scale. A long window separates nearby frequencies better at the cost of coarser time tracking. The `times` range is a local axis: it starts at [[first_time]] s and ends at [[last_time]] s."
+      ]
+    },
+    "window_section": {
+      "ja": [
+        "### 窓関数は漏れと振幅の読み方を変える",
+        "",
+        "同じ2つの近接トーンへboxcar窓とHann窓を適用します。窓関数は単なる見た目の設定ではなく、端点の不連続、サイドローブ、ピーク幅、振幅補正に関わります。結果のピークと、ピークから離れた領域のレベルを比較して選択します。"
+      ],
+      "en": [
+        "### A window changes leakage and amplitude interpretation",
+        "",
+        "The same two nearby tones are analyzed with a boxcar and a Hann window. A window is not only a display choice: it affects edge discontinuities, sidelobes, peak width, and amplitude correction. Compare the peaks and the level away from the tones before choosing one."
+      ]
+    },
+    "window_evidence": {
+      "ja": [
+        "**窓関数の証拠**",
+        "",
+        "- boxcar: 最大 [[boxcar_peak]] dB、ピーク外の最大値 [[boxcar_off_peak]] dB",
+        "- Hann: 最大 [[hann_peak]] dB、ピーク外の最大値 [[hann_off_peak]] dB",
+        "",
+        "この例では、Hann窓のサイドローブが低くなり、近接成分の間の漏れを読みやすくします。ただし、狭いピークを分離したいか、漏れを抑えたいか、振幅をどう校正するかで窓を選びます。"
+      ],
+      "en": [
+        "**Window evidence**",
+        "",
+        "- Boxcar: maximum [[boxcar_peak]] dB; maximum away from the peaks [[boxcar_off_peak]] dB",
+        "- Hann: maximum [[hann_peak]] dB; maximum away from the peaks [[hann_off_peak]] dB",
+        "",
+        "In this example the Hann sidelobes are lower, making leakage between nearby components easier to interpret. Choose the window according to whether separation, leakage suppression, or calibrated amplitude matters most."
+      ]
+    },
+    "welch_section": {
+      "ja": [
+        "## 2. Welch法: 平均化された片側ピーク振幅スペクトル",
+        "",
+        "Welch法は、信号を複数の窓付きセグメントへ分け、セグメントごとのパワースペクトルを平均した後、ピーク振幅へ戻します。したがって現行Wandasの返り値は入力単位の**片側ピーク振幅スペクトル**であり、PSDや1 Hzあたりの密度ではありません。"
+      ],
+      "en": [
+        "## 2. Welch: an averaged one-sided peak-amplitude spectrum",
+        "",
+        "Welch analysis divides a signal into windowed segments, averages their power spectra, and converts the result back to peak amplitude. Therefore the current Wandas result is a **one-sided peak-amplitude spectrum** in the input unit, not a PSD or a density per hertz."
+      ]
+    },
+    "welch_evidence": {
+      "ja": [
+        "### セグメント数、overlap、`n_fft`を結果と対応づける",
+        "3つとも`average=\"mean\"`でセグメントを平均し、チャンネル基準 [[reference]]（単位 `[[unit]]`）との振幅比を表示しています。",
+        "",
+        "| 設定 | shape | セグメント数 | overlap | 周波数グリッド間隔 |",
+        "| --- | --- | ---: | ---: | ---: |",
+        "| 基準 (`n_fft=512`, `win_length=512`, `hop_length=256`) | `[[reference_shape]]` | [[reference_segments]] | [[reference_overlap]] samples | [[bin_spacing]] Hz |",
+        "| overlapを増やす (`hop_length=128`) | `[[overlap_shape]]` | [[overlap_segments]] | [[more_overlap]] samples | [[bin_spacing]] Hz |",
+        "| 同じ窓をゼロパディング (`n_fft=1024`) | `[[padded_shape]]` | [[padded_segments]] | [[reference_overlap]] samples | [[padded_bin_spacing]] Hz |",
+        "",
+        "overlapを増やすと平均へ参加するセグメント数は増えますが、隣り合うセグメントの共有サンプルも増えるため、独立な情報量が同じ割合で増えるわけではありません。`n_fft`だけを増やした結果はグリッドが細かくなるだけで、実際の窓長512 samplesの分解能は変わりません。",
+        "",
+        "この結果は線形ピーク振幅の最大値 [[linear_peak]]（入力単位）を、チャンネル基準との振幅比 `20 * log10(amplitude / channel_ref)` で [[db_peak]] dB と表示します。FFTは単一窓の細部、Welchはノイズ下で安定した代表スペクトルというように、目的で使い分けます。"
+      ],
+      "en": [
+        "### Connect segment count, overlap, and `n_fft` to the evidence",
+        "",
+        "| Setting | shape | Segments | Overlap | Frequency-grid spacing |",
+        "| --- | --- | ---: | ---: | ---: |",
+        "| Reference (`n_fft=512`, `win_length=512`, `hop_length=256`) | `[[reference_shape]]` | [[reference_segments]] | [[reference_overlap]] samples | [[bin_spacing]] Hz |",
+        "| More overlap (`hop_length=128`) | `[[overlap_shape]]` | [[overlap_segments]] | [[more_overlap]] samples | [[bin_spacing]] Hz |",
+        "| Same window with zero padding (`n_fft=1024`) | `[[padded_shape]]` | [[padded_segments]] | [[reference_overlap]] samples | [[padded_bin_spacing]] Hz |",
+        "",
+        "More overlap adds segments to the average, but neighboring segments also share more samples, so independent information does not increase in the same proportion. Increasing only `n_fft` makes the grid finer; it does not change the resolution of the 512-sample window.",
+        "",
+        "All three examples use `average=\"mean\"` to average segments. Here the maximum linear peak amplitude is [[linear_peak]] in the input unit, and its amplitude ratio to channel reference [[reference]] (unit `[[unit]]`) is shown as [[db_peak]] dB using `20 * log10(amplitude / channel_ref)`. Use FFT for detail from one window and Welch for a more stable representative spectrum under noise."
+      ]
+    },
+    "noct_section": {
+      "ja": [
+        "## 3. N-octave: 帯域として測る",
+        "",
+        "N-octaveは等比幅の帯域ごとにRMS振幅をまとめて帯域レベルとして読む、音響・振動計測向けの表現です。FFT/Welchの細かい周波数ビンを読むのではなく、帯域単位で比較したいときに使います。"
+      ],
+      "en": [
+        "## 3. N-octave: measure bands",
+        "",
+        "N-octave returns an RMS amplitude for each logarithmically spaced band, which is useful for acoustic and vibration measurements. Use it when you need band-level summaries rather than the fine frequency bins of an FFT or Welch spectrum."
+      ]
+    },
+    "noct_evidence": {
+      "ja": [
+        "### 現行APIのband center、width、単位、referenceを読む",
+        "",
+        "- 帯域数: [[band_count]]、band center: [[center_start]]–[[center_end]] Hz",
+        "- 先頭帯域のnominal width: 約 [[first_width]] Hz（現行公開Frameはcenterを公開し、widthはcenterと`n`/`G`から計算）",
+        "- `n=[[n]]` は1/[[n]] octaveを意味する。`n=1/3`ではなく、`n=3`と書く",
+        "- `G=[[G]]` は中心周波数系列の比の規約、`fr=[[fr]]` Hzは基準周波数。`G`はgainではない",
+        "- 入力単位: `[[unit]]`、振幅reference: [[reference]] Pa。raw band levelは[[reference_center]] Hzで [[reference_level]] dB SPL、A-weightedは [[reference_a_level]] dB SPL",
+        "",
+        "ここではband centerとnominal widthを軸に、raw levelとA-weighted levelを比較します。N-octaveは帯域ごとの基準化された要約、FFT/Welchは周波数成分の探索やピーク位置の確認、と役割を分けます。"
+      ],
+      "en": [
+        "### Read band centers, width, units, and reference from the current API",
+        "",
+        "- Band count: [[band_count]]; band centers: [[center_start]]–[[center_end]] Hz",
+        "- First nominal band width: about [[first_width]] Hz (the current public Frame exposes centers; derive width from the center and `n`/`G`)",
+        "- `n=[[n]]` means 1/[[n]] octave. Write `n=3` for a third octave, not `n=1/3`",
+        "- `G=[[G]]` is the center-frequency-series convention, and `fr=[[fr]]` Hz is the reference frequency. `G` is not gain",
+        "- Input unit: `[[unit]]`; amplitude reference: [[reference]] Pa. The raw band level at [[reference_center]] Hz is [[reference_level]] dB SPL, and the A-weighted level is [[reference_a_level]] dB SPL",
+        "",
+        "This example compares raw and A-weighted levels using band centers and nominal widths. N-octave is a standardized band-level summary; FFT/Welch are better for exploring components and locating peaks."
+      ]
+    },
+    "level_section": {
+      "ja": [
+        "## 4. 周波数・時間重み付きレベル",
+        "",
+        "`sound_level()`は、まず周波数重み付け（A/C/Z）、次に一次指数平滑の時間重み付けを適用します。現行実装ではFastの時定数は0.125 s、Slowは1.0 sです。dB=Falseは平滑化した線形RMS振幅、dB=Trueはreferenceに対するdB値を返します。Paを2e-5 Pa基準で扱うときだけ、そのdB値をdB SPLとして読みます。"
+      ],
+      "en": [
+        "## 4. Frequency- and time-weighted levels",
+        "",
+        "`sound_level()` applies frequency weighting (A/C/Z) and then first-order exponential time smoothing. In the current implementation Fast uses a 0.125 s time constant and Slow uses 1.0 s. With `dB=False` it returns the smoothed linear RMS amplitude; with `dB=True` it returns a dB value relative to the reference. Read that value as dB SPL only for Pa data with the 2e-5 Pa reference."
+      ]
+    },
+    "level_evidence": {
+      "ja": [
+        "### 時系列と要約を同時に確認する",
+        "",
+        "- shape: linear `[[linear_shape]]`、Fast `[[fast_shape]]`、Slow `[[slow_shape]]`; sampling rate: [[sampling_rate]] Hz",
+        "- 入力: `[[unit]]`、reference [[reference]]。dB出力単位: `[[output_unit]]`",
+        "- 線形RMSの低レベル区間/高レベル区間: [[linear_low]] / [[linear_high]]",
+        "- A/Fの低レベル区間/高レベル区間: [[fast_low]] / [[fast_high]] dB SPL",
+        "- A/Sの高レベル区間: [[slow_high]] dB SPL",
+        "- ピーク: Fast [[fast_peak]] dB SPL、Slow [[slow_peak]] dB SPL",
+        "",
+        "Fastは変化へ早く追従し、Slowは変化をより長く平均するため、立ち上がり・立ち下がりの時系列が異なります。要約値だけでなく時系列を残すと、どの区間がピークや代表値へ影響したかを説明できます。"
+      ],
+      "en": [
+        "### Inspect the time series and summaries together",
+        "",
+        "- Shapes: linear `[[linear_shape]]`, Fast `[[fast_shape]]`, Slow `[[slow_shape]]`; sampling rate: [[sampling_rate]] Hz",
+        "- Input: `[[unit]]`, reference [[reference]]. dB output unit: `[[output_unit]]`",
+        "- Linear RMS in the low/high sections: [[linear_low]] / [[linear_high]]",
+        "- A/F level in the low/high sections: [[fast_low]] / [[fast_high]] dB SPL",
+        "- A/S level in the high section: [[slow_high]] dB SPL",
+        "- Peaks: Fast [[fast_peak]] dB SPL; Slow [[slow_peak]] dB SPL",
+        "",
+        "Fast follows a change sooner, while Slow averages it over a longer time. Their onset and decay time series therefore differ. Keeping the series as well as summary values lets you explain which interval contributed to a peak or representative level."
+      ]
+    },
+    "dataset_section": {
+      "ja": [
+        "## 5. FrameDataset: 集合を遅延のまま比較する",
+        "",
+        "`wd.from_folder()`はフォルダ内のファイルをcollection-levelの`ChannelFrameDataset`として見つけます。ファイル発見はFrameを作らず、`lazy_loading=True`ではitem取得後もサンプル配列を遅延できます。`frame.data`が、この例でサンプル値をmaterializeする境界です。",
+        "",
+        "`path_metadata=True`でパス由来の`condition`をmetadataへ取り込み、読み込み前に`select(condition=...)`します。比較前にsampling rate、unit、reference、shapeをそろえることが公平性の条件です。"
+      ],
+      "en": [
+        "## 5. FrameDataset: compare a collection lazily",
+        "",
+        "`wd.from_folder()` discovers files as a collection-level `ChannelFrameDataset`. Discovery does not create Frames, and with `lazy_loading=True` the sample array can remain lazy after an item is selected. In this example `frame.data` is the boundary where sample values are materialized.",
+        "",
+        "With `path_metadata=True`, the path-derived `condition` becomes metadata, so `select(condition=...)` can run before reading samples. A fair comparison first aligns sampling rate, unit, reference, and shape."
+      ]
+    },
+    "dataset_evidence": {
+      "ja": [
+        "### collectionの状態と公平な比較条件",
+        "",
+        "- 発見したファイル数 [[file_count]]、選択前のloaded count [[loaded_before]]",
+        "- `condition=changed`の選択数 [[selected_count]]、選択直後のloaded count [[selected_loaded_before]]、item取得後 [[selected_loaded_after_item]]",
+        "- `frame.data`のmaterialized型: `[[materialized_type]]`; 選択したcondition: `[[selected_condition]]`",
+        "- 比較したsampling rates: `[[sampling_rates]]`",
+        "- 比較したunits: `[[units]]`",
+        "- 比較したreferences: `[[references]]`",
+        "- 変換後shape: `[[shapes]]`",
+        "",
+        "`dataset.apply(callable)`はcollectionへ同じ公開Frame操作を遅延適用し、item取得時に変換Frameを作ります。ここでは各Frameの`data`を読んでから同じmetadata条件を確認しています。値が同じ単位・基準・sampling rate・shapeでなければ、スペクトルの差を処理差ではなく入力条件の差と誤解する可能性があります。"
+      ],
+      "en": [
+        "### Collection state and fair comparison conditions",
+        "",
+        "- Files discovered: [[file_count]]; loaded count before selection: [[loaded_before]]",
+        "- `condition=changed` selections: [[selected_count]]; loaded immediately after selection: [[selected_loaded_before]]; after item access: [[selected_loaded_after_item]]",
+        "- Materialized `frame.data` type: `[[materialized_type]]`; selected condition: `[[selected_condition]]`",
+        "- Sampling rates compared: `[[sampling_rates]]`",
+        "- Units compared: `[[units]]`",
+        "- References compared: `[[references]]`",
+        "- Shapes after transformation: `[[shapes]]`",
+        "",
+        "`dataset.apply(callable)` applies the same public Frame operation lazily across the collection and creates a transformed Frame when an item is requested. Here each Frame is read through `.data` before its metadata conditions are checked. If unit, reference, sampling rate, or shape differs, a spectral difference may be an input-condition difference rather than a processing difference."
+      ]
+    },
+    "summary": {
+      "ja": [
+        "## まとめ",
+        "",
+        "- STFTは`win_length`で真の時間・周波数トレードオフを決め、`n_fft`のゼロパディングを分解能の改善と混同しない",
+        "- 窓関数は漏れ、ピーク幅、振幅の解釈を変えるため、目的と実測結果で選ぶ",
+        "- Welchはセグメント平均による片側ピーク振幅スペクトルで、PSDではない。overlapはセグメント数を増やすが独立情報量とは同じではない",
+        "- N-octaveは標準化された帯域要約、FFT/Welchは周波数成分の探索という役割で使い分ける",
+        "- A/FとA/Sは同じ入力でも時間重み付けで時系列が変わる。linear/dB/dB SPLとreferenceを明記する",
+        "- FrameDatasetはcollection-levelの遅延境界とmetadata条件を確認してから公平に比較する",
+        "",
+        "これらのdB表示は現行Wandas APIの計算結果を示す教材上の例です。規格適合を保証する測定器の代替とはみなさず、必要な規格・校正条件を別途確認してください。"
+      ],
+      "en": [
+        "## Summary",
+        "",
+        "- Use `win_length` to set the true time/frequency trade-off in an STFT; do not mistake `n_fft` zero padding for improved resolution",
+        "- A window changes leakage, peak width, and amplitude interpretation, so choose it from the purpose and observed evidence",
+        "- Welch returns a segment-averaged one-sided peak-amplitude spectrum, not a PSD. More overlap adds segments but not the same amount of independent information",
+        "- Use N-octave for standardized band summaries and FFT/Welch for exploring frequency components",
+        "- A/F and A/S produce different time series from the same input. State whether values are linear, dB, or dB SPL and state the reference",
+        "- Check the collection-level lazy boundary and metadata conditions before comparing FrameDataset results",
+        "",
+        "These dB displays demonstrate the current Wandas API calculation. They are not a claim of measurement-instrument or standards compliance; confirm the required standards and calibration conditions separately."
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Teaching contract

Learning Path 04 teaches learners to choose a representation and parameters from evidence:

- STFT: analysis window length, FFT size, frame spacing, window function, axes, and dB reference.
- Welch: window/FFT roles, segment count, averaging stability, overlap caveats, and peak-amplitude output.
- N-octave: band centers/widths, units, references, A-weighting, and when band summaries differ from FFT/Welch.
- Frequency/time-weighted levels: A-weighting, Fast/Slow, linear RMS, dB, dB SPL, references, and time-series evidence.
- FrameDataset: collection-level comparison, lazy loading/materialization, metadata grouping, and fair comparison conditions.

Each section displays numerical or structural evidence that supports the choice.

## Technical audit and corrections

- Audited the current STFT implementation and documented the distinction between `win_length`, `n_fft`, and `hop_length`; zero padding is described as a finer grid, not added resolution.
- Described the current single-channel STFT shape as `(frequency, time)`, with `times`/`freqs` axes and boundary-padding behavior.
- Made Hann/window leakage and main-lobe tradeoffs explicit without calling `sampling_rate / win_length` an exact resolution.
- Made Welch `average="mean"` explicit and showed the actual channel unit/reference. The lesson states that Wandas returns a one-sided peak-amplitude spectrum, not PSD or per-Hz density.
- Corrected N-octave wording to RMS amplitude per band and kept `G`, `n`, `fr`, reference, and A-weighting tied to the current API.
- Corrected FrameDataset evidence to distinguish metadata/shape checks while transformed sample values remain lazy from explicit sample materialization through the selected frame's `.data` and plotted frames' `frame.plot()`.
- Removed the repository documentation audio helper from learner-visible code.

## Japanese/English implementation

- One Python source is used for both locales.
- Lesson-specific catalog: `learning-path/translations/04_advanced_processing.json`.
- Manifest entry adds `locales: ["ja", "en"]` and the catalog; `common.json` is unchanged.
- Visible code is locale-neutral and identical in both exports. Translation machinery and translated/dynamic Markdown remain hidden.

## Cell policy

Visible cells contain public NumPy/SciPy/Matplotlib/Wandas imports, input values, parameters, operations, and plots. Hidden cells contain `mo`, locale/catalog helpers, translated Markdown, dynamic result rendering, and navigation.

## URLs and navigation

Expected deployed pages:

- Japanese: https://kasahart.github.io/wandas/learning-path/04_advanced_processing.html
- English: https://kasahart.github.io/wandas/en/learning-path/04_advanced_processing.html

Manifest-driven navigation currently resolves:

- JA: previous 03 JA; next 05 JA.
- EN: previous 03 EN; next 05 Japanese fallback marked `Japanese only`.

After Learning Path 05 is merged and rebased, the 04 English next link will resolve to 05 English automatically.

## Local validation

- `marimo check --strict`: passed.
- Catalog/source validation: passed.
- JA/EN lesson export to `/tmp/wandas-lp04-review`: passed.
- Translated HTML validation: passed.
- `pytest tests/docs -q --no-cov`: 54 passed.
- `mkdocs build --strict -f docs/mkdocs.yml`: passed; only existing unlisted-page warnings remain.
- Ruff check/format, Ty, git diff check: passed.
- JA/EN exported visible code comparison: identical.
- Independent API/translation/HTML review: REVIEW_PASS; follow-up runtime and resource findings were addressed.

## Known limitations

- marimo 0.23.9 keeps the exported HTML `lang`/browser title metadata shared between locales; visible page content, language switch, and navigation are translated. Fixing that would require a shared exporter contract change outside this PR.
- The examples demonstrate current Wandas API calculations and do not claim instrument or standards compliance.
- Generated HTML is validation output only and is not committed.

## Follow-up review fixes

- Changed the final STFT tones to nearby 1,200 Hz and 1,240 Hz components so the short-window versus long-window separation claim is supported by the plots.
- Reported each STFT configuration's actual local time range: short and zero-padded end at 3.016 s, while the long window ends at 3.072 s for this input.
- Made the window evidence select a single channel, validate frequency/value shapes, and exclude ±20 Hz main-lobe neighborhoods around the two tones. The executed leakage values are boxcar -28.3 dB versus Hann -48.4 dB, supporting the stated conclusion.
- Registered `temporary_directory.cleanup` with `atexit`, removed the unused collection-wide eager materialization list, and reduced the level-generation cell outputs to the values consumed downstream.
- Clarified that collection metadata/shape checks happen while transformed sample values remain lazy; the selected frame's `.data` and the plot's `frame.plot()` are the explicit sample materialization boundaries.
- GitHub Actions CI run `31188205844` succeeded: `Determine required checks`, `Build Documentation`, `Lint and Type Check`, and `CI Gate`; Build Documentation completed source/catalog/full-plan checks, JA/EN export, generated HTML validation, documentation contract tests, and MkDocs.

## Status

This pull request is Ready for review, targets `main`, and has not been merged.

Latest head after the review fixes: `71f9a0d090eeda86289b6c12ce9933b5be90ad11`.
