### PR TITLE
Add explicit Frame dtype conversion for compact caches

### DIFF
--- a/docs/src/api/processing.md
+++ b/docs/src/api/processing.md
@@ -15,6 +15,8 @@ operationを提供します。各operationの数値契約はGoogle style docstri
 
 ::: wandas.processing.cepstral
 
+::: wandas.processing.conversion
+
 ::: wandas.processing.stats
 
 ::: wandas.processing.filters

--- a/docs/src/assets/benchmarks/issue-438/README.md
+++ b/docs/src/assets/benchmarks/issue-438/README.md
@@ -1,0 +1,49 @@
+# Issue #438 resident-cache dtype evidence
+
+This archived evidence measures the resident process memory and raw tensor size for
+the explicit cache-dtype workflow introduced by Issue #438. The base revision is
+`38d4cd29705e2a430119d2941b8d33138c730a0e`; the candidate revision is
+`19c13ce656d8334809d473e04fe47d3171815b09`. Both revisions used `uv.lock`
+SHA-256 `4ef530af6b76bfa0ad997392615109f16cbe677b374f5ce9c87aacff4f242db4`.
+
+Each scenario materialized a lazy `(2, 8_000_000)` `float64` `ChannelFrame` in an
+isolated process. The base and candidate controls called `cache()` directly. The
+compact candidate called `astype("float32").cache()`. Three trials were interleaved
+in base-control, candidate-control, candidate-compact order.
+
+| Scenario | Cached dtype | Raw bytes | Median current RSS |
+| --- | --- | ---: | ---: |
+| Base control | `float64` | 128,000,000 | 278,294,528 |
+| Candidate control | `float64` | 128,000,000 | 278,659,072 |
+| Candidate compact | `float32` | 64,000,000 | 214,630,400 |
+
+The compact raw tensor is exactly 50% of the candidate control. Its median current
+RSS is 22.98% lower, while the base and candidate control medians differ by 0.13%.
+These process-level measurements are representative evidence, not a general memory
+guarantee. In particular, upstream operations may retain or create wider temporary
+arrays during materialization, and peak RSS is allocator- and workload-dependent.
+
+The complete observations, including environment versions and peak RSS, are in
+[`resident-memory.json`](resident-memory.json). The bridge script is
+[`benchmark.py`](benchmark.py), SHA-256
+`f316888d8c26d410c138fa261ef80f15e5601e7d7a972f2461fdd2270267d120`.
+Measurements used the command template recorded in the JSON, with the current
+directory set to the corresponding clean detached worktree. To reproduce the three
+scenarios from a checkout containing the candidate commit:
+
+```bash
+repo_root=$PWD
+benchmark_script=$repo_root/docs/src/assets/benchmarks/issue-438/benchmark.py
+
+git worktree add --detach /tmp/wandas-issue438-base 38d4cd29705e2a430119d2941b8d33138c730a0e
+cd /tmp/wandas-issue438-base
+uv run --locked python "$benchmark_script" --mode control --channels 2 --samples 8000000
+
+cd "$repo_root"
+git worktree add --detach /tmp/wandas-issue438-candidate 19c13ce656d8334809d473e04fe47d3171815b09
+cd /tmp/wandas-issue438-candidate
+uv run --locked python "$benchmark_script" --mode control --channels 2 --samples 8000000
+uv run --locked python "$benchmark_script" --mode compact --channels 2 --samples 8000000
+```
+
+The environment was Linux x86-64, Python 3.10.20, NumPy 2.2.6, and Dask 2025.11.0.

--- a/docs/src/assets/benchmarks/issue-438/README.md
+++ b/docs/src/assets/benchmarks/issue-438/README.md
@@ -23,6 +23,23 @@ These process-level measurements are representative evidence, not a general memo
 guarantee. In particular, upstream operations may retain or create wider temporary
 arrays during materialization, and peak RSS is allocator- and workload-dependent.
 
+## Already-resident source
+
+A second scenario starts from a 128,000,000-byte `float64` NumPy array through
+`ChannelFrame.from_numpy`. Frame results retain their immediate receiver through
+`previous`, so both variants keep that source reachable after callers delete their
+own references:
+
+| Scenario | Retained source | Cached raw tensor | Median current RSS |
+| --- | ---: | ---: | ---: |
+| Eager-backed control | 128,000,000 | 128,000,000 | 406,376,448 |
+| Eager-backed compact | 128,000,000 | 64,000,000 | 342,462,464 |
+
+The compact cache still halves the new cached tensor, but does not release the wider
+source. Median process RSS was therefore 15.73% lower rather than 22.98% lower. The
+overall resident saving depends on whether upstream Frame data is virtual/lazy or
+already resident and retained by the Frame chain.
+
 The complete observations, including environment versions and peak RSS, are in
 [`resident-memory.json`](resident-memory.json). The bridge script is
 [`benchmark.py`](benchmark.py), SHA-256
