### PR TITLE
Replace lazy Operation self-registration with explicit providers

### DIFF
--- a/docs/src/contributing/frame-operation-extensions.md
+++ b/docs/src/contributing/frame-operation-extensions.md
@@ -132,6 +132,32 @@ class Gain(ChannelIndependentAudioOperation[NDArrayReal, NDArrayReal]):
 register_operation(Gain)
 ```
 
+Lazy Operations use an explicit provider declaration. The implementation module
+must not call `register_operation()` while it is imported; the provider names the
+module and class attribute that `get_operation()` will resolve after import:
+
+```python
+register_lazy_operation(
+    "my_operation",
+    "my_package.operations",
+    attribute_name="MyOperation",
+)
+```
+
+Keep the implementation class's `name` equal to the registered name. Public
+export names, provider attribute names, and Operation registry names are separate
+contracts. Eager and lazy providers cannot claim the same name, and only the
+identical provider may be registered again. A lazy registration does not import
+the module; an import, attribute lookup, or class-validation failure leaves the
+provider and resolved-class cache unchanged. Import failures retain their original
+exception. Hot reload and replacement of a class object are outside the registry
+contract.
+
+`register_lazy_operation()` requires the keyword-only `attribute_name` argument;
+the former two-argument import-side-effect form is not supported. Recipe replay
+implementations that are private still need an explicit provider, even though
+they are not public `wandas.processing` exports.
+
 A cross-channel kernel must use the conservative base explicitly:
 
 ```python
@@ -432,6 +458,15 @@ PR作成前に次を確認します。
   the built-in Recipe owner completeness contract;
   ``@recipe_operation`` methodを所有する公開Frame／mixinがbuilt-in Recipe owner完全性contractに
   含まれている。
+- every lazy Operation has an explicit module/attribute provider, and its module
+  import does not mutate the Operation provider mapping;
+  すべてのlazy Operationがmodule／attributeを明示したproviderを持ち、module importがOperation
+  provider mappingを変更しない。
+- Operation names are collision-safe across eager and lazy providers, and the
+  public export, direct implementation import, and `get_operation()` resolve the
+  same class object;
+  eager／lazyをまたぐOperation name衝突を拒否し、public export、実装moduleの直接import、
+  `get_operation()`が同じclass objectを返す。
 - tests cover Unit, Domain, and Integration layers where applicable;
   該当するUnit、Domain、Integration層をtestがcoverする。
 - no new compatibility shim, duplicate state, or operation-specific Recipe branch was

--- a/docs/src/release-notes/v0.6.3.md
+++ b/docs/src/release-notes/v0.6.3.md
@@ -22,6 +22,11 @@ Wandas 0.6.3 makes N-octave synthesis use the authoritative FFT size stored by
   `CoherenceFrame` construction structural and lazy by preserving supplied
   real values without scanning, clipping, or replacing them; the processing
   operation continues to own the mathematical coherence contract.
