### PR TITLE
Prepare Wandas 0.7.1 release

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
       - Scalability Contract: explanation/scalability-contract.md
       - Spectral Numerical Contracts: explanation/spectral-numerical-contracts.md
   - Release Notes:
+      - Wandas 0.7.1: release-notes/v0.7.1.md
       - Wandas 0.7.0: release-notes/v0.7.0.md
       - Wandas 0.6.3 (not released): release-notes/v0.6.3.md
       - Wandas 0.6.2: release-notes/v0.6.2.md

--- a/docs/src/explanation/public-api-stability.md
+++ b/docs/src/explanation/public-api-stability.md
@@ -11,7 +11,7 @@ Wandasは0.xのプロジェクトのため、後方互換性を損なう変更�
 - Signatures, parameters, returns, exceptions, units, and numerical behavior are
   authoritative in the generated [API Reference](../api/index.md) and its
   Python docstrings.
-- `BaseFrame.astype()` is an additive 0.7.0 lazy, immutable numerical API. Version
+- `BaseFrame.astype()` is an additive 0.7.1 lazy, immutable numerical API. Version
   1 supports `float32`/`float64` for real or integer Frames and
   `complex64`/`complex128` for complex Frames. It records the normalized dtype in
   lineage and Recipe ID `wandas.frame.astype`; cross-domain and other output dtypes

--- a/docs/src/explanation/public-api-stability.md
+++ b/docs/src/explanation/public-api-stability.md
@@ -11,7 +11,7 @@ Wandasは0.xのプロジェクトのため、後方互換性を損なう変更�
 - Signatures, parameters, returns, exceptions, units, and numerical behavior are
   authoritative in the generated [API Reference](../api/index.md) and its
   Python docstrings.
-- `BaseFrame.astype()` is an additive 0.7.1 lazy, immutable numerical API. Version
+- `BaseFrame.astype(dtype)` is an additive 0.7.1 lazy, immutable numerical API. Version
   1 supports `float32`/`float64` for real or integer Frames and
   `complex64`/`complex128` for complex Frames. It records the normalized dtype in
   lineage and Recipe ID `wandas.frame.astype`; cross-domain and other output dtypes

--- a/docs/src/how-to/pyodide-browser.md
+++ b/docs/src/how-to/pyodide-browser.md
@@ -78,7 +78,7 @@ install Wandas from PyPI.
 To verify an exact version after it has been published to PyPI, run:
 
 ```bash
-bash scripts/test_pyodide.sh published 0.7.0
+bash scripts/test_pyodide.sh published 0.7.1
 ```
 
 The release workflow runs this published-package smoke after the PyPI upload
@@ -88,6 +88,6 @@ autoplay still require a real browser check for your origin.
 repository rootから引数なしで実行すると、checkoutから候補wheelをbuildし、ブラウザ例との
 version整合性、候補wheelを使うbrowser-guide workload、Pyodide test subsetを検証します。
 PyPIの公開artifactはinstallしません。公開後のversionを確認する場合は
-`bash scripts/test_pyodide.sh published 0.7.0`を実行します。この公開artifact smokeは
+`bash scripts/test_pyodide.sh published 0.7.1`を実行します。この公開artifact smokeは
 release workflowでもPyPI upload後、GitHub Release作成前に実行されます。DOM、CORS header、
 audio autoplayは対象originの実ブラウザでも確認してください。

--- a/docs/src/release-notes/v0.7.0.md
+++ b/docs/src/release-notes/v0.7.0.md
@@ -18,25 +18,11 @@ workflow. Review the compatibility table before upgrading from 0.6.x.
 - Built-in Frame, WDF, and Recipe extension contracts are checked for exact
   public type coverage, codec ownership, Recipe ownership, and deterministic
   registration order while preserving Dask-lazy construction.
-- `BaseFrame.astype()` provides a lazy, immutable, Recipe-capable precision boundary,
-  so `frame.astype("float32").cache()` or a complex64 equivalent can reduce the
-  cached raw tensor's resident bytes while leaving `cache()` argument-free.
 - The executable Learning Path, tutorial, documentation contracts, and Pyodide
   browser smoke tests now provide a broader release-validation surface.
 
 ## Changes
 
