### PR TITLE
chore: prepare Wandas 0.7.0 release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -112,6 +112,33 @@ jobs:
           with:
             password: ${{secrets.PYPI_API_TOKEN}}
 
+    verify-pypi-pyodide:
+        name: Verify published package in Pyodide
+        needs: publish-to-pypi
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+        steps:
+            - name: リポジトリをチェックアウト
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.sha }}
+
+            - name: Node.js 22 をセットアップ
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "22"
+
+            - name: npm と Pyodide 配布物をキャッシュ
+              uses: actions/cache@v4
+              with:
+                  path: |
+                      ~/.npm
+                      ~/.cache/wandas/pyodide/314.0.3
+                  key: ${{ runner.os }}-node22-pyodide-314.0.3-${{ hashFiles('scripts/pyodide/package.json', 'scripts/pyodide/package-lock.json', 'scripts/pyodide/requirements.txt') }}
+
+            - name: PyPI の公開物を Pyodide で検証
+              run: bash scripts/test_pyodide.sh published "${GITHUB_REF_NAME#v}"
+
 
     github-release:
         name: >-
@@ -119,6 +146,7 @@ jobs:
             and upload them to GitHub Release
         needs:
         - publish-to-pypi
+        - verify-pypi-pyodide
         runs-on: ubuntu-latest
 
         permissions:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -111,7 +111,7 @@ nav:
       - Spectral Numerical Contracts: explanation/spectral-numerical-contracts.md
   - Release Notes:
       - Wandas 0.7.0: release-notes/v0.7.0.md
-      - Wandas 0.6.3: release-notes/v0.6.3.md
+      - Wandas 0.6.3 (not released): release-notes/v0.6.3.md
       - Wandas 0.6.2: release-notes/v0.6.2.md
       - Wandas 0.6.1: release-notes/v0.6.1.md
       - Wandas 0.6.0: release-notes/v0.6.0.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
       - Scalability Contract: explanation/scalability-contract.md
       - Spectral Numerical Contracts: explanation/spectral-numerical-contracts.md
   - Release Notes:
+      - Wandas 0.7.0: release-notes/v0.7.0.md
       - Wandas 0.6.3: release-notes/v0.6.3.md
       - Wandas 0.6.2: release-notes/v0.6.2.md
       - Wandas 0.6.1: release-notes/v0.6.1.md

