### PR TITLE
docs: translate Learning Path 08

### DIFF
--- a/learning-path/08_metadata_driven_dataset_search.py
+++ b/learning-path/08_metadata_driven_dataset_search.py
@@ -4,216 +4,229 @@ __generated_with = "0.23.9"
 app = marimo.App()
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _():
-    # この教材で使用するライブラリを読み込む
-    import pathlib
-
     import marimo as mo
-    import pandas as pd
 
-    import wandas as wd
+    from scripts.learning_path_i18n import (
+        docs_relative_href,
+        language_switch_markdown,
+        load_catalog,
+        locale_from_argv,
+        navigation_markdown,
+    )
 
-    return mo, pathlib, pd, wd
+    locale = locale_from_argv()
+    catalog = load_catalog("08_metadata_driven_dataset_search", locale)
+
+    def t(key, **values):
+        return catalog.text(key, **values)
+
+    return docs_relative_href, language_switch_markdown, locale, mo, navigation_markdown, t
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    # メタデータで必要な音声ファイルだけを選ぶ
+def _(mo, t):
+    mo.md(f"# {t('title')}\n\n{t('intro')}")
+    return
 
-    録音ファイルが増えると、「どのファイルを処理するか」を決めるだけでも時間がかかります。
-    対象を選ぶために、すべての波形を先に読み込む必要はありません。フォルダ名やファイル名、
-    CSVに記録した属性を使えば、必要なファイルだけを絞り込んでから信号処理を始められます。
 
-    フォルダでグループや収録単位を分けている場合は、`path_metadata=True` を指定するだけで
-    相対パスからメタデータを推論できます。`dataset.select()` はそのメタデータを完全一致で
-    検索します。独自の解析コードを書かずに、必要なファイルだけを選べます。
-
-    3件の短い合成WAVとsidecar CSVからなるデモデータを同梱しているため、
-    手元のWAVやCSVは必要ありません。
-
-    このチュートリアルでは次の流れを実行します。
-
-    1. グループと収録単位で分けた同梱サンプルを確認する
-    2. `path_metadata=True` でフォルダ階層をメタデータにする
-    3. ファイルを選択する
-    4. Dataset全体に処理チェーンを定義してからファイルを選択する
-    5. 外部属性が必要な場合だけsidecar CSVをlookupとして利用する
-    """)
+@app.cell(hide_code=True)
+def _(language_switch_markdown, locale, mo):
+    mo.md(language_switch_markdown("08_metadata_driven_dataset_search", locale))
     return
 
 
 @app.cell
+def _():
+    import pathlib
+
+    import pandas as pd
+
+    import wandas as wd
+
+    return pathlib, pd, wd
+
+
+@app.cell
 def _(pathlib):
-    # リポジトリに同梱されたデモデータの場所と件数を確認する
     root = pathlib.Path(__file__).parent / "data" / "metadata_search"
     _relative_paths = sorted(path.relative_to(root) for path in root.rglob("*.wav"))
-
-    print(f"同梱データセット: {root}")
-    print(f"WAV: {len(_relative_paths)}件")
-    return (root,)
+    file_count = len(_relative_paths)
+    assert file_count == 3
+    return file_count, root
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 1. パス由来メタデータで選択する
+def _(file_count, mo, root, t):
+    mo.md(t("discovery_result", root=root, count=file_count))
+    return
 
-    この例では `group/batch/filename.wav` という単純なフォルダ規則を使います。
-    `path_metadata=True` を指定すると、通常のフォルダ名はルートから順に
-    `partition_0`、`partition_1` というキーになります。
 
-    サンプルのフォルダ構造は次のとおりです。
-
-    ```text
-    demo_folder/
-    ├── group_a/
-    │   ├── batch_01/
-    │   │   └── recording_001.wav
-    │   └── batch_02/
-    │       └── recording_002.wav
-    └── group_b/
-        └── batch_01/
-            └── recording_003.wav
-    ```
-
-    たとえば `group_a/batch_01/recording_001.wav` には
-    `{"partition_0": "group_a", "partition_1": "batch_01"}` が付きます。
-    ルートフォルダとファイル名は対象外です。この推論は相対パスだけを調べ、音声ファイルを開きません。
-    """)
+@app.cell(hide_code=True)
+def _(mo, t):
+    mo.md(t("path_metadata_section"))
     return
 
 
 @app.cell
 def _(root, wd):
