### PR TITLE
Prepare Wandas 0.7.2 development

### DIFF
--- a/docs/src/release-notes/v0.7.1.md
+++ b/docs/src/release-notes/v0.7.1.md
@@ -1,48 +1,158 @@
 # Wandas 0.7.1
 
-Wandas 0.7.1 adds explicit boundaries for reusing bounded computed Frame data
-and choosing its numerical precision. The release keeps Frame state immutable,
-preserves Dask-lazy construction, and leaves WDF and Recipe schema versions
-unchanged.
+Wandas 0.7.1 makes repeated work on bounded recordings more explicit. Use
+`cache()` to keep one computed Frame result in local memory, and use
+`astype(dtype)` before `cache()` when a smaller floating-point representation is
+an acceptable tradeoff. Both APIs preserve Wandas' immutable, chainable Frame
+workflow.
 
-## Highlights
+Wandas 0.7.1では、メモリに収まる収録データを繰り返し利用する流れを明示的に
+扱えるようになりました。計算済みFrameをローカルメモリへ保持するには`cache()`、
+精度とのtrade-offを許容して常駐dtypeを縮小するには`cache()`の前に
+`astype(dtype)`を使用します。どちらもWandasのimmutableでchainableなFrameの
+使い方を維持します。
 
-- `BaseFrame.cache()` computes the raw Dask tensor once and returns the same
-  concrete Frame type around an isolated in-memory snapshot. It preserves
-  metadata, axes, calibration, Frame-specific state, lineage, and operation
-  history without adding a Recipe node.
-- `BaseFrame.astype(dtype)` provides a lazy, immutable, Recipe-capable precision
-  boundary. Use `frame.astype("float32").cache()` or the `complex64` equivalent
-  to reduce the cached raw tensor size when the precision tradeoff is acceptable.
-- `astype()` preserves Dask chunk boundaries and records its normalized dtype in
-  lineage and Recipe ID `wandas.frame.astype`; `cache()` remains an argument-free
-  execution boundary.
+## Install / インストール
 