--- a/docs/src/how-to/pyodide-browser.md
+++ b/docs/src/how-to/pyodide-browser.md
@@ -70,10 +70,24 @@ From the repository root, run:
 bash scripts/test_pyodide.sh
 ```
 
-This check builds a wheel from the current checkout, validates the published
-installation smoke, and runs the Pyodide test subset. DOM behavior, CORS
-headers, and audio autoplay still require a real browser check for your origin.
+The default check builds a candidate wheel from the current checkout, verifies
+that the browser example pins the same Wandas version, runs the browser-guide
+workload against that wheel, and then runs the Pyodide test subset. It does not
+install Wandas from PyPI.
 
-repository rootから上記コマンドを実行します。これはcheckoutからwheelをbuildし、公開artifactの
-install smokeとPyodide test subsetを検証します。DOM、CORS header、audio autoplayは対象originの
-実ブラウザでも確認してください。
+To verify an exact version after it has been published to PyPI, run:
+
+```bash
+bash scripts/test_pyodide.sh published 0.7.0
+```
+
+The release workflow runs this published-package smoke after the PyPI upload
+and before creating the GitHub Release. DOM behavior, CORS headers, and audio
+autoplay still require a real browser check for your origin.
+
+repository rootから引数なしで実行すると、checkoutから候補wheelをbuildし、ブラウザ例との
+version整合性、候補wheelを使うbrowser-guide workload、Pyodide test subsetを検証します。
+PyPIの公開artifactはinstallしません。公開後のversionを確認する場合は
+`bash scripts/test_pyodide.sh published 0.7.0`を実行します。この公開artifact smokeは
+release workflowでもPyPI upload後、GitHub Release作成前に実行されます。DOM、CORS header、
+audio autoplayは対象originの実ブラウザでも確認してください。

--- a/docs/src/release-notes/v0.6.3.md
+++ b/docs/src/release-notes/v0.6.3.md
@@ -1,7 +1,9 @@
-# Wandas 0.6.3
+# Wandas 0.6.3 (not released)
 
-Wandas 0.6.3 makes N-octave synthesis use the authoritative FFT size stored by
-`SpectralFrame` and preserves the released Recipe v1 meaning during replay.
+Wandas 0.6.3 was not published, and no `v0.6.3` tag exists. This page records
+changes that were initially planned for 0.6.3 after the 0.6.2 release. They
+first ship in 0.7.0; the [Wandas 0.7.0 release notes](v0.7.0.md) are the
+authoritative compatibility and migration record.
 
 ## Changes
 
@@ -23,17 +25,9 @@ Wandas 0.6.3 makes N-octave synthesis use the authoritative FFT size stored by
   real values without scanning, clipping, or replacing them; the processing
   operation continues to own the mathematical coherence contract.
 
-## Compatibility
+## Compatibility status
 
-The following numerical-correctness compatibility changes take effect in 0.6.3.
-The previous bin-count inference is not retained as a direct-operation shim because
-it cannot distinguish adjacent odd and even FFT sizes.
-
-| Affected surface or artifact | Classification | Deprecation start | Replacement or migration | Removal/change version | Exception reason and decision link |
-| --- | --- | --- | --- | --- | --- |
-| `wandas.processing.NOctSynthesis` constructor | Stable user surface | None | Pass the positive source `n_fft`; `SpectralFrame.noct_synthesis()` supplies it automatically. | 0.6.3 | Numerical-correctness exception approved by [Issue #398](https://github.com/kasahart/wandas/issues/398). |
-| `wandas.spectral.noct_synthesis` Recipe v1 | Serialized operation version | None | Existing v1 payloads replay through the legacy meaning; new public calls emit version 2. | 0.6.3 | Persisted numerical meaning is kept separate from the corrected current behavior; [Issue #398](https://github.com/kasahart/wandas/issues/398). |
-| `wandas.audio.fft`, `wandas.audio.welch`, and `wandas.audio.cepstrum` Recipe v1 | Serialized operation versions | None | Existing v1 payloads replay through the released meaning; new public calls emit version 2. | 0.6.3 | Persisted numerical meaning is kept separate from the corrected current behavior; [Issue #397](https://github.com/kasahart/wandas/issues/397), parent [#391](https://github.com/kasahart/wandas/issues/391). |
-| `SpectralFrame` and `SpectrogramFrame` spectral NumPy properties | Public return shape | None | Single-channel properties follow `frame.data` without a leading singleton channel axis; multi-channel properties retain the channel axis. Numerical definitions are unchanged. | 0.6.3 | Public shape consistency correction; [Issue #400](https://github.com/kasahart/wandas/issues/400), parent [#391](https://github.com/kasahart/wandas/issues/391). |
-| `ChannelFrame.coherence()`, `.csd()`, and `.transfer_function()` | Public result type and WDF frame type | None | Use `CoherenceFrame`, `CrossSpectralFrame`, and `TransferFunctionFrame`; existing Recipe v1 payloads keep their recorded display/denominator contracts, while new calls emit v2. | 0.6.3 | Quantity meaning is represented by exact Frame type and typed pair state; [Issue #406](https://github.com/kasahart/wandas/issues/406). |
-| Direct `CoherenceFrame` construction and WDF decoding | Stable constructor and persisted-data behavior | None | Validate externally supplied coherence values before construction when an application requires finite `[0, 1]` data; `ChannelFrame.coherence()` continues to produce mathematically valid coherence values. | 0.6.3 | Constructor validation now preserves Dask laziness and external Dask data/graph identity without a full-value scan; [Issue #424](https://github.com/kasahart/wandas/issues/424) and [PR #425](https://github.com/kasahart/wandas/pull/425). |
+No compatibility change became effective under version 0.6.3. The planned
+changes above, including their numerical-correctness exceptions and Recipe
+replay guarantees, are classified with an effective version of 0.7.0 in the
+[0.7.0 compatibility table](v0.7.0.md#compatibility).

--- a/docs/src/release-notes/v0.7.0.md
+++ b/docs/src/release-notes/v0.7.0.md
@@ -23,6 +23,15 @@ workflow. Review the compatibility table before upgrading from 0.6.x.
 
 ## Changes
 
+- [Issue #365](https://github.com/kasahart/wandas/issues/365) and
+  [PR #382](https://github.com/kasahart/wandas/pull/382): correct IFFT
+  normalization while preserving the released Recipe v1 amplitude scaling and
+  emitting Recipe v2 for current calls.
+- [Issue #368](https://github.com/kasahart/wandas/issues/368) and
+  [PR #386](https://github.com/kasahart/wandas/pull/386): distinguish linear
+  RMS, calibrated physical quantities, reference-relative dB, and sound levels;
+  preserve released Recipe v1 numerics and metadata while current level calls
+  emit Recipe v2.
 - [Issue #397](https://github.com/kasahart/wandas/issues/397) (parent
   [#391](https://github.com/kasahart/wandas/issues/391)): preserve released
   Recipe v1 replay and emit Recipe v2 for corrected FFT, Welch, and cepstrum
@@ -68,6 +77,8 @@ the numerical-correctness or persisted-meaning decisions.
 | `wandas.processing.NOctSynthesis` constructor | Stable | None | Pass the positive source `n_fft`; `SpectralFrame.noct_synthesis()` supplies it automatically. | 0.7.0 | Numerical-correctness exception approved by [Issue #398](https://github.com/kasahart/wandas/issues/398). |
 | `wandas.spectral.noct_synthesis` Recipe v1 | Serialized | None | Existing v1 payloads replay through the legacy meaning; new public calls emit version 2. | 0.7.0 | Persisted numerical meaning is kept separate from corrected current behavior; [Issue #398](https://github.com/kasahart/wandas/issues/398). |
 | `wandas.audio.fft`, `wandas.audio.welch`, and `wandas.audio.cepstrum` Recipe v1 | Serialized | None | Existing v1 payloads replay through the released meaning; new public calls emit version 2. | 0.7.0 | Persisted numerical meaning is kept separate from corrected current behavior; [Issue #397](https://github.com/kasahart/wandas/issues/397), parent [#391](https://github.com/kasahart/wandas/issues/391). |
+| `wandas.spectral.ifft` Recipe v1 and `SpectralFrame.ifft()` | Stable / Serialized | None | Existing v1 payloads replay the released amplitude scaling; new calls emit version 2 and use the corrected inverse normalization. | 0.7.0 | Numerical correctness is corrected without reinterpreting persisted v1 payloads; [Issue #365](https://github.com/kasahart/wandas/issues/365), [PR #382](https://github.com/kasahart/wandas/pull/382). |
+| `wandas.audio.rms_trend` and `wandas.audio.sound_level` Recipe v1 | Stable / Serialized | None | Existing v1 payloads replay their released numerics and metadata; new calls emit version 2 with corrected calibrated numerics and physical-unit/reference metadata. | 0.7.0 | Acoustic quantity correctness is corrected without reinterpreting persisted v1 payloads; [Issue #368](https://github.com/kasahart/wandas/issues/368), [PR #386](https://github.com/kasahart/wandas/pull/386). |
 | `SpectralFrame` and `SpectrogramFrame` spectral NumPy properties | Stable | None | Single-channel properties follow `frame.data` without a leading singleton channel axis; multi-channel properties retain the channel axis. | 0.7.0 | Public shape consistency correction; [Issue #400](https://github.com/kasahart/wandas/issues/400). |
 | `ChannelFrame.coherence()`, `.csd()`, and `.transfer_function()` | Stable / Serialized | None | Use `CoherenceFrame`, `CrossSpectralFrame`, and `TransferFunctionFrame`; existing Recipe v1 payloads retain their released contracts, while new calls emit current versions. | 0.7.0 | Quantity meaning is represented by exact Frame type and typed pair state; [Issue #406](https://github.com/kasahart/wandas/issues/406). |
 | Direct `CoherenceFrame` construction and WDF decoding | Stable / Serialized | None | Applications that require finite `[0, 1]` coherence should validate external values before construction; `ChannelFrame.coherence()` continues to produce mathematically valid values. | 0.7.0 | Structural construction preserves Dask laziness and supplied data/graph identity without a full-value scan; [Issue #424](https://github.com/kasahart/wandas/issues/424). |

--- a/docs/src/release-notes/v0.7.0.md
+++ b/docs/src/release-notes/v0.7.0.md
@@ -1,0 +1,73 @@
+# Wandas 0.7.0
+
+Wandas 0.7.0 is a feature release centered on typed spectral results, explicit
+WDF and Recipe contracts, and stronger validation around immutable Frame state.
+It also expands the executable documentation and browser-oriented validation
+workflow. Review the compatibility table before upgrading from 0.6.x.
+
+## Highlights
+
+- Dedicated `CoherenceFrame`, `CrossSpectralFrame`, and `TransferFunctionFrame`
+  types now own pairwise spectral quantities, ordered channel-pair metadata,
+  quantity-specific properties, plotting, and WDF round-trips.
+- Corrected FFT, Welch, cepstrum, IFFT, N-octave, and level-processing behavior
+  keeps released Recipe meanings replayable while current public calls emit the
+  corresponding current Recipe contracts.
+- Spectral NumPy properties follow the canonical `Frame.data` channel shape,
+  and independent numerical oracles cover inverse spectral transforms.
+- Built-in Frame, WDF, and Recipe extension contracts are checked for exact
+  public type coverage, codec ownership, Recipe ownership, and deterministic
+  registration order while preserving Dask-lazy construction.
+- The executable Learning Path, tutorial, documentation contracts, and Pyodide
+  browser smoke tests now provide a broader release-validation surface.
+
+## Changes
+
+- [Issue #397](https://github.com/kasahart/wandas/issues/397) (parent
+  [#391](https://github.com/kasahart/wandas/issues/391)): preserve released
+  Recipe v1 replay and emit Recipe v2 for corrected FFT, Welch, and cepstrum
+  calls.
+- [Issue #398](https://github.com/kasahart/wandas/issues/398): make N-octave
+  synthesis use authoritative FFT-size provenance and validate its ratio
+  conventions at the Operation boundary.
+- [Issue #400](https://github.com/kasahart/wandas/issues/400) and
+  [PR #417](https://github.com/kasahart/wandas/pull/417): align materialized
+  spectral properties with the public Frame channel-axis shape.
+- [Issue #401](https://github.com/kasahart/wandas/issues/401),
+  [Issue #406](https://github.com/kasahart/wandas/issues/406), and
+  [PR #419](https://github.com/kasahart/wandas/pull/419): define pairwise
+  spectral contracts and add typed coherence, CSD, and transfer-function
+  Frames.
+- [Issue #402](https://github.com/kasahart/wandas/issues/402) and
+  [PR #418](https://github.com/kasahart/wandas/pull/418): add independent
+  ISTFT numerical-oracle coverage.
+- [Issue #411](https://github.com/kasahart/wandas/issues/411) and
+  [PR #416](https://github.com/kasahart/wandas/pull/416): split fast CI from
+  full compatibility validation and close ref-routing and validation gaps.
+- [Issue #424](https://github.com/kasahart/wandas/issues/424): keep direct
+  `CoherenceFrame` construction structural and Dask-lazy without scanning,
+  clipping, or replacing supplied values.
+- [PR #420](https://github.com/kasahart/wandas/pull/420),
+  [PR #421](https://github.com/kasahart/wandas/pull/421),
+  [PR #422](https://github.com/kasahart/wandas/pull/422), and
+  [PR #423](https://github.com/kasahart/wandas/pull/423): improve the
+  executable tutorial, organize Recipe learning materials, and add robust
+  Learning Path internationalization validation.
+- [Commit 1c9ab6f](https://github.com/kasahart/wandas/commit/1c9ab6fa8907dfc51d7e4f88a73ce2f29b34a3eb): add shared built-in Frame, WDF,
+  and Recipe contract coverage.
+
+## Compatibility
+
+WDF remains format version 0.4 and Recipe JSON remains schema version 2. Readers
+continue to reject unsupported versions explicitly. The following public or
+serialized meanings change in this 0.x feature release; the linked issues record
+the numerical-correctness or persisted-meaning decisions.
+
+| Affected surface or artifact | Classification | Deprecation start | Replacement or migration | Removal/change version | Exception reason and decision link |
+| --- | --- | --- | --- | --- | --- |
+| `wandas.processing.NOctSynthesis` constructor | Stable | None | Pass the positive source `n_fft`; `SpectralFrame.noct_synthesis()` supplies it automatically. | 0.7.0 | Numerical-correctness exception approved by [Issue #398](https://github.com/kasahart/wandas/issues/398). |
+| `wandas.spectral.noct_synthesis` Recipe v1 | Serialized | None | Existing v1 payloads replay through the legacy meaning; new public calls emit version 2. | 0.7.0 | Persisted numerical meaning is kept separate from corrected current behavior; [Issue #398](https://github.com/kasahart/wandas/issues/398). |
+| `wandas.audio.fft`, `wandas.audio.welch`, and `wandas.audio.cepstrum` Recipe v1 | Serialized | None | Existing v1 payloads replay through the released meaning; new public calls emit version 2. | 0.7.0 | Persisted numerical meaning is kept separate from corrected current behavior; [Issue #397](https://github.com/kasahart/wandas/issues/397), parent [#391](https://github.com/kasahart/wandas/issues/391). |
+| `SpectralFrame` and `SpectrogramFrame` spectral NumPy properties | Stable | None | Single-channel properties follow `frame.data` without a leading singleton channel axis; multi-channel properties retain the channel axis. | 0.7.0 | Public shape consistency correction; [Issue #400](https://github.com/kasahart/wandas/issues/400). |
+| `ChannelFrame.coherence()`, `.csd()`, and `.transfer_function()` | Stable / Serialized | None | Use `CoherenceFrame`, `CrossSpectralFrame`, and `TransferFunctionFrame`; existing Recipe v1 payloads retain their released contracts, while new calls emit current versions. | 0.7.0 | Quantity meaning is represented by exact Frame type and typed pair state; [Issue #406](https://github.com/kasahart/wandas/issues/406). |
+| Direct `CoherenceFrame` construction and WDF decoding | Stable / Serialized | None | Applications that require finite `[0, 1]` coherence should validate external values before construction; `ChannelFrame.coherence()` continues to produce mathematically valid values. | 0.7.0 | Structural construction preserves Dask laziness and supplied data/graph identity without a full-value scan; [Issue #424](https://github.com/kasahart/wandas/issues/424). |

--- a/examples/pyodide/index.html
+++ b/examples/pyodide/index.html
@@ -26,7 +26,7 @@
 
     <script>
       const PYODIDE_VERSION = "314.0.3";
-      const WANDAS_VERSION = "0.6.1";
+      const WANDAS_VERSION = "0.7.0";
       const PYODIDE_BASE =
         `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/`;
       const SAMPLE_WAV_URL =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wandas"
-version = "0.6.2"
+version = "0.7.0"
 description = "Wandas is an open source library for efficient signal analysis in Python"
 authors = [{name = "kasahart", email="kasahart66@gmail.com"}]
 maintainers = [

--- a/scripts/run_pyodide_tests.mjs
+++ b/scripts/run_pyodide_tests.mjs
@@ -41,11 +41,16 @@ const mode = options.mode;
 const repositoryRoot = path.resolve(options["repository-root"]);
 const runtimeDir = path.resolve(options["runtime-dir"]);
 const expectedPyodideVersion = options["expected-pyodide-version"];
-if (!["guide-smoke", "html-smoke", "source-tests"].includes(mode)) {
+const wheelModes = new Set(["wheel-guide-smoke", "source-tests"]);
+const guideModes = new Set(["wheel-guide-smoke", "published-guide-smoke"]);
+if (!["html-smoke", ...wheelModes, "published-guide-smoke"].includes(mode)) {
   throw new Error(`Unsupported Pyodide harness mode: ${mode}`);
 }
-if (mode === "source-tests" && !options.wheel) {
-  throw new Error("source-tests requires --wheel PATH");
+if (wheelModes.has(mode) && !options.wheel) {
+  throw new Error(`${mode} requires --wheel PATH`);
+}
+if (mode === "source-tests" && !options["expected-wandas-version"]) {
+  throw new Error("source-tests requires an expected Wandas version");
 }
 if (mode === "html-smoke") {
   const expectedWandasVersion = options["expected-wandas-version"];
@@ -80,7 +85,9 @@ if (mode === "html-smoke") {
       `Browser example is missing required fragments: ${missingFragments.join(", ")}`,
     );
   }
-  console.log("Browser example source: required Pyodide, Wandas, WAV, and browser fragments found");
+  console.log(
+    "Browser example source consistency: required Pyodide, Wandas, WAV, and browser fragments found",
+  );
   process.exitCode = 0;
   process.exit();
 }
@@ -104,11 +111,20 @@ console.log(`Runtime: Pyodide ${pyodideModule.version} / ${pyodide.runPython("im
 await pyodide.loadPackage("micropip");
 pyodide.globals.set("wandas_locked_requirements_json", JSON.stringify(lockedRequirements));
 
-if (mode === "guide-smoke") {
-  const wandasInstallSpec = options["wandas-install-spec"];
+let localWheelUri;
+if (wheelModes.has(mode)) {
+  const wheelPath = path.resolve(options.wheel);
+  const virtualWheel = `/work/dist/${path.basename(wheelPath)}`;
+  writeVirtualFile(pyodide, wheelPath, virtualWheel);
+  localWheelUri = `emfs:${virtualWheel}`;
+}
+
+if (guideModes.has(mode)) {
+  const wandasInstallSpec =
+    mode === "wheel-guide-smoke" ? localWheelUri : options["wandas-install-spec"];
   const expectedWandasVersion = options["expected-wandas-version"];
   if (!wandasInstallSpec || !expectedWandasVersion) {
-    throw new Error("guide-smoke requires a Wandas install spec and expected version");
+    throw new Error(`${mode} requires a Wandas install spec and expected version`);
   }
 
   pyodide.globals.set("wandas_install_spec", wandasInstallSpec);
@@ -156,7 +172,7 @@ if (
     or not np.isfinite(filtered_values).all()
     or np.allclose(filtered_values, samples)
 ):
-    raise RuntimeError("Published Wandas artifact failed the browser guide smoke")
+    raise RuntimeError("Wandas artifact failed the browser guide smoke")
 
 figure, axis = plt.subplots(figsize=(4, 2))
 original.plot(ax=axis, color="0.65", label="original")
@@ -165,7 +181,7 @@ png = BytesIO()
 figure.savefig(png, format="png")
 plt.close(figure)
 if not png.getvalue().startswith(b"\\x89PNG\\r\\n\\x1a\\n"):
-    raise RuntimeError("Published Wandas artifact failed to render a PNG")
+    raise RuntimeError("Wandas artifact failed to render a PNG")
 
 generated_wav_path = "/tmp/wandas-guide-smoke.wav"
 filtered.to_wav(generated_wav_path)
@@ -175,7 +191,7 @@ if (
     or round_trip.n_channels != 1
     or round_trip.to_numpy().shape != samples.shape
 ):
-    raise RuntimeError("Published Wandas artifact failed the WAV round trip")
+    raise RuntimeError("Wandas artifact failed the WAV round trip")
 
 print(
     "Browser guide install: "
@@ -185,13 +201,6 @@ print(
 `);
   process.exitCode = 0;
 } else {
-  // The mode-specific validation above guarantees this is a string.
-  const wheelPath = path.resolve(options.wheel);
-
-  pyodide.FS.mkdirTree("/work/dist");
-  const virtualWheel = `/work/dist/${path.basename(wheelPath)}`;
-  writeVirtualFile(pyodide, wheelPath, virtualWheel);
-
   copyTree(pyodide, path.join(repositoryRoot, "tests", "core"), "/work/tests/core");
   copyTree(
     pyodide,
@@ -215,16 +224,25 @@ print(
   );
 
   await pyodide.loadPackage("pytest");
-  pyodide.globals.set("wandas_wheel_uri", `emfs:${virtualWheel}`);
+  pyodide.globals.set("wandas_wheel_uri", localWheelUri);
+  pyodide.globals.set("expected_wandas_version", options["expected-wandas-version"]);
   await pyodide.runPythonAsync(`
+import importlib.metadata
 import json
 import micropip
 
 await micropip.install(
     [*json.loads(wandas_locked_requirements_json), wandas_wheel_uri]
 )
+
+actual_version = importlib.metadata.version("wandas")
+if actual_version != expected_wandas_version:
+    raise RuntimeError(
+        f"Installed Wandas {actual_version}, expected {expected_wandas_version}"
+    )
 `);
   pyodide.globals.delete("wandas_wheel_uri");
+  pyodide.globals.delete("expected_wandas_version");
 
   const exitCode = pyodide.runPython(`
 import runpy

--- a/scripts/test_pyodide.sh
+++ b/scripts/test_pyodide.sh
@@ -2,7 +2,9 @@
 set -euo pipefail
 
 PYODIDE_VERSION="314.0.3"
-WANDAS_GUIDE_VERSION="0.6.1"
+# The guide smoke runs before the candidate tag is published, so test the
+# latest already-published release rather than the v0.7.0 candidate.
+WANDAS_GUIDE_VERSION="0.6.2"
 
 repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 runtime_manifest_dir="${repository_root}/scripts/pyodide"

--- a/scripts/test_pyodide.sh
+++ b/scripts/test_pyodide.sh
@@ -2,9 +2,28 @@
 set -euo pipefail
 
 PYODIDE_VERSION="314.0.3"
-# The guide smoke runs before the candidate tag is published, so test the
-# latest already-published release rather than the v0.7.0 candidate.
-WANDAS_GUIDE_VERSION="0.6.2"
+
+test_target="${1:-candidate}"
+published_version=""
+case "${test_target}" in
+    candidate)
+        if (($# != 0 && $# != 1)); then
+            echo "usage: $0 [candidate | published VERSION]" >&2
+            exit 2
+        fi
+        ;;
+    published)
+        if (($# != 2)); then
+            echo "usage: $0 published VERSION" >&2
+            exit 2
+        fi
+        published_version="$2"
+        ;;
+    *)
+        echo "usage: $0 [candidate | published VERSION]" >&2
+        exit 2
+        ;;
+esac
 
 repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 runtime_manifest_dir="${repository_root}/scripts/pyodide"
@@ -17,7 +36,11 @@ cleanup() {
 }
 trap cleanup EXIT
 
-for command in node npm uv; do
+required_commands=(node npm)
+if [[ "${test_target}" == "candidate" ]]; then
+    required_commands+=(uv)
+fi
+for command in "${required_commands[@]}"; do
     if ! command -v "${command}" >/dev/null 2>&1; then
         echo "error: ${command} is required to run the Pyodide test harness" >&2
         exit 2
@@ -73,6 +96,24 @@ if [[
     printf '%s\n' "${runtime_manifest_hash}" >"${runtime_dir}/.wandas-runtime-manifest.sha256"
 fi
 
+if [[ "${test_target}" == "published" ]]; then
+    echo "Validating the published Wandas ${published_version} browser-guide installation"
+    node \
+        "${repository_root}/scripts/run_pyodide_tests.mjs" \
+        --mode "published-guide-smoke" \
+        --repository-root "${repository_root}" \
+        --runtime-dir "${runtime_dir}" \
+        --expected-pyodide-version "${PYODIDE_VERSION}" \
+        --wandas-install-spec "wandas==${published_version}" \
+        --expected-wandas-version "${published_version}"
+    exit 0
+fi
+
+wandas_candidate_version="$(
+    cd "${repository_root}"
+    uv version --short
+)"
+
 wheel_dir="${temporary_dir}/dist"
 mkdir -p "${wheel_dir}"
 (
@@ -93,25 +134,26 @@ echo "Repository: ${repository_root}"
 echo "Wheel: ${wheel_path}"
 echo "Node.js: $(node --version)"
 echo "Pyodide: ${PYODIDE_VERSION}"
+echo "Wandas candidate: ${wandas_candidate_version}"
 
-echo "Validating the complete browser example source"
+echo "Checking browser example source consistency"
 node \
     "${repository_root}/scripts/run_pyodide_tests.mjs" \
     --mode "html-smoke" \
     --repository-root "${repository_root}" \
     --runtime-dir "${runtime_dir}" \
     --expected-pyodide-version "${PYODIDE_VERSION}" \
-    --expected-wandas-version "${WANDAS_GUIDE_VERSION}"
+    --expected-wandas-version "${wandas_candidate_version}"
 
-echo "Validating the published browser-guide installation"
+echo "Validating the candidate wheel with the browser-guide workload"
 node \
     "${repository_root}/scripts/run_pyodide_tests.mjs" \
-    --mode "guide-smoke" \
+    --mode "wheel-guide-smoke" \
     --repository-root "${repository_root}" \
     --runtime-dir "${runtime_dir}" \
+    --wheel "${wheel_path}" \
     --expected-pyodide-version "${PYODIDE_VERSION}" \
-    --wandas-install-spec "wandas==${WANDAS_GUIDE_VERSION}" \
-    --expected-wandas-version "${WANDAS_GUIDE_VERSION}"
+    --expected-wandas-version "${wandas_candidate_version}"
 
 echo "Validating the wheel built from the current checkout"
 node \
@@ -120,4 +162,5 @@ node \
     --repository-root "${repository_root}" \
     --runtime-dir "${runtime_dir}" \
     --wheel "${wheel_path}" \
-    --expected-pyodide-version "${PYODIDE_VERSION}"
+    --expected-pyodide-version "${PYODIDE_VERSION}" \
+    --expected-wandas-version "${wandas_candidate_version}"

--- a/tests/test_ci_route.py
+++ b/tests/test_ci_route.py
@@ -369,6 +369,8 @@ def test_release_publish_waits_for_full_compatibility() -> None:
     build_job = workflow["jobs"]["build"]
     installation_job = workflow["jobs"]["test-installation"]
     publish_job = workflow["jobs"]["publish-to-pypi"]
+    pyodide_verify_job = workflow["jobs"]["verify-pypi-pyodide"]
+    github_release_job = workflow["jobs"]["github-release"]
 
     assert full_job["uses"] == "./.github/workflows/full-compatibility.yml"
     assert full_job["with"]["ref"] == "${{ github.sha }}"
@@ -381,6 +383,12 @@ def test_release_publish_waits_for_full_compatibility() -> None:
     assert len(installation_checkout) == 1
     assert installation_checkout[0]["with"]["ref"] == "${{ github.sha }}"
     assert installation_job["needs"] == "build"
+    assert pyodide_verify_job["needs"] == "publish-to-pypi"
+    assert "verify-pypi-pyodide" in github_release_job["needs"]
+    pyodide_verify_step = next(
+        step for step in pyodide_verify_job["steps"] if "test_pyodide.sh published" in step.get("run", "")
+    )
+    assert '"${GITHUB_REF_NAME#v}"' in pyodide_verify_step["run"]
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -3946,7 +3946,7 @@ wheels = [
 
 [[package]]
 name = "wandas"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "cattrs" },


### PR DESCRIPTION
## Summary

- Bump the package and lockfile version from 0.6.2 to 0.7.0.
- Add the v0.7.0 release notes and MkDocs navigation entry.
- Validate the browser-guide workload against the 0.7.0 wheel built from the current checkout.
- Keep the HTML version check as a source-consistency check rather than treating it as browser execution.
- Move the PyPI installation smoke to a post-publish CD job and require it before creating the GitHub Release.

## User impact

This prepares the repository metadata and documentation for the 0.7.0 release and makes pre-release Pyodide validation exercise the actual release candidate. It does not create a tag, publish to PyPI, or change WDF/Recipe schema versions.

## Validation

- `uv lock --check`
- `uv run --locked ruff format --check wandas tests scripts learning-path`
- `uv run --locked ruff check wandas tests scripts learning-path`
- `uv run --locked ty check wandas tests scripts learning-path`
- `uv run --locked python scripts/check_public_docstrings.py`
- `uv run --locked mkdocs build --strict -f docs/mkdocs.yml`
- `uv run --locked marimo check --strict learning-path/*.py`
- `uv build` produced `wandas-0.7.0.tar.gz` and `wandas-0.7.0-py3-none-any.whl`
- `uv run pytest tests/test_ci_route.py`: 60 passed
- `uv run ruff check tests/test_ci_route.py`
- `uv run ruff format --check tests/test_ci_route.py`
- `uv run ty check tests/test_ci_route.py`
- `bash -n scripts/test_pyodide.sh`
- Workflow YAML parse check
- GitHub Actions: all 11 checks passed
- Pyodide candidate guide smoke installed Wandas 0.7.0 from the locally built wheel
- Pyodide candidate test suite: 336 passed, 7 skipped
- Full local pytest before the CI fix: 3336 passed, 3 skipped; two existing Docs failures remain from the ignored `learning-path/06_skill_validation.py` file (fixture path resolution and private `.compute()` detection).
- Docs tests excluding those two existing failures: 52 passed.

Unrelated working-tree changes were left unstaged and uncommitted.