-    # フォルダ階層をメタデータとして推論するDatasetを作る
     dataset = wd.from_folder(
         str(root),
         recursive=True,
         file_extensions=[".wav"],
         path_metadata=True,
     )
-    print("見つかったWAVファイル:", len(dataset), "件")
+    assert dataset.get_metadata()["lazy_loading"] is True
     return (dataset,)
+
+
+@app.cell(hide_code=True)
+def _(dataset, mo, t):
+    dataset_metadata = dataset.get_metadata()
+    mo.md(
+        t(
+            "dataset_result",
+            count=len(dataset),
+            lazy_loading=dataset_metadata["lazy_loading"],
+            loaded_count=dataset_metadata["loaded_count"],
+        )
+    )
+    return
 
 
 @app.cell
 def _(dataset):
-    # 1階層目と2階層目のフォルダ条件に一致するファイルだけを選択する
     selected = dataset.select(partition_0="group_a", partition_1="batch_01")
-    print("group_a / batch_01 に一致したファイル:", len(selected), "件")
+    assert len(selected) == 1
     return (selected,)
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    `select()` の複数条件はAND、値は完全一致です。未知のキーはタイプミスとして
-    `KeyError` になり、一致しない条件は長さ0の有効なDatasetを返します。
+def _(mo, selected, t):
+    mo.md(t("selection_result", count=len(selected)))
+    return
 
-    ### 遅延読み込み
 
-    Wandasは、必要になった段階でファイルの内容を読み込みます。処理は次の3段階に分かれます。
+@app.cell
+def _(dataset):
+    try:
+        dataset.select(missing_key="value")
+    except KeyError as error:
+        unknown_key_error = type(error).__name__
+    else:
+        raise AssertionError("Unknown metadata keys must raise KeyError")
 
-    1. `from_folder()` と `select()`：パスとメタデータだけを使って候補を絞る
-    2. `selected[0]`：選んだファイルの音声ヘッダーを読み、Frameを作る
-    3. `frame.data`：選んだファイルの波形サンプルを実際に読み込む
+    empty_selection = dataset.select(partition_0="missing_group")
+    assert len(empty_selection) == 0
+    return empty_selection, unknown_key_error
 
-    `loaded_count` は、これまでにFrame作成を試みたファイル数です（失敗して `None` になった項目も
-    含みます）。`select()` の直後は0件で、ここで使う正常なサンプルでは `selected[0]` を実行すると
-    1件になります。つまり、選択だけでは音声ヘッダーや波形を読みません。
-    """)
+
+@app.cell(hide_code=True)
+def _(empty_selection, mo, t, unknown_key_error):
+    mo.md(
+        t(
+            "selection_contract",
+            error=unknown_key_error,
+            empty_count=len(empty_selection),
+        )
+    )
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo, t):
+    mo.md(t("lazy_loading_section"))
     return
 
 
 @app.cell
 def _(selected):
-    # selected[0]の前後でFrameの遅延読み込みを確認する
-    print("select()直後にFrame作成を試行済み:", selected.get_metadata()["loaded_count"], "件")
+    before_count = selected.get_metadata()["loaded_count"]
     selected_frame = selected[0]
-    assert selected_frame is not None, "選択した音声ファイルを読み込めませんでした"
-    print("selected[0]後にFrame作成を試行済み:", selected.get_metadata()["loaded_count"], "件")
-    return (selected_frame,)
+    assert selected_frame is not None
+    after_item_count = selected.get_metadata()["loaded_count"]
+    sample_values = selected_frame.data
+    after_data_count = selected.get_metadata()["loaded_count"]
+    assert before_count == 0
+    assert after_item_count == 1
+    assert after_data_count == after_item_count
+    sample_preview = sample_values[:5].tolist()
+    return after_data_count, after_item_count, before_count, sample_preview
 
 
-@app.cell
-def _(selected_frame):
-    # dataプロパティで波形サンプルを読み込む
-    samples = selected_frame.data
-    print("dataで読み込んだ波形の先頭5サンプル:", samples[:5])
+@app.cell(hide_code=True)
+def _(after_data_count, after_item_count, before_count, mo, sample_preview, t):
+    mo.md(
+        t(
+            "lazy_boundary_result",
+            before=before_count,
+            after_item=after_item_count,
+            after_data=after_data_count,
+            samples=sample_preview,
+        )
+    )
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ### Datasetに処理をまとめて定義してから選ぶ
-
-    ファイルを選んだ後に、1件ずつ `normalize()` や `stft()` を呼ぶ必要はありません。
-    Datasetに対して処理チェーンを定義すると、各ファイルへ同じ処理が自動的に適用されます。
-    メタデータは処理後のDatasetにも保持されるため、`normalize().stft()` の後でも
-    `select()` を使えます。要素へアクセスするとFrameと処理グラフが作られ、波形の読み込みと
-    数値計算は `data` にアクセスするまで遅延されます。
-    """)
+def _(mo, t):
+    mo.md(t("dataset_chaining_section"))
     return
 
 
 @app.cell
 def _(dataset):