@@ -47,3 +64,10 @@ uv run --locked python "$benchmark_script" --mode compact --channels 2 --samples
 ```
 
 The environment was Linux x86-64, Python 3.10.20, NumPy 2.2.6, and Dask 2025.11.0.
+
+The eager-backed observations are in
+[`resident-source-memory.json`](resident-source-memory.json). Its bridge script is
+[`benchmark_resident_source.py`](benchmark_resident_source.py), SHA-256
+`d15f5351269dbae9210a701360533185de7ac824f578f2138ad5f20805dfa51f`, and uses the
+same environment, lock, shape, and three interleaved trials at candidate revision
+`21cc9fba428acbcd71d6afdf3cff6eed0e027ea3`.

--- a/docs/src/assets/benchmarks/issue-438/benchmark.py
+++ b/docs/src/assets/benchmarks/issue-438/benchmark.py
@@ -1,0 +1,104 @@
+"""Isolated resident-memory probe for Issue #438 cache dtype reduction."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import os
+import platform
+import resource
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _current_rss_bytes() -> int:
+    """Return current Linux resident bytes from procfs."""
+    resident_pages = int(Path("/proc/self/statm").read_text().split()[1])
+    return resident_pages * os.sysconf("SC_PAGE_SIZE")
+
+
+def _peak_rss_bytes() -> int:
+    """Normalize ru_maxrss to bytes on Linux and macOS."""
+    value = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return int(value if sys.platform == "darwin" else value * 1024)
+
+
+def _sha256(path: Path) -> str:
+    """Return one file's SHA-256 digest."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def measure(mode: str, channels: int, samples: int) -> dict[str, Any]:
+    """Build and retain one cache scenario, then report process memory."""
+    project_root = Path.cwd().resolve()
+    sys.path.insert(0, str(project_root))
+
+    import dask
+    import dask.array as da
+    import numpy as np
+
+    from wandas.frames.channel import ChannelFrame
+
+    source = da.ones((channels, samples), chunks=(1, -1), dtype=np.float64)
+    frame = ChannelFrame(source, sampling_rate=48_000.0)
+    started = time.perf_counter_ns()
+    cached = (frame.astype("float32") if mode == "compact" else frame).cache()
+    materialization_ns = time.perf_counter_ns() - started
+    del frame, source
+    gc.collect()
+
+    raw_bytes = int(cached._data.size * cached._data.dtype.itemsize)
+    lock_path = project_root / "uv.lock"
+    return {
+        "schema_version": 1,
+        "issue": 438,
+        "mode": mode,
+        "revision": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=project_root,
+            text=True,
+        ).strip(),
+        "worktree_clean": subprocess.call(
+            ["git", "diff", "--quiet"],
+            cwd=project_root,
+        )
+        == 0,
+        "environment": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "numpy": np.__version__,
+            "dask": dask.__version__,
+            "uv_lock_sha256": _sha256(lock_path),
+        },
+        "input": {
+            "channels": channels,
+            "samples": samples,
+            "dtype": "float64",
+        },
+        "cache": {
+            "dtype": cached._data.dtype.name,
+            "raw_bytes": raw_bytes,
+            "current_rss_bytes": _current_rss_bytes(),
+            "peak_rss_bytes": _peak_rss_bytes(),
+            "materialization_ns": materialization_ns,
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse one isolated measurement scenario."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("control", "compact"), required=True)
+    parser.add_argument("--channels", type=int, default=2)
+    parser.add_argument("--samples", type=int, default=8_000_000)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    print(json.dumps(measure(args.mode, args.channels, args.samples), sort_keys=True))

--- a/docs/src/assets/benchmarks/issue-438/benchmark_resident_source.py
+++ b/docs/src/assets/benchmarks/issue-438/benchmark_resident_source.py
@@ -1,0 +1,118 @@
+"""Resident-memory probe for Issue #438 with an eager-backed source."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import os
+import platform
+import resource
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+def _current_rss_bytes() -> int:
+    """Return current Linux resident bytes from procfs."""
+    resident_pages = int(Path("/proc/self/statm").read_text().split()[1])
+    return resident_pages * os.sysconf("SC_PAGE_SIZE")
+
+
+def _peak_rss_bytes() -> int:
+    """Normalize ru_maxrss to bytes on Linux and macOS."""
+    value = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return int(value if sys.platform == "darwin" else value * 1024)
+
+
+def _sha256(path: Path) -> str:
+    """Return one file's SHA-256 digest."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def measure(mode: str, channels: int, samples: int) -> dict[str, Any]:
+    """Cache an eager-backed source and report retained process memory."""
+    project_root = Path.cwd().resolve()
+    sys.path.insert(0, str(project_root))
+
+    import dask
+    import numpy as np
+
+    from wandas.frames.channel import ChannelFrame
+
+    values = np.ones((channels, samples), dtype=np.float64)
+    frame = ChannelFrame.from_numpy(values, sampling_rate=48_000.0)
+    source_raw_bytes = int(values.nbytes)
+    del values
+    gc.collect()
+
+    started = time.perf_counter_ns()
+    cached = (frame.astype("float32") if mode == "compact" else frame).cache()
+    materialization_ns = time.perf_counter_ns() - started
+    del frame
+    gc.collect()
+
+    previous = cached.previous
+    if previous is None:
+        raise AssertionError("cache result did not retain its receiver")
+    retained_source = previous if mode == "control" else previous.previous
+    if retained_source is None:
+        raise AssertionError("cache lineage did not retain the eager-backed source")
+    retained_source_raw_bytes = int(retained_source._data.size * retained_source._data.dtype.itemsize)
+    raw_bytes = int(cached._data.size * cached._data.dtype.itemsize)
+    lock_path = project_root / "uv.lock"
+    return {
+        "schema_version": 1,
+        "issue": 438,
+        "mode": mode,
+        "revision": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=project_root,
+            text=True,
+        ).strip(),
+        "worktree_clean": subprocess.call(
+            ["git", "diff", "--quiet"],
+            cwd=project_root,
+        )
+        == 0,
+        "environment": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "numpy": np.__version__,
+            "dask": dask.__version__,
+            "uv_lock_sha256": _sha256(lock_path),
+        },
+        "input": {
+            "channels": channels,
+            "samples": samples,
+            "dtype": "float64",
+            "raw_bytes": source_raw_bytes,
+            "backing": "ChannelFrame.from_numpy",
+        },
+        "cache": {
+            "dtype": cached._data.dtype.name,
+            "raw_bytes": raw_bytes,
+            "retained_source_dtype": retained_source._data.dtype.name,
+            "retained_source_raw_bytes": retained_source_raw_bytes,
+            "current_rss_bytes": _current_rss_bytes(),
+            "peak_rss_bytes": _peak_rss_bytes(),
+            "materialization_ns": materialization_ns,
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse one isolated measurement scenario."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("control", "compact"), required=True)
+    parser.add_argument("--channels", type=int, default=2)
+    parser.add_argument("--samples", type=int, default=8_000_000)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    print(json.dumps(measure(args.mode, args.channels, args.samples), sort_keys=True))

--- a/docs/src/assets/benchmarks/issue-438/resident-memory.json
+++ b/docs/src/assets/benchmarks/issue-438/resident-memory.json
@@ -1,0 +1,273 @@
+{
+  "schema_version": 1,
+  "script_sha256": "f316888d8c26d410c138fa261ef80f15e5601e7d7a972f2461fdd2270267d120",
+  "command_template": [
+    "/workspaces/wandas/.venv/bin/python3",
+    "/workspaces/wandas/.worktrees/issue-438-astype/docs/src/assets/benchmarks/issue-438/benchmark.py",
+    "--mode",
+    "<control|compact>",
+    "--channels",
+    "2",
+    "--samples",
+    "8000000"
+  ],
+  "run_order": [
+    "base-control",
+    "candidate-control",
+    "candidate-compact"
+  ],
+  "observations": [
+    {
+      "cache": {
+        "current_rss_bytes": 280211456,
+        "dtype": "float64",
+        "materialization_ns": 86325121,
+        "peak_rss_bytes": 535470080,
+        "raw_bytes": 128000000
+      },
+      "environment": {
+        "dask": "2025.11.0",
+        "numpy": "2.2.6",
+        "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+        "python": "3.10.20",
+        "uv_lock_sha256": "4ef530af6b76bfa0ad997392615109f16cbe677b374f5ce9c87aacff4f242db4"
+      },
+      "input": {
+        "channels": 2,
+        "dtype": "float64",
+        "samples": 8000000
+      },
+      "issue": 438,
+      "mode": "control",
+      "revision": "38d4cd29705e2a430119d2941b8d33138c730a0e",
+      "schema_version": 1,
+      "worktree_clean": true,
+      "scenario": "base-control",
+      "run": 1
+    },
+    {
+      "cache": {
+        "current_rss_bytes": 280215552,
+        "dtype": "float64",
+        "materialization_ns": 90303129,
+        "peak_rss_bytes": 535953408,
+        "raw_bytes": 128000000
+      },
+      "environment": {
+        "dask": "2025.11.0",
+        "numpy": "2.2.6",
+        "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+        "python": "3.10.20",
+        "uv_lock_sha256": "4ef530af6b76bfa0ad997392615109f16cbe677b374f5ce9c87aacff4f242db4"
+      },
+      "input": {
+        "channels": 2,
+        "dtype": "float64",
+        "samples": 8000000
+      },
+      "issue": 438,
+      "mode": "control",
+      "revision": "19c13ce656d8334809d473e04fe47d3171815b09",
+      "schema_version": 1,
+      "worktree_clean": true,
+      "scenario": "candidate-control",
+      "run": 1
+    },
+    {
+      "cache": {
+        "current_rss_bytes": 214069248,
+        "dtype": "float32",
+        "materialization_ns": 68844201,
+        "peak_rss_bytes": 340901888,
+        "raw_bytes": 64000000
+      },
+      "environment": {
+        "dask": "2025.11.0",
+        "numpy": "2.2.6",
+        "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+        "python": "3.10.20",
+        "uv_lock_sha256": "4ef530af6b76bfa0ad997392615109f16cbe677b374f5ce9c87aacff4f242db4"
+      },
+      "input": {
+        "channels": 2,
+        "dtype": "float64",
+        "samples": 8000000
+      },
+      "issue": 438,
+      "mode": "compact",
+      "revision": "19c13ce656d8334809d473e04fe47d3171815b09",
+      "schema_version": 1,
+      "worktree_clean": true,
+      "scenario": "candidate-compact",
+      "run": 1
+    },
+    {
+      "cache": {
+        "current_rss_bytes": 278192128,
+        "dtype": "float64",
+        "materialization_ns": 86850293,
+        "peak_rss_bytes": 532656128,
+        "raw_bytes": 128000000
+      },
+      "environment": {
+        "dask": "2025.11.0",
+        "numpy": "2.2.6",
+        "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+        "python": "3.10.20",
+        "uv_lock_sha256": "4ef530af6b76bfa0ad997392615109f16cbe677b374f5ce9c87aacff4f242db4"
+      },
+      "input": {
+        "channels": 2,
+        "dtype": "float64",
+        "samples": 8000000
+      },
+      "issue": 438,
+      "mode": "control",
+      "revision": "38d4cd29705e2a430119d2941b8d33138c730a0e",
+      "schema_version": 1,
+      "worktree_clean": true,
+      "scenario": "base-control",
+      "run": 2
+    },
+    {
+      "cache": {
+        "current_rss_bytes": 278507520,
+        "dtype": "float64",
+        "materialization_ns": 94167525,
+        "peak_rss_bytes": 533155840,
+        "raw_bytes": 128000000
+      },
+      "environment": {
+        "dask": "2025.11.0",
+        "numpy": "2.2.6",
+        "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+        "python": "3.10.20",
+        "uv_lock_sha256": "4ef530af6b76bfa0ad997392615109f16cbe677b374f5ce9c87aacff4f242db4"
+      },
+      "input": {
+        "channels": 2,
+        "dtype": "float64",
+        "samples": 8000000
+      },
+      "issue": 438,
+      "mode": "control",
+      "revision": "19c13ce656d8334809d473e04fe47d3171815b09",
+      "schema_version": 1,
+      "worktree_clean": true,
+      "scenario": "candidate-control",
+      "run": 2
+    },
+    {
+      "cache": {
+        "current_rss_bytes": 214630400,
+        "dtype": "float32",
+        "materialization_ns": 66470787,
+        "peak_rss_bytes": 341680128,
+        "raw_bytes": 64000000
+      },
+      "environment": {
+        "dask": "2025.11.0",
+        "numpy": "2.2.6",
+        "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+        "python": "3.10.20",
+        "uv_lock_sha256": "4ef530af6b76bfa0ad997392615109f16cbe677b374f5ce9c87aacff4f242db4"
+      },
+      "input": {
+        "channels": 2,
+        "dtype": "float64",
+        "samples": 8000000
+      },
+      "issue": 438,
+      "mode": "compact",
+      "revision": "19c13ce656d8334809d473e04fe47d3171815b09",
+      "schema_version": 1,
+      "worktree_clean": true,
+      "scenario": "candidate-compact",
+      "run": 2
+    },
+    {
+      "cache": {
+        "current_rss_bytes": 278294528,
+        "dtype": "float64",
+        "materialization_ns": 89038165,
+        "peak_rss_bytes": 532512768,
+        "raw_bytes": 128000000
+      },
+      "environment": {
+        "dask": "2025.11.0",
+        "numpy": "2.2.6",
+        "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+        "python": "3.10.20",
+        "uv_lock_sha256": "4ef530af6b76bfa0ad997392615109f16cbe677b374f5ce9c87aacff4f242db4"
+      },
+      "input": {
+        "channels": 2,
+        "dtype": "float64",
+        "samples": 8000000
+      },
+      "issue": 438,
+      "mode": "control",
+      "revision": "38d4cd29705e2a430119d2941b8d33138c730a0e",
+      "schema_version": 1,
+      "worktree_clean": true,
+      "scenario": "base-control",
+      "run": 3
+    },
+    {
+      "cache": {
+        "current_rss_bytes": 278659072,
+        "dtype": "float64",
+        "materialization_ns": 88433516,
+        "peak_rss_bytes": 533540864,
+        "raw_bytes": 128000000
+      },
+      "environment": {
+        "dask": "2025.11.0",
+        "numpy": "2.2.6",
+        "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+        "python": "3.10.20",
+        "uv_lock_sha256": "4ef530af6b76bfa0ad997392615109f16cbe677b374f5ce9c87aacff4f242db4"
+      },
+      "input": {
+        "channels": 2,
+        "dtype": "float64",
+        "samples": 8000000
+      },
+      "issue": 438,
+      "mode": "control",
+      "revision": "19c13ce656d8334809d473e04fe47d3171815b09",
+      "schema_version": 1,
+      "worktree_clean": true,
+      "scenario": "candidate-control",
+      "run": 3
+    },
+    {
+      "cache": {
+        "current_rss_bytes": 214761472,
+        "dtype": "float32",
+        "materialization_ns": 72328796,
+        "peak_rss_bytes": 341639168,
+        "raw_bytes": 64000000
+      },
+      "environment": {
+        "dask": "2025.11.0",
+        "numpy": "2.2.6",
+        "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+        "python": "3.10.20",
+        "uv_lock_sha256": "4ef530af6b76bfa0ad997392615109f16cbe677b374f5ce9c87aacff4f242db4"
+      },
+      "input": {
+        "channels": 2,
+        "dtype": "float64",
+        "samples": 8000000
+      },
+      "issue": 438,
+      "mode": "compact",
+      "revision": "19c13ce656d8334809d473e04fe47d3171815b09",
+      "schema_version": 1,
+      "worktree_clean": true,
+      "scenario": "candidate-compact",
+      "run": 3
+    }
+  ]
+}

--- a/docs/src/assets/benchmarks/issue-438/resident-source-memory.json
+++ b/docs/src/assets/benchmarks/issue-438/resident-source-memory.json
@@ -1,0 +1,212 @@
+{
+  "schema_version": 1,
+  "script_sha256": "d15f5351269dbae9210a701360533185de7ac824f578f2138ad5f20805dfa51f",
+  "command_template": [
+    "/workspaces/wandas/.venv/bin/python3",
+    "/workspaces/wandas/.worktrees/issue-438-astype/docs/src/assets/benchmarks/issue-438/benchmark_resident_source.py",
+    "--mode",
+    "<control|compact>",
+    "--channels",
+    "2",
+    "--samples",
+    "8000000"
+  ],
+  "run_order": [
+    "resident-control",
+    "resident-compact"
+  ],
+  "observations": [
+    {
+      "cache": {
+        "current_rss_bytes": 406630400,
+        "dtype": "float64",
+        "materialization_ns": 90520500,
+        "peak_rss_bytes": 661430272,
+        "raw_bytes": 128000000,
+        "retained_source_dtype": "float64",
+        "retained_source_raw_bytes": 128000000
+      },
+      "environment": {
+        "dask": "2025.11.0",
+        "numpy": "2.2.6",
+        "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+        "python": "3.10.20",
+        "uv_lock_sha256": "4ef530af6b76bfa0ad997392615109f16cbe677b374f5ce9c87aacff4f242db4"
+      },
+      "input": {
+        "backing": "ChannelFrame.from_numpy",
+        "channels": 2,
+        "dtype": "float64",
+        "raw_bytes": 128000000,
+        "samples": 8000000
+      },
+      "issue": 438,
+      "mode": "control",
+      "revision": "21cc9fba428acbcd71d6afdf3cff6eed0e027ea3",
+      "schema_version": 1,
+      "worktree_clean": true,
+      "scenario": "resident-control",
+      "run": 1
+    },
+    {
+      "cache": {
+        "current_rss_bytes": 342052864,
+        "dtype": "float32",
+        "materialization_ns": 75453832,
+        "peak_rss_bytes": 468389888,
+        "raw_bytes": 64000000,
+        "retained_source_dtype": "float64",
+        "retained_source_raw_bytes": 128000000
+      },
+      "environment": {
+        "dask": "2025.11.0",
+        "numpy": "2.2.6",
+        "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+        "python": "3.10.20",
+        "uv_lock_sha256": "4ef530af6b76bfa0ad997392615109f16cbe677b374f5ce9c87aacff4f242db4"
+      },
+      "input": {
+        "backing": "ChannelFrame.from_numpy",
+        "channels": 2,
+        "dtype": "float64",
+        "raw_bytes": 128000000,
+        "samples": 8000000
+      },
+      "issue": 438,
+      "mode": "compact",
+      "revision": "21cc9fba428acbcd71d6afdf3cff6eed0e027ea3",
+      "schema_version": 1,
+      "worktree_clean": true,
+      "scenario": "resident-compact",
+      "run": 1
+    },
+    {
+      "cache": {
+        "current_rss_bytes": 406274048,
+        "dtype": "float64",
+        "materialization_ns": 91554051,
+        "peak_rss_bytes": 661037056,
+        "raw_bytes": 128000000,
+        "retained_source_dtype": "float64",
+        "retained_source_raw_bytes": 128000000
+      },
+      "environment": {
+        "dask": "2025.11.0",
+        "numpy": "2.2.6",
+        "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+        "python": "3.10.20",
+        "uv_lock_sha256": "4ef530af6b76bfa0ad997392615109f16cbe677b374f5ce9c87aacff4f242db4"
+      },
+      "input": {
+        "backing": "ChannelFrame.from_numpy",
+        "channels": 2,
+        "dtype": "float64",
+        "raw_bytes": 128000000,
+        "samples": 8000000
+      },
+      "issue": 438,
+      "mode": "control",
+      "revision": "21cc9fba428acbcd71d6afdf3cff6eed0e027ea3",
+      "schema_version": 1,
+      "worktree_clean": true,
+      "scenario": "resident-control",
+      "run": 2
+    },
+    {
+      "cache": {
+        "current_rss_bytes": 342695936,
+        "dtype": "float32",
+        "materialization_ns": 73428643,
+        "peak_rss_bytes": 469008384,
+        "raw_bytes": 64000000,
+        "retained_source_dtype": "float64",
+        "retained_source_raw_bytes": 128000000
+      },
+      "environment": {
+        "dask": "2025.11.0",
+        "numpy": "2.2.6",
+        "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+        "python": "3.10.20",
+        "uv_lock_sha256": "4ef530af6b76bfa0ad997392615109f16cbe677b374f5ce9c87aacff4f242db4"
+      },
+      "input": {
+        "backing": "ChannelFrame.from_numpy",
+        "channels": 2,
+        "dtype": "float64",
+        "raw_bytes": 128000000,
+        "samples": 8000000
+      },
+      "issue": 438,
+      "mode": "compact",
+      "revision": "21cc9fba428acbcd71d6afdf3cff6eed0e027ea3",
+      "schema_version": 1,
+      "worktree_clean": true,
+      "scenario": "resident-compact",
+      "run": 2
+    },
+    {
+      "cache": {
+        "current_rss_bytes": 406376448,
+        "dtype": "float64",
+        "materialization_ns": 93933484,
+        "peak_rss_bytes": 661254144,
+        "raw_bytes": 128000000,
+        "retained_source_dtype": "float64",
+        "retained_source_raw_bytes": 128000000
+      },
+      "environment": {
+        "dask": "2025.11.0",
+        "numpy": "2.2.6",
+        "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+        "python": "3.10.20",
+        "uv_lock_sha256": "4ef530af6b76bfa0ad997392615109f16cbe677b374f5ce9c87aacff4f242db4"
+      },
+      "input": {
+        "backing": "ChannelFrame.from_numpy",
+        "channels": 2,
+        "dtype": "float64",
+        "raw_bytes": 128000000,
+        "samples": 8000000
+      },
+      "issue": 438,
+      "mode": "control",
+      "revision": "21cc9fba428acbcd71d6afdf3cff6eed0e027ea3",
+      "schema_version": 1,
+      "worktree_clean": true,
+      "scenario": "resident-control",
+      "run": 3
+    },
+    {
+      "cache": {
+        "current_rss_bytes": 342462464,
+        "dtype": "float32",
+        "materialization_ns": 61412425,
+        "peak_rss_bytes": 469049344,
+        "raw_bytes": 64000000,
+        "retained_source_dtype": "float64",
+        "retained_source_raw_bytes": 128000000
+      },
+      "environment": {
+        "dask": "2025.11.0",
+        "numpy": "2.2.6",
+        "platform": "Linux-7.0.0-28-generic-x86_64-with-glibc2.36",
+        "python": "3.10.20",
+        "uv_lock_sha256": "4ef530af6b76bfa0ad997392615109f16cbe677b374f5ce9c87aacff4f242db4"
+      },
+      "input": {
+        "backing": "ChannelFrame.from_numpy",
+        "channels": 2,
+        "dtype": "float64",
+        "raw_bytes": 128000000,
+        "samples": 8000000
+      },
+      "issue": 438,
+      "mode": "compact",
+      "revision": "21cc9fba428acbcd71d6afdf3cff6eed0e027ea3",
+      "schema_version": 1,
+      "worktree_clean": true,
+      "scenario": "resident-compact",
+      "run": 3
+    }
+  ]
+}

--- a/docs/src/explanation/public-api-stability.md
+++ b/docs/src/explanation/public-api-stability.md
@@ -11,6 +11,11 @@ Wandasは0.xのプロジェクトのため、後方互換性を損なう変更�
 - Signatures, parameters, returns, exceptions, units, and numerical behavior are
   authoritative in the generated [API Reference](../api/index.md) and its
   Python docstrings.
+- `BaseFrame.astype()` is an additive 0.7.0 lazy, immutable numerical API. Version
+  1 supports `float32`/`float64` for real or integer Frames and
+  `complex64`/`complex128` for complex Frames. It records the normalized dtype in
+  lineage and Recipe ID `wandas.frame.astype`; cross-domain and other output dtypes
+  are rejected without changing WDF or Recipe schema versions.
 
 安定した公開APIを変更する場合は、原則としてruntime deprecation warningを出し、
 移行方法をrelease notesに記載します。未対応のWDF／Recipe schemaは推測せず明示的に失敗します。

--- a/docs/src/how-to/cache-computed-data.md
+++ b/docs/src/how-to/cache-computed-data.md
@@ -63,9 +63,13 @@ Channel calibration is preserved separately, so applying a non-unit factor throu
 The [`BaseFrame.cache()` API Reference](../api/core.md#wandas.core.base_frame.BaseFrame.cache)
 is the authoritative source for memory, ownership, lineage, and exception behavior.
 Representative timing evidence is archived with the
-[Issue #326 benchmark assets](../assets/benchmarks/issue-326/README.md).
+[Issue #326 benchmark assets](../assets/benchmarks/issue-326/README.md). Representative
+resident-memory evidence for dtype reduction is archived with the
+[Issue #438 benchmark assets](../assets/benchmarks/issue-438/README.md).
 
 memory、ownership、lineage、例外の契約は
 [`BaseFrame.cache()` API Reference](../api/core.md#wandas.core.base_frame.BaseFrame.cache)を正本とします。
 代表timing evidenceは
-[Issue #326 benchmark assets](../assets/benchmarks/issue-326/README.md)に保存しています。
+[Issue #326 benchmark assets](../assets/benchmarks/issue-326/README.md)に保存しています。dtype縮小時の
+代表resident-memory evidenceは
+[Issue #438 benchmark assets](../assets/benchmarks/issue-438/README.md)に保存しています。

--- a/docs/src/how-to/cache-computed-data.md
+++ b/docs/src/how-to/cache-computed-data.md
@@ -23,6 +23,43 @@ returns a chainable Frame backed by computed raw data. The original Frame is unc
 `.data`は1回のアクセス用にcalibration適用済みNumPy値を返しますが、`cache()`は計算済みraw
 dataを持つchain可能なFrameを返します。元のFrameは変更されません。
 
+## Reduce the resident cache dtype explicitly / cache常駐dtypeを明示的に縮小する
+
+Place `astype()` before `cache()` when the precision tradeoff is acceptable and the
+resident raw tensor should use less memory:
+
+精度とのtrade-offを許容でき、常駐するraw tensorのメモリを削減したい場合は、`cache()`の前に
+`astype()`を置きます。
+
+```python
+audio32 = audio.astype("float32").cache()
+spectrogram64 = spectrogram.astype("complex64").cache()
+```
+
+For the same shape, a cached `float32` raw tensor uses half the bytes of `float64`;
+`complex64` likewise uses half the bytes of `complex128`. Reduced precision changes
+numerical meaning, so `astype()` is lazy, immutable, and recorded as one
+`wandas.frame.astype` lineage and Recipe node. `cache()` remains a no-argument
+execution boundary and adds no lineage or Recipe node.
+
+同じshapeなら、cacheされた`float32` raw tensorは`float64`の半分、`complex64`は
+`complex128`の半分のbyte数になります。精度縮小は数値的意味を変えるため、`astype()`は
+lazyかつimmutableな`wandas.frame.astype` lineage／Recipe nodeとして1件記録されます。
+`cache()`は引数なしの実行境界のままで、lineage／Recipe nodeを追加しません。
+
+This is a resident-cache guarantee, not an all-stage peak-memory guarantee. An
+upstream operation may still create a temporary `float64` or `complex128` result
+during materialization before `astype()` produces the smaller resident tensor.
+Channel calibration is preserved separately, so applying a non-unit factor through
+`.data` or another numerical API can also promote a `float32` raw tensor to
+`float64`. Check accuracy on representative signals before reducing precision.
+
+これはcache作成後の常駐量に対する保証であり、全計算段階のpeak memory保証ではありません。
+上流Operationが`float64`／`complex128`を生成する場合、materialization中には`astype()`が
+小さい常駐tensorを作る前の一時配列が残ります。またchannel calibrationは別に保持されるため、
+1以外のfactorを`.data`や数値APIで適用すると、`float32` raw tensorが`float64`へ昇格する
+場合があります。精度を縮小する前に代表signalでaccuracyを確認してください。
+
 The [`BaseFrame.cache()` API Reference](../api/core.md#wandas.core.base_frame.BaseFrame.cache)
 is the authoritative source for memory, ownership, lineage, and exception behavior.
 Representative timing evidence is archived with the

--- a/docs/src/how-to/cache-computed-data.md
+++ b/docs/src/how-to/cache-computed-data.md
@@ -50,13 +50,21 @@ lazyかつimmutableな`wandas.frame.astype` lineage／Recipe nodeとして1件�
 This is a resident-cache guarantee, not an all-stage peak-memory guarantee. An
 upstream operation may still create a temporary `float64` or `complex128` result
 during materialization before `astype()` produces the smaller resident tensor.
+Frames also retain their immediate receiver through `previous`. If the source is
+already backed by a resident NumPy array or another cache, that wider source remains
+reachable from the compact result; only the new cached raw tensor is guaranteed to
+shrink. Total process-memory savings therefore depend on the upstream graph and
+retained Frame chain.
 Channel calibration is preserved separately, so applying a non-unit factor through
 `.data` or another numerical API can also promote a `float32` raw tensor to
 `float64`. Check accuracy on representative signals before reducing precision.
 
 これはcache作成後の常駐量に対する保証であり、全計算段階のpeak memory保証ではありません。
 上流Operationが`float64`／`complex128`を生成する場合、materialization中には`astype()`が
-小さい常駐tensorを作る前の一時配列が残ります。またchannel calibrationは別に保持されるため、
+小さい常駐tensorを作る前の一時配列が残ります。Frameは`previous`経由で直前の
+receiverも保持するため、入力が常駐NumPy配列や別のcacheである場合、その広いdtypeのsourceも
+compact結果からreachableなままです。保証されるは新しいcached raw tensorの縮小であり、
+プロセス全体の削減量は上流graphと保持されるFrame chainに依存します。またchannel calibrationは別に保持されるため、
 1以外のfactorを`.data`や数値APIで適用すると、`float32` raw tensorが`float64`へ昇格する
 場合があります。精度を縮小する前に代表signalでaccuracyを確認してください。
 

--- a/docs/src/release-notes/v0.7.0.md
+++ b/docs/src/release-notes/v0.7.0.md
@@ -18,6 +18,9 @@ workflow. Review the compatibility table before upgrading from 0.6.x.
 - Built-in Frame, WDF, and Recipe extension contracts are checked for exact
   public type coverage, codec ownership, Recipe ownership, and deterministic
   registration order while preserving Dask-lazy construction.
+- `BaseFrame.astype()` provides a lazy, immutable, Recipe-capable precision boundary,
+  so `frame.astype("float32").cache()` or a complex64 equivalent can reduce the
+  cached raw tensor's resident bytes while leaving `cache()` argument-free.
 - The executable Learning Path, tutorial, documentation contracts, and Pyodide
   browser smoke tests now provide a broader release-validation surface.
 
@@ -26,6 +29,14 @@ workflow. Review the compatibility table before upgrading from 0.6.x.
 - [Issue #326](https://github.com/kasahart/wandas/issues/326): add the minimal
   no-argument `BaseFrame.cache()` API for reusing the computed raw data of bounded
   in-memory Frames without changing lineage or serialized schemas.
+- [Issue #438](https://github.com/kasahart/wandas/issues/438): make resident cache
+  precision explicit by adding `BaseFrame.astype()` on top of the no-argument
+  `cache()` boundary, with registry key `astype` and Recipe ID
+  `wandas.frame.astype`. Version 1 keeps real/integer Frames in float32/float64 and
+  complex Frames in complex64/complex128, rejects cross-domain or other output
+  dtypes before graph construction, and makes resident cache precision explicit via
+  `frame.astype("float32").cache()` without adding `read(dtype=...)`, global dtype
+  configuration, or `cache(dtype=...)`.
 - [Issue #365](https://github.com/kasahart/wandas/issues/365) and
   [PR #382](https://github.com/kasahart/wandas/pull/382): correct IFFT
   normalization while preserving the released Recipe v1 amplitude scaling and
@@ -89,6 +100,7 @@ the numerical-correctness or persisted-meaning decisions.
 | Affected surface or artifact | Classification | Deprecation start | Replacement or migration | Removal/change version | Exception reason and decision link |
 | --- | --- | --- | --- | --- | --- |
 | `BaseFrame.cache()` | Stable (additive) | None | Use for reusable bounded results; use `.data` for one-off NumPy values. | 0.7.0 | Minimal materialization boundary approved by [Issue #326](https://github.com/kasahart/wandas/issues/326). |
+| `BaseFrame.astype()` | Stable / Serialized (additive) | None | Call `frame.astype("float32").cache()` for a smaller real resident cache or use `complex64` for complex Frames; retain 64/128-bit precision when the precision loss is unacceptable. | 0.7.0 | Precision conversion is explicit numerical meaning recorded as `wandas.frame.astype`; `cache()` remains argument-free. [Issue #438](https://github.com/kasahart/wandas/issues/438). |
 | `wandas.processing.NOctSynthesis` constructor | Stable | None | Pass the positive source `n_fft`; `SpectralFrame.noct_synthesis()` supplies it automatically. | 0.7.0 | Numerical-correctness exception approved by [Issue #398](https://github.com/kasahart/wandas/issues/398). |
 | `wandas.spectral.noct_synthesis` Recipe v1 | Serialized | None | Existing v1 payloads replay through the legacy meaning; new public calls emit version 2. | 0.7.0 | Persisted numerical meaning is kept separate from corrected current behavior; [Issue #398](https://github.com/kasahart/wandas/issues/398). |
 | `wandas.audio.fft`, `wandas.audio.welch`, and `wandas.audio.cepstrum` Recipe v1 | Serialized | None | Existing v1 payloads replay through the released meaning; new public calls emit version 2. | 0.7.0 | Persisted numerical meaning is kept separate from corrected current behavior; [Issue #397](https://github.com/kasahart/wandas/issues/397), parent [#391](https://github.com/kasahart/wandas/issues/391). |

--- a/tests/frames/test_frame_astype.py
+++ b/tests/frames/test_frame_astype.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import dask.array as da
+import numpy as np
+import pytest
+from dask import delayed
+from dask.callbacks import Callback
+
+from tests.builtin_frame_cases import BUILTIN_FRAME_CASES
+from wandas.core.base_frame import BaseFrame
+from wandas.core.metadata import ChannelCalibration
+from wandas.frames.channel import ChannelFrame
+
+
+def _assert_state_value_equal(actual: Any, expected: Any) -> None:
+    if isinstance(expected, np.ndarray):
+        np.testing.assert_array_equal(actual, expected)
+    else:
+        assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "frame_factory",
+    [pytest.param(case.factory, id=case.id) for case in BUILTIN_FRAME_CASES],
+)
+def test_astype_preserves_every_builtin_frame_family_and_state(
+    frame_factory: Callable[[], BaseFrame[Any]],
+) -> None:
+    frame = frame_factory().with_source_time_offset(0.25)
+    target = "complex64" if frame._data.dtype.kind == "c" else "float32"
+    expected_raw = frame._data.compute().astype(target)
+    expected_state = frame._get_additional_init_kwargs()
+
+    converted = frame.astype(target)
+
+    assert converted is not frame
+    assert type(converted) is type(frame)
+    assert converted.previous is frame
+    assert isinstance(converted._data, da.Array)
+    assert converted._data.dtype == np.dtype(target)
+    assert converted._data.shape == frame._data.shape
+    np.testing.assert_array_equal(converted._data.compute(), expected_raw)
+    assert converted.label == frame.label
+    assert converted.metadata == frame.metadata
+    assert converted.channels.to_list() == frame.channels.to_list()
+    assert converted._channel_ids == frame._channel_ids
+    np.testing.assert_array_equal(converted.source_time_offset, frame.source_time_offset)
+    assert converted._xr.dims == frame._xr.dims
+    assert set(converted._xr.coords) == set(frame._xr.coords)
+    for coordinate_name in frame._xr.coords:
+        np.testing.assert_array_equal(
+            converted._xr.coords[coordinate_name].values,
+            frame._xr.coords[coordinate_name].values,
+        )
+    actual_state = converted._get_additional_init_kwargs()
+    assert actual_state.keys() == expected_state.keys()
+    for name, expected in expected_state.items():
+        _assert_state_value_equal(actual_state[name], expected)
+
+
+def test_astype_is_lazy_immutable_and_records_one_normalized_lineage_entry() -> None:
+    calls: list[str] = []
+    values = np.array([[1.125, 2.25, 4.5]], dtype=np.float64)
+
+    @delayed
+    def source() -> np.ndarray[Any, Any]:
+        calls.append("source")
+        return values
+
+    lazy = da.from_delayed(source(), shape=values.shape, dtype=values.dtype)
+    frame = ChannelFrame(
+        lazy,
+        sampling_rate=8.0,
+        label="source",
+        metadata={"nested": {"value": 1}},
+        channel_metadata=[
+            {
+                "label": "mic",
+                "calibration": ChannelCalibration(factor=3.0, unit="Pa"),
+            }
+        ],
+        source_time_offset=0.5,
+    )
+    original_history = frame.operation_history
+    executed: list[Any] = []
+
+    with Callback(pretask=lambda key, _graph, _state: executed.append(key)):
+        converted = frame.astype(np.float32)
+
+    assert calls == []
+    assert executed == []
+    assert converted._data.dtype == np.dtype(np.float32)
+    assert frame._data.dtype == np.dtype(np.float64)
+    assert frame.operation_history == original_history
+    assert len(converted.operation_history) == len(original_history) + 1
+    assert converted.operation_history[-1] == {
+        "operation": "wandas.frame.astype",
+        "version": 1,
+        "params": {"dtype": "float32"},
+    }
+    assert converted.channels[0].calibration == frame.channels[0].calibration
+    np.testing.assert_allclose(converted._data.compute(), values.astype(np.float32))
+    public_values = converted.data
+    assert public_values.dtype == np.dtype(np.float64)
+    np.testing.assert_allclose(public_values, values[0].astype(np.float32) * 3.0)
+    assert calls == ["source", "source"]
+
+
+@pytest.mark.parametrize(
+    ("values", "target", "expected"),
+    [
+        (
+            np.array([[1.123456789, -2.987654321]], dtype=np.float64),
+            "float32",
+            np.array([[1.123456789, -2.987654321]], dtype=np.float32),
+        ),
+        (
+            np.array([[1.123456789 + 2.987654321j]], dtype=np.complex128),
+            "complex64",
+            np.array([[1.123456789 + 2.987654321j]], dtype=np.complex64),
+        ),
+    ],
+)
+def test_astype_converts_values_without_changing_input(
+    values: np.ndarray[Any, Any],
+    target: str,
+    expected: np.ndarray[Any, Any],
+) -> None:
+    frame = ChannelFrame.from_numpy(values.copy(), sampling_rate=8.0)
+
+    converted = frame.astype(target)
+
+    np.testing.assert_array_equal(converted._data.compute(), expected)
+    np.testing.assert_array_equal(frame._data.compute(), values)
+
+
+@pytest.mark.parametrize(
+    ("values", "target", "message"),
+    [
+        (np.ones((1, 4), dtype=np.float64), "complex64", "real or integer input"),
+        (np.ones((1, 4), dtype=np.complex128), "float32", "Use 'complex64'"),
+        (np.ones((1, 4), dtype=np.float64), "float16", "float32, float64"),
+        (np.ones((1, 4), dtype=np.float64), "int32", "float32, float64"),
+    ],
+)
+def test_astype_rejects_invalid_target_synchronously(
+    values: np.ndarray[Any, Any],
+    target: str,
+    message: str,
+) -> None:
+    frame = ChannelFrame.from_numpy(values, sampling_rate=8.0)
+
+    with pytest.raises(ValueError, match=message):
+        frame.astype(target)
+
+
+def test_astype_then_cache_computes_once_and_halves_cached_raw_tensor_bytes() -> None:
+    calls: list[str] = []
+    values = np.linspace(-1.0, 1.0, 4096, dtype=np.float64).reshape(1, -1)
+
+    @delayed
+    def source() -> np.ndarray[Any, Any]:
+        calls.append("source")
+        return values
+
+    lazy = da.from_delayed(source(), shape=values.shape, dtype=values.dtype)
+    frame = ChannelFrame(lazy, sampling_rate=4096.0)
+
+    cached = frame.astype("float32").cache()
+
+    assert calls == ["source"]
+    assert cached._data.dtype == np.dtype(np.float32)
+    cached_raw = cached._data.compute()
+    assert calls == ["source"]
+    assert cached_raw.nbytes == values.nbytes // 2
+    np.testing.assert_allclose(cached_raw, values.astype(np.float32))
+    np.testing.assert_array_equal(cached.data, cached.data)
+    assert calls == ["source"]

--- a/tests/pipeline/test_astype_recipe.py
+++ b/tests/pipeline/test_astype_recipe.py
@@ -40,3 +40,16 @@ def test_astype_recipe_rejects_invalid_real_frame_target_at_apply(dtype: str) ->
 
     with pytest.raises((ValueError, RecipeExecutionError)):
         RecipePlan.from_dict(payload).apply({"signal": source})
+
+
+@pytest.mark.parametrize(
+    "entries",
+    [[], [["dtype", "float32"], ["unexpected", True]]],
+)
+def test_astype_recipe_rejects_noncanonical_parameter_shape(entries: list[list[object]]) -> None:
+    source = ChannelFrame.from_numpy(np.ones(8, dtype=np.float64), sampling_rate=8.0)
+    payload = RecipePlan.from_frame(source.astype("float32"), input_names=("signal",)).to_dict()
+    payload["nodes"][-1]["params"]["entries"] = entries
+
+    with pytest.raises(ValueError, match="params violate"):
+        RecipePlan.from_dict(payload).apply({"signal": source})

--- a/tests/pipeline/test_astype_recipe.py
+++ b/tests/pipeline/test_astype_recipe.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from wandas.frames.channel import ChannelFrame
+from wandas.pipeline import RecipeExecutionError, RecipePlan
+
+
+def test_astype_recipe_extracts_serializes_and_replays_normalized_dtype() -> None:
+    source = ChannelFrame.from_numpy(
+        np.array([[1.125, 2.25, 4.5]], dtype=np.float64),
+        sampling_rate=8.0,
+        metadata={"recording": "source"},
+        ch_labels=["mic"],
+    ).with_source_time_offset(0.25)
+    expected = source.astype(np.float32)
+
+    payload = RecipePlan.from_frame(expected, input_names=("signal",)).to_dict()
+    replayed = RecipePlan.from_dict(payload).apply({"signal": source})
+
+    assert payload["nodes"][-1]["operation"] == "wandas.frame.astype"
+    assert payload["nodes"][-1]["params"] == {
+        "$type": "map",
+        "entries": [["dtype", "float32"]],
+    }
+    assert type(replayed) is type(expected)
+    assert replayed._data.dtype == expected._data.dtype == np.dtype(np.float32)
+    np.testing.assert_array_equal(replayed._data.compute(), expected._data.compute())
+    assert replayed.metadata == expected.metadata
+    assert replayed.channels.to_list() == expected.channels.to_list()
+    np.testing.assert_array_equal(replayed.source_time_offset, expected.source_time_offset)
+
+
+@pytest.mark.parametrize("dtype", ["float16", "int16", "bool", "object", "complex64"])
+def test_astype_recipe_rejects_invalid_real_frame_target_at_apply(dtype: str) -> None:
+    source = ChannelFrame.from_numpy(np.ones(8, dtype=np.float64), sampling_rate=8.0)
+    payload = RecipePlan.from_frame(source.astype("float32"), input_names=("signal",)).to_dict()
+    payload["nodes"][-1]["params"]["entries"][0][1] = dtype
+
+    with pytest.raises((ValueError, RecipeExecutionError)):
+        RecipePlan.from_dict(payload).apply({"signal": source})

--- a/tests/pipeline/test_builtin_recipe_contract.py
+++ b/tests/pipeline/test_builtin_recipe_contract.py
@@ -17,6 +17,7 @@ _EXPECTED_BUILTIN_RECIPE_ORDER = (
     ("wandas.channel.rename_channels", 1),
     ("wandas.frame.get_channel", 1),
     ("wandas.frame.index", 1),
+    ("wandas.frame.astype", 1),
     ("wandas.operator.add", 1),
     ("wandas.operator.subtract", 1),
     ("wandas.operator.multiply", 1),

--- a/tests/processing/test_astype_operation.py
+++ b/tests/processing/test_astype_operation.py
@@ -75,6 +75,15 @@ def test_astype_rejects_values_that_are_not_explicit_numpy_dtypes(dtype: Any) ->
         Astype(8.0, dtype=dtype)
 
 
+@pytest.mark.parametrize("input_dtype", [np.dtype(np.bool_), np.dtype(object)])
+def test_astype_rejects_non_numeric_input_dtype(input_dtype: np.dtype[Any]) -> None:
+    values = np.ones((2, 8), dtype=input_dtype)
+    source = da.from_array(values, chunks=(1, -1))
+
+    with pytest.raises(ValueError, match="Unsupported input dtype"):
+        Astype(8.0, dtype="float32").process(source)
+
+
 def test_astype_has_stable_registry_key_and_public_export() -> None:
     operation = create_operation("astype", 8.0, dtype="float32")
 

--- a/tests/processing/test_astype_operation.py
+++ b/tests/processing/test_astype_operation.py
@@ -49,6 +49,17 @@ def test_astype_preserves_existing_channel_and_time_axis_chunks() -> None:
     np.testing.assert_array_equal(result.compute(), values.astype(np.float32))
 
 
+def test_astype_eager_kernel_converts_without_mutating_input() -> None:
+    values = np.array([[1.125, -2.25]], dtype=np.float64)
+    original = values.copy()
+
+    result = Astype(2.0, dtype="float32")._process(values)
+
+    assert result.dtype == np.dtype(np.float32)
+    np.testing.assert_array_equal(result, original.astype(np.float32))
+    np.testing.assert_array_equal(values, original)
+
+
 @pytest.mark.parametrize(
     ("input_dtype", "target", "message"),
     [

--- a/tests/processing/test_astype_operation.py
+++ b/tests/processing/test_astype_operation.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any
+
+import dask.array as da
+import numpy as np
+import pytest
+from dask.callbacks import Callback
+
+from wandas.processing import Astype, create_operation, get_operation
+
+
+@pytest.mark.parametrize(
+    ("input_dtype", "target", "expected_dtype"),
+    [
+        (np.dtype(np.int16), "float32", np.dtype(np.float32)),
+        (np.dtype(np.float64), np.float32, np.dtype(np.float32)),
+        (np.dtype(np.float32), np.dtype("float64"), np.dtype(np.float64)),
+        (np.dtype(np.complex128), "complex64", np.dtype(np.complex64)),
+        (np.dtype(np.complex64), np.complex128, np.dtype(np.complex128)),
+    ],
+)
+def test_astype_builds_lazy_graph_with_exact_output_dtype(
+    input_dtype: np.dtype[Any],
+    target: Any,
+    expected_dtype: np.dtype[Any],
+) -> None:
+    values = np.arange(16).reshape(2, 8).astype(input_dtype)
+    source = da.from_array(values, chunks=(1, -1))
+    executed: list[Any] = []
+
+    with Callback(pretask=lambda key, _graph, _state: executed.append(key)):
+        result = Astype(8.0, dtype=target).process(source)
+
+    assert executed == []
+    assert result.shape == source.shape
+    assert result.dtype == expected_dtype
+    np.testing.assert_array_equal(result.compute(), values.astype(expected_dtype))
+    np.testing.assert_array_equal(source.compute(), values)
+
+
+@pytest.mark.parametrize(
+    ("input_dtype", "target", "message"),
+    [
+        (np.dtype(np.float64), "complex64", "real or integer input"),
+        (np.dtype(np.complex128), "float32", "Use 'complex64'"),
+        (np.dtype(np.complex128), "float64", "complex input"),
+        (np.dtype(np.float64), "float16", "float32, float64"),
+        (np.dtype(np.float64), "int16", "float32, float64"),
+        (np.dtype(np.float64), "bool", "float32, float64"),
+        (np.dtype(np.float64), "object", "float32, float64"),
+    ],
+)
+def test_astype_rejects_unsupported_or_cross_domain_dtype_before_graph_build(
+    input_dtype: np.dtype[Any],
+    target: Any,
+    message: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = da.ones((2, 8), chunks=(1, -1), dtype=input_dtype)
+
+    def unexpected_graph(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("graph construction must not start")
+
+    monkeypatch.setattr(Astype, "_build_execution_graph", unexpected_graph)
+
+    with pytest.raises(ValueError, match=message):
+        operation = Astype(8.0, dtype=target)
+        operation.process(source)
+
+
+@pytest.mark.parametrize("dtype", [None, "not-a-dtype"])
+def test_astype_rejects_values_that_are_not_explicit_numpy_dtypes(dtype: Any) -> None:
+    with pytest.raises(TypeError, match="explicit NumPy dtype|valid NumPy dtype"):
+        Astype(8.0, dtype=dtype)
+
+
+def test_astype_has_stable_registry_key_and_public_export() -> None:
+    operation = create_operation("astype", 8.0, dtype="float32")
+
+    assert type(operation) is Astype
+    assert get_operation("astype") is Astype
+    assert operation.name == "astype"
+    assert operation.params == {"dtype": "float32"}

--- a/tests/processing/test_astype_operation.py
+++ b/tests/processing/test_astype_operation.py
@@ -39,6 +39,16 @@ def test_astype_builds_lazy_graph_with_exact_output_dtype(
     np.testing.assert_array_equal(source.compute(), values)
 
 
+def test_astype_preserves_existing_channel_and_time_axis_chunks() -> None:
+    values = np.arange(40, dtype=np.float64).reshape(2, 20)
+    source = da.from_array(values, chunks=(1, 6))
+
+    result = Astype(20.0, dtype="float32").process(source)
+
+    assert result.chunks == source.chunks
+    np.testing.assert_array_equal(result.compute(), values.astype(np.float32))
+
+
 @pytest.mark.parametrize(
     ("input_dtype", "target", "message"),
     [

--- a/tests/processing/test_operation_lazy_metadata_contract.py
+++ b/tests/processing/test_operation_lazy_metadata_contract.py
@@ -22,6 +22,7 @@ from wandas.processing.cepstral import (
     SpectralEnvelope,
     SpectrogramCepstrum,
 )
+from wandas.processing.conversion import Astype
 from wandas.processing.custom import CustomOperation
 from wandas.processing.effects import AddWithSNR, Fade, HpssHarmonic, HpssPercussive, Normalize, RemoveDC
 from wandas.processing.filters import AWeighting, BandPassFilter, HighPassFilter, LowPassFilter
@@ -225,6 +226,7 @@ def _operation_cases() -> list[OperationCase]:
     psycho = _psycho_signal()
 
     return [
+        OperationCase("astype", lambda: Astype(SR, dtype="float32"), real64),
         OperationCase(
             "custom",
             lambda: CustomOperation(SR, func=_custom_halve, output_shape_func=_halve_shape),

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -1654,6 +1654,9 @@ class BaseFrame(ABC, Generic[T]):
             Channel calibration is preserved rather than folded into the raw
             tensor. A later ``frame.data`` access can therefore be promoted by
             calibration arithmetic even when the cached raw tensor is float32.
+            Frame results retain their immediate receiver through ``previous``;
+            an already-resident wider source therefore remains reachable even
+            though the new cached raw tensor is smaller.
         """
         from wandas.frames._astype import astype_frame
 

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -15,6 +15,7 @@ from dask.array.core import Array as DaArray
 
 from wandas.pipeline.decorators import OperationCapture, recipe_operation
 from wandas.processing.calibration import apply_channel_factors
+from wandas.processing.conversion import _normalize_astype_dtype, _validate_astype_recipe_params
 from wandas.processing.semantic import (
     ImmutableList,
     InputBinding,
@@ -393,6 +394,17 @@ def _validate_source_time_offset_recipe_params(params: Mapping[str, Any]) -> Non
 
 def _apply_source_time_offset_recipe(inputs: tuple[Any, ...], params: Mapping[str, Any]) -> Any:
     return inputs[0].with_source_time_offset(_decode_source_time_offset_recipe_params(params))
+
+
+def _capture_astype(args: tuple[Any, ...], params: Mapping[str, Any]) -> OperationCapture:
+    """Capture astype intent with a canonical dtype string."""
+    receiver = cast("BaseFrame[Any]", args[0])
+    dtype = _normalize_astype_dtype(receiver._data.dtype, params["dtype"])
+    return OperationCapture(
+        (InputBinding("frame", "frame"),),
+        (receiver.lineage,),
+        {"dtype": dtype},
+    )
 
 
 class BaseFrame(ABC, Generic[T]):
@@ -1599,6 +1611,57 @@ class BaseFrame(ABC, Generic[T]):
             ),
         )
         return self._create_new_instance(cached_data)
+
+    @recipe_operation(
+        "wandas.frame.astype",
+        capture=_capture_astype,
+        validate_params=_validate_astype_recipe_params,
+    )
+    def astype(self: S, dtype: npt.DTypeLike) -> S:
+        """Return a lazy Frame whose raw tensor uses an explicit floating dtype.
+
+        Real and integer Frames support ``float32`` and ``float64``. Complex
+        Frames support ``complex64`` and ``complex128``. Conversions across the
+        real/complex domain boundary and integer, boolean, object, or float16
+        outputs are rejected before a Dask graph is built.
+
+        The conversion is applied to the raw internal tensor, so the concrete
+        Frame type, metadata, axes, channel IDs and calibration, source-time
+        offsets, and Frame-specific constructor state are preserved. The source
+        Frame remains unchanged. Graph construction is lazy, and one
+        ``wandas.frame.astype`` lineage and Recipe node records the canonical
+        dtype string.
+
+        Args:
+            dtype: Target NumPy dtype. Supported targets are ``float32`` and
+                ``float64`` for real/integer Frames, or ``complex64`` and
+                ``complex128`` for complex Frames.
+
+        Returns:
+            A new lazy Frame of the same concrete type with converted raw dtype.
+
+        Raises:
+            TypeError: If *dtype* is not a valid NumPy dtype.
+            ValueError: If the target dtype is unsupported or crosses the
+                real/complex numerical domain.
+
+        Examples:
+            >>> cached = frame.astype("float32").cache()
+
+        Notes:
+            Channel calibration is preserved rather than folded into the raw
+            tensor. A later ``frame.data`` access can therefore be promoted by
+            calibration arithmetic even when the cached raw tensor is float32.
+        """
+        from wandas.processing import Astype
+
+        target = _normalize_astype_dtype(self._data.dtype, dtype)
+        operation = Astype(self.sampling_rate, dtype=target)
+        processed_data = operation.process(self._data)
+        return self._create_new_instance(
+            processed_data,
+            lineage=self._required_semantic_lineage(),
+        )
 
     @abstractmethod
     def plot(self, plot_type: str = "default", ax: "Axes | None" = None, **kwargs: Any) -> "Axes | Iterator[Axes]":

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -15,7 +15,6 @@ from dask.array.core import Array as DaArray
 
 from wandas.pipeline.decorators import OperationCapture, recipe_operation
 from wandas.processing.calibration import apply_channel_factors
-from wandas.processing.conversion import _normalize_astype_dtype, _validate_astype_recipe_params
 from wandas.processing.semantic import (
     ImmutableList,
     InputBinding,
@@ -397,14 +396,17 @@ def _apply_source_time_offset_recipe(inputs: tuple[Any, ...], params: Mapping[st
 
 
 def _capture_astype(args: tuple[Any, ...], params: Mapping[str, Any]) -> OperationCapture:
-    """Capture astype intent with a canonical dtype string."""
-    receiver = cast("BaseFrame[Any]", args[0])
-    dtype = _normalize_astype_dtype(receiver._data.dtype, params["dtype"])
-    return OperationCapture(
-        (InputBinding("frame", "frame"),),
-        (receiver.lineage,),
-        {"dtype": dtype},
-    )
+    """Delegate astype Recipe capture to the Frame orchestration layer."""
+    from wandas.frames._astype import capture_astype
+
+    return capture_astype(args, params)
+
+
+def _validate_astype_recipe_params(params: Mapping[str, Any]) -> None:
+    """Delegate astype Recipe validation to the Frame orchestration layer."""
+    from wandas.frames._astype import validate_astype_recipe_params
+
+    validate_astype_recipe_params(params)
 
 
 class BaseFrame(ABC, Generic[T]):
@@ -1653,15 +1655,9 @@ class BaseFrame(ABC, Generic[T]):
             tensor. A later ``frame.data`` access can therefore be promoted by
             calibration arithmetic even when the cached raw tensor is float32.
         """
-        from wandas.processing import Astype
+        from wandas.frames._astype import astype_frame
 
-        target = _normalize_astype_dtype(self._data.dtype, dtype)
-        operation = Astype(self.sampling_rate, dtype=target)
-        processed_data = operation.process(self._data)
-        return self._create_new_instance(
-            processed_data,
-            lineage=self._required_semantic_lineage(),
-        )
+        return cast(S, astype_frame(self, dtype))
 
     @abstractmethod
     def plot(self, plot_type: str = "default", ax: "Axes | None" = None, **kwargs: Any) -> "Axes | Iterator[Axes]":

--- a/wandas/core/base_frame.py
+++ b/wandas/core/base_frame.py
@@ -1618,7 +1618,7 @@ class BaseFrame(ABC, Generic[T]):
         validate_params=_validate_astype_recipe_params,
     )
     def astype(self: S, dtype: npt.DTypeLike) -> S:
-        """Return a lazy Frame whose raw tensor uses an explicit floating dtype.
+        """Return a lazy Frame whose raw tensor uses a real or complex floating dtype.
 
         Real and integer Frames support ``float32`` and ``float64``. Complex
         Frames support ``complex64`` and ``complex128``. Conversions across the

--- a/wandas/frames/_astype.py
+++ b/wandas/frames/_astype.py
@@ -1,0 +1,50 @@
+"""Frame-owned orchestration for explicit raw dtype conversion."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import numpy.typing as npt
+
+from wandas.pipeline.decorators import OperationCapture
+from wandas.processing.conversion import (
+    _SUPPORTED_TARGET_DTYPES,
+    Astype,
+    _normalize_astype_dtype,
+)
+from wandas.processing.semantic import InputBinding
+
+
+def capture_astype(args: tuple[Any, ...], params: Mapping[str, Any]) -> OperationCapture:
+    """Capture Frame astype intent with a canonical dtype string."""
+    receiver = args[0]
+    dtype = _normalize_astype_dtype(receiver._data.dtype, params["dtype"])
+    return OperationCapture(
+        (InputBinding("frame", "frame"),),
+        (receiver.lineage,),
+        {"dtype": dtype},
+    )
+
+
+def validate_astype_recipe_params(params: Mapping[str, Any]) -> None:
+    """Validate the canonical serialized parameter contract for Frame astype."""
+    if set(params) != {"dtype"}:
+        raise ValueError("astype Recipe params must contain exactly 'dtype'")
+    dtype = params["dtype"]
+    if not isinstance(dtype, str) or dtype not in _SUPPORTED_TARGET_DTYPES:
+        raise ValueError("astype Recipe dtype must be one of float32, float64, complex64, or complex128")
+
+
+def astype_frame(frame: Any, dtype: npt.DTypeLike) -> Any:
+    """Apply the processing cast while preserving Frame-owned state and lineage."""
+    target = _normalize_astype_dtype(frame._data.dtype, dtype)
+    operation = Astype(frame.sampling_rate, dtype=target)
+    processed_data = operation.process(frame._data)
+    return frame._create_new_instance(
+        processed_data,
+        lineage=frame._required_semantic_lineage(),
+    )
+
+
+__all__: list[str] = []

--- a/wandas/processing/__init__.py
+++ b/wandas/processing/__init__.py
@@ -15,6 +15,7 @@ from wandas.processing.base import (
     register_operation,
 )
 from wandas.processing.calibration import apply_channel_factors
+from wandas.processing.conversion import Astype
 from wandas.processing.effects import (
     AddWithSNR,
     HpssHarmonic,
@@ -124,6 +125,8 @@ __all__ = [  # noqa: RUF022  # intentionally grouped by category
     "get_operation",
     "register_lazy_operation",
     "register_operation",
+    # Conversion
+    "Astype",
     # Cepstral
     "Cepstrum",
     "Lifter",

--- a/wandas/processing/conversion.py
+++ b/wandas/processing/conversion.py
@@ -86,7 +86,7 @@ def _validate_astype_recipe_params(params: Mapping[str, Any]) -> None:
 
 
 class Astype(ChannelIndependentAudioOperation[Any, Any]):
-    """Convert a raw Frame tensor to an explicitly supported floating dtype.
+    """Convert a raw Frame tensor to a supported real or complex floating dtype.
 
     The eager kernel is channel-independent, preserves shape, and never mutates
     its input. :meth:`process` builds a lazy Dask graph whose dtype metadata is

--- a/wandas/processing/conversion.py
+++ b/wandas/processing/conversion.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
 import numpy as np
 import numpy.typing as npt
+from dask.array.core import Array as DaArray
 
 from wandas.processing.base import ChannelIndependentAudioOperation, register_operation
 
@@ -76,15 +76,6 @@ def _normalize_astype_dtype(input_dtype: npt.DTypeLike, dtype: npt.DTypeLike) ->
     )
 
 
-def _validate_astype_recipe_params(params: Mapping[str, Any]) -> None:
-    """Validate the canonical serialized parameter contract for astype."""
-    if set(params) != {"dtype"}:
-        raise ValueError("astype Recipe params must contain exactly 'dtype'")
-    dtype = params["dtype"]
-    if not isinstance(dtype, str) or dtype not in _SUPPORTED_TARGET_DTYPES:
-        raise ValueError("astype Recipe dtype must be one of float32, float64, complex64, or complex128")
-
-
 class Astype(ChannelIndependentAudioOperation[Any, Any]):
     """Convert a raw Frame tensor to a supported real or complex floating dtype.
 
@@ -134,6 +125,18 @@ class Astype(ChannelIndependentAudioOperation[Any, Any]):
         """Return exact output metadata after validating the source domain."""
         del input_dtypes
         return np.dtype(_normalize_astype_dtype(input_dtype, self.dtype))
+
+    def _build_execution_graph(
+        self,
+        data: DaArray,
+        inputs: tuple[DaArray, ...],
+        *,
+        output_shape: tuple[int, ...],
+        output_dtype: np.dtype[Any],
+    ) -> DaArray:
+        """Cast each existing Dask block without changing chunk boundaries."""
+        del inputs, output_shape
+        return data.astype(output_dtype)
 
     def _process(self, data: np.ndarray[Any, Any]) -> np.ndarray[Any, Any]:
         """Convert one eager channel-first tensor without mutating the input."""

--- a/wandas/processing/conversion.py
+++ b/wandas/processing/conversion.py
@@ -1,0 +1,147 @@
+"""Explicit numerical representation conversions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+from wandas.processing.base import ChannelIndependentAudioOperation, register_operation
+
+_REAL_TARGET_DTYPES = frozenset({"float32", "float64"})
+_COMPLEX_TARGET_DTYPES = frozenset({"complex64", "complex128"})
+_SUPPORTED_TARGET_DTYPES = _REAL_TARGET_DTYPES | _COMPLEX_TARGET_DTYPES
+
+
+def _normalize_target_dtype(dtype: npt.DTypeLike) -> str:
+    """Return the canonical name for a target NumPy dtype."""
+    if dtype is None:
+        raise TypeError(
+            "Invalid dtype for astype\n"
+            "  Got: None\n"
+            "  Expected: an explicit NumPy dtype\n"
+            "Use 'float32', 'float64', 'complex64', or 'complex128'."
+        )
+    try:
+        target = np.dtype(dtype)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            "Invalid dtype for astype\n"
+            f"  Got: {dtype!r}\n"
+            "  Expected: a valid NumPy dtype\n"
+            "Use 'float32', 'float64', 'complex64', or 'complex128'."
+        ) from exc
+    return target.name
+
+
+def _normalize_astype_dtype(input_dtype: npt.DTypeLike, dtype: npt.DTypeLike) -> str:
+    """Validate an astype conversion and return its canonical target name."""
+    source = np.dtype(input_dtype)
+    target = _normalize_target_dtype(dtype)
+
+    if source.kind == "c":
+        if target == "float32":
+            raise ValueError(
+                "Invalid dtype conversion for complex input\n"
+                "  Got: float32\n"
+                "  Expected: complex64 or complex128\n"
+                "Use 'complex64' to reduce a complex Frame to 32-bit components."
+            )
+        if target not in _COMPLEX_TARGET_DTYPES:
+            raise ValueError(
+                "Invalid dtype conversion for complex input\n"
+                f"  Got: {target}\n"
+                "  Expected: complex64 or complex128\n"
+                "Keep complex Frames in the complex numerical domain."
+            )
+        return target
+
+    if source.kind in {"f", "i", "u"}:
+        if target not in _REAL_TARGET_DTYPES:
+            raise ValueError(
+                "Invalid dtype conversion for real or integer input\n"
+                f"  Got: {target}\n"
+                "  Expected: float32, float64\n"
+                "Keep real and integer Frames in the real numerical domain."
+            )
+        return target
+
+    raise ValueError(
+        "Unsupported input dtype for astype\n"
+        f"  Got: {source.name}\n"
+        "  Expected: a real, integer, or complex numeric dtype\n"
+        "Convert non-numeric data before constructing a Frame."
+    )
+
+
+def _validate_astype_recipe_params(params: Mapping[str, Any]) -> None:
+    """Validate the canonical serialized parameter contract for astype."""
+    if set(params) != {"dtype"}:
+        raise ValueError("astype Recipe params must contain exactly 'dtype'")
+    dtype = params["dtype"]
+    if not isinstance(dtype, str) or dtype not in _SUPPORTED_TARGET_DTYPES:
+        raise ValueError("astype Recipe dtype must be one of float32, float64, complex64, or complex128")
+
+
+class Astype(ChannelIndependentAudioOperation[Any, Any]):
+    """Convert a raw Frame tensor to an explicitly supported floating dtype.
+
+    The eager kernel is channel-independent, preserves shape, and never mutates
+    its input. :meth:`process` builds a lazy Dask graph whose dtype metadata is
+    the exact selected target before computation. Real or integer inputs can
+    produce float32/float64; complex inputs can produce complex64/complex128.
+
+    Args:
+        sampling_rate: Sampling rate in Hz. It is preserved and does not affect
+            the numerical cast.
+        dtype: Supported target NumPy dtype or equivalent dtype-like value.
+
+    Raises:
+        TypeError: If *dtype* is not understood by NumPy.
+        ValueError: If the target is unsupported or :meth:`process` receives an
+            input whose real/complex domain does not match it.
+    """
+
+    name = "astype"
+    _display = "astype"
+
+    def __init__(self, sampling_rate: float, dtype: npt.DTypeLike) -> None:
+        """Initialize a dtype conversion with a canonical target dtype."""
+        super().__init__(sampling_rate, dtype=_normalize_target_dtype(dtype))
+
+    @property
+    def dtype(self) -> str:
+        """Return the canonical target dtype name."""
+        return self._config_value("dtype")
+
+    def validate_params(self) -> None:
+        """Reject unsupported target representations at construction time."""
+        if self.dtype not in _SUPPORTED_TARGET_DTYPES:
+            raise ValueError(
+                "Unsupported dtype for astype\n"
+                f"  Got: {self.dtype}\n"
+                "  Expected: float32, float64, complex64, or complex128\n"
+                "Choose a supported floating representation."
+            )
+
+    def calculate_output_dtype(
+        self,
+        input_dtype: np.dtype[Any],
+        *input_dtypes: np.dtype[Any],
+    ) -> np.dtype[Any]:
+        """Return exact output metadata after validating the source domain."""
+        del input_dtypes
+        return np.dtype(_normalize_astype_dtype(input_dtype, self.dtype))
+
+    def _process(self, data: np.ndarray[Any, Any]) -> np.ndarray[Any, Any]:
+        """Convert one eager channel-first tensor without mutating the input."""
+        target = _normalize_astype_dtype(data.dtype, self.dtype)
+        return data.astype(target, copy=False)
+
+
+register_operation(Astype)
+
+
+__all__ = ["Astype"]


### PR DESCRIPTION
## Summary

- add lazy, immutable `BaseFrame.astype(dtype)` across every built-in Frame family
- support real/integer → `float32`/`float64` and complex → `complex64`/`complex128`, with synchronous validation for unsupported or cross-domain casts
- register `astype` as `wandas.frame.astype` so normalized dtype choices survive lineage and Recipe extract/serialize/apply
- preserve Frame type, metadata, axes, calibration, channel IDs, source-time offsets, and Frame-specific state
- keep `cache()` as the existing no-argument, non-lineage execution boundary
- preserve existing Dask block boundaries during the elementwise cast
- document precision, calibration promotion, temporary peak-memory limits, retained source Frames, and archived resident-memory evidence

## Why

PR #439 made `cache()` an explicit materialization boundary, but a cached graph that produces `float64` or `complex128` still retains the wider raw tensor. Precision conversion has numerical meaning, so this keeps it as an inspectable and replayable Frame operation:

```python
cached = frame.astype("float32").cache()
```

This reduces post-cache resident storage without hiding dtype semantics inside `cache()`.

## Compatibility

This is an additive v0.7 API. Existing `cache()` behavior and signature are unchanged. Unsupported output domains and dtypes fail before a Dask graph is built. Frame orchestration and Recipe validation live under `wandas/frames`; the numerical conversion remains under `wandas/processing`.

## Evidence

For a lazy `(2, 8_000_000)` float64 frame in isolated processes:

| Scenario | Retained source | Raw cache tensor | Median current RSS |
| --- | ---: | ---: | ---: |
| virtual-source `cache()` | none | 128,000,000 bytes | 278,659,072 bytes |
| virtual-source `astype("float32").cache()` | none | 64,000,000 bytes | 214,630,400 bytes |
| eager-backed `cache()` | 128,000,000 bytes | 128,000,000 bytes | 406,376,448 bytes |
| eager-backed `astype("float32").cache()` | 128,000,000 bytes | 64,000,000 bytes | 342,462,464 bytes |

The new raw cache tensor is exactly 50% of the float64 control. Median current RSS was 22.98% lower with a virtual source and 15.73% lower when `previous` kept a 128 MB `from_numpy` source reachable. The documented guarantee is therefore limited to the new cached raw tensor; total process savings depend on the retained Frame chain. Full observations and reproduction details are committed under `docs/src/assets/benchmarks/issue-438/`.

## Review follow-up

- clarify in public docstrings that the operation supports real and complex floating representations
- cover non-numeric input, malformed Recipe parameters, and the eager kernel; all modified conversion lines are covered
- move Frame-level astype orchestration and Recipe parameter ownership to `wandas/frames/_astype.py`
- use blockwise Dask casting and verify channel/time chunks are unchanged
- add an eager-backed source benchmark and document that `previous` retains the wider source

## Checks

- `uv run pytest`: 3445 passed, 3 skipped
- focused astype/Frame/Recipe/lazy-metadata tests: 100 passed across compatible isolated groups
- `uv run pytest tests/pipeline`: 392 passed
- `wandas/processing/conversion.py`: 100% focused coverage
- `uv run ruff check .`
- `uv run ty check`
- `uv run mkdocs build --strict -f docs/mkdocs.yml`
- `git diff --check`

Closes #438