### PR TITLE
docs: expose English Learning Path entry points

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -233,8 +233,9 @@ Wandas は、特に次のような場面で便利です。
 ## 次に読む
 
 - [公式ドキュメント](https://kasahart.github.io/wandas/) - ガイド、API リファレンス、使用例。
-- [学習パス](https://github.com/kasahart/wandas/tree/main/learning-path/) - marimo アプリベースのステップ別チュートリアル。
-- [チュートリアル](https://kasahart.github.io/wandas/tutorial/) - 基本ワークフローを順に確認できます。
+- [5分チュートリアル](https://kasahart.github.io/wandas/tutorial/) - 基本ワークフローを順に確認できます。
+- [日本語 Learning Path](https://kasahart.github.io/wandas/learning-path/00_why_wandas.html) - 公開済みの00から学習順に進めます。
+- [Learning Path のソース](https://github.com/kasahart/wandas/tree/main/learning-path/) - 公開教材の元になっている marimo ファイルです。
 - [Issue Tracker](https://github.com/kasahart/wandas/issues) - バグ報告や機能提案。
 
 ## プロジェクトの状態

--- a/README.md
+++ b/README.md
@@ -240,8 +240,9 @@ Wandas is especially useful when you want to:
 ## Learn More
 
 - [Documentation](https://kasahart.github.io/wandas/) - Guides, API reference, and examples.
-- [Learning Path](https://github.com/kasahart/wandas/tree/main/learning-path/) - Step-by-step marimo learning apps.
-- [Tutorial](https://kasahart.github.io/wandas/tutorial/) - A guided walkthrough of the core workflow.
+- [Five-minute Tutorial](https://kasahart.github.io/wandas/tutorial/) - A guided walkthrough of the core workflow.
+- [English Learning Path](https://kasahart.github.io/wandas/en/learning-path/00_why_wandas.html) - Start the executed English lessons at 00 and continue in order.
+- [Learning Path source files](https://github.com/kasahart/wandas/tree/main/learning-path/) - The marimo source behind the published lessons.
 - [Issue Tracker](https://github.com/kasahart/wandas/issues) - Report bugs or propose ideas.
 
 ## Project Status

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,9 +8,11 @@ library, understand its contracts, and contribute to it.
 
 - **Try Wandas first:** complete the [five-minute Tutorial](tutorial/index.md)
   to create, process, and visualize a signal.
-- **Continue learning:** proceed through the executable
-  <a href="learning-path/01_getting_started.html">Learning Path</a>, starting
-  with Getting Started.
+- **Continue learning in English:** start the executable
+  <a href="en/learning-path/00_why_wandas.html">English Learning Path</a> at 00
+  and continue in order.
+- **日本語で学ぶ:** <a href="learning-path/00_why_wandas.html">日本語 Learning Path</a>
+  を00から順番に進めてください。
 - **Complete a task:** start with a [How-to guide](how-to/cepstral-analysis.md).
 - **Check an API contract:** open the [API Reference](api/index.md), generated
   from Python docstrings.

--- a/docs/src/tutorial/index.md
+++ b/docs/src/tutorial/index.md
@@ -186,7 +186,7 @@ you want another view, while the original Frame remains available for reuse.
 
 Continue with the executable
 <a href="../en/learning-path/00_why_wandas.html">English Learning Path</a>.
-Start at 00 and continue in manifest order toward real data and signal-processing basics.
+Start at 00 and continue in order toward real data and signal-processing basics.
 
 次は、実行可能な
 <a href="../learning-path/00_why_wandas.html">日本語 Learning Path</a>

--- a/docs/src/tutorial/index.md
+++ b/docs/src/tutorial/index.md
@@ -185,12 +185,12 @@ you want another view, while the original Frame remains available for reuse.
 ## Next step / 次のステップ
 
 Continue with the executable
-<a href="../learning-path/01_getting_started.html">Getting Started Learning Path</a>.
-It leads into working with real data and signal-processing basics.
+<a href="../en/learning-path/00_why_wandas.html">English Learning Path</a>.
+Start at 00 and continue in manifest order toward real data and signal-processing basics.
 
 次は、実行可能な
-<a href="../learning-path/01_getting_started.html">Getting Started Learning Path</a>
-へ進んでください。実データの読み込み、基本的な信号処理へ順番に進めます。
+<a href="../learning-path/00_why_wandas.html">日本語 Learning Path</a>
+を00から順番に進めてください。実データの読み込み、基本的な信号処理へ進みます。
 
 For a specific task or API contract, use the
 [How-to guide](../how-to/cepstral-analysis.md) or

--- a/tests/docs/test_tutorial_contract.py
+++ b/tests/docs/test_tutorial_contract.py
@@ -1,4 +1,5 @@
 import os
+import posixpath
 import re
 import subprocess
 import sys
@@ -6,6 +7,8 @@ from html.parser import HTMLParser
 from pathlib import Path
 
 import pytest
+
+from scripts.learning_path_i18n import load_manifest, output_path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MKDOCS_CONFIG = REPO_ROOT / "docs/mkdocs.yml"
@@ -82,6 +85,15 @@ def _has_href(hrefs: list[str], fragment: str) -> bool:
     return any(fragment in href for href in hrefs)
 
 
+def _normalized_learning_path_target(site_dir: Path, page: Path, href: str) -> str | None:
+    """Normalize a local Learning Path href against its generated page."""
+    if href.startswith(("http://", "https://")) or "learning-path/" not in href:
+        return None
+    href_without_fragment = href.split("#", 1)[0]
+    relative_page = page.relative_to(site_dir)
+    return posixpath.normpath(posixpath.join(relative_page.parent.as_posix(), href_without_fragment))
+
+
 def test_tutorial_build_contains_executed_code_and_inline_svg(built_site: Path) -> None:
     """The tutorial's executable source and generated figures are the docs contract."""
     site_dir = built_site
@@ -118,17 +130,28 @@ def test_learning_path_navigation_contract(built_site: Path) -> None:
     assert "Five-minute Tutorial: tutorial/index.md" in config
 
     home_source = (REPO_ROOT / "docs/src/index.md").read_text(encoding="utf-8")
-    assert home_source.index("Try Wandas first") < home_source.index("Continue learning")
+    assert home_source.index("Try Wandas first") < home_source.index("Continue learning in English")
 
     home = built_site / "index.html"
     home_hrefs = _hrefs(home)
     assert _has_href(home_hrefs, "tutorial/")
-    assert _has_href(home_hrefs, "learning-path/01_getting_started.html")
+    assert _has_href(home_hrefs, "learning-path/00_why_wandas.html")
+    assert _has_href(home_hrefs, "en/learning-path/00_why_wandas.html")
 
     tutorial = built_site / "tutorial" / "index.html"
     tutorial_hrefs = _hrefs(tutorial)
-    assert _has_href(tutorial_hrefs, "learning-path/01_getting_started.html")
+    assert _has_href(tutorial_hrefs, "learning-path/00_why_wandas.html")
+    assert _has_href(tutorial_hrefs, "en/learning-path/00_why_wandas.html")
     assert not any("tutorial/pipeline-recipes" in href for href in tutorial_hrefs)
+
+    manifest_targets = {
+        output_path(Path(), lesson, locale).as_posix() for lesson in load_manifest() for locale in lesson.locales
+    }
+    for page, hrefs in ((home, home_hrefs), (tutorial, tutorial_hrefs)):
+        targets = {
+            target for href in hrefs if (target := _normalized_learning_path_target(built_site, page, href)) is not None
+        }
+        assert targets <= manifest_targets
 
     legacy_source = REPO_ROOT / "docs/src/tutorial/pipeline-recipes.md"
     legacy_text = legacy_source.read_text(encoding="utf-8")

--- a/tests/docs/test_tutorial_contract.py
+++ b/tests/docs/test_tutorial_contract.py
@@ -135,13 +135,9 @@ def test_learning_path_navigation_contract(built_site: Path) -> None:
     home = built_site / "index.html"
     home_hrefs = _hrefs(home)
     assert _has_href(home_hrefs, "tutorial/")
-    assert _has_href(home_hrefs, "learning-path/00_why_wandas.html")
-    assert _has_href(home_hrefs, "en/learning-path/00_why_wandas.html")
 
     tutorial = built_site / "tutorial" / "index.html"
     tutorial_hrefs = _hrefs(tutorial)
-    assert _has_href(tutorial_hrefs, "learning-path/00_why_wandas.html")
-    assert _has_href(tutorial_hrefs, "en/learning-path/00_why_wandas.html")
     assert not any("tutorial/pipeline-recipes" in href for href in tutorial_hrefs)
 
     manifest_targets = {
@@ -152,6 +148,7 @@ def test_learning_path_navigation_contract(built_site: Path) -> None:
             target for href in hrefs if (target := _normalized_learning_path_target(built_site, page, href)) is not None
         }
         assert targets <= manifest_targets
+        assert {"learning-path/00_why_wandas.html", "en/learning-path/00_why_wandas.html"} <= targets
 
     legacy_source = REPO_ROOT / "docs/src/tutorial/pipeline-recipes.md"
     legacy_text = legacy_source.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Make the published English Learning Path discoverable from the README, Docs Home, and five-minute Tutorial while keeping the Japanese entry path explicit.

### Entry changes

- README.md now separates Documentation, Five-minute Tutorial, English Learning Path, and Learning Path source files.
- The English README points to `https://kasahart.github.io/wandas/en/learning-path/00_why_wandas.html`.
- README.ja.md points to the Japanese `00_why_wandas.html` entry and keeps the source-files link distinct.
- Docs Home and the Tutorial route English text to English lesson 00 and Japanese text to Japanese lesson 00.

### Regression contract

The docs contract test now derives valid lesson export targets from `learning-path/manifest.json`, checks both locale entry links, and rejects local Learning Path links outside the manifest export set.

## Validation

- `uv run pytest tests/docs -q --no-cov`
- `uv run mkdocs build --strict -f docs/mkdocs.yml`
- `uv run marimo check --strict learning-path/*.py`
- translated Learning Path export and HTML validation
- `uv run ruff format --check wandas tests scripts learning-path`
- `uv run ruff check wandas tests scripts learning-path`
- `uv run ty check wandas tests scripts learning-path`
- `git diff --check`

No Learning Path source, catalog, or manifest locale declarations are changed.