-    # Dataset全体に処理を定義した後で、解析対象を選択する
     processed_dataset = dataset.normalize().stft(n_fft=128)
     processed_selected = processed_dataset.select(partition_0="group_a", partition_1="batch_01")
-    print("処理後に選択したファイル:", len(processed_selected), "件")
-    return (processed_selected,)
+    assert len(processed_selected) == 1
+    processed_frame = processed_selected[0]
+    assert processed_frame is not None
+    processed_values = processed_frame.data
+    assert processed_values.size > 0
+    assert processed_frame.metadata["partition_0"] == "group_a"
+    assert processed_frame.metadata["partition_1"] == "batch_01"
+    return processed_frame, processed_selected
 
 
-@app.cell
-def _(processed_selected):
-    # 処理後のFrameにも選択に使ったメタデータが保持されることを確認する
-    _selected_spectrogram = processed_selected[0]
-    assert _selected_spectrogram is not None
-
-    print("STFT後もpartition_0を保持:", _selected_spectrogram.metadata["partition_0"])
+@app.cell(hide_code=True)
+def _(mo, processed_frame, processed_selected, t):
+    mo.md(
+        t(
+            "transform_result",
+            count=len(processed_selected),
+            metadata=processed_frame.metadata["partition_0"],
+        )
+    )
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## 2. CSVのメタデータでファイルを選ぶ
-
-    フォルダ階層にない属性をCSVで管理している場合は、`metadata_resolver` で対象を選べます。
-    CSVを `pandas.read_csv()` でDataFrameとして読み、内容を表で表示した後、
-    lookup（パスをキーにした辞書）へ変換します。resolverは相対パスをキーにlookupを
-    参照するだけです。信号CSVを誤って音声として
-    読み込まないよう、`file_extensions=[".wav"]` を明示します。
-
-    この例は `lookup[path.as_posix()]` を使うため、CSVにないWAVがあればDataset構築時に
-    エラーになります。入力漏れに早く気づけるので、通常はこちらを推奨します。
-    """)
+def _(mo, t):
+    mo.md(t("csv_section"))
     return
 
 
 @app.cell
-def _(mo, pd, root):
-    # pandasで同梱CSVを読み込み、内容を表として表示する
-    sidecar_path = root / "recordings.csv"
-    recordings = pd.read_csv(sidecar_path)
-    mo.vstack([mo.md("**pandasで読み込んだ recordings.csv**"), recordings])
+def _(pd, root):
+    recordings = pd.read_csv(root / "recordings.csv")
     return (recordings,)
+
+
+@app.cell(hide_code=True)
+def _(mo, recordings, t):
+    mo.vstack([mo.md(t("csv_table")), recordings])
+    return
 
 
 @app.cell
 def _(recordings):
-    # DataFrameを相対パスから属性を引けるlookupへ変換する
     lookup = recordings.set_index("path")[["condition", "priority"]].to_dict(orient="index")
     return (lookup,)
 
 
 @app.cell
 def _(lookup, root, wd):
-    # CSV由来のメタデータを条件にファイルを選択する
     csv_dataset = wd.from_folder(
         str(root),
         recursive=True,
@@ -221,27 +234,26 @@ def _(lookup, root, wd):
         metadata_resolver=lambda path: lookup[path.as_posix()],
     )
     reference_files = csv_dataset.select(condition="reference", priority=1)
-    print("CSV条件に一致した件数:", len(reference_files))
+    assert len(reference_files) == 1
+    return (reference_files,)
+
+
+@app.cell(hide_code=True)
+def _(mo, reference_files, t):
+    mo.md(t("csv_result", count=len(reference_files)))
     return
 
 
 @app.cell(hide_code=True)
-def _(mo):
-    mo.md(r"""
-    ## まとめ
+def _(docs_relative_href, locale, mo, t):
+    api_link = f"[Frame Dataset utility reference]({docs_relative_href(locale, 'api/utils/')})"
+    mo.md(t("summary", api_link=api_link))
+    return
 
