### PR TITLE
Require worktrees for editing tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,10 @@
 
 - Use `uv` for Python commands. Check `git status --short` before editing and
   preserve unrelated changes.
-- For each new task that will modify files, work in a dedicated Git worktree.
-  If the current session is not already in one, stop before editing and ask the
-  user to restart Codex from a worktree.
+- For each new task that will modify files, work in a dedicated linked Git
+  worktree, not the primary checkout. If the current session is in the primary
+  checkout, stop before editing and ask the user to restart Codex from a linked
+  worktree.
 - Preserve Frame immutability, metadata, lineage, and Dask laziness.
   `operation_history` is a derived compatibility view of lineage.
 - Keep orchestration and metadata in `wandas/frames`; keep numerical algorithms

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,9 @@
 
 - Use `uv` for Python commands. Check `git status --short` before editing and
   preserve unrelated changes.
+- For each new task that will modify files, work in a dedicated Git worktree.
+  If the current session is not already in one, stop before editing and ask the
+  user to restart Codex from a worktree.
 - Preserve Frame immutability, metadata, lineage, and Dask laziness.
   `operation_history` is a derived compatibility view of lineage.
 - Keep orchestration and metadata in `wandas/frames`; keep numerical algorithms


### PR DESCRIPTION
## Summary

- require new file-modifying tasks to run in a dedicated Git worktree
- tell Codex to stop and request a restart when the current session is not already in a worktree

## Why

This gives Codex a minimal repository-level instruction to isolate editing tasks while keeping read-only work unaffected.

## Impact

Codex sessions started from the primary checkout should avoid edits and ask to be restarted from a worktree.

## Validation

- `git diff --check`
- repository commit hooks (ruff and ty had no applicable files)