-## Changes
+```bash
+pip install --upgrade "wandas==0.7.1"
+```
+
+## Highlights / ハイライト
+
+### Reuse a computed Frame / 計算済みFrameを再利用
+
+`BaseFrame.cache()` synchronously evaluates the raw Dask tensor once and returns
+a new Frame of the same concrete type backed by an isolated in-memory snapshot.
+The source Frame remains unchanged. Later materializations and downstream
+operations reuse the computed samples.
+
+`BaseFrame.cache()`はraw Dask tensorを同期的に1回評価し、独立したin-memory
+snapshotを持つ同じ具象Frame型を返します。元のFrameは変更されません。その後の
+materializationや下流Operationでは、計算済みsampleを再利用できます。
+
+```python
+import wandas as wd
+
+audio = wd.read("motor.wav")
+spectrogram = audio.stft(n_fft=2048, hop_length=512)
+
+cached = spectrogram.cache()  # computes synchronously here
+levels = cached.dB            # reuses the computed STFT
+magnitude = cached.abs()      # downstream operations reuse it too
+```
+
+`cache()` preserves metadata, axes, channel calibration, source-time offsets,
+Frame-specific state, lineage, and operation history. Caching is an execution
+detail, so it does not add a lineage or Recipe node.
+
+`cache()`はmetadata、axis、channel calibration、source-time offset、Frame固有state、
+lineage、operation historyを維持します。cacheは実行上の詳細であり、lineage／Recipe
+nodeは追加しません。
+
+### Choose resident precision explicitly / 常駐精度を明示的に選ぶ
+
+`BaseFrame.astype(dtype)` is lazy and immutable. Place it before `cache()` to
+choose the raw dtype of the newly cached tensor:
+
+`BaseFrame.astype(dtype)`はlazyかつimmutableです。新しくcacheするraw tensorの
+dtypeを選ぶ場合は、`cache()`の前に置きます。
+
+```python
+audio32 = audio.astype("float32").cache()
+spectrogram64 = spectrogram.astype("complex64").cache()
+```
+
+For an equal shape, `float32` uses half the raw tensor bytes of `float64`, and
+`complex64` uses half the bytes of `complex128`. The conversion is recorded as
+one `wandas.frame.astype` lineage and Recipe node, so the precision decision is
+inspectable and replayable.
+
+同じshapeなら、`float32` raw tensorは`float64`の半分、`complex64`は
+`complex128`の半分のbyte数です。変換は`wandas.frame.astype`のlineage／Recipe
+nodeとして1件記録されるため、精度の選択を確認・再生できます。
+
+## Which API should I use? / APIの使い分け
+
+| Goal / 目的 | API | Result / 結果 |
+| --- | --- | --- |
+| Get calibrated NumPy values once / calibration適用済みNumPy値を1回取得 | `frame.data` | Materializes and returns a detached NumPy value / 実体化して独立したNumPy値を返す |
+| Reuse a bounded computed result / メモリに収まる計算結果を再利用 | `frame.cache()` | Returns a chainable Frame backed by computed raw samples / 計算済みraw sampleを持つchainable Frameを返す |
+| Reuse a smaller raw tensor when reduced precision is acceptable / 精度低下を許容して小さいraw tensorを再利用 | `frame.astype("float32").cache()` or `frame.astype("complex64").cache()` | Records the dtype conversion, then caches the converted raw tensor / dtype変換を記録して変換後raw tensorをcacheする |
+
+## Important limits / 重要な制約
+
+- `cache()` materializes the complete raw Frame synchronously in the local
+  process. Use it only for bounded recordings that fit in memory. It is not a
+  distributed cache and has no eviction, capacity, status, release, or scheduler
+  controls.
+- `astype(...).cache()` guarantees the dtype and byte size of the new resident
+  raw tensor, not lower peak memory for every computation stage. An upstream
+  operation may still produce a wider temporary array.
+- Frames retain their immediate receiver through `previous`. If the source is
+  already an in-memory NumPy array or another cache, that wider source can remain
+  reachable from the compact result.
+- Channel calibration remains separate from the raw tensor. Calibration
+  arithmetic may promote a `float32` raw tensor when values are exposed through
+  `.data` or another numerical API. Check accuracy on representative signals
+  before reducing precision.
+- Real and integer Frames accept `float32` or `float64`; complex Frames accept
+  `complex64` or `complex128`. Cross-domain, `float16`, integer, boolean, and
+  object outputs are rejected before a Dask graph is built.
+
+- `cache()`はFrame全体のraw tensorをローカルprocessへ同期的に実体化します。
+  メモリに収まるbounded recordingだけに使用してください。distributed cacheではなく、
+  eviction、capacity、status、release、schedulerの制御はありません。
+- `astype(...).cache()`が保証するのは、新しく常駐するraw tensorのdtypeとbyte数です。
+  全計算段階のpeak memory削減は保証しません。上流Operationがより広いdtypeの一時配列を
+  生成する場合があります。
+- Frameは`previous`経由で直前のreceiverを保持します。入力がすでにin-memory NumPy配列や
+  別のcacheである場合、広いdtypeのsourceがcompact結果からreachableなままになることが
+  あります。
+- Channel calibrationはraw tensorとは別に保持されます。`.data`などで値を取得するとき、
+  calibration計算により`float32` raw tensorが昇格する場合があります。精度を縮小する前に、
+  代表的なsignalでaccuracyを確認してください。
+- real／integer Frameの出力は`float32`または`float64`、complex Frameの出力は
+  `complex64`または`complex128`です。domainをまたぐ変換、`float16`、integer、boolean、
+  object出力はDask graph構築前に拒否されます。
+
+## Compatibility / 互換性
+
+This release is additive: it contains no removals or incompatible semantic
+changes. WDF remains format version 0.4 and Recipe JSON remains schema version 2.
+Existing code does not need to adopt caching or dtype conversion.
+
+このreleaseはadditiveであり、削除や非互換な意味変更はありません。WDFはformat version
+0.4、Recipe JSONはschema version 2のままです。既存コードでcacheやdtype変換を導入する
+必要はありません。
+
+## Validation and changes / 検証と変更一覧
+
+The release passed the full Python 3.10–3.14 compatibility matrix on Ubuntu and
+Windows, documentation and type checks, candidate and published-package Pyodide
+smokes, isolated wheel installation, and Sigstore artifact signing.
+
+Python 3.10–3.14のUbuntu／Windows互換性matrix、documentation／type check、候補版と
+公開版のPyodide smoke、隔離wheel install、Sigstore artifact署名を通過しています。
 
 - [PR #439](https://github.com/kasahart/wandas/pull/439) and
   [Issue #326](https://github.com/kasahart/wandas/issues/326): add the minimal
-  no-argument `BaseFrame.cache()` API for reusable bounded results.
+  no-argument `BaseFrame.cache()` API.
 - [PR #441](https://github.com/kasahart/wandas/pull/441) and
-  [Issue #438](https://github.com/kasahart/wandas/issues/438): add explicit
-  Frame dtype conversion for compact caches, including Recipe replay and
-  representative resident-memory evidence.
+  [Issue #438](https://github.com/kasahart/wandas/issues/438): add explicit,
+  Recipe-capable Frame dtype conversion.
 - [PR #440](https://github.com/kasahart/wandas/pull/440) and
-  [PR #442](https://github.com/kasahart/wandas/pull/442): clarify repository
-  worktree isolation so concurrent editing agents use separate worktrees and
-  branches without forcing an unnecessary restart for isolated work.
+  [PR #442](https://github.com/kasahart/wandas/pull/442): refine repository
+  worktree isolation for concurrent agents.
+- [PR #443](https://github.com/kasahart/wandas/pull/443): prepare and validate
+  the 0.7.1 release.
 
-## Compatibility
+See [Reuse Computed Frame Data](https://kasahart.github.io/wandas/how-to/cache-computed-data/)
+for the focused workflow and the
+[generated API Reference](https://kasahart.github.io/wandas/api/core/#wandas.core.base_frame.BaseFrame.cache)
+for authoritative signatures, exceptions, ownership, and memory behavior.
 
-This release contains no removals or incompatible semantic changes. WDF remains
-format version 0.4 and Recipe JSON remains schema version 2.
-
-`BaseFrame.cache()` is an additive stable API. Use it for reusable bounded
-results that fit in local process memory; use `.data` for a one-off NumPy value.
-Caching is an execution detail and does not change lineage or serialized schemas.
-
-`BaseFrame.astype(dtype)` is an additive stable and serialized API. Version 1 accepts
-`float32` and `float64` for real or integer Frames, and `complex64` and
-`complex128` for complex Frames. Cross-domain and other output dtypes are
-rejected before graph construction. Retain 64/128-bit precision when the
-precision loss from 32/64-bit storage is unacceptable.
+具体的な手順は[計算済みFrameの再利用](https://kasahart.github.io/wandas/how-to/cache-computed-data/)、
+signature、exception、ownership、memory behaviorの正本は
+[生成されたAPI Reference](https://kasahart.github.io/wandas/api/core/#wandas.core.base_frame.BaseFrame.cache)
+を参照してください。

--- a/examples/pyodide/index.html
+++ b/examples/pyodide/index.html
@@ -26,7 +26,7 @@
 
     <script>
       const PYODIDE_VERSION = "314.0.3";
-      const WANDAS_VERSION = "0.7.1";
+      const WANDAS_VERSION = "0.7.2";
       const PYODIDE_BASE =
         `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/`;
       const SAMPLE_WAV_URL =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wandas"
-version = "0.7.1"
+version = "0.7.2"
 description = "Wandas is an open source library for efficient signal analysis in Python"
 authors = [{name = "kasahart", email="kasahart66@gmail.com"}]
 maintainers = [

--- a/uv.lock
+++ b/uv.lock
@@ -3946,7 +3946,7 @@ wheels = [
 
 [[package]]
 name = "wandas"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "cattrs" },


### PR DESCRIPTION
## Summary

- expand the v0.7.1 release notes into a bilingual, user-facing guide with installation, examples, API selection, memory/precision limits, compatibility, and validation details
- advance the project and lockfile development version from 0.7.1 to 0.7.2
- synchronize the Pyodide browser example with the 0.7.2 candidate version while keeping the published-package how-to command on the latest released 0.7.1

## Why

The published v0.7.1 notes currently expose only an automated pull-request list and do not explain when users should choose `.data`, `cache()`, or `astype(...).cache()`. After the 0.7.1 release, the main branch also needs a coherent 0.7.2 candidate identity so package builds and the browser source-consistency gate agree.

## User and developer impact

Users get a practical, bilingual 0.7.1 upgrade guide with explicit bounded-memory and precision caveats. Development builds now identify as 0.7.2; no runtime behavior, dependency, WDF format, or Recipe schema changes are introduced by this PR.

## Validation

- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest tests/docs` (`54 passed`)
- `uv run pytest tests/pyodide` (`14 passed`)
- `uv run mkdocs build --strict -f docs/mkdocs.yml`
- `uv build` produced the 0.7.2 wheel and sdist
- isolated 0.7.2 wheel installation and `scripts/test_installation.py`
- browser example contains the exact 0.7.2 candidate fragment required by the Node harness
- `git diff --check`

The full local browser harness was skipped because Node.js is not installed in this workspace; GitHub CI runs the same source and Pyodide checks with Node.js 22. A representative scalability benchmark was not run because this PR changes documentation and version metadata only and cannot affect materialization, graph, task-count, timing, or memory behavior.