-    - フォルダ階層で選ぶ場合は、まず `path_metadata=True` を使う
-    - `select()` は波形を読む前に完全一致で絞り込む
-    - Dataset全体に `normalize()`、`stft()` などを定義してから選択できる
-    - パス由来メタデータはロードしたFrameと変換結果へ伝播する
-    - 外部属性が必要な場合だけ、CSVをlookupへ変換してresolver契約へ接続する
 
-    APIの詳細とエラー契約は
-    [Frame Dataset utility reference](../api/utils/)
-    を参照してください。
-
-    **前のmarimoアプリ**: [07_per_channel_calibration](07_per_channel_calibration.html)
-    """)
+@app.cell(hide_code=True)
+def _(locale, mo, navigation_markdown):
+    mo.md(navigation_markdown("08_metadata_driven_dataset_search", locale))
     return
 
 

--- a/learning-path/08_metadata_driven_dataset_search.py
+++ b/learning-path/08_metadata_driven_dataset_search.py
@@ -22,7 +22,7 @@ def _():
     def t(key, **values):
         return catalog.text(key, **values)
 
-    return docs_relative_href, language_switch_markdown, locale, mo, navigation_markdown, t
+    return catalog, docs_relative_href, language_switch_markdown, locale, mo, navigation_markdown, t
 
 
 @app.cell(hide_code=True)
@@ -51,15 +51,16 @@ def _():
 @app.cell
 def _(pathlib):
     root = pathlib.Path(__file__).parent / "data" / "metadata_search"
-    _relative_paths = sorted(path.relative_to(root) for path in root.rglob("*.wav"))
-    file_count = len(_relative_paths)
+    relative_paths = sorted(path.relative_to(root).as_posix() for path in root.rglob("*.wav"))
+    file_count = len(relative_paths)
     assert file_count == 3
-    return file_count, root
+    return file_count, relative_paths, root
 
 
 @app.cell(hide_code=True)
-def _(file_count, mo, root, t):
-    mo.md(t("discovery_result", root=root, count=file_count))
+def _(file_count, mo, relative_paths, root, t):
+    paths = "\n".join(f"- `{path}`" for path in relative_paths)
+    mo.md(t("discovery_result", root=root, count=file_count, paths=paths))
     return
 
 
@@ -191,11 +192,12 @@ def _(dataset):
 
 @app.cell(hide_code=True)
 def _(mo, processed_frame, processed_selected, t):
+    metadata = {key: processed_frame.metadata[key] for key in ("partition_0", "partition_1")}
     mo.md(
         t(
             "transform_result",
             count=len(processed_selected),
-            metadata=processed_frame.metadata["partition_0"],
+            metadata=metadata,
         )
     )
     return
@@ -245,8 +247,9 @@ def _(mo, reference_files, t):
 
 
 @app.cell(hide_code=True)
-def _(docs_relative_href, locale, mo, t):
-    api_link = f"[Frame Dataset utility reference]({docs_relative_href(locale, 'api/utils/')})"
+def _(catalog, docs_relative_href, locale, mo, t):
+    suffix = f" ({catalog.text('navigation.japanese_only')})" if locale == "en" else ""
+    api_link = f"[Frame Dataset utility reference{suffix}]({docs_relative_href(locale, 'api/utils/')})"
     mo.md(t("summary", api_link=api_link))
     return
 

--- a/learning-path/manifest.json
+++ b/learning-path/manifest.json
@@ -57,7 +57,8 @@
     {
       "id": "08_metadata_driven_dataset_search",
       "source": "learning-path/08_metadata_driven_dataset_search.py",
-      "locales": ["ja"]
+      "locales": ["ja", "en"],
+      "catalog": "08_metadata_driven_dataset_search.json"
     }
   ]
 }

--- a/learning-path/translations/08_metadata_driven_dataset_search.json
+++ b/learning-path/translations/08_metadata_driven_dataset_search.json
@@ -30,8 +30,18 @@
       ]
     },
     "discovery_result": {
-      "ja": ["同梱データセット: `[[root]]`（WAV [[count]]件）"],
-      "en": ["Bundled dataset: `[[root]]` ([[count]] WAV files)"]
+      "ja": [
+        "同梱データセット: `[[root]]`（WAV [[count]]件）",
+        "",
+        "相対pathから推論される階層:",
+        "[[paths]]"
+      ],
+      "en": [
+        "Bundled dataset: `[[root]]` ([[count]] WAV files)",
+        "",
+        "Hierarchy used for path metadata:",
+        "[[paths]]"
+      ]
     },
     "path_metadata_section": {
       "ja": [
@@ -114,19 +124,19 @@
       ]
     },
     "transform_result": {
-      "ja": ["変換後Datasetの選択件数: [[count]]、Frameに伝播したpartition: `[[metadata]]`"],
-      "en": ["Selected files after the transform: [[count]]; partition propagated to the Frame: `[[metadata]]`"]
+      "ja": ["変換後Datasetの選択件数: [[count]]、Frameへ伝播したpath metadata: `[[metadata]]`"],
+      "en": ["Selected files after the transform: [[count]]; path metadata propagated to the Frame: `[[metadata]]`"]
     },
     "csv_section": {
       "ja": [
         "## 3. sidecar CSVのmetadataで選ぶ",
         "",
-        "フォルダ階層にない属性は、`metadata_resolver`で相対pathからlookupできます。ここではCSVをDataFrameとして読み、pathをkeyにしたdictionaryへ変換します。resolverはDataset discovery時に呼ばれるため、信号CSVをWAVとして読むことはありません。"
+        "フォルダ階層にない属性は、`metadata_resolver`で相対pathからlookupできます。ここではCSVをDataFrameとして読み、pathをkeyにしたdictionaryへ変換します。`file_extensions=[\".wav\"]`がsidecar CSVをDataset候補から除外します。resolverは自分でファイルを絞り込むのではなく、WAV候補のdiscovery時に呼ばれます。filterを外すとdefaultのsupported formatsにCSVも含まれるため、`recordings.csv`まで発見されてlookupが失敗します。"
       ],
       "en": [
         "## 3. Select with sidecar CSV metadata",
         "",
-        "Attributes that are not encoded in folders can be resolved from a relative path with `metadata_resolver`. The example reads the CSV as a DataFrame and converts it to a path-keyed dictionary. The resolver runs during Dataset discovery, so the signal CSV is not treated as a WAV file."
+        "Attributes that are not encoded in folders can be resolved from a relative path with `metadata_resolver`. The example reads the CSV as a DataFrame and converts it to a path-keyed dictionary. The explicit `file_extensions=[\".wav\"]` filter excludes the sidecar CSV from Dataset candidates. The resolver does not filter files itself; it runs during discovery for the WAV candidates. Without the filter, the default supported formats include CSV, so `recordings.csv` would also be discovered and the lookup would fail."
       ]
     },
     "csv_table": {

--- a/learning-path/translations/08_metadata_driven_dataset_search.json
+++ b/learning-path/translations/08_metadata_driven_dataset_search.json
@@ -1,0 +1,165 @@
+{
+  "lesson": "08_metadata_driven_dataset_search",
+  "messages": {
+    "title": {
+      "ja": ["メタデータで必要な音声ファイルだけを選ぶ"],
+      "en": ["Select only the recordings you need with metadata"]
+    },
+    "intro": {
+      "ja": [
+        "録音ファイルが増えると、「どのファイルを処理するか」を決めるだけでも時間がかかります。すべての波形を先に読み込まず、フォルダ階層やsidecar CSVの属性で候補を選んでから信号処理を始められます。",
+        "",
+        "この教材では、`from_folder()` / `select()` → `dataset[index]` → `frame.data`という3つの境界を確認します。",
+        "",
+        "1. `path_metadata=True`で相対パスのparent directoryからmetadataを推論する",
+        "2. `select()`のAND / exact-match、unknown key、empty selectionを確認する",
+        "3. `lazy_loading`、`loaded_count`、Frame作成とwaveform materializationを区別する",
+        "4. Dataset-level operation chainingとmetadata propagationを確認する",
+        "5. 外部属性が必要な場合だけsidecar CSVを`metadata_resolver`へ接続する"
+      ],
+      "en": [
+        "As a recording collection grows, deciding which files to process can become work by itself. Use folder partitions or attributes from a sidecar CSV to select candidates before starting signal processing, without loading every waveform first.",
+        "",
+        "This lesson follows the three boundaries `from_folder()` / `select()` → `dataset[index]` → `frame.data`.",
+        "",
+        "1. Infer metadata from relative parent directories with `path_metadata=True`",
+        "2. Check the AND / exact-match contract of `select()`, including unknown keys and empty selections",
+        "3. Distinguish `lazy_loading`, `loaded_count`, Frame creation, and waveform materialization",
+        "4. Check Dataset-level operation chaining and metadata propagation",
+        "5. Connect a sidecar CSV to `metadata_resolver` only when external attributes are needed"
+      ]
+    },
+    "discovery_result": {
+      "ja": ["同梱データセット: `[[root]]`（WAV [[count]]件）"],
+      "en": ["Bundled dataset: `[[root]]` ([[count]] WAV files)"]
+    },
+    "path_metadata_section": {
+      "ja": [
+        "## 1. パス由来metadataで選択する",
+        "",
+        "`group/batch/filename.wav`のような通常のdirectory segmentは、rootから順に`partition_0`、`partition_1`というkeyになります。`group=group_a`のようなHive-style segmentは`group`をkeyにします。root folderとfilenameはmetadataに含まれません。",
+        "",
+        "path metadataの探索は相対pathだけを調べ、Frameを生成せず、audio headerやwaveform sampleも読みません。`path_metadata=True`と`metadata_resolver`は同時に指定できません。"
+      ],
+      "en": [
+        "## 1. Select with path-derived metadata",
+        "",
+        "A plain directory segment such as `group/batch/filename.wav` becomes `partition_0`, `partition_1`, and so on from the root. A Hive-style segment such as `group=group_a` uses `group` as its key. The root folder and filename are not included in metadata.",
+        "",
+        "Path metadata inspects relative paths only. It creates no Frame and reads neither audio headers nor waveform samples. `path_metadata=True` and `metadata_resolver` cannot be enabled together."
+      ]
+    },
+    "dataset_result": {
+      "ja": ["Dataset: [[count]]件、`lazy_loading=[[lazy_loading]]`、構築直後の`loaded_count=[[loaded_count]]`"],
+      "en": ["Dataset: [[count]] files, `lazy_loading=[[lazy_loading]]`, and `loaded_count=[[loaded_count]]` immediately after construction"]
+    },
+    "selection_result": {
+      "ja": ["`partition_0=group_a` AND `partition_1=batch_01` の一致: [[count]]件"],
+      "en": ["Exact match for `partition_0=group_a` AND `partition_1=batch_01`: [[count]] file(s)"]
+    },
+    "selection_contract": {
+      "ja": ["unknown metadata keyの結果: `[[error]]`、不一致条件のempty selection: [[empty_count]]件"],
+      "en": ["Unknown metadata key result: `[[error]]`; a non-matching condition returns an empty selection of [[empty_count]] file(s)"]
+    },
+    "lazy_loading_section": {
+      "ja": [
+        "### 遅延読み込みの境界",
+        "",
+        "`lazy_loading=True`はdefaultです。`from_folder()`と`select()`はpathとdiscovered metadataで候補を扱い、Frameを作りません。",
+        "",
+        "- `dataset[index]`: その1ファイルのFrameを作成・cacheします。WAVのheaderやshapeを同期的に確認しますが、audio sampleのdecodeはDask graphへ遅延されます。",
+        "- `frame.data`: FrameのDask graphをcomputeし、選択したファイルのwaveform sampleをNumPy arrayとしてmaterializeします。",
+        "",
+        "`loaded_count`はFrameのloadまたはtransformを試行したitem数です。失敗して`None`になったitemも含み、`frame.data`を読むだけでは増えません。`lazy_loading=False`ならDataset構築時に全itemのloadを試行します。"
+      ],
+      "en": [
+        "### Lazy-loading boundaries",
+        "",
+        "`lazy_loading=True` is the default. `from_folder()` and `select()` work with paths and discovered metadata; they do not create Frames.",
+        "",
+        "- `dataset[index]`: creates and caches the Frame for that one file. WAV header and shape information are inspected synchronously, while audio sample decoding is deferred into the Dask graph.",
+        "- `frame.data`: computes the Frame's Dask graph and materializes the selected file's waveform samples as a NumPy array.",
+        "",
+        "`loaded_count` counts items whose Frame load or transform has been attempted. It includes items that failed and became `None`; reading `frame.data` alone does not increase it. With `lazy_loading=False`, Dataset construction attempts every item."
+      ]
+    },
+    "lazy_boundary_result": {
+      "ja": [
+        "`select()`直後のloaded_count: [[before]]",
+        "`selected[0]`後のloaded_count: [[after_item]]",
+        "`frame.data`後のloaded_count: [[after_data]]",
+        "materializeした先頭sample: `[[samples]]`"
+      ],
+      "en": [
+        "loaded_count after `select()`: [[before]]",
+        "loaded_count after `selected[0]`: [[after_item]]",
+        "loaded_count after `frame.data`: [[after_data]]",
+        "First samples materialized: `[[samples]]`"
+      ]
+    },
+    "dataset_chaining_section": {
+      "ja": [
+        "## 2. Dataset-level operationをchainしてから選ぶ",
+        "",
+        "Datasetへ`normalize().stft()`を定義すると、各itemへ同じ処理がlazyに適用されます。`select()`は変換後のDatasetにも使えます。要素へアクセスするとsource DatasetからFrameと処理graphが組み立てられ、`frame.data`でwaveform読み込みと数値計算が実行されます。",
+        "",
+        "path metadataは派生Datasetへcopyされ、成功したFrameとtransform結果へ伝播します。元DatasetとFrameは変更されません。"
+      ],
+      "en": [
+        "## 2. Chain Dataset operations before selecting",
+        "",
+        "Defining `normalize().stft()` on a Dataset applies the same work lazily to each item. `select()` remains available on the transformed Dataset. Accessing an item builds the Frame and processing graph through the source Dataset; `frame.data` then executes waveform loading and numerical computation.",
+        "",
+        "Path metadata is copied into derived Datasets and propagates to successful Frames and transform results. The source Dataset and Frames are not mutated."
+      ]
+    },
+    "transform_result": {
+      "ja": ["変換後Datasetの選択件数: [[count]]、Frameに伝播したpartition: `[[metadata]]`"],
+      "en": ["Selected files after the transform: [[count]]; partition propagated to the Frame: `[[metadata]]`"]
+    },
+    "csv_section": {
+      "ja": [
+        "## 3. sidecar CSVのmetadataで選ぶ",
+        "",
+        "フォルダ階層にない属性は、`metadata_resolver`で相対pathからlookupできます。ここではCSVをDataFrameとして読み、pathをkeyにしたdictionaryへ変換します。resolverはDataset discovery時に呼ばれるため、信号CSVをWAVとして読むことはありません。"
+      ],
+      "en": [
+        "## 3. Select with sidecar CSV metadata",
+        "",
+        "Attributes that are not encoded in folders can be resolved from a relative path with `metadata_resolver`. The example reads the CSV as a DataFrame and converts it to a path-keyed dictionary. The resolver runs during Dataset discovery, so the signal CSV is not treated as a WAV file."
+      ]
+    },
+    "csv_table": {
+      "ja": ["**sidecar `recordings.csv`**"],
+      "en": ["**Sidecar `recordings.csv`**"]
+    },
+    "csv_result": {
+      "ja": ["CSV条件 `condition=reference` AND `priority=1` の一致: [[count]]件"],
+      "en": ["CSV exact match for `condition=reference` AND `priority=1`: [[count]] file(s)"]
+    },
+    "summary": {
+      "ja": [
+        "## まとめ",
+        "",
+        "- `path_metadata=True`はrelative parent pathからplain / Hive-style metadataを推論する",
+        "- `select()`はmetadataだけをAND / exact-matchし、unknown keyは`KeyError`、不一致はempty Datasetを返す",
+        "- `dataset[index]`はFrameを作り、`frame.data`がwaveformと処理graphをmaterializeする",
+        "- Dataset-level operation chainとpath metadataは派生結果へ伝播する",
+        "- 外部属性だけを`metadata_resolver`でsidecar lookupへ接続する",
+        "",
+        "APIの詳細とエラー契約は[[api_link]]を参照してください。"
+      ],
+      "en": [
+        "## Summary",
+        "",
+        "- `path_metadata=True` infers plain and Hive-style metadata from relative parent paths",
+        "- `select()` performs an AND / exact-match over metadata; an unknown key raises `KeyError`, while no match returns an empty Dataset",
+        "- `dataset[index]` creates a Frame, and `frame.data` materializes the waveform and processing graph",
+        "- Dataset-level operation chains and path metadata propagate to derived results",
+        "- Use `metadata_resolver` to connect only external attributes to a sidecar lookup",
+        "",
+        "See [[api_link]] for the API and error contracts."
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add the English export for `08_metadata_driven_dataset_search` using the existing Learning Path i18n contract and manifest-driven navigation.

## Technical coverage

- Aligns the lesson with current `wd.from_folder()`, `path_metadata=True`, Hive-style metadata, and `dataset.select()` behavior.
- Demonstrates AND / exact-match selection, unknown metadata keys, and empty selections.
- Describes the `from_folder/select` → `dataset[index]` → `frame.data` boundaries precisely.
- Distinguishes path discovery and metadata selection from Frame creation/header inspection and later waveform materialization.
- Verifies default `lazy_loading=True`, `loaded_count` semantics, and Dataset-level lazy transforms.
- Covers metadata propagation after `normalize().stft()` and sidecar CSV lookup through `metadata_resolver`.
- Keeps visible code language-neutral and moves locale setup, prose, translated results, and navigation to hidden cells.

The single Python source and visible exports are shared by ja/en; the final navigation is derived from manifest order.

## Files

- `learning-path/08_metadata_driven_dataset_search.py`
- `learning-path/translations/08_metadata_driven_dataset_search.json`
- `learning-path/manifest.json`

## Validation

- `uv run marimo check --strict learning-path/*.py`
- manifest/catalog validation
- ja/en lesson export and translated HTML validation
- `uv run pytest tests/utils/test_frame_dataset_metadata.py tests/utils/test_frame_dataset.py -q --no-cov`
- `uv run pytest tests/docs -q --no-cov`
- `uv run mkdocs build --strict -f docs/mkdocs.yml`
- full ruff format/check, ty, and `git diff --check`