-- [Issue #326](https://github.com/kasahart/wandas/issues/326): add the minimal
-  no-argument `BaseFrame.cache()` API for reusing the computed raw data of bounded
-  in-memory Frames without changing lineage or serialized schemas.
-- [Issue #438](https://github.com/kasahart/wandas/issues/438): make resident cache
-  precision explicit by adding `BaseFrame.astype()` on top of the no-argument
-  `cache()` boundary, with registry key `astype` and Recipe ID
-  `wandas.frame.astype`. Version 1 keeps real/integer Frames in float32/float64 and
-  complex Frames in complex64/complex128, rejects cross-domain or other output
-  dtypes before graph construction, and makes resident cache precision explicit via
-  `frame.astype("float32").cache()` without adding `read(dtype=...)`, global dtype
-  configuration, or `cache(dtype=...)`.
 - [Issue #365](https://github.com/kasahart/wandas/issues/365) and
   [PR #382](https://github.com/kasahart/wandas/pull/382): correct IFFT
   normalization while preserving the released Recipe v1 amplitude scaling and
@@ -99,8 +85,6 @@ the numerical-correctness or persisted-meaning decisions.
 
 | Affected surface or artifact | Classification | Deprecation start | Replacement or migration | Removal/change version | Exception reason and decision link |
 | --- | --- | --- | --- | --- | --- |
-| `BaseFrame.cache()` | Stable (additive) | None | Use for reusable bounded results; use `.data` for one-off NumPy values. | 0.7.0 | Minimal materialization boundary approved by [Issue #326](https://github.com/kasahart/wandas/issues/326). |
-| `BaseFrame.astype()` | Stable / Serialized (additive) | None | Call `frame.astype("float32").cache()` for a smaller real resident cache or use `complex64` for complex Frames; retain 64/128-bit precision when the precision loss is unacceptable. | 0.7.0 | Precision conversion is explicit numerical meaning recorded as `wandas.frame.astype`; `cache()` remains argument-free. [Issue #438](https://github.com/kasahart/wandas/issues/438). |
 | `wandas.processing.NOctSynthesis` constructor | Stable | None | Pass the positive source `n_fft`; `SpectralFrame.noct_synthesis()` supplies it automatically. | 0.7.0 | Numerical-correctness exception approved by [Issue #398](https://github.com/kasahart/wandas/issues/398). |
 | `wandas.spectral.noct_synthesis` Recipe v1 | Serialized | None | Existing v1 payloads replay through the legacy meaning; new public calls emit version 2. | 0.7.0 | Persisted numerical meaning is kept separate from corrected current behavior; [Issue #398](https://github.com/kasahart/wandas/issues/398). |
 | `wandas.audio.fft`, `wandas.audio.welch`, and `wandas.audio.cepstrum` Recipe v1 | Serialized | None | Existing v1 payloads replay through the released meaning; new public calls emit version 2. | 0.7.0 | Persisted numerical meaning is kept separate from corrected current behavior; [Issue #397](https://github.com/kasahart/wandas/issues/397), parent [#391](https://github.com/kasahart/wandas/issues/391). |

--- a/docs/src/release-notes/v0.7.1.md
+++ b/docs/src/release-notes/v0.7.1.md
@@ -11,7 +11,7 @@ unchanged.
   concrete Frame type around an isolated in-memory snapshot. It preserves
   metadata, axes, calibration, Frame-specific state, lineage, and operation
   history without adding a Recipe node.
-- `BaseFrame.astype()` provides a lazy, immutable, Recipe-capable precision
+- `BaseFrame.astype(dtype)` provides a lazy, immutable, Recipe-capable precision
   boundary. Use `frame.astype("float32").cache()` or the `complex64` equivalent
   to reduce the cached raw tensor size when the precision tradeoff is acceptable.
 - `astype()` preserves Dask chunk boundaries and records its normalized dtype in
@@ -41,7 +41,7 @@ format version 0.4 and Recipe JSON remains schema version 2.
 results that fit in local process memory; use `.data` for a one-off NumPy value.
 Caching is an execution detail and does not change lineage or serialized schemas.
 
-`BaseFrame.astype()` is an additive stable and serialized API. Version 1 accepts
+`BaseFrame.astype(dtype)` is an additive stable and serialized API. Version 1 accepts
 `float32` and `float64` for real or integer Frames, and `complex64` and
 `complex128` for complex Frames. Cross-domain and other output dtypes are
 rejected before graph construction. Retain 64/128-bit precision when the

--- a/docs/src/release-notes/v0.7.1.md
+++ b/docs/src/release-notes/v0.7.1.md
@@ -1,0 +1,48 @@
+# Wandas 0.7.1
+
+Wandas 0.7.1 adds explicit boundaries for reusing bounded computed Frame data
+and choosing its numerical precision. The release keeps Frame state immutable,
+preserves Dask-lazy construction, and leaves WDF and Recipe schema versions
+unchanged.
+
+## Highlights
+
+- `BaseFrame.cache()` computes the raw Dask tensor once and returns the same
+  concrete Frame type around an isolated in-memory snapshot. It preserves
+  metadata, axes, calibration, Frame-specific state, lineage, and operation
+  history without adding a Recipe node.
+- `BaseFrame.astype()` provides a lazy, immutable, Recipe-capable precision
+  boundary. Use `frame.astype("float32").cache()` or the `complex64` equivalent
+  to reduce the cached raw tensor size when the precision tradeoff is acceptable.
+- `astype()` preserves Dask chunk boundaries and records its normalized dtype in
+  lineage and Recipe ID `wandas.frame.astype`; `cache()` remains an argument-free
+  execution boundary.
+
+## Changes
+
+- [PR #439](https://github.com/kasahart/wandas/pull/439) and
+  [Issue #326](https://github.com/kasahart/wandas/issues/326): add the minimal
+  no-argument `BaseFrame.cache()` API for reusable bounded results.
+- [PR #441](https://github.com/kasahart/wandas/pull/441) and
+  [Issue #438](https://github.com/kasahart/wandas/issues/438): add explicit
+  Frame dtype conversion for compact caches, including Recipe replay and
+  representative resident-memory evidence.
+- [PR #440](https://github.com/kasahart/wandas/pull/440) and
+  [PR #442](https://github.com/kasahart/wandas/pull/442): clarify repository
+  worktree isolation so concurrent editing agents use separate worktrees and
+  branches without forcing an unnecessary restart for isolated work.
+
+## Compatibility
+
+This release contains no removals or incompatible semantic changes. WDF remains
+format version 0.4 and Recipe JSON remains schema version 2.
+
+`BaseFrame.cache()` is an additive stable API. Use it for reusable bounded
+results that fit in local process memory; use `.data` for a one-off NumPy value.
+Caching is an execution detail and does not change lineage or serialized schemas.
+
+`BaseFrame.astype()` is an additive stable and serialized API. Version 1 accepts
+`float32` and `float64` for real or integer Frames, and `complex64` and
+`complex128` for complex Frames. Cross-domain and other output dtypes are
+rejected before graph construction. Retain 64/128-bit precision when the
+precision loss from 32/64-bit storage is unacceptable.

--- a/examples/pyodide/index.html
+++ b/examples/pyodide/index.html
@@ -26,7 +26,7 @@
 
     <script>
       const PYODIDE_VERSION = "314.0.3";
-      const WANDAS_VERSION = "0.7.0";
+      const WANDAS_VERSION = "0.7.1";
       const PYODIDE_BASE =
         `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/`;
       const SAMPLE_WAV_URL =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wandas"
-version = "0.7.0"
+version = "0.7.1"
 description = "Wandas is an open source library for efficient signal analysis in Python"
 authors = [{name = "kasahart", email="kasahart66@gmail.com"}]
 maintainers = [

--- a/uv.lock
+++ b/uv.lock
@@ -3946,7 +3946,7 @@ wheels = [
 
 [[package]]
 name = "wandas"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "cattrs" },


### PR DESCRIPTION
## Summary

- bump the package and lockfile version from 0.7.0 to 0.7.1
- add the 0.7.1 release notes for `BaseFrame.cache()` and `BaseFrame.astype()`
- restore the already-published 0.7.0 notes to their tagged contents and correct the `astype()` introduction version to 0.7.1
- add the new notes to the documentation navigation and synchronize the Pyodide browser example and published smoke command

## Why

PRs #439 and #441 landed after the v0.7.0 tag. Their documentation had been appended to the historical 0.7.0 notes, so this release preparation moves that content to the version where the APIs first ship.

## User impact

Wandas 0.7.1 publishes additive `cache()` and `astype()` Frame APIs without removals or incompatible semantic changes. WDF remains format version 0.4 and Recipe JSON remains schema version 2.

## Validation

- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest tests/docs` (`54 passed`)
- `uv run pytest tests/pyodide` (`14 passed`)
- `uv run mkdocs build --strict -f docs/mkdocs.yml`
- `uv build` produced `wandas-0.7.1.tar.gz` and `wandas-0.7.1-py3-none-any.whl`
- isolated wheel installation and `scripts/test_installation.py`
- browser example source pin matches the 0.7.1 candidate; the full local harness was skipped because Node.js is not installed in this workspace, and GitHub CI runs it with Node.js 22
- `git diff --check`