+- [Issue #430](https://github.com/kasahart/wandas/issues/430): replace lazy
+  Operation import-side-effect registration with explicit module/attribute
+  providers. Built-in lazy Operation use and public class imports remain
+  unchanged; `get_operation()`, `create_operation()`, and Recipe replay still
+  resolve the same implementations.
 
 ## Compatibility
 
@@ -37,3 +42,4 @@ it cannot distinguish adjacent odd and even FFT sizes.
 | `SpectralFrame` and `SpectrogramFrame` spectral NumPy properties | Public return shape | None | Single-channel properties follow `frame.data` without a leading singleton channel axis; multi-channel properties retain the channel axis. Numerical definitions are unchanged. | 0.6.3 | Public shape consistency correction; [Issue #400](https://github.com/kasahart/wandas/issues/400), parent [#391](https://github.com/kasahart/wandas/issues/391). |
 | `ChannelFrame.coherence()`, `.csd()`, and `.transfer_function()` | Public result type and WDF frame type | None | Use `CoherenceFrame`, `CrossSpectralFrame`, and `TransferFunctionFrame`; existing Recipe v1 payloads keep their recorded display/denominator contracts, while new calls emit v2. | 0.6.3 | Quantity meaning is represented by exact Frame type and typed pair state; [Issue #406](https://github.com/kasahart/wandas/issues/406). |
 | Direct `CoherenceFrame` construction and WDF decoding | Stable constructor and persisted-data behavior | None | Validate externally supplied coherence values before construction when an application requires finite `[0, 1]` data; `ChannelFrame.coherence()` continues to produce mathematically valid coherence values. | 0.6.3 | Constructor validation now preserves Dask laziness and external Dask data/graph identity without a full-value scan; [Issue #424](https://github.com/kasahart/wandas/issues/424) and [PR #425](https://github.com/kasahart/wandas/pull/425). |
+| `register_lazy_operation()` | Public helper signature and registration behavior | None | Supply the required keyword-only `attribute_name`, for example `register_lazy_operation("my_operation", "my_package.operations", attribute_name="MyOperation")`. Remove module-level `register_operation()` calls from lazy modules. | 0.6.3 | The old two-argument import-side-effect form is discontinued; explicit providers make eager/lazy collisions and failed resolution deterministic without import rollback machinery; [Issue #430](https://github.com/kasahart/wandas/issues/430). |

--- a/tests/pipeline/test_spectral_recipe_versions.py
+++ b/tests/pipeline/test_spectral_recipe_versions.py
@@ -26,8 +26,18 @@ from wandas.pipeline import RecipePlan, default_recipe_registry
 from wandas.pipeline.errors import RecipeExecutionError
 from wandas.processing import get_operation
 from wandas.processing.cepstral import Cepstrum, _RecipeCepstrumV1
-from wandas.processing.spectral import FFT, TransferFunction, Welch, _RecipeFFTV1, _RecipeWelchV1
+from wandas.processing.spectral import (
+    FFT,
+    TransferFunction,
+    Welch,
+    _RecipeFFTV1,
+    _RecipeIFFTV1,
+    _RecipeNOctSynthesisV1,
+    _RecipeTransferFunctionV1,
+    _RecipeWelchV1,
+)
 from wandas.processing.spectral_contracts import derive_transfer_domain
+from wandas.processing.temporal import _RecipeRmsTrendV1, _RecipeSoundLevelV1
 
 _SAMPLING_RATE = 8_000
 _FLOOR = 1e-6
@@ -910,13 +920,21 @@ def test_default_registry_contains_v1_and_v2_for_all_spectral_recipe_operations(
         assert registry.require(operation_id, 2).version == 2
     assert registry.require("wandas.frame.select_pair", 1).version == 1
 
+    for private_name, operation_class in (
+        ("_recipe_fft_v1", _RecipeFFTV1),
+        ("_recipe_welch_v1", _RecipeWelchV1),
+        ("_recipe_cepstrum_v1", _RecipeCepstrumV1),
+        ("_recipe_ifft_v1", _RecipeIFFTV1),
+        ("_recipe_noct_synthesis_v1", _RecipeNOctSynthesisV1),
+        ("_recipe_transfer_function_v1", _RecipeTransferFunctionV1),
+        ("_recipe_rms_trend_v1", _RecipeRmsTrendV1),
+        ("_recipe_sound_level_v1", _RecipeSoundLevelV1),
+    ):
+        assert get_operation(private_name) is operation_class
+
     for private_name in (
-        "_recipe_fft_v1",
-        "_recipe_welch_v1",
-        "_recipe_cepstrum_v1",
         "_coherence_recipe_v1",
         "_csd_recipe_v1",
-        "_recipe_transfer_function_v1",
     ):
         with pytest.raises(ValueError, match="Unknown operation type"):
             get_operation(private_name)

--- a/tests/processing/test_base_operations.py
+++ b/tests/processing/test_base_operations.py
@@ -1,6 +1,6 @@
 import abc
 from collections import Counter, defaultdict, namedtuple
-from typing import Any
+from typing import Any, cast
 from unittest import mock
 
 import cloudpickle
@@ -14,11 +14,13 @@ from dask.base import tokenize
 from wandas.processing import ChannelIndependentAudioOperation as PublicChannelIndependentAudioOperation
 from wandas.processing import base as base_module
 from wandas.processing.base import (
-    _OPERATION_MODULES,
-    _OPERATION_REGISTRY,
+    _OPERATION_CACHE,
+    _OPERATION_PROVIDERS,
     AudioOperation,
     ChannelIndependentAudioOperation,
     _config_values_equal,
+    _EagerOperationProvider,
+    _LazyOperationProvider,
     _snapshot_config_value,
     _validate_channel_first_array,
     create_operation,
@@ -32,16 +34,27 @@ from wandas.utils.dask_helpers import da_from_array
 from wandas.utils.types import NDArrayReal
 
 
+@pytest.fixture(autouse=True)
+def _restore_operation_state():
+    providers = dict(_OPERATION_PROVIDERS)
+    cache = dict(_OPERATION_CACHE)
+    yield
+    _OPERATION_PROVIDERS.clear()
+    _OPERATION_PROVIDERS.update(providers)
+    _OPERATION_CACHE.clear()
+    _OPERATION_CACHE.update(cache)
+
+
 class TestOperationRegistry:
     """Test registry-related functions."""
 
     def test_get_operation_normal(self) -> None:
         """Test get_operation returns a registered operation."""
         # Test for existing operations
-        assert "highpass_filter" in _OPERATION_REGISTRY
-        assert "lowpass_filter" in _OPERATION_REGISTRY
+        assert isinstance(_OPERATION_PROVIDERS["highpass_filter"], _EagerOperationProvider)
+        assert isinstance(_OPERATION_PROVIDERS["lowpass_filter"], _EagerOperationProvider)
 
-    def test_get_operation_imports_lazy_registered_module(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_get_operation_imports_explicit_lazy_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
         class LazyTestOperation(AudioOperation[NDArrayReal, NDArrayReal]):
             name = "lazy_test_op"
 
@@ -50,17 +63,20 @@ class TestOperationRegistry:
 
         def fake_import_module(module_name: str) -> object:
             assert module_name == "tests.fake_lazy_module"
-            register_operation(LazyTestOperation)
-            return object()
+            return mock.Mock(LazyTestOperation=LazyTestOperation)
 
         monkeypatch.setattr("wandas.processing.base.importlib.import_module", fake_import_module)
-        register_lazy_operation("lazy_test_op", "tests.fake_lazy_module")
+        register_lazy_operation(
+            "lazy_test_op",
+            "tests.fake_lazy_module",
+            attribute_name="LazyTestOperation",
+        )
 
-        try:
-            assert get_operation("lazy_test_op") is LazyTestOperation
-        finally:
-            _OPERATION_MODULES.pop("lazy_test_op", None)
-            _OPERATION_REGISTRY.pop("lazy_test_op", None)
+        assert get_operation("lazy_test_op") is LazyTestOperation
+        provider = _OPERATION_PROVIDERS["lazy_test_op"]
+        assert isinstance(provider, _LazyOperationProvider)
+        assert provider.attribute_name == "LazyTestOperation"
+        assert _OPERATION_CACHE["lazy_test_op"] is LazyTestOperation
 
     def test_get_operation_error(self) -> None:
         """Test get_operation raises ValueError for unknown operations."""
@@ -84,9 +100,7 @@ class TestOperationRegistry:
         register_operation(TestOperation)
         assert get_operation("test_register_op") == TestOperation
 
-        # Clean up
-        if "test_register_op" in _OPERATION_REGISTRY:
-            del _OPERATION_REGISTRY["test_register_op"]
+        assert _OPERATION_CACHE["test_register_op"] is TestOperation
 
     def test_register_operation_same_class_is_idempotent(self) -> None:
         class IdempotentOperation(AudioOperation[NDArrayReal, NDArrayReal]):
@@ -95,13 +109,13 @@ class TestOperationRegistry:
             def _process(self, x: NDArrayReal) -> NDArrayReal:
                 return x
 
-        try:
-            register_operation(IdempotentOperation)
-            register_operation(IdempotentOperation)
+        register_operation(IdempotentOperation)
+        register_operation(IdempotentOperation)
 
-            assert _OPERATION_REGISTRY["idempotent_op"] is IdempotentOperation
-        finally:
-            _OPERATION_REGISTRY.pop("idempotent_op", None)
+        provider = _OPERATION_PROVIDERS["idempotent_op"]
+        assert isinstance(provider, _EagerOperationProvider)
+        assert provider.operation_class is IdempotentOperation
+        assert _OPERATION_CACHE["idempotent_op"] is IdempotentOperation
 
     def test_register_operation_error(self) -> None:
         """Test registering an invalid class raises TypeError."""
@@ -110,8 +124,8 @@ class TestOperationRegistry:
         class InvalidClass:
             pass
 
-        with pytest.raises(TypeError, match="Strategy class must inherit from AudioOperation."):
-            register_operation(InvalidClass)
+        with pytest.raises(TypeError, match="expected a concrete AudioOperation subclass"):
+            register_operation(cast(Any, InvalidClass))
 
     def test_create_operation_with_different_types(self) -> None:
         """Test creating operations of different types."""
@@ -395,17 +409,14 @@ class TestAudioOperation:
             def _process(self, x: NDArrayReal) -> NDArrayReal:
                 return x * self._config_snapshot()["gain"]
 
-        try:
-            register_operation(SuperOnlyGainOperation)
-            op = create_operation("super_only_gain_op", 16000, gain=2.0)
-            data = da_from_array(np.array([[1.0, 2.0]]), chunks=(1, -1))
-            result = op.process(data)
+        register_operation(SuperOnlyGainOperation)
+        op = create_operation("super_only_gain_op", 16000, gain=2.0)
+        data = da_from_array(np.array([[1.0, 2.0]]), chunks=(1, -1))
+        result = op.process(data)
 
-            assert op.params == {"gain": 2.0}
-            assert op.to_params() == {"gain": 2.0}
-            np.testing.assert_array_equal(result.compute(), np.array([[2.0, 4.0]]))
-        finally:
-            _OPERATION_REGISTRY.pop("super_only_gain_op", None)
+        assert op.params == {"gain": 2.0}
+        assert op.to_params() == {"gain": 2.0}
+        np.testing.assert_array_equal(result.compute(), np.array([[2.0, 4.0]]))
 
     def test_base_config_snapshots_constructor_inputs_for_params_and_compute(self) -> None:
         class BaseConfigOperation(AudioOperation[NDArrayReal, NDArrayReal]):
@@ -1136,5 +1147,5 @@ class TestAudioOperation:
             def abstract_method(self) -> None:
                 pass
 
-        with pytest.raises(TypeError, match="Cannot register abstract"):
+        with pytest.raises(TypeError, match="class is abstract"):
             register_operation(AbstractOp)

--- a/tests/processing/test_custom_operation.py
+++ b/tests/processing/test_custom_operation.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from dask.array.core import Array as DaArray
 
-from wandas.processing.base import _OPERATION_REGISTRY, create_operation, get_operation
+from wandas.processing.base import _OPERATION_PROVIDERS, _EagerOperationProvider, create_operation, get_operation
 from wandas.processing.custom import CustomOperation
 from wandas.utils.dask_helpers import da_from_array
 
@@ -99,8 +99,9 @@ class TestCustomOperation:
 
     def test_custom_operation_registered(self) -> None:
         """CustomOperation is registered in the operation registry."""
-        # Ensure registration side effect ran on import
-        assert _OPERATION_REGISTRY.get("custom") is CustomOperation
+        provider = _OPERATION_PROVIDERS.get("custom")
+        assert isinstance(provider, _EagerOperationProvider)
+        assert provider.operation_class is CustomOperation
 
         created = create_operation("custom", 16000, func=lambda x: x)
         assert isinstance(created, CustomOperation)

--- a/tests/processing/test_operation_lazy_metadata_contract.py
+++ b/tests/processing/test_operation_lazy_metadata_contract.py
@@ -15,7 +15,7 @@ import wandas.processing.spectral as spectral_module
 import wandas.processing.stats  # noqa: F401
 import wandas.processing.temporal  # noqa: F401
 from tests.processing_helpers import run_operation_lazy
-from wandas.processing.base import _OPERATION_REGISTRY, AudioOperation
+from wandas.processing.base import _OPERATION_PROVIDERS, AudioOperation
 from wandas.processing.cepstral import (
     Cepstrum,
     Lifter,
@@ -346,8 +346,6 @@ def test_operation_lazy_metadata_contract_mocks_optional_backends(
 
 def test_operation_lazy_metadata_contract_covers_every_registered_operation() -> None:
     covered_names = {case.name for case in OPERATION_CASES}
-    concrete_registered_names = {
-        name for name, operation_class in _OPERATION_REGISTRY.items() if not operation_class.__name__.startswith("_")
-    }
+    concrete_registered_names = {name for name in _OPERATION_PROVIDERS if not name.startswith("_")}
 
     assert covered_names == concrete_registered_names

--- a/tests/processing/test_operation_provider_contract.py
+++ b/tests/processing/test_operation_provider_contract.py
@@ -146,7 +146,7 @@ def test_register_operation_rejects_non_class_without_changing_state() -> None:
     with pytest.raises((TypeError, ValueError)) as error:
         register_operation(cast(Any, object()))
 
-    _assert_error_mentions(error, "AudioOperation")
+    _assert_error_mentions(error, "Operation name <unavailable>", "AudioOperation")
     assert _OPERATION_PROVIDERS == providers_before
     assert _OPERATION_CACHE == cache_before
 

--- a/tests/processing/test_operation_provider_contract.py
+++ b/tests/processing/test_operation_provider_contract.py
@@ -151,6 +151,30 @@ def test_register_operation_rejects_non_class_without_changing_state() -> None:
     assert _OPERATION_CACHE == cache_before
 
 
+def test_register_operation_reports_issubclass_type_error_without_changing_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operation_name = "contract_issubclass_type_error"
+    operation_class = _make_operation_class(operation_name)
+    providers_before = dict(_OPERATION_PROVIDERS)
+    cache_before = dict(_OPERATION_CACHE)
+    real_issubclass = issubclass
+
+    def fail_for_candidate(candidate: Any, parent: Any) -> bool:
+        if candidate is operation_class:
+            raise TypeError("synthetic subclass check failure")
+        return real_issubclass(candidate, parent)
+
+    monkeypatch.setattr(base_module, "issubclass", fail_for_candidate, raising=False)
+
+    with pytest.raises(TypeError) as error:
+        register_operation(operation_class)
+
+    _assert_error_mentions(error, operation_name, "AudioOperation", "expected")
+    assert _OPERATION_PROVIDERS == providers_before
+    assert _OPERATION_CACHE == cache_before
+
+
 @pytest.mark.parametrize(
     ("operation_class_factory", "expected_message"),
     [
@@ -506,6 +530,16 @@ def test_get_operation_cache_hit_returns_same_class_without_reimporting(
     assert import_calls == 1
 
 
+def test_get_operation_republishes_eager_provider_after_cache_eviction() -> None:
+    operation_name = "contract_eager_cache_republication"
+    operation_class = _make_operation_class(operation_name)
+    register_operation(operation_class)
+    _OPERATION_CACHE.pop(operation_name)
+
+    assert get_operation(operation_name) is operation_class
+    assert _OPERATION_CACHE[operation_name] is operation_class
+
+
 def test_create_operation_uses_get_operation_as_its_resolution_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -658,3 +692,52 @@ def test_concurrent_lazy_resolution_converges_and_does_not_block_other_import(
     assert outcomes["slow-first"] is slow_module.SlowOperation
     assert outcomes["slow-second"] is slow_module.SlowOperation
     assert outcomes["fast"] is fast_module.FastOperation
+
+
+def test_concurrent_lazy_resolution_rejects_distinct_class_objects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operation_name = "contract_concurrent_identity_conflict"
+    module_name = "tests.module_for_concurrent_identity_conflict"
+    attribute_name = "PublishedOperation"
+    first_class = _make_operation_class(operation_name)
+    second_class = _make_operation_class(operation_name)
+    first_module = _module_with_operation(module_name, attribute_name, first_class)
+    second_module = _module_with_operation(module_name, attribute_name, second_class)
+    register_lazy_operation(operation_name, module_name, attribute_name=attribute_name)
+
+    imports_ready = threading.Barrier(2)
+    modules = [first_module, second_module]
+    modules_lock = threading.Lock()
+
+    def fake_import(requested_name: str, *_args: Any, **_kwargs: Any) -> ModuleType:
+        assert requested_name == module_name
+        imports_ready.wait(timeout=5)
+        with modules_lock:
+            return modules.pop()
+
+    monkeypatch.setattr(base_module.importlib, "import_module", fake_import)
+    outcomes: dict[str, object] = {}
+
+    def resolve(label: str) -> None:
+        try:
+            outcomes[label] = get_operation(operation_name)
+        except BaseException as error:  # pragma: no cover - reported below
+            outcomes[label] = error
+
+    first = threading.Thread(target=resolve, args=("first",))
+    second = threading.Thread(target=resolve, args=("second",))
+    first.start()
+    second.start()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    successful = [outcome for outcome in outcomes.values() if not isinstance(outcome, BaseException)]
+    failures = [outcome for outcome in outcomes.values() if isinstance(outcome, ValueError)]
+    assert len(successful) == 1
+    assert successful[0] in (first_class, second_class)
+    assert len(failures) == 1
+    assert "conflicting class objects" in str(failures[0])
+    assert _OPERATION_CACHE[operation_name] is successful[0]

--- a/tests/processing/test_operation_provider_contract.py
+++ b/tests/processing/test_operation_provider_contract.py
@@ -1,0 +1,647 @@
+from __future__ import annotations
+
+import abc
+import importlib
+import threading
+from collections.abc import Callable, Iterator
+from types import ModuleType
+from typing import Any, cast
+
+import pytest
+
+import wandas.processing.base as base_module
+from wandas.processing.base import (
+    _OPERATION_CACHE,
+    _OPERATION_PROVIDERS,
+    AudioOperation,
+    _EagerOperationProvider,
+    _LazyOperationProvider,
+    create_operation,
+    get_operation,
+    register_lazy_operation,
+    register_operation,
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_operation_state() -> Iterator[None]:
+    """Keep provider and resolved-class state isolated between contract tests."""
+    providers = dict(_OPERATION_PROVIDERS)
+    cache = dict(_OPERATION_CACHE)
+    yield
+    _OPERATION_PROVIDERS.clear()
+    _OPERATION_PROVIDERS.update(providers)
+    _OPERATION_CACHE.clear()
+    _OPERATION_CACHE.update(cache)
+
+
+def _make_operation_class(
+    operation_name: Any,
+    *,
+    module_name: str = "tests.fake_operation_implementations",
+) -> type[AudioOperation[Any, Any]]:
+    """Create a concrete operation with a controllable registry name."""
+
+    class FakeOperation(AudioOperation[Any, Any]):
+        name = operation_name
+
+        def _process(self, data: Any) -> Any:
+            return data
+
+    FakeOperation.__module__ = module_name
+    return FakeOperation
+
+
+def _make_non_operation_class() -> type[object]:
+    class NotAnAudioOperation:
+        name = "not_an_audio_operation"
+
+    return NotAnAudioOperation
+
+
+def _make_abstract_operation(operation_name: str) -> type[AudioOperation[Any, Any]]:
+    class AbstractOperation(AudioOperation[Any, Any], abc.ABC):
+        name = operation_name
+
+        @abc.abstractmethod
+        def _process(self, data: Any) -> Any:
+            raise NotImplementedError
+
+    return AbstractOperation
+
+
+def _module_with_operation(
+    module_name: str,
+    attribute_name: str,
+    operation_class: object,
+) -> ModuleType:
+    module = ModuleType(module_name)
+    setattr(module, attribute_name, operation_class)
+    return module
+
+
+def _patch_import_module(monkeypatch: pytest.MonkeyPatch, module: ModuleType) -> None:
+    def fake_import_module(requested_name: str, *_args: Any, **_kwargs: Any) -> ModuleType:
+        assert requested_name == module.__name__
+        return module
+
+    monkeypatch.setattr(base_module.importlib, "import_module", fake_import_module)
+
+
+def _assert_error_mentions(error: pytest.ExceptionInfo[BaseException], *parts: str) -> None:
+    message = str(error.value)
+    assert all(part in message for part in parts), message
+
+
+def test_register_operation_publishes_one_eager_provider_and_cache_entry() -> None:
+    operation_class = _make_operation_class("contract_eager_registration")
+
+    register_operation(operation_class)
+
+    provider = _OPERATION_PROVIDERS[operation_class.name]
+    assert isinstance(provider, _EagerOperationProvider)
+    assert provider.operation_class is operation_class
+    assert _OPERATION_CACHE[operation_class.name] is operation_class
+    assert get_operation(operation_class.name) is operation_class
+
+
+def test_register_operation_same_class_object_is_idempotent() -> None:
+    operation_class = _make_operation_class("contract_eager_idempotence")
+
+    register_operation(operation_class)
+    provider_before = _OPERATION_PROVIDERS[operation_class.name]
+    cache_before = _OPERATION_CACHE[operation_class.name]
+
+    register_operation(operation_class)
+
+    assert _OPERATION_PROVIDERS[operation_class.name] is provider_before
+    assert _OPERATION_CACHE[operation_class.name] is cache_before is operation_class
+
+
+def test_register_operation_rejects_same_module_and_qualname_from_factory() -> None:
+    first_class = _make_operation_class("contract_eager_identity_conflict")
+    second_class = _make_operation_class("contract_eager_identity_conflict")
+    assert first_class is not second_class
+    assert first_class.__module__ == second_class.__module__
+    assert first_class.__qualname__ == second_class.__qualname__
+
+    register_operation(first_class)
+    providers_before = dict(_OPERATION_PROVIDERS)
+    cache_before = dict(_OPERATION_CACHE)
+
+    with pytest.raises(ValueError) as error:
+        register_operation(second_class)
+
+    _assert_error_mentions(error, "contract_eager_identity_conflict")
+    assert _OPERATION_PROVIDERS == providers_before
+    assert _OPERATION_CACHE == cache_before
+
+
+def test_register_operation_rejects_non_class_without_changing_state() -> None:
+    providers_before = dict(_OPERATION_PROVIDERS)
+    cache_before = dict(_OPERATION_CACHE)
+
+    with pytest.raises((TypeError, ValueError)) as error:
+        register_operation(cast(Any, object()))
+
+    _assert_error_mentions(error, "AudioOperation")
+    assert _OPERATION_PROVIDERS == providers_before
+    assert _OPERATION_CACHE == cache_before
+
+
+@pytest.mark.parametrize(
+    ("operation_class_factory", "expected_message"),
+    [
+        (_make_non_operation_class, "AudioOperation"),
+        (lambda: _make_abstract_operation("contract_abstract_eager"), "abstract"),
+        (lambda: _make_operation_class(""), "non-blank str"),
+        (lambda: _make_operation_class(" "), "non-blank str"),
+    ],
+    ids=["non-subclass", "abstract", "blank-name", "whitespace-name"],
+)
+def test_register_operation_validates_candidate_before_mutating_state(
+    operation_class_factory: Callable[[], object],
+    expected_message: str,
+) -> None:
+    providers_before = dict(_OPERATION_PROVIDERS)
+    cache_before = dict(_OPERATION_CACHE)
+
+    with pytest.raises((TypeError, ValueError)) as error:
+        register_operation(cast(Any, operation_class_factory()))
+
+    _assert_error_mentions(error, expected_message)
+    assert _OPERATION_PROVIDERS == providers_before
+    assert _OPERATION_CACHE == cache_before
+
+
+def test_register_lazy_operation_requires_explicit_keyword_attribute_name() -> None:
+    register_without_attribute = cast(Callable[..., None], register_lazy_operation)
+
+    with pytest.raises(TypeError):
+        register_without_attribute(
+            "contract_missing_attribute",
+            "tests.fake_lazy_module",
+        )
+
+
+@pytest.mark.parametrize(
+    ("operation_name", "module_name", "attribute_name"),
+    [
+        ("", "tests.fake_lazy_module", "Operation"),
+        (" ", "tests.fake_lazy_module", "Operation"),
+        ("contract_invalid_lazy", "", "Operation"),
+        ("contract_invalid_lazy", " ", "Operation"),
+        ("contract_invalid_lazy", "tests.fake_lazy_module", ""),
+        ("contract_invalid_lazy", "tests.fake_lazy_module", " "),
+        (None, "tests.fake_lazy_module", "Operation"),
+    ],
+    ids=[
+        "blank-name",
+        "whitespace-name",
+        "blank-module",
+        "whitespace-module",
+        "blank-attribute",
+        "whitespace-attribute",
+        "non-string-name",
+    ],
+)
+def test_register_lazy_operation_validates_provider_fields_atomically(
+    operation_name: Any,
+    module_name: str,
+    attribute_name: str,
+) -> None:
+    providers_before = dict(_OPERATION_PROVIDERS)
+    cache_before = dict(_OPERATION_CACHE)
+
+    with pytest.raises((TypeError, ValueError)):
+        register_lazy_operation(
+            cast(str, operation_name),
+            module_name,
+            attribute_name=attribute_name,
+        )
+
+    assert _OPERATION_PROVIDERS == providers_before
+    assert _OPERATION_CACHE == cache_before
+
+
+def test_register_lazy_operation_records_explicit_provider_without_importing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import_called = False
+
+    def fail_import(*_args: Any, **_kwargs: Any) -> ModuleType:
+        nonlocal import_called
+        import_called = True
+        raise AssertionError("lazy provider registration must not import its module")
+
+    monkeypatch.setattr(base_module.importlib, "import_module", fail_import)
+    register_lazy_operation(
+        "contract_lazy_registration",
+        "tests.module_for_contract_lazy_registration",
+        attribute_name="ExplicitOperation",
+    )
+
+    provider = _OPERATION_PROVIDERS["contract_lazy_registration"]
+    assert isinstance(provider, _LazyOperationProvider)
+    assert provider.module_name == "tests.module_for_contract_lazy_registration"
+    assert provider.attribute_name == "ExplicitOperation"
+    assert "contract_lazy_registration" not in _OPERATION_CACHE
+    assert import_called is False
+
+
+def test_register_lazy_operation_same_provider_is_idempotent() -> None:
+    register_lazy_operation(
+        "contract_lazy_idempotence",
+        "tests.module_for_contract_lazy_idempotence",
+        attribute_name="ExplicitOperation",
+    )
+    provider_before = _OPERATION_PROVIDERS["contract_lazy_idempotence"]
+    cache_before = dict(_OPERATION_CACHE)
+
+    register_lazy_operation(
+        "contract_lazy_idempotence",
+        "tests.module_for_contract_lazy_idempotence",
+        attribute_name="ExplicitOperation",
+    )
+
+    assert _OPERATION_PROVIDERS["contract_lazy_idempotence"] is provider_before
+    assert _OPERATION_CACHE == cache_before
+
+
+@pytest.mark.parametrize(
+    ("conflicting_module", "conflicting_attribute"),
+    [
+        ("tests.other_lazy_module", "ExplicitOperation"),
+        ("tests.module_for_contract_lazy_conflict", "OtherOperation"),
+    ],
+    ids=["module-conflict", "attribute-conflict"],
+)
+def test_register_lazy_operation_rejects_different_provider(
+    conflicting_module: str,
+    conflicting_attribute: str,
+) -> None:
+    operation_name = "contract_lazy_provider_conflict"
+    original_module = "tests.module_for_contract_lazy_conflict"
+    original_attribute = "ExplicitOperation"
+    register_lazy_operation(operation_name, original_module, attribute_name=original_attribute)
+    providers_before = dict(_OPERATION_PROVIDERS)
+    cache_before = dict(_OPERATION_CACHE)
+
+    with pytest.raises(ValueError) as error:
+        register_lazy_operation(operation_name, conflicting_module, attribute_name=conflicting_attribute)
+
+    _assert_error_mentions(error, operation_name, conflicting_module, conflicting_attribute)
+    assert _OPERATION_PROVIDERS == providers_before
+    assert _OPERATION_CACHE == cache_before
+
+
+def test_register_eager_then_lazy_conflict_preserves_eager_provider_and_cache() -> None:
+    operation_name = "contract_eager_then_lazy_conflict"
+    operation_class = _make_operation_class(operation_name)
+    register_operation(operation_class)
+    providers_before = dict(_OPERATION_PROVIDERS)
+    cache_before = dict(_OPERATION_CACHE)
+
+    with pytest.raises(ValueError) as error:
+        register_lazy_operation(
+            operation_name,
+            "tests.module_for_eager_then_lazy_conflict",
+            attribute_name="OtherOperation",
+        )
+
+    _assert_error_mentions(error, operation_name)
+    assert _OPERATION_PROVIDERS == providers_before
+    assert _OPERATION_CACHE == cache_before
+
+
+def test_register_lazy_then_eager_conflict_preserves_lazy_provider_and_cache() -> None:
+    operation_name = "contract_lazy_then_eager_conflict"
+    module_name = "tests.module_for_lazy_then_eager_conflict"
+    attribute_name = "ExplicitOperation"
+    register_lazy_operation(operation_name, module_name, attribute_name=attribute_name)
+    providers_before = dict(_OPERATION_PROVIDERS)
+    cache_before = dict(_OPERATION_CACHE)
+
+    with pytest.raises(ValueError) as error:
+        register_operation(_make_operation_class(operation_name))
+
+    _assert_error_mentions(error, operation_name)
+    assert _OPERATION_PROVIDERS == providers_before
+    assert _OPERATION_CACHE == cache_before
+
+
+def test_get_operation_resolves_explicit_attribute_even_when_class_module_differs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operation_name = "contract_explicit_attribute_resolution"
+    module_name = "tests.provider_module_for_explicit_attribute"
+    attribute_name = "PublishedOperation"
+    operation_class = _make_operation_class(operation_name, module_name="tests.implementation_module")
+    module = _module_with_operation(module_name, attribute_name, operation_class)
+    _patch_import_module(monkeypatch, module)
+    register_lazy_operation(operation_name, module_name, attribute_name=attribute_name)
+    provider_before = _OPERATION_PROVIDERS[operation_name]
+
+    resolved = get_operation(operation_name)
+
+    assert resolved is operation_class
+    assert operation_class.__module__ != module_name
+    assert _OPERATION_PROVIDERS[operation_name] is provider_before
+    assert _OPERATION_CACHE[operation_name] is operation_class
+
+
+def test_get_operation_preserves_import_exception_and_allows_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    operation_name = "contract_import_exception"
+    module_name = "tests.module_for_import_exception"
+    attribute_name = "ExplicitOperation"
+    register_lazy_operation(operation_name, module_name, attribute_name=attribute_name)
+    providers_before = dict(_OPERATION_PROVIDERS)
+    cache_before = dict(_OPERATION_CACHE)
+    import_error = ImportError("dependency unavailable for provider module")
+
+    def fail_import(requested_name: str, *_args: Any, **_kwargs: Any) -> ModuleType:
+        assert requested_name == module_name
+        raise import_error
+
+    monkeypatch.setattr(base_module.importlib, "import_module", fail_import)
+    with pytest.raises(ImportError) as error:
+        get_operation(operation_name)
+
+    assert error.value is import_error
+    assert _OPERATION_PROVIDERS == providers_before
+    assert _OPERATION_CACHE == cache_before
+
+    operation_class = _make_operation_class(operation_name)
+    module = _module_with_operation(module_name, attribute_name, operation_class)
+    _patch_import_module(monkeypatch, module)
+    assert get_operation(operation_name) is operation_class
+    assert _OPERATION_CACHE[operation_name] is operation_class
+
+
+def test_get_operation_reports_missing_explicit_attribute_without_caching(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operation_name = "contract_missing_attribute"
+    module_name = "tests.module_for_missing_attribute"
+    attribute_name = "MissingOperation"
+    module = ModuleType(module_name)
+    _patch_import_module(monkeypatch, module)
+    register_lazy_operation(operation_name, module_name, attribute_name=attribute_name)
+    providers_before = dict(_OPERATION_PROVIDERS)
+    cache_before = dict(_OPERATION_CACHE)
+
+    with pytest.raises((AttributeError, ValueError)) as error:
+        get_operation(operation_name)
+
+    _assert_error_mentions(error, module_name, attribute_name)
+    assert _OPERATION_PROVIDERS == providers_before
+    assert _OPERATION_CACHE == cache_before
+
+
+def test_get_operation_rejects_non_class_without_caching(monkeypatch: pytest.MonkeyPatch) -> None:
+    operation_name = "contract_non_class_candidate"
+    module_name = "tests.module_for_non_class_candidate"
+    attribute_name = "PublishedOperation"
+    module = _module_with_operation(module_name, attribute_name, object())
+    _patch_import_module(monkeypatch, module)
+    register_lazy_operation(operation_name, module_name, attribute_name=attribute_name)
+    providers_before = dict(_OPERATION_PROVIDERS)
+    cache_before = dict(_OPERATION_CACHE)
+
+    with pytest.raises((TypeError, ValueError)) as error:
+        get_operation(operation_name)
+
+    _assert_error_mentions(error, operation_name, module_name, attribute_name, "AudioOperation")
+    assert _OPERATION_PROVIDERS == providers_before
+    assert _OPERATION_CACHE == cache_before
+
+
+def test_get_operation_rejects_non_subclass_without_caching(monkeypatch: pytest.MonkeyPatch) -> None:
+    operation_name = "contract_non_subclass_candidate"
+    module_name = "tests.module_for_non_subclass_candidate"
+    attribute_name = "PublishedOperation"
+    module = _module_with_operation(module_name, attribute_name, _make_non_operation_class())
+    _patch_import_module(monkeypatch, module)
+    register_lazy_operation(operation_name, module_name, attribute_name=attribute_name)
+    providers_before = dict(_OPERATION_PROVIDERS)
+    cache_before = dict(_OPERATION_CACHE)
+
+    with pytest.raises((TypeError, ValueError)) as error:
+        get_operation(operation_name)
+
+    _assert_error_mentions(error, operation_name, module_name, attribute_name, "AudioOperation")
+    assert _OPERATION_PROVIDERS == providers_before
+    assert _OPERATION_CACHE == cache_before
+
+
+def test_get_operation_rejects_abstract_class_without_caching(monkeypatch: pytest.MonkeyPatch) -> None:
+    operation_name = "contract_abstract_candidate"
+    module_name = "tests.module_for_abstract_candidate"
+    attribute_name = "PublishedOperation"
+    module = _module_with_operation(
+        module_name,
+        attribute_name,
+        _make_abstract_operation(operation_name),
+    )
+    _patch_import_module(monkeypatch, module)
+    register_lazy_operation(operation_name, module_name, attribute_name=attribute_name)
+    providers_before = dict(_OPERATION_PROVIDERS)
+    cache_before = dict(_OPERATION_CACHE)
+
+    with pytest.raises((TypeError, ValueError)) as error:
+        get_operation(operation_name)
+
+    _assert_error_mentions(error, operation_name, module_name, attribute_name, "abstract")
+    assert _OPERATION_PROVIDERS == providers_before
+    assert _OPERATION_CACHE == cache_before
+
+
+def test_get_operation_rejects_class_name_mismatch_without_caching(monkeypatch: pytest.MonkeyPatch) -> None:
+    operation_name = "contract_provider_name_mismatch"
+    module_name = "tests.module_for_provider_name_mismatch"
+    attribute_name = "PublishedOperation"
+    module = _module_with_operation(
+        module_name,
+        attribute_name,
+        _make_operation_class("different_operation_name"),
+    )
+    _patch_import_module(monkeypatch, module)
+    register_lazy_operation(operation_name, module_name, attribute_name=attribute_name)
+    providers_before = dict(_OPERATION_PROVIDERS)
+    cache_before = dict(_OPERATION_CACHE)
+
+    with pytest.raises((TypeError, ValueError)) as error:
+        get_operation(operation_name)
+
+    _assert_error_mentions(error, operation_name, module_name, attribute_name, "different_operation_name")
+    assert _OPERATION_PROVIDERS == providers_before
+    assert _OPERATION_CACHE == cache_before
+
+
+def test_get_operation_cache_hit_returns_same_class_without_reimporting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operation_name = "contract_cache_hit"
+    module_name = "tests.module_for_cache_hit"
+    attribute_name = "PublishedOperation"
+    operation_class = _make_operation_class(operation_name)
+    module = _module_with_operation(module_name, attribute_name, operation_class)
+    import_calls = 0
+
+    def fake_import(requested_name: str, *_args: Any, **_kwargs: Any) -> ModuleType:
+        nonlocal import_calls
+        assert requested_name == module_name
+        import_calls += 1
+        return module
+
+    monkeypatch.setattr(base_module.importlib, "import_module", fake_import)
+    register_lazy_operation(operation_name, module_name, attribute_name=attribute_name)
+
+    first = get_operation(operation_name)
+    second = get_operation(operation_name)
+
+    assert first is second is operation_class
+    assert import_calls == 1
+
+
+def test_create_operation_uses_get_operation_as_its_resolution_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operation_name = "contract_create_operation_resolution"
+    operation_class = _make_operation_class(operation_name)
+    register_operation(operation_class)
+    calls: list[str] = []
+    real_get_operation = base_module.get_operation
+
+    def recording_get_operation(name: str) -> type[AudioOperation[Any, Any]]:
+        calls.append(name)
+        return real_get_operation(name)
+
+    monkeypatch.setattr(base_module, "get_operation", recording_get_operation)
+    created = create_operation(operation_name, 16000)
+
+    assert isinstance(created, operation_class)
+    assert calls == [operation_name]
+
+
+@pytest.mark.parametrize(
+    ("operation_name", "module_name", "attribute_name"),
+    [
+        ("cepstrum", "wandas.processing.cepstral", "Cepstrum"),
+        ("coherence", "wandas.processing.spectral", "Coherence"),
+        ("roughness_dw", "wandas.processing.psychoacoustic", "RoughnessDw"),
+    ],
+    ids=["cepstrum", "coherence", "roughness-dw"],
+)
+def test_public_lazy_export_direct_import_and_get_operation_share_identity(
+    operation_name: str,
+    module_name: str,
+    attribute_name: str,
+) -> None:
+    import wandas.processing as processing
+
+    module = importlib.import_module(module_name)
+    direct_class = getattr(module, attribute_name)
+
+    assert get_operation(operation_name) is direct_class
+    assert getattr(processing, attribute_name) is direct_class
+
+
+def test_builtin_lazy_and_private_recipe_declarations_use_explicit_providers() -> None:
+    import wandas.processing as processing
+
+    declarations = (*processing._LAZY_OPERATION_CLASSES.values(), *processing._PRIVATE_LAZY_OPERATION_PROVIDERS)
+    for operation_name, module_name, attribute_name in declarations:
+        provider = _OPERATION_PROVIDERS[operation_name]
+        assert provider == _LazyOperationProvider(module_name, attribute_name)
+
+
+def test_builtin_eager_private_recipe_operations_have_explicit_providers() -> None:
+    from wandas.processing.temporal import _RecipeRmsTrendV1, _RecipeSoundLevelV1
+
+    for operation_class in (_RecipeRmsTrendV1, _RecipeSoundLevelV1):
+        provider = _OPERATION_PROVIDERS[operation_class.name]
+        assert provider == _EagerOperationProvider(operation_class)
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "wandas.processing.cepstral",
+        "wandas.processing.spectral",
+        "wandas.processing.psychoacoustic",
+    ],
+    ids=["cepstral", "spectral", "psychoacoustic"],
+)
+def test_direct_lazy_module_import_does_not_mutate_provider_or_cache(module_name: str) -> None:
+    providers_before = dict(_OPERATION_PROVIDERS)
+    cache_before = dict(_OPERATION_CACHE)
+
+    importlib.import_module(module_name)
+
+    assert _OPERATION_PROVIDERS == providers_before
+    assert _OPERATION_CACHE == cache_before
+
+
+def test_concurrent_lazy_resolution_converges_and_does_not_block_other_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    slow_name = "contract_concurrent_slow"
+    fast_name = "contract_concurrent_fast"
+    slow_module = _module_with_operation(
+        "tests.module_for_concurrent_slow",
+        "SlowOperation",
+        _make_operation_class(slow_name),
+    )
+    fast_module = _module_with_operation(
+        "tests.module_for_concurrent_fast",
+        "FastOperation",
+        _make_operation_class(fast_name),
+    )
+    register_lazy_operation(slow_name, slow_module.__name__, attribute_name="SlowOperation")
+    register_lazy_operation(fast_name, fast_module.__name__, attribute_name="FastOperation")
+
+    slow_import_started = threading.Event()
+    release_slow_import = threading.Event()
+    fast_import_finished = threading.Event()
+    outcomes: dict[str, object] = {}
+
+    def fake_import(requested_name: str, *_args: Any, **_kwargs: Any) -> ModuleType:
+        if requested_name == slow_module.__name__:
+            slow_import_started.set()
+            if not release_slow_import.wait(timeout=5):
+                raise TimeoutError("slow provider import was not released")
+            return slow_module
+        if requested_name == fast_module.__name__:
+            fast_import_finished.set()
+            return fast_module
+        raise AssertionError(f"unexpected provider module: {requested_name}")
+
+    monkeypatch.setattr(base_module.importlib, "import_module", fake_import)
+
+    def resolve(label: str, operation_name: str) -> None:
+        try:
+            outcomes[label] = get_operation(operation_name)
+        except BaseException as error:  # pragma: no cover - reported below
+            outcomes[label] = error
+
+    slow_first = threading.Thread(target=resolve, args=("slow-first", slow_name))
+    slow_second = threading.Thread(target=resolve, args=("slow-second", slow_name))
+    fast = threading.Thread(target=resolve, args=("fast", fast_name))
+    slow_first.start()
+    assert slow_import_started.wait(timeout=2)
+    slow_second.start()
+    fast.start()
+
+    try:
+        assert fast_import_finished.wait(timeout=2), "a distinct provider import was blocked by the slow import"
+    finally:
+        release_slow_import.set()
+        slow_first.join(timeout=5)
+        slow_second.join(timeout=5)
+        fast.join(timeout=5)
+
+    assert not any(isinstance(outcome, BaseException) for outcome in outcomes.values())
+    assert outcomes["slow-first"] is slow_module.SlowOperation
+    assert outcomes["slow-second"] is slow_module.SlowOperation
+    assert outcomes["fast"] is fast_module.FastOperation

--- a/tests/processing/test_operation_provider_contract.py
+++ b/tests/processing/test_operation_provider_contract.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import abc
 import importlib
+import subprocess
+import sys
 import threading
 from collections.abc import Callable, Iterator
 from types import ModuleType
@@ -574,13 +576,24 @@ def test_builtin_eager_private_recipe_operations_have_explicit_providers() -> No
     ids=["cepstral", "spectral", "psychoacoustic"],
 )
 def test_direct_lazy_module_import_does_not_mutate_provider_or_cache(module_name: str) -> None:
-    providers_before = dict(_OPERATION_PROVIDERS)
-    cache_before = dict(_OPERATION_CACHE)
+    check = f"""
+import importlib
 
-    importlib.import_module(module_name)
+import wandas.processing.base as base
 
-    assert _OPERATION_PROVIDERS == providers_before
-    assert _OPERATION_CACHE == cache_before
+providers_before = dict(base._OPERATION_PROVIDERS)
+cache_before = dict(base._OPERATION_CACHE)
+importlib.import_module({module_name!r})
+assert base._OPERATION_PROVIDERS == providers_before
+assert base._OPERATION_CACHE == cache_before
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", check],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
 
 
 def test_concurrent_lazy_resolution_converges_and_does_not_block_other_import(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -191,8 +191,8 @@ def test_frames_module_all_matches_documented_frames() -> None:
 def test_processing_all_excludes_internal_registry_helpers() -> None:
     import wandas.processing as processing
 
-    assert "_OPERATION_MODULES" not in processing.__all__
-    assert "_OPERATION_REGISTRY" not in processing.__all__
+    assert "_OPERATION_PROVIDERS" not in processing.__all__
+    assert "_OPERATION_CACHE" not in processing.__all__
     assert all(getattr(processing, name) is not None for name in processing.__all__)
 
 

--- a/wandas/processing/__init__.py
+++ b/wandas/processing/__init__.py
@@ -41,38 +41,73 @@ from wandas.processing.temporal import (
 
 _LAZY_OPERATION_CLASSES = {
     # Cepstral
-    "Cepstrum": ("cepstrum", "wandas.processing.cepstral"),
-    "Lifter": ("lifter", "wandas.processing.cepstral"),
-    "SpectralEnvelope": ("spectral_envelope", "wandas.processing.cepstral"),
-    "SpectrogramCepstrum": ("spectrogram_cepstrum", "wandas.processing.cepstral"),
+    "Cepstrum": ("cepstrum", "wandas.processing.cepstral", "Cepstrum"),
+    "Lifter": ("lifter", "wandas.processing.cepstral", "Lifter"),
+    "SpectralEnvelope": (
+        "spectral_envelope",
+        "wandas.processing.cepstral",
+        "SpectralEnvelope",
+    ),
+    "SpectrogramCepstrum": (
+        "spectrogram_cepstrum",
+        "wandas.processing.cepstral",
+        "SpectrogramCepstrum",
+    ),
     # Spectral
-    "CSD": ("csd", "wandas.processing.spectral"),
-    "Coherence": ("coherence", "wandas.processing.spectral"),
-    "FFT": ("fft", "wandas.processing.spectral"),
-    "IFFT": ("ifft", "wandas.processing.spectral"),
-    "ISTFT": ("istft", "wandas.processing.spectral"),
-    "NOctSpectrum": ("noct_spectrum", "wandas.processing.spectral"),
-    "NOctSynthesis": ("noct_synthesis", "wandas.processing.spectral"),
-    "STFT": ("stft", "wandas.processing.spectral"),
-    "TransferFunction": ("transfer_function", "wandas.processing.spectral"),
-    "Welch": ("welch", "wandas.processing.spectral"),
+    "CSD": ("csd", "wandas.processing.spectral", "CSD"),
+    "Coherence": ("coherence", "wandas.processing.spectral", "Coherence"),
+    "FFT": ("fft", "wandas.processing.spectral", "FFT"),
+    "IFFT": ("ifft", "wandas.processing.spectral", "IFFT"),
+    "ISTFT": ("istft", "wandas.processing.spectral", "ISTFT"),
+    "NOctSpectrum": ("noct_spectrum", "wandas.processing.spectral", "NOctSpectrum"),
+    "NOctSynthesis": ("noct_synthesis", "wandas.processing.spectral", "NOctSynthesis"),
+    "STFT": ("stft", "wandas.processing.spectral", "STFT"),
+    "TransferFunction": (
+        "transfer_function",
+        "wandas.processing.spectral",
+        "TransferFunction",
+    ),
+    "Welch": ("welch", "wandas.processing.spectral", "Welch"),
     # Psychoacoustic
-    "LoudnessZwst": ("loudness_zwst", "wandas.processing.psychoacoustic"),
-    "LoudnessZwtv": ("loudness_zwtv", "wandas.processing.psychoacoustic"),
-    "RoughnessDw": ("roughness_dw", "wandas.processing.psychoacoustic"),
-    "RoughnessDwSpec": ("roughness_dw_spec", "wandas.processing.psychoacoustic"),
-    "SharpnessDin": ("sharpness_din", "wandas.processing.psychoacoustic"),
-    "SharpnessDinSt": ("sharpness_din_st", "wandas.processing.psychoacoustic"),
+    "LoudnessZwst": ("loudness_zwst", "wandas.processing.psychoacoustic", "LoudnessZwst"),
+    "LoudnessZwtv": ("loudness_zwtv", "wandas.processing.psychoacoustic", "LoudnessZwtv"),
+    "RoughnessDw": ("roughness_dw", "wandas.processing.psychoacoustic", "RoughnessDw"),
+    "RoughnessDwSpec": (
+        "roughness_dw_spec",
+        "wandas.processing.psychoacoustic",
+        "RoughnessDwSpec",
+    ),
+    "SharpnessDin": ("sharpness_din", "wandas.processing.psychoacoustic", "SharpnessDin"),
+    "SharpnessDinSt": ("sharpness_din_st", "wandas.processing.psychoacoustic", "SharpnessDinSt"),
 }
 
-for _operation_name, _module_name in _LAZY_OPERATION_CLASSES.values():
-    register_lazy_operation(_operation_name, _module_name)
+# These Recipe replay implementations are intentionally private and are not
+# public ``wandas.processing`` exports.  They still have stable operation names
+# in the runtime registry so persisted Recipe meanings have an explicit provider.
+_PRIVATE_LAZY_OPERATION_PROVIDERS = (
+    ("_recipe_cepstrum_v1", "wandas.processing.cepstral", "_RecipeCepstrumV1"),
+    ("_recipe_fft_v1", "wandas.processing.spectral", "_RecipeFFTV1"),
+    ("_recipe_ifft_v1", "wandas.processing.spectral", "_RecipeIFFTV1"),
+    ("_recipe_welch_v1", "wandas.processing.spectral", "_RecipeWelchV1"),
+    ("_recipe_noct_synthesis_v1", "wandas.processing.spectral", "_RecipeNOctSynthesisV1"),
+    ("_recipe_transfer_function_v1", "wandas.processing.spectral", "_RecipeTransferFunctionV1"),
+)
+
+for _operation_name, _module_name, _attribute_name in (
+    *_LAZY_OPERATION_CLASSES.values(),
+    *_PRIVATE_LAZY_OPERATION_PROVIDERS,
+):
+    register_lazy_operation(
+        _operation_name,
+        _module_name,
+        attribute_name=_attribute_name,
+    )
 
 
 def __getattr__(name: str) -> Any:
     lazy_operation = _LAZY_OPERATION_CLASSES.get(name)
     if lazy_operation is not None:
-        operation_name, _ = lazy_operation
+        operation_name, _, _ = lazy_operation
         operation_class = get_operation(operation_name)
         globals()[name] = operation_class
         return operation_class

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -517,11 +517,12 @@ def _validate_operation_class(
 ) -> type[AudioOperation[Any, Any]]:
     """Validate an operation name and its concrete ``AudioOperation`` class."""
     expected = f"a concrete {AudioOperation.__name__} subclass"
-    name_context = (
-        f"Operation name {name!r}"
-        if isinstance(name, str) and name.strip()
-        else f"Operation name {name!r} (expected a non-blank str)"
-    )
+    if isinstance(name, str):
+        name_context = (
+            f"Operation name {name!r}" if name.strip() else f"Operation name {name!r} (expected a non-blank str)"
+        )
+    else:
+        name_context = f"Operation name <unavailable> (got {name!r}; expected a non-blank str)"
 
     if not inspect.isclass(operation_class):
         raise TypeError(

--- a/wandas/processing/base.py
+++ b/wandas/processing/base.py
@@ -4,8 +4,10 @@ import inspect
 import logging
 from collections import defaultdict
 from collections.abc import Callable, Iterator, Mapping, MutableMapping
+from dataclasses import dataclass
 from functools import wraps
-from typing import Any, ClassVar, Generic, NoReturn, TypeVar, cast
+from threading import Lock
+from typing import Any, ClassVar, Generic, NoReturn, TypeAlias, TypeVar, cast
 
 import dask.array as da
 import numpy as np
@@ -478,42 +480,221 @@ def _try_build_channelwise_graph(
     return da.concatenate(channel_results, axis=0)
 
 
-# Automatically collect operation types and corresponding classes
-_OPERATION_REGISTRY: dict[str, type[AudioOperation[Any, Any]]] = {}
-_OPERATION_MODULES: dict[str, str] = {}
+@dataclass(frozen=True, slots=True)
+class _EagerOperationProvider:
+    """Provider for an operation class that is already imported."""
+
+    operation_class: type[AudioOperation[Any, Any]]
 
 
-def register_operation(operation_class: type) -> None:
-    """Register a new operation type"""
+@dataclass(frozen=True, slots=True)
+class _LazyOperationProvider:
+    """Provider for an operation class exposed by a module attribute."""
 
-    if not issubclass(operation_class, AudioOperation):
-        raise TypeError("Strategy class must inherit from AudioOperation.")
-    if inspect.isabstract(operation_class):
-        raise TypeError("Cannot register abstract AudioOperation class.")
-
-    existing = _OPERATION_REGISTRY.get(operation_class.name)
-    if (
-        existing is not None
-        and existing.__module__ == operation_class.__module__
-        and existing.__qualname__ == operation_class.__qualname__
-    ):
-        return
-
-    _OPERATION_REGISTRY[operation_class.name] = operation_class
+    module_name: str
+    attribute_name: str
 
 
-def register_lazy_operation(name: str, module_name: str) -> None:
-    """Register an operation that can be loaded from *module_name* on demand."""
-    _OPERATION_MODULES[name] = module_name
+_OperationProvider: TypeAlias = _EagerOperationProvider | _LazyOperationProvider
+
+_OPERATION_PROVIDERS: dict[str, _OperationProvider] = {}
+_OPERATION_CACHE: dict[str, type[AudioOperation[Any, Any]]] = {}
+_OPERATION_LOCK = Lock()
+
+
+def _validate_nonblank_string(value: object, *, field_name: str) -> str:
+    """Validate and return a required non-blank string field."""
+    if not isinstance(value, str):
+        raise TypeError(f"Invalid {field_name}: got {value!r} ({type(value).__name__}); expected a non-blank str.")
+    if not value.strip():
+        raise ValueError(f"Invalid {field_name}: got {value!r}; expected a non-blank str.")
+    return value
+
+
+def _validate_operation_class(
+    name: object,
+    operation_class: object,
+) -> type[AudioOperation[Any, Any]]:
+    """Validate an operation name and its concrete ``AudioOperation`` class."""
+    expected = f"a concrete {AudioOperation.__name__} subclass"
+    name_context = (
+        f"Operation name {name!r}"
+        if isinstance(name, str) and name.strip()
+        else f"Operation name {name!r} (expected a non-blank str)"
+    )
+
+    if not inspect.isclass(operation_class):
+        raise TypeError(
+            f"Invalid Operation class for {name_context}: got "
+            f"{operation_class!r} ({type(operation_class).__name__}); expected {expected}."
+        )
+
+    candidate = cast(type[AudioOperation[Any, Any]], operation_class)
+    try:
+        is_audio_operation = issubclass(candidate, AudioOperation)
+    except TypeError as exc:
+        raise TypeError(f"Invalid Operation class for {name_context}: got {candidate!r}; expected {expected}.") from exc
+    if not is_audio_operation:
+        raise TypeError(f"Invalid Operation class for {name_context}: got {candidate!r}; expected {expected}.")
+    if inspect.isabstract(candidate):
+        raise TypeError(
+            f"Cannot register abstract Operation class for {name_context}: class is abstract; "
+            f"got {candidate!r}; expected {expected}."
+        )
+
+    class_name = getattr(candidate, "name", None)
+    if not isinstance(class_name, str) or not class_name.strip():
+        raise ValueError(
+            f"Invalid Operation class for {name_context}: got {candidate!r} "
+            f"with name={class_name!r}; expected operation_class.name to be a "
+            "non-blank str equal to the registered Operation name."
+        )
+    operation_name = _validate_nonblank_string(name, field_name="Operation name")
+    if class_name != operation_name:
+        raise ValueError(
+            f"Invalid Operation class for {operation_name!r}: got {candidate!r} "
+            f"with name={class_name!r}; expected operation_class.name to equal "
+            f"{operation_name!r}."
+        )
+    return candidate
+
+
+def _provider_description(provider: _OperationProvider) -> str:
+    """Describe a provider in a registration conflict message."""
+    if isinstance(provider, _EagerOperationProvider):
+        return f"eager class {provider.operation_class!r}"
+    return f"lazy module {provider.module_name!r} attribute {provider.attribute_name!r}"
+
+
+def _raise_provider_conflict(
+    name: str,
+    existing: _OperationProvider,
+    requested: str,
+) -> NoReturn:
+    """Raise an actionable error for a name already owned by another provider."""
+    raise ValueError(
+        f"Operation name {name!r} is already owned by {_provider_description(existing)}; "
+        f"cannot register {requested}. Use a unique Operation name or keep the "
+        "existing provider declaration."
+    )
+
+
+def register_operation(
+    operation_class: type[AudioOperation[Any, Any]],
+) -> None:
+    """Register a concrete eager ``AudioOperation`` class.
+
+    The class's ``name`` is its single provider key. Re-registering the exact
+    same class object is idempotent; another class or a lazy provider owning the
+    same name is rejected.
+    """
+    declared_name = getattr(operation_class, "name", None) if inspect.isclass(operation_class) else None
+    validated_class = _validate_operation_class(declared_name, operation_class)
+    operation_name = validated_class.name
+    provider = _EagerOperationProvider(validated_class)
+
+    with _OPERATION_LOCK:
+        existing = _OPERATION_PROVIDERS.get(operation_name)
+        if existing is None:
+            _OPERATION_PROVIDERS[operation_name] = provider
+            _OPERATION_CACHE[operation_name] = validated_class
+            return
+        if isinstance(existing, _EagerOperationProvider) and existing.operation_class is validated_class:
+            return
+    _raise_provider_conflict(
+        operation_name,
+        existing,
+        f"eager class {validated_class!r}",
+    )
+
+
+def register_lazy_operation(
+    name: str,
+    module_name: str,
+    *,
+    attribute_name: str,
+) -> None:
+    """Register a lazy operation provider using an explicit module attribute.
+
+    Registration stores ``module_name`` and the required keyword-only
+    ``attribute_name`` without importing the module. The referenced class must
+    expose a non-blank ``name`` equal to *name* when it is resolved. Only the
+    exact same provider declaration may be registered more than once.
+    """
+    operation_name = _validate_nonblank_string(name, field_name="Operation name")
+    provider_module = _validate_nonblank_string(module_name, field_name="module name")
+    provider_attribute = _validate_nonblank_string(attribute_name, field_name="attribute name")
+    provider = _LazyOperationProvider(provider_module, provider_attribute)
+
+    with _OPERATION_LOCK:
+        existing = _OPERATION_PROVIDERS.get(operation_name)
+        if existing is None:
+            _OPERATION_PROVIDERS[operation_name] = provider
+            return
+        if (
+            isinstance(existing, _LazyOperationProvider)
+            and existing.module_name == provider.module_name
+            and existing.attribute_name == provider.attribute_name
+        ):
+            return
+    _raise_provider_conflict(
+        operation_name,
+        existing,
+        f"lazy module {provider.module_name!r} attribute {provider.attribute_name!r}",
+    )
 
 
 def get_operation(name: str) -> type[AudioOperation[Any, Any]]:
-    """Get operation class by name"""
-    if name not in _OPERATION_REGISTRY and name in _OPERATION_MODULES:
-        importlib.import_module(_OPERATION_MODULES[name])
-    if name not in _OPERATION_REGISTRY:
-        raise ValueError(f"Unknown operation type: {name}")
-    return _OPERATION_REGISTRY[name]
+    """Resolve and return a registered ``AudioOperation`` class by name."""
+    operation_name = _validate_nonblank_string(name, field_name="Operation name")
+
+    with _OPERATION_LOCK:
+        cached = _OPERATION_CACHE.get(operation_name)
+        if cached is not None:
+            return cached
+        provider = _OPERATION_PROVIDERS.get(operation_name)
+
+    if provider is None:
+        raise ValueError(
+            f"Unknown operation type: {operation_name!r}. Register it with "
+            "register_operation() or register_lazy_operation()."
+        )
+
+    if isinstance(provider, _EagerOperationProvider):
+        operation_class = provider.operation_class
+    else:
+        module = importlib.import_module(provider.module_name)
+        try:
+            candidate = getattr(module, provider.attribute_name)
+        except AttributeError as exc:
+            raise AttributeError(
+                f"Could not resolve Operation {operation_name!r}: module "
+                f"{provider.module_name!r} has no attribute "
+                f"{provider.attribute_name!r}; expected that attribute to expose "
+                f"a concrete {AudioOperation.__name__} subclass."
+            ) from exc
+        try:
+            operation_class = _validate_operation_class(operation_name, candidate)
+        except (TypeError, ValueError) as exc:
+            raise type(exc)(
+                f"Invalid lazy Operation provider for {operation_name!r}: "
+                f"module {provider.module_name!r}, attribute "
+                f"{provider.attribute_name!r} provided {candidate!r}; {exc}"
+            ) from exc
+
+    with _OPERATION_LOCK:
+        cached = _OPERATION_CACHE.get(operation_name)
+        if cached is not None:
+            if cached is operation_class:
+                return cached
+        else:
+            _OPERATION_CACHE[operation_name] = operation_class
+            return operation_class
+    raise ValueError(
+        f"Operation name {operation_name!r} was resolved to conflicting "
+        f"class objects: cache contains {cached!r}, while provider "
+        f"resolved {operation_class!r}."
+    )
 
 
 def create_operation(name: str, sampling_rate: float, **params: Any) -> AudioOperation[Any, Any]:

--- a/wandas/processing/cepstral.py
+++ b/wandas/processing/cepstral.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 import numpy as np
 from scipy.signal import get_window
 
-from wandas.processing.base import AudioOperation, register_operation
+from wandas.processing.base import AudioOperation
 from wandas.processing.spectral import _normalize_rfft_amplitude
 from wandas.utils.types import NDArrayComplex, NDArrayReal
 
@@ -531,10 +531,6 @@ class SpectralEnvelope(AudioOperation[NDArrayReal, NDArrayComplex]):
         envelope = np.exp(np.real(log_envelope))
         restored_axis = np.moveaxis(envelope, -1, axis)
         return np.asarray(restored_axis, dtype=np.complex128)
-
-
-for _operation in (Cepstrum, SpectrogramCepstrum, Lifter, SpectralEnvelope):
-    register_operation(_operation)
 
 
 __all__ = [

--- a/wandas/processing/psychoacoustic.py
+++ b/wandas/processing/psychoacoustic.py
@@ -11,7 +11,7 @@ from typing import Any, ClassVar, overload
 
 import numpy as np
 
-from wandas.processing.base import AudioOperation, get_operation, register_operation
+from wandas.processing.base import AudioOperation
 from wandas.utils.optional_imports import require_mosqito_sq_metric
 from wandas.utils.types import NDArrayReal
 
@@ -110,11 +110,6 @@ def _validate_sharpness_params(weighting: str, field_type: str) -> None:
         raise ValueError(
             f"Invalid field type\n  Got: '{field_type}'\n  Expected: 'free' or 'diffuse'\nUse a supported field type"
         )
-
-
-def _register_canonical(operation_class: type[AudioOperation[Any, Any]]) -> None:
-    register_operation(operation_class)
-    globals()[operation_class.__name__] = get_operation(operation_class.name)
 
 
 class _PsychoacousticOperation(AudioOperation[NDArrayReal, NDArrayReal]):
@@ -244,10 +239,6 @@ class LoudnessZwtv(_ZwickerTimeVaryingBase):
         return _process_per_channel(x, _compute)
 
 
-# Register the operation
-_register_canonical(LoudnessZwtv)
-
-
 class LoudnessZwst(_SteadyStateBase):
     """
     Calculate steady-state loudness using Zwicker method (ISO 532-1:2017).
@@ -334,10 +325,6 @@ class LoudnessZwst(_SteadyStateBase):
             return float(loudness_n)
 
         return _process_per_channel(x, _compute, scalar=True)
-
-
-# Register the operation
-_register_canonical(LoudnessZwst)
 
 
 class _RoughnessBase(_PsychoacousticOperation):
@@ -471,10 +458,6 @@ class RoughnessDw(_RoughnessBase):
         return _process_per_channel(x, _compute)
 
 
-# Register the operation
-_register_canonical(RoughnessDw)
-
-
 class RoughnessDwSpec(_RoughnessBase):
     """Specific roughness (R_spec) operation.
 
@@ -584,10 +567,6 @@ class RoughnessDwSpec(_RoughnessBase):
         return np.stack(r_spec_list, axis=0)
 
 
-# Register the operation
-_register_canonical(RoughnessDwSpec)
-
-
 class SharpnessDin(_ZwickerTimeVaryingBase):
     """
     Calculate time-varying sharpness using DIN 45692 method.
@@ -689,10 +668,6 @@ class SharpnessDin(_ZwickerTimeVaryingBase):
             return sharpness_s
 
         return _process_per_channel(x, _compute)
-
-
-# Register the operation
-_register_canonical(SharpnessDin)
 
 
 class SharpnessDinSt(_SteadyStateBase):
@@ -801,7 +776,3 @@ class SharpnessDinSt(_SteadyStateBase):
             )
 
         return _process_per_channel(x, _compute, scalar=True)
-
-
-# Register the operation
-_register_canonical(SharpnessDinSt)

--- a/wandas/processing/spectral.py
+++ b/wandas/processing/spectral.py
@@ -8,7 +8,7 @@ from dask.array.core import Array as DaArray
 from scipy.signal import ShortTimeFFT
 from scipy.signal.windows import get_window
 
-from wandas.processing.base import AudioOperation, ChannelIndependentAudioOperation, register_operation
+from wandas.processing.base import AudioOperation, ChannelIndependentAudioOperation
 from wandas.processing.spectral_contracts import (
     as_output_input_pairs,
     flatten_output_input_pairs,
@@ -1371,19 +1371,3 @@ class _RecipeTransferFunctionV1(TransferFunction):
         )
         h_f = p_yx / p_xx[np.newaxis, :, :]
         return h_f.transpose(1, 0, 2).reshape(-1, h_f.shape[-1])
-
-
-# Register all operations
-for op_class in [
-    FFT,
-    IFFT,
-    STFT,
-    ISTFT,
-    Welch,
-    NOctSpectrum,
-    NOctSynthesis,
-    Coherence,
-    CSD,
-    TransferFunction,
-]:
-    register_operation(op_class)

--- a/wandas/processing/temporal.py
+++ b/wandas/processing/temporal.py
@@ -1234,6 +1234,15 @@ class _RecipeSoundLevelV1(SoundLevel):
         return np.asarray(result, dtype=output_dtype)
 
 
-# Register all operations
-for op_class in [ReSampling, Trim, RmsTrend, FixLength, SoundLevel]:
+# Register all operations, including the private Recipe v1 implementations
+# used directly by replay handlers.
+for op_class in [
+    ReSampling,
+    Trim,
+    RmsTrend,
+    FixLength,
+    SoundLevel,
+    _RecipeRmsTrendV1,
+    _RecipeSoundLevelV1,
+]:
     register_operation(op_class)


### PR DESCRIPTION
## Summary

- Replace lazy Operation module-import self-registration with explicit module/attribute providers.
- Use `_OPERATION_PROVIDERS` as the single Operation-name ownership mapping and `_OPERATION_CACHE` only as its resolved-class cache.
- Centralize eager and lazy class validation, collision handling, cache publication, and actionable resolution errors.
- Remove lazy-module registry mutation and add focused provider, identity, Recipe replay, failure-atomicity, and concurrency contracts.

## Why

Lazy implementation modules are now ordinary Python imports. Provider declaration happens explicitly in `wandas.processing`, and resolution publishes a class only after import, attribute lookup, and validation succeed. No import rollback, `sys.modules` cleanup, activation manager, import hook, stack inspection, or special activation path is involved.

## Provider contract

- Eager providers and lazy providers share `_OPERATION_PROVIDERS`; one Operation name has one owner.
- Re-registering the identical eager class object or identical lazy `(module_name, attribute_name)` provider is a no-op.
- Any other eager/eager, lazy/lazy, or eager/lazy collision raises an actionable `ValueError` without changing provider or cache state.
- Lazy registration requires explicit keyword-only `attribute_name` and does not import the module.
- Lazy resolution imports and validates outside the registry lock, then atomically publishes the validated class to the cache.
- Import errors retain their original exception; missing attributes and validation failures identify the Operation, module, and attribute.
- Hot reload and class replacement are outside the registry contract.

## Built-in / Recipe provider inventory

The pre-change inventory covered all eager modules, public lazy exports, and private Recipe replay implementations.

- Built-in eager providers: 22 (20 public built-ins plus `_RecipeRmsTrendV1` and `_RecipeSoundLevelV1`).
- Built-in lazy providers: 26 (20 public lazy exports plus six private Recipe v1 providers).
- Public lazy providers: 20.
- Private Recipe replay providers: 8 total (six lazy and two eager).
- Private lazy Recipe names: `_recipe_cepstrum_v1`, `_recipe_fft_v1`, `_recipe_ifft_v1`, `_recipe_welch_v1`, `_recipe_noct_synthesis_v1`, and `_recipe_transfer_function_v1`.

The direct-import `wandas.processing.custom` extension remains an eager extension registration and is not included in the built-in counts.

## Concurrency model

The implementation uses one short `Lock` only for provider/cache dictionary reads and cache publication. Arbitrary module import, attribute lookup, and class validation never run while the lock is held. Concurrent callers resolving the same class converge on the first published class; a different class object produces an explicit conflict. No condition variable, owner thread, nested activation, rollback state, or import cleanup is used.

## Public API migration

`register_lazy_operation(name, module_name, *, attribute_name)` is now the required public helper signature. The former two-argument import-side-effect form has no fallback or compatibility shim. Extension authors must remove module-level `register_operation()` calls from lazy modules, declare the module and attribute explicitly, and keep `OperationClass.name == name`. Built-in lazy imports, `get_operation()`, `create_operation()`, and Recipe replay usage remain available.

## Explicit non-goals

- No public manifest redesign, plugin discovery, entry points, or uninstall API.
- No hot-reload support, class replacement, module rollback, or general module-side-effect management.
- No Frame, WDF, Recipe schema, or numerical algorithm changes.

## Validation

- Provider contract: `40 passed`.
- Focused normal and reverse suites: `1514 passed` each.
- Public lazy identity smoke: passed for Cepstrum, Coherence, and RoughnessDw.
- Full Python 3.10 serial: `3378 passed, 3 skipped`.
- Full Python 3.10 xdist: `3378 passed, 3 skipped`.
- Lockfile-based Python 3.14 xdist: `3372 passed, 9 skipped`.
- Ruff format/check, ty, public docstring check, marimo check, Learning Path i18n/export contracts, strict MkDocs, and core-only wheel install smoke: passed.
- `bash scripts/test_pyodide.sh`: not runnable in this environment because Node.js is not installed; the script exits before tests begin.

## Compatibility impact

The only intentional public API break is the required keyword-only `attribute_name` for `register_lazy_operation()`. Built-in lazy public class imports and runtime/Recipe resolution behavior are preserved. Failed registration or resolution leaves the provider mapping and resolved-class cache unchanged.

## Why rollback is no longer needed

Provider ownership is explicit and stable before resolution. A lazy module does not mutate the registry, and the cache is updated only after successful class lookup and validation. Therefore failed imports do not require import-side-effect transactions, `sys.modules` snapshots, public-attribute rollback, or cleanup machinery.

Closes #430.
Completes the remaining Operation-registration scope of